### PR TITLE
fix Anthropic client parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ mcp_client = MCPClient.create_client(
 claude_tools = mcp_client.to_anthropic_tools
 
 # Use with Anthropic client
-client = Anthropic::Client.new(access_token: ENV['ANTHROPIC_API_KEY'])
+client = Anthropic::Client.new(api_key: ENV['ANTHROPIC_API_KEY'])
 # See examples directory for complete implementation
 ```
 

--- a/examples/ruby_anthropic_mcp.rb
+++ b/examples/ruby_anthropic_mcp.rb
@@ -37,7 +37,7 @@ stdio_server = mcp_client.servers.first
 puts "STDIO server env EXAMPLE_ENV_VAR: #{stdio_server.env['EXAMPLE_ENV_VAR']}"
 
 # Initialize the Anthropic client
-client = Anthropic::Client.new(access_token: api_key)
+client = Anthropic::Client.new(api_key: api_key)
 
 # Get MCPClient tools
 mcp_client.list_tools


### PR DESCRIPTION
When trying the examples, I figured out, that the parameter for the API key for Anthropic is invalid. It may have changed or is an copy&paste error from the other samples.

Wrong parameter: `access_token`
Correct parameter: `api_key`

See documentation at https://github.com/anthropics/anthropic-sdk-ruby?tab=readme-ov-file#usage