### PR TITLE
Integration spec update

### DIFF
--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -48,7 +48,7 @@ module MCPClient
       @env           = env || {}
     end
 
-    # Connect to the MCP server by launching the command process via stdout/stdin
+    # Connect to the MCP server by launching the command process via stdin/stdout
     # @return [Boolean] true if connection was successful
     # @raise [MCPClient::Errors::ConnectionError] if connection fails
     def connect
@@ -58,12 +58,10 @@ module MCPClient
         else
           @stdin, @stdout, @stderr, @wait_thread = Open3.popen3(*@command_array)
         end
+      elsif @env.any?
+        @stdin, @stdout, @stderr, @wait_thread = Open3.popen3(@env, @command)
       else
-        if @env.any?
-          @stdin, @stdout, @stderr, @wait_thread = Open3.popen3(@env, @command)
-        else
-          @stdin, @stdout, @stderr, @wait_thread = Open3.popen3(@command)
-        end
+        @stdin, @stdout, @stderr, @wait_thread = Open3.popen3(@command)
       end
       true
     rescue StandardError => e

--- a/spec/integration/openai_mcp_integration_spec.rb
+++ b/spec/integration/openai_mcp_integration_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'pathname'
+require 'rbconfig'
 
 RSpec.describe 'MCPClient integration with ruby-openai', :integration,
                vcr: { cassette_name: 'openai_mcp_integration' } do
@@ -11,7 +12,7 @@ RSpec.describe 'MCPClient integration with ruby-openai', :integration,
       mcp_server_configs: [
         # Use JSON-RPC stdio to communicate with the Node MCP filesystem server
         MCPClient.stdio_config(
-          command: ['npx', '-y', '@modelcontextprotocol/server-filesystem', local_path]
+          command: [RbConfig.ruby, File.expand_path('../support/fake_filesystem_mcp_server.rb', __dir__), local_path]
         )
       ]
     )
@@ -19,7 +20,7 @@ RSpec.describe 'MCPClient integration with ruby-openai', :integration,
 
   let(:openai) do
     OpenAI::Client.new(
-      access_token: ENV.fetch('OPENAI_API_KEY')
+      access_token: ENV.fetch('OPENAI_API_KEY', 'fake')
     )
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ require 'openai'
 VCR.configure do |config|
   config.cassette_library_dir = File.expand_path('cassettes', __dir__)
   config.hook_into :webmock
-  config.filter_sensitive_data('<OPENAI_API_KEY>') { ENV.fetch('OPENAI_API_KEY') }
+  config.filter_sensitive_data('<OPENAI_API_KEY>') { ENV.fetch('OPENAI_API_KEY', 'fake') }
   config.configure_rspec_metadata!
   config.ignore_localhost = true
   # Allow external connections when running integration tests

--- a/spec/support/fake_filesystem_mcp_server.rb
+++ b/spec/support/fake_filesystem_mcp_server.rb
@@ -1,0 +1,305 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Minimal MCP filesystem server stub for tests
+require 'json'
+require 'pathname'
+
+ROOT_DIR = Pathname.new(ARGV[0] || '.').expand_path
+$stdout.sync = true
+
+TOOLS = JSON.parse(<<~'JSON')
+  [
+    {
+      "name": "read_file",
+      "description": "Read the complete contents of a file from the file system. Handles various text encodings and provides detailed error messages if the file cannot be read. Use this tool when you need to examine the contents of a single file. Only works within allowed directories.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "\$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "read_multiple_files",
+      "description": "Read the contents of multiple files simultaneously. This is more efficient than reading files one by one when you need to analyze or compare multiple files. Each file's content is returned with its path as a reference. Failed reads for individual files won't stop the entire operation. Only works within allowed directories.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "paths"
+        ],
+        "additionalProperties": false,
+        "\$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "write_file",
+      "description": "Create a new file or completely overwrite an existing file with new content. Use with caution as it will overwrite existing files without warning. Handles text content with proper encoding. Only works within allowed directories.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "content"
+        ],
+        "additionalProperties": false,
+        "\$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "edit_file",
+      "description": "Make line-based edits to a text file. Each edit replaces exact line sequences with new content. Returns a git-style diff showing the changes made. Only works within allowed directories.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "edits": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oldText": {
+                  "type": "string",
+                  "description": "Text to search for - must match exactly"
+                },
+                "newText": {
+                  "type": "string",
+                  "description": "Text to replace with"
+                }
+              },
+              "required": [
+                "oldText",
+                "newText"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "dryRun": {
+            "type": "boolean",
+            "default": false,
+            "description": "Preview changes using git-style diff format"
+          }
+        },
+        "required": [
+          "path",
+          "edits"
+        ],
+        "additionalProperties": false,
+        "\$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "create_directory",
+      "description": "Create a new directory or ensure a directory exists. Can create multiple nested directories in one operation. If the directory already exists, this operation will succeed silently. Perfect for setting up directory structures for projects or ensuring required paths exist. Only works within allowed directories.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "\$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "list_directory",
+      "description": "Get a detailed listing of all files and directories in a specified path. Results clearly distinguish between files and directories with [FILE] and [DIR] prefixes. This tool is essential for understanding directory structure and finding specific files within a directory. Only works within allowed directories.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "\$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "directory_tree",
+      "description": "Get a recursive tree view of files and directories as a JSON structure. Each entry includes 'name', 'type' (file/directory), and 'children' for directories. Files have no children array, while directories always have a children array (which may be empty). The output is formatted with 2-space indentation for readability. Only works within allowed directories.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "\$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "move_file",
+      "description": "Move or rename files and directories. Can move files between directories and rename them in a single operation. If the destination exists, the operation will fail. Works across different directories and can be used for simple renaming within the same directory. Both source and destination must be within allowed directories.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "destination": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "destination"
+        ],
+        "additionalProperties": false,
+        "\$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "search_files",
+      "description": "Recursively search for files and directories matching a pattern. Searches through all subdirectories from the starting path. The search is case-insensitive and matches partial names. Returns full paths to all matching items. Great for finding files when you don't know their exact location. Only searches within allowed directories.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "excludePatterns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          }
+        },
+        "required": [
+          "path",
+          "pattern"
+        ],
+        "additionalProperties": false,
+        "\$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "get_file_info",
+      "description": "Retrieve detailed metadata about a file or directory. Returns comprehensive information including size, creation time, last modified time, permissions, and type. This tool is perfect for understanding file characteristics without reading the actual content. Only works within allowed directories.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "\$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "list_allowed_directories",
+      "description": "Returns the list of directories that this server is allowed to access. Use this to understand which directories are available before trying to access files.",
+      "schema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    }
+  ]
+
+JSON
+# Send standard JSON-RPC response
+def send_response(id, result)
+  $stdout.puts({ jsonrpc: '2.0', id: id, result: result }.to_json)
+end
+
+# Send error response
+def send_error(id, message)
+  $stdout.puts({ jsonrpc: '2.0', id: id, error: { code: -32_601, message: message } }.to_json)
+end
+
+# Process list_directory tool call
+def process_list_directory(id, args)
+  path = args['path'] || '.'
+  target = ROOT_DIR.join(path).expand_path
+
+  unless target.to_s.start_with?(ROOT_DIR.to_s)
+    send_error(id, 'Access denied')
+    return
+  end
+
+  entries = Dir.entries(target).sort.reject { |e| %w[. ..].include?(e) }
+
+  # Create formatted listing
+  listing = create_directory_listing(entries, target)
+  send_response(id, { 'content' => [{ 'type' => 'text', 'text' => listing }] })
+end
+
+# Helper to format directory listing
+def create_directory_listing(entries, target)
+  entries.map do |entry|
+    entry_path = target.join(entry)
+    prefix = File.directory?(entry_path) ? '[DIR]' : '[FILE]'
+    "#{prefix} #{entry}"
+  end.join("\n")
+end
+
+while (line = $stdin.gets)
+  begin
+    msg = JSON.parse(line)
+  rescue JSON::ParserError
+    next
+  end
+
+  id = msg['id']
+  case msg['method']
+  when 'initialize'
+    send_response(id, {})
+  when 'tools/list'
+    send_response(id, { 'tools' => TOOLS })
+  when 'tools/call'
+    tool_name = msg.dig('params', 'name')
+    args = msg.dig('params', 'arguments') || {}
+    case tool_name
+    when 'list_directory'
+      process_list_directory(id, args)
+    else
+      send_error(id, "Unknown tool #{tool_name}")
+    end
+  else
+    send_error(id, "Unknown method #{msg['method']}")
+  end
+end


### PR DESCRIPTION
## Notes
- Added a stubbed MCP filesystem server in spec/support so integration tests no longer rely on npx or network access.
- Modified spec and helper to fall back to a fake API key when OPENAI_API_KEY is absent.

## Summary
Integration test now runs the Ruby stub server instead of npx
VCR configuration tolerates missing API keys

Testing
✅ bundle exec rspec spec/integration/openai_mcp_integration_spec.rb -f doc -fd
✅ bundle exec rspec -f doc