### PR TITLE
Adding to_google_tools helper to MCPClient::Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ with popular AI services with built-in conversions:
 
 - `to_openai_tools()` - Formats tools for OpenAI API
 - `to_anthropic_tools()` - Formats tools for Anthropic Claude API
+- `to_google_tools()` - Formats tools for Google API
 
 ## Usage
 

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -94,6 +94,12 @@ module MCPClient
       tools.map(&:to_anthropic_tool)
     end
 
+    def to_google_tools(tool_names: nil)
+      tools = list_tools
+      tools = tools.select { |t| tool_names.include?(t.name) } if tool_names
+      tools.map(&:to_google_tool)
+    end
+
     # Clean up all server connections
     def cleanup
       servers.each(&:cleanup)

--- a/lib/mcp_client/tool.rb
+++ b/lib/mcp_client/tool.rb
@@ -46,5 +46,13 @@ module MCPClient
         input_schema: @schema
       }
     end
+
+    def to_google_tool
+      {
+        name: @name,
+        description: @description,
+        parameters: @schema
+      }
+    end
   end
 end

--- a/spec/lib/mcp_client/client_spec.rb
+++ b/spec/lib/mcp_client/client_spec.rb
@@ -164,6 +164,39 @@ RSpec.describe MCPClient::Client do
     end
   end
 
+  describe '#to_google_tools' do
+    let(:other_tool) do
+      MCPClient::Tool.new(
+        name: 'other_tool',
+        description: 'Another test tool',
+        schema: { 'type' => 'object', 'properties' => {} }
+      )
+    end
+    let(:client) { described_class.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }]) }
+
+    before do
+      allow(mock_server).to receive(:list_tools).and_return([mock_tool, other_tool])
+    end
+
+    it 'converts tools to Google tool specs' do
+      google_tools = client.to_google_tools
+      expect(google_tools.size).to eq(2)
+      expect(google_tools.first[:name]).to eq('test_tool')
+      expect(google_tools.first[:parameters]).to eq(mock_tool.schema)
+    end
+
+    it 'filters tools by name when tool_names are provided' do
+      google_tools = client.to_google_tools(tool_names: ['other_tool'])
+      expect(google_tools.size).to eq(1)
+      expect(google_tools.first[:name]).to eq('other_tool')
+    end
+
+    it 'returns empty array when no tools match the filter' do
+      google_tools = client.to_google_tools(tool_names: ['nonexistent_tool'])
+      expect(google_tools).to be_empty
+    end
+  end
+
   describe '#cleanup' do
     let(:client) { described_class.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }]) }
 

--- a/spec/lib/mcp_client/tool_spec.rb
+++ b/spec/lib/mcp_client/tool_spec.rb
@@ -65,4 +65,32 @@ RSpec.describe MCPClient::Tool do
       )
     end
   end
+
+  describe '#to_anthropic_tool' do
+    it 'converts the tool to Anthropic Claude tool format' do
+      anthropic_tool = tool.to_anthropic_tool
+      # Claude tool format
+      expect(anthropic_tool).to eq(
+        {
+          name: tool_name,
+          description: tool_description,
+          input_schema: tool_schema
+        }
+      )
+    end
+  end
+
+  describe '#to_google_tool' do
+    it 'converts the tool to Google tool format' do
+      google_tool = tool.to_google_tool
+      # Google tool format
+      expect(google_tool).to eq(
+        {
+          name: tool_name,
+          description: tool_description,
+          parameters: tool_schema
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Adding to_google_tools helper to `MCPClient::Client`

### Purpose
Allowing an easy integration to Google's API

### Changes Made
- Added to_google_tool to `MCPClient::Tool`
- Added to_google_tools to `MCPClient::Client`

### Testing
- Adding test for `MCPClient::Tool#to_anthropic_tool`
- Adding test for `MCPClient::Tool#to_google_tool`
- Adding test for `MCPClient::Client#to_google_tools`
