### PR TITLE
Enhance SSE implementation and add Faraday HTTP support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ Metrics/MethodLength:
   Max: 60
 
 Metrics/ClassLength:
-  Max: 400
+  Max: 500
   Exclude:
     - 'spec/**/*'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
   remote: .
   specs:
     ruby-mcp-client (0.4.1)
+      faraday (~> 2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
   specs:
     ruby-mcp-client (0.4.1)
       faraday (~> 2.0)
+      faraday-retry (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -35,6 +36,8 @@ GEM
       multipart-post (~> 2.0)
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
+    faraday-retry (2.3.1)
+      faraday (~> 2.0)
     hashdiff (1.1.2)
     json (2.10.2)
     language_server-protocol (3.17.0.4)

--- a/README.md
+++ b/README.md
@@ -100,9 +100,8 @@ result = client.send_rpc('another_method', params: { data: 123 }) # Uses first a
 client.send_notification('status_update', params: { status: 'ready' })
 
 # Check server connectivity 
-client.ping # Basic connectivity check
-client.ping({ echo: "hello" }) # With optional parameters 
-client.ping({}, server_index: 1) # Ping a specific server by index
+client.ping # Basic connectivity check (zero-parameter heartbeat call)
+client.ping(server_index: 1) # Ping a specific server by index
 
 # Clear cached tools to force fresh fetch on next list
 client.clear_cache
@@ -156,7 +155,7 @@ puts "Page snapshot: #{title_result}"
 screenshot_result = sse_client.call_tool('browser_take_screenshot', {})
 
 # Ping the server to verify connectivity
-ping_result = sse_client.ping({ echo: "test ping" })
+ping_result = sse_client.ping
 puts "Ping successful: #{ping_result.inspect}"
 
 # Clean up

--- a/README.md
+++ b/README.md
@@ -110,6 +110,61 @@ client.clear_cache
 client.cleanup
 ```
 
+### Server-Sent Events (SSE) Example
+
+The SSE transport provides robust connection handling for remote MCP servers:
+
+```ruby
+require 'mcp_client'
+require 'logger'
+
+# Optional logger for debugging
+logger = Logger.new($stdout)
+logger.level = Logger::INFO
+
+# Create an MCP client that connects to a Playwright MCP server via SSE
+# First run: npx @playwright/mcp@latest --port 8931
+sse_client = MCPClient.create_client(
+  mcp_server_configs: [
+    MCPClient.sse_config(
+      base_url: 'http://localhost:8931/sse',
+      read_timeout: 30,  # Timeout in seconds
+    )
+  ]
+)
+
+# List available tools
+tools = sse_client.list_tools
+
+# Launch a browser
+result = sse_client.call_tool('browser_install', {})
+result = sse_client.call_tool('browser_navigate', { url: 'about:blank' })
+# No browser ID needed with these tool names
+
+# Create a new page
+page_result = sse_client.call_tool('browser_tab_new', {})
+# No page ID needed with these tool names
+
+# Navigate to a website
+sse_client.call_tool('browser_navigate', { url: 'https://example.com' })
+
+# Get page title
+title_result = sse_client.call_tool('browser_snapshot', {})
+puts "Page snapshot: #{title_result}"
+
+# Take a screenshot
+screenshot_result = sse_client.call_tool('browser_take_screenshot', {})
+
+# Ping the server to verify connectivity
+ping_result = sse_client.ping({ echo: "test ping" })
+puts "Ping successful: #{ping_result.inspect}"
+
+# Clean up
+sse_client.cleanup
+```
+
+See `examples/mcp_sse_server_example.rb` for the full Playwright SSE example.
+
 ### Integration Examples
 
 The repository includes examples for integrating with popular AI APIs:
@@ -196,6 +251,7 @@ Complete examples can be found in the `examples/` directory:
 - `ruby_openai_mcp.rb` - Integration with alexrudall/ruby-openai gem
 - `openai_ruby_mcp.rb` - Integration with official openai/openai-ruby gem
 - `ruby_anthropic_mcp.rb` - Integration with alexrudall/ruby-anthropic gem
+- `mcp_sse_server_example.rb` - SSE transport with Playwright MCP
 
 ## MCP Server Compatibility
 
@@ -205,7 +261,20 @@ This client works with any MCP-compatible server, including:
 - [@playwright/mcp](https://www.npmjs.com/package/@playwright/mcp) - Browser automation
 - Custom servers implementing the MCP protocol
 
-### Server Implementation Features
+## Key Features
+
+### Client Features
+
+- **Multiple transports** - Support for both stdio and SSE transports
+- **Multiple servers** - Connect to multiple MCP servers simultaneously
+- **Tool discovery** - Find tools by name or pattern
+- **Atomic tool calls** - Simple API for invoking tools with parameters
+- **Batch support** - Call multiple tools in a single operation
+- **API conversions** - Built-in format conversion for OpenAI and Anthropic APIs
+- **Thread safety** - Synchronized access for thread-safe operation
+- **Server notifications** - Support for JSON-RPC notifications
+- **Custom RPC methods** - Send any custom JSON-RPC method
+- **Consistent error handling** - Rich error types for better exception handling
 
 ### Server-Sent Events (SSE) Implementation
 
@@ -226,7 +295,7 @@ The SSE client implementation provides these key features:
 
 ## Requirements
 
-- Ruby >= 2.7.0
+- Ruby >= 3.2.0
 - No runtime dependencies
 
 ## Implementing an MCP Server

--- a/examples/mcp_sse_server_example.rb
+++ b/examples/mcp_sse_server_example.rb
@@ -75,7 +75,7 @@ puts 'Browser closed'
 # Ping the server to check connectivity
 puts "\nPinging server:"
 begin
-  ping_result = sse_client.ping({ echo: 'test ping' })
+  ping_result = sse_client.ping
   puts "Ping successful: #{ping_result.inspect}"
 rescue StandardError => e
   puts "Ping failed: #{e.message}"

--- a/examples/mcp_sse_server_example.rb
+++ b/examples/mcp_sse_server_example.rb
@@ -20,7 +20,7 @@ sse_client = MCPClient.create_client(
     # Local Playwright MCP SSE server
     MCPClient.sse_config(
       base_url: 'http://localhost:8931/sse',
-      read_timeout: 30,  # Timeout in seconds
+      read_timeout: 30 # Timeout in seconds
     )
   ]
 )
@@ -40,17 +40,17 @@ puts "\nFound #{browser_tools.length} browser-related tools"
 
 # Launch a browser
 puts "\nLaunching browser..."
-result = sse_client.call_tool('browser_install', {})
-puts "Browser installed"
-result = sse_client.call_tool('browser_navigate', { url: 'about:blank' })
+sse_client.call_tool('browser_install', {})
+puts 'Browser installed'
+sse_client.call_tool('browser_navigate', { url: 'about:blank' })
 # No browser ID needed with these tool names
-puts "Browser launched and navigated to blank page"
+puts 'Browser launched and navigated to blank page'
 
 # Create a new page
 puts "\nCreating a new page..."
-page_result = sse_client.call_tool('browser_tab_new', {})
+sse_client.call_tool('browser_tab_new', {})
 # No page ID needed with these tool names
-puts "New tab created"
+puts 'New tab created'
 
 # Navigate to a website
 puts "\nNavigating to a website..."
@@ -64,8 +64,8 @@ puts "Page title: #{title_result}"
 
 # Take a screenshot
 puts "\nTaking a screenshot..."
-screenshot_result = sse_client.call_tool('browser_take_screenshot', {})
-puts "Screenshot captured successfully"
+sse_client.call_tool('browser_take_screenshot', {})
+puts 'Screenshot captured successfully'
 
 # Close browser
 puts "\nClosing browser..."

--- a/examples/mcp_sse_server_example.rb
+++ b/examples/mcp_sse_server_example.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# MCPClient integration example using the openai/openai-ruby gem
+require_relative '../lib/mcp_client'
+require 'bundler/setup'
+require 'json'
+require 'logger'
+
+# This example shows how to work with a Playwright MCP server via Server-Sent Events (SSE)
+# Connect to Playwright MCP with: npx @playwright/mcp@latest --port 8931
+
+# Create a logger for debugging (optional)
+logger = Logger.new($stdout)
+logger.level = Logger::INFO
+
+# Create an MCP client that connects to the Playwright MCP server over SSE
+sse_client = MCPClient.create_client(
+  mcp_server_configs: [
+    # Local Playwright MCP SSE server
+    MCPClient.sse_config(
+      base_url: 'http://localhost:8931/sse',
+      read_timeout: 30,  # Timeout in seconds
+    )
+  ]
+)
+
+puts 'Connected to Playwright MCP server with SSE transport'
+
+# List all available tools
+tools = sse_client.list_tools
+puts "Found #{tools.length} tools:"
+tools.each do |tool|
+  puts "- #{tool.name}: #{tool.description&.split("\n")&.first}"
+end
+
+# Find tools by name pattern (supports string or regex)
+browser_tools = sse_client.find_tools(/browser/)
+puts "\nFound #{browser_tools.length} browser-related tools"
+
+# Launch a browser
+puts "\nLaunching browser..."
+result = sse_client.call_tool('browser_install', {})
+puts "Browser installed"
+result = sse_client.call_tool('browser_navigate', { url: 'about:blank' })
+# No browser ID needed with these tool names
+puts "Browser launched and navigated to blank page"
+
+# Create a new page
+puts "\nCreating a new page..."
+page_result = sse_client.call_tool('browser_tab_new', {})
+# No page ID needed with these tool names
+puts "New tab created"
+
+# Navigate to a website
+puts "\nNavigating to a website..."
+sse_client.call_tool('browser_navigate', { url: 'https://example.com' })
+puts 'Navigated to example.com'
+
+# Get page title
+puts "\nGetting page title..."
+title_result = sse_client.call_tool('browser_snapshot', {})
+puts "Page title: #{title_result}"
+
+# Take a screenshot
+puts "\nTaking a screenshot..."
+screenshot_result = sse_client.call_tool('browser_take_screenshot', {})
+puts "Screenshot captured successfully"
+
+# Close browser
+puts "\nClosing browser..."
+sse_client.call_tool('browser_close', {})
+puts 'Browser closed'
+
+# Ping the server to check connectivity
+puts "\nPinging server:"
+begin
+  ping_result = sse_client.ping({ echo: 'test ping' })
+  puts "Ping successful: #{ping_result.inspect}"
+rescue StandardError => e
+  puts "Ping failed: #{e.message}"
+end
+
+# Clean up connections
+sse_client.cleanup
+puts "\nConnection cleaned up"

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -163,17 +163,16 @@ module MCPClient
       end
     end
 
-    # Ping the MCP server to check connectivity
-    # @param params [Hash] optional parameters for the ping request
+    # Ping the MCP server to check connectivity (zero-parameter heartbeat call)
     # @param server_index [Integer, nil] optional index of a specific server to ping, nil for first available
     # @return [Object] result from the ping request
     # @raise [MCPClient::Errors::ServerNotFound] if no server is available
-    def ping(params = {}, server_index: nil)
+    def ping(server_index: nil)
       if server_index.nil?
         # Ping first available server
         raise MCPClient::Errors::ServerNotFound, 'No server available for ping' if @servers.empty?
 
-        @servers.first.ping(params)
+        @servers.first.ping
       else
         # Ping specified server
         if server_index >= @servers.length
@@ -181,7 +180,7 @@ module MCPClient
                 "Server at index #{server_index} not found"
         end
 
-        @servers[server_index].ping(params)
+        @servers[server_index].ping
       end
     end
 

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -31,9 +31,9 @@ module MCPClient
       # Register default and user-defined notification handlers on each server
       @servers.each do |server|
         server.on_notification do |method, params|
-          # Default handling: clear tool cache on tools list change
-          clear_cache if method == 'notifications/tools/list_changed'
-          # Invoke user listeners
+          # Default notification processing (e.g., cache invalidation, logging)
+          process_notification(server, method, params)
+          # Invoke user-defined listeners
           @notification_listeners.each { |cb| cb.call(server, method, params) }
         end
       end
@@ -185,7 +185,73 @@ module MCPClient
       end
     end
 
+    # Send a raw JSON-RPC request to a server
+    # @param method [String] JSON-RPC method name
+    # @param params [Hash] parameters for the request
+    # @param server [Integer, String, Symbol, MCPClient::ServerBase, nil] server selector
+    # @return [Object] result from the JSON-RPC response
+    def send_rpc(method, params: {}, server: nil)
+      srv = select_server(server)
+      srv.rpc_request(method, params)
+    end
+
+    # Send a raw JSON-RPC notification to a server (no response expected)
+    # @param method [String] JSON-RPC method name
+    # @param params [Hash] parameters for the notification
+    # @param server [Integer, String, Symbol, MCPClient::ServerBase, nil] server selector
+    # @return [void]
+    def send_notification(method, params: {}, server: nil)
+      srv = select_server(server)
+      srv.rpc_notify(method, params)
+    end
+
     private
+
+    # Process incoming JSON-RPC notifications with default handlers
+    # @param server [MCPClient::ServerBase] the server that emitted the notification
+    # @param method [String] JSON-RPC notification method
+    # @param params [Hash] parameters for the notification
+    # @return [void]
+    def process_notification(server, method, params)
+      case method
+      when 'notifications/tools/list_changed'
+        logger.warn("[#{server.class}] Tool list has changed, clearing tool cache")
+        clear_cache
+      when 'notifications/resources/updated'
+        logger.warn("[#{server.class}] Resource #{params['uri']} updated")
+      when 'notifications/prompts/list_changed'
+        logger.warn("[#{server.class}] Prompt list has changed")
+      when 'notifications/resources/list_changed'
+        logger.warn("[#{server.class}] Resource list has changed")
+      end
+    end
+
+    # Select a server based on index, type, or instance
+    # @param server_arg [Integer, String, Symbol, MCPClient::ServerBase, nil] server selector
+    # @return [MCPClient::ServerBase]
+    def select_server(server_arg)
+      case server_arg
+      when nil
+        raise MCPClient::Errors::ServerNotFound, 'No server available' if @servers.empty?
+
+        @servers.first
+      when Integer
+        @servers.fetch(server_arg) do
+          raise MCPClient::Errors::ServerNotFound, "Server at index #{server_arg} not found"
+        end
+      when String, Symbol
+        key = server_arg.to_s.downcase
+        srv = @servers.find { |s| s.class.name.split('::').last.downcase.end_with?(key) }
+        raise MCPClient::Errors::ServerNotFound, "Server of type #{server_arg} not found" unless srv
+
+        srv
+      else
+        raise ArgumentError, "Invalid server argument: #{server_arg.inspect}" unless @servers.include?(server_arg)
+
+        server_arg
+
+      end
+    end
 
     # Validate parameters against tool JSON schema (checks required properties)
     # @param tool [MCPClient::Tool] tool definition with schema

--- a/lib/mcp_client/server_base.rb
+++ b/lib/mcp_client/server_base.rb
@@ -45,11 +45,10 @@ module MCPClient
       raise NotImplementedError, 'Subclasses must implement rpc_notify'
     end
 
-    # Ping the MCP server to check connectivity
-    # @param params [Hash] optional parameters for the ping request
+    # Ping the MCP server to check connectivity (zero-parameter heartbeat call)
     # @return [Object] result from the ping request
-    def ping(params = {})
-      rpc_request('ping', params)
+    def ping
+      rpc_request('ping')
     end
 
     # Register a callback to receive JSON-RPC notifications

--- a/ruby-mcp-client.gemspec
+++ b/ruby-mcp-client.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   # HTTP instrumentation
   spec.add_dependency 'faraday', '~> 2.0'
+  spec.add_dependency 'faraday-retry', '~> 2.0'
 
   spec.add_development_dependency 'rdoc', '~> 6.5'
   spec.add_development_dependency 'rspec', '~> 3.12'

--- a/ruby-mcp-client.gemspec
+++ b/ruby-mcp-client.gemspec
@@ -15,8 +15,10 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir.glob('lib/**/*.rb') + ['README.md', 'LICENSE']
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.2.0'
   spec.require_paths = ['lib']
+  # HTTP instrumentation
+  spec.add_dependency 'faraday', '~> 2.0'
 
   spec.add_development_dependency 'rdoc', '~> 6.5'
   spec.add_development_dependency 'rspec', '~> 3.12'

--- a/spec/lib/mcp_client/client_spec.rb
+++ b/spec/lib/mcp_client/client_spec.rb
@@ -364,4 +364,136 @@ RSpec.describe MCPClient::Client do
       end
     end
   end
+
+  describe '#send_rpc' do
+    let(:client) { described_class.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }]) }
+    let(:rpc_result) { { 'result' => 'success' } }
+
+    before do
+      allow(mock_server).to receive(:rpc_request).and_return(rpc_result)
+    end
+
+    it 'sends RPC request to the first server by default' do
+      result = client.send_rpc('test_method', params: { arg: 'value' })
+      expect(mock_server).to have_received(:rpc_request).with('test_method', { arg: 'value' })
+      expect(result).to eq(rpc_result)
+    end
+
+    it 'sends RPC request to specified server by index' do
+      client.send_rpc('test_method', params: { arg: 'value' }, server: 0)
+      expect(mock_server).to have_received(:rpc_request).with('test_method', { arg: 'value' })
+    end
+
+    context 'with multiple servers' do
+      let(:mock_server2) { instance_double(MCPClient::ServerBase) }
+      let(:multi_client) do
+        client = described_class.new(mcp_server_configs: [
+                                       { type: 'stdio', command: 'test1' },
+                                       { type: 'stdio', command: 'test2' }
+                                     ])
+        client.instance_variable_set(:@servers, [mock_server, mock_server2])
+        client
+      end
+
+      before do
+        allow(mock_server2).to receive(:rpc_request).and_return({ 'result' => 'server2' })
+        allow(mock_server2).to receive(:on_notification)
+      end
+
+      it 'sends RPC to specified server by index' do
+        result = multi_client.send_rpc('test_method', params: { arg: 'value' }, server: 1)
+        expect(mock_server2).to have_received(:rpc_request).with('test_method', { arg: 'value' })
+        expect(result).to eq({ 'result' => 'server2' })
+      end
+
+      it 'sends RPC to server by type string' do
+        # Need to mock finding server by type
+        expect(multi_client).to receive(:select_server).with('stdio').and_return(mock_server2)
+
+        result = multi_client.send_rpc('test_method', params: { arg: 'value' }, server: 'stdio')
+        expect(mock_server2).to have_received(:rpc_request).with('test_method', { arg: 'value' })
+        expect(result).to eq({ 'result' => 'server2' })
+      end
+
+      it 'sends RPC to server instance directly' do
+        result = multi_client.send_rpc('test_method', params: { arg: 'value' }, server: mock_server2)
+        expect(mock_server2).to have_received(:rpc_request).with('test_method', { arg: 'value' })
+        expect(result).to eq({ 'result' => 'server2' })
+      end
+    end
+  end
+
+  describe '#send_notification' do
+    let(:client) { described_class.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }]) }
+
+    before do
+      allow(mock_server).to receive(:rpc_notify)
+    end
+
+    it 'sends notification to the first server by default' do
+      client.send_notification('test_event', params: { arg: 'value' })
+      expect(mock_server).to have_received(:rpc_notify).with('test_event', { arg: 'value' })
+    end
+
+    it 'sends notification to specified server by index' do
+      client.send_notification('test_event', params: { arg: 'value' }, server: 0)
+      expect(mock_server).to have_received(:rpc_notify).with('test_event', { arg: 'value' })
+    end
+
+    context 'with multiple servers' do
+      let(:mock_server2) { instance_double(MCPClient::ServerBase) }
+      let(:multi_client) do
+        client = described_class.new(mcp_server_configs: [
+                                       { type: 'stdio', command: 'test1' },
+                                       { type: 'stdio', command: 'test2' }
+                                     ])
+        client.instance_variable_set(:@servers, [mock_server, mock_server2])
+        client
+      end
+
+      before do
+        allow(mock_server2).to receive(:rpc_notify)
+        allow(mock_server2).to receive(:on_notification)
+      end
+
+      it 'sends notification to specified server by index' do
+        multi_client.send_notification('test_event', params: { arg: 'value' }, server: 1)
+        expect(mock_server2).to have_received(:rpc_notify).with('test_event', { arg: 'value' })
+      end
+    end
+  end
+
+  describe 'notification handling' do
+    let(:client) { described_class.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }]) }
+    let(:notification_callback) { double('callback') }
+
+    before do
+      allow(notification_callback).to receive(:call)
+    end
+
+    it 'registers notification listeners' do
+      client.on_notification { |server, method, params| notification_callback.call(server, method, params) }
+
+      # Simulate notification
+      server = client.servers.first
+      client.instance_variable_get(:@notification_listeners).each do |cb|
+        cb.call(server, 'test_event', { data: 'test' })
+      end
+
+      expect(notification_callback).to have_received(:call).with(server, 'test_event', { data: 'test' })
+    end
+
+    it 'handles tools/list_changed notification by clearing cache' do
+      # Stub list_tools to populate the cache
+      allow(mock_server).to receive(:list_tools).and_return([mock_tool])
+
+      client.list_tools # Fill cache
+      expect(client.tool_cache).not_to be_empty
+
+      # Manually trigger process_notification with tools/list_changed
+      client.send(:process_notification, client.servers.first, 'notifications/tools/list_changed', {})
+
+      expect(client.tool_cache).to be_empty
+    end
+  end
 end

--- a/spec/lib/mcp_client/client_spec.rb
+++ b/spec/lib/mcp_client/client_spec.rb
@@ -307,18 +307,12 @@ RSpec.describe MCPClient::Client do
 
     it 'pings the first server by default' do
       result = client.ping
-      expect(mock_server).to have_received(:ping).with({})
+      expect(mock_server).to have_received(:ping)
       expect(result).to eq(ping_result)
     end
 
-    it 'passes parameters to the server ping method' do
-      params = { echo: 'hello' }
-      client.ping(params)
-      expect(mock_server).to have_received(:ping).with(params)
-    end
-
     it 'pings a specific server when server_index is provided' do
-      client.ping({}, server_index: 0)
+      client.ping(server_index: 0)
       expect(mock_server).to have_received(:ping)
     end
 
@@ -329,7 +323,7 @@ RSpec.describe MCPClient::Client do
 
     it 'raises ServerNotFound when invalid server_index is provided' do
       expect do
-        client.ping({}, server_index: 1)
+        client.ping(server_index: 1)
       end.to raise_error(MCPClient::Errors::ServerNotFound, 'Server at index 1 not found')
     end
 
@@ -357,7 +351,7 @@ RSpec.describe MCPClient::Client do
       end
 
       it 'pings the specified server when server_index is provided' do
-        result = multi_client.ping({}, server_index: 1)
+        result = multi_client.ping(server_index: 1)
         expect(mock_server).not_to have_received(:ping)
         expect(mock_server2).to have_received(:ping)
         expect(result).to eq({ 'status' => 'ok', 'server' => '2' })

--- a/spec/lib/mcp_client/server_sse_spec.rb
+++ b/spec/lib/mcp_client/server_sse_spec.rb
@@ -282,7 +282,6 @@ RSpec.describe MCPClient::ServerSSE do
       server.instance_variable_set(:@sse_connected, true)
       server.instance_variable_set(:@tools, [double('tool')])
 
-
       # Call cleanup and verify state
       server.cleanup
 

--- a/spec/lib/mcp_client/server_sse_spec.rb
+++ b/spec/lib/mcp_client/server_sse_spec.rb
@@ -333,14 +333,8 @@ RSpec.describe MCPClient::ServerSSE do
 
   describe '#ping' do
     it 'delegates to rpc_request and returns the result' do
-      allow(server).to receive(:rpc_request).with('ping', {}).and_return({})
+      allow(server).to receive(:rpc_request).with('ping').and_return({})
       expect(server.ping).to eq({})
-    end
-
-    it 'passes parameters to rpc_request' do
-      params = { foo: 'bar' }
-      allow(server).to receive(:rpc_request).with('ping', params).and_return({ 'status' => 'ok' })
-      expect(server.ping(params)).to eq({ 'status' => 'ok' })
     end
   end
 

--- a/spec/lib/mcp_client/server_stdio_spec.rb
+++ b/spec/lib/mcp_client/server_stdio_spec.rb
@@ -248,14 +248,8 @@ RSpec.describe MCPClient::ServerStdio do
 
   describe '#ping' do
     it 'delegates to rpc_request and returns the result' do
-      allow(server).to receive(:rpc_request).with('ping', {}).and_return({})
+      allow(server).to receive(:rpc_request).with('ping').and_return({})
       expect(server.ping).to eq({})
-    end
-
-    it 'passes parameters to rpc_request' do
-      params = { foo: 'bar' }
-      allow(server).to receive(:rpc_request).with('ping', params).and_return({ 'status' => 'ok' })
-      expect(server.ping(params)).to eq({ 'status' => 'ok' })
     end
   end
 


### PR DESCRIPTION
  ## Summary
  - Added Faraday HTTP client for improved connection handling and reliability
  - Implemented comprehensive SSE transport with Playwright MCP integration
  - Enhanced notification handling and added RPC functionality
  - Updated documentation with new examples and API features

  ## Key changes
  - Replaced Net::HTTP with Faraday for better HTTP connections and error handling
  - Added new `send_rpc` and `send_notification` methods for direct JSON-RPC communication
  - Implemented robust notification processing with proper handlers
  - Improved server selection mechanism for multi-server setups
  - Updated documentation with the latest browser automation API approach
  - Added comprehensive tests for new functionality
  - Updated Ruby version requirement to 3.2.0

  ## Dependencies
  - Added Faraday (~> 2.0) as a dependency for improved HTTP client functionality