### PR TITLE
Add :ssl_verify option to allow disabling ssl validation for dev

### DIFF
--- a/lib/mcp_client.rb
+++ b/lib/mcp_client.rb
@@ -45,14 +45,31 @@ module MCPClient
             env: cfg[:env]
           )
         when 'sse'
-          configs << MCPClient.sse_config(base_url: cfg[:url], headers: cfg[:headers] || {}, name: cfg[:name],
-                                          logger: logger)
+          configs << MCPClient.sse_config(
+            base_url: cfg[:url],
+            headers: cfg[:headers] || {},
+            ssl_verify: cfg[:ssl_verify].nil? ? true : cfg[:ssl_verify],
+            name: cfg[:name],
+            logger: logger
+          )
         when 'http'
-          configs << MCPClient.http_config(base_url: cfg[:url], endpoint: cfg[:endpoint],
-                                           headers: cfg[:headers] || {}, name: cfg[:name], logger: logger)
+          configs << MCPClient.http_config(
+            base_url: cfg[:url],
+            endpoint: cfg[:endpoint],
+            headers: cfg[:headers] || {},
+            ssl_verify: cfg[:ssl_verify].nil? ? true : cfg[:ssl_verify],
+            name: cfg[:name],
+            logger: logger
+          )
         when 'streamable_http'
-          configs << MCPClient.streamable_http_config(base_url: cfg[:url], endpoint: cfg[:endpoint],
-                                                      headers: cfg[:headers] || {}, name: cfg[:name], logger: logger)
+          configs << MCPClient.streamable_http_config(
+            base_url: cfg[:url],
+            endpoint: cfg[:endpoint],
+            headers: cfg[:headers] || {},
+            ssl_verify: cfg[:ssl_verify].nil? ? true : cfg[:ssl_verify],
+            name: cfg[:name],
+            logger: logger
+          )
         end
       end
     end
@@ -81,11 +98,12 @@ module MCPClient
   # @param ping [Integer] time in seconds after which to send ping if no activity (default: 10)
   # @param retries [Integer] number of retry attempts (default: 0)
   # @param retry_backoff [Integer] backoff delay in seconds (default: 1)
+  # @param ssl_verify [Boolean] enable SSL certificate verification (default: true)
   # @param name [String, nil] optional name for this server
   # @param logger [Logger, nil] optional logger for server operations
   # @return [Hash] server configuration
   def self.sse_config(base_url:, headers: {}, read_timeout: 30, ping: 10, retries: 0, retry_backoff: 1,
-                      name: nil, logger: nil)
+                      ssl_verify: true, name: nil, logger: nil)
     {
       type: 'sse',
       base_url: base_url,
@@ -94,6 +112,7 @@ module MCPClient
       ping: ping,
       retries: retries,
       retry_backoff: retry_backoff,
+      ssl_verify: ssl_verify,
       name: name,
       logger: logger
     }
@@ -106,11 +125,12 @@ module MCPClient
   # @param read_timeout [Integer] read timeout in seconds (default: 30)
   # @param retries [Integer] number of retry attempts (default: 3)
   # @param retry_backoff [Integer] backoff delay in seconds (default: 1)
+  # @param ssl_verify [Boolean] enable SSL certificate verification (default: true)
   # @param name [String, nil] optional name for this server
   # @param logger [Logger, nil] optional logger for server operations
   # @return [Hash] server configuration
   def self.http_config(base_url:, endpoint: '/rpc', headers: {}, read_timeout: 30, retries: 3, retry_backoff: 1,
-                       name: nil, logger: nil)
+                       ssl_verify: true, name: nil, logger: nil)
     {
       type: 'http',
       base_url: base_url,
@@ -119,6 +139,7 @@ module MCPClient
       read_timeout: read_timeout,
       retries: retries,
       retry_backoff: retry_backoff,
+      ssl_verify: ssl_verify,
       name: name,
       logger: logger
     }
@@ -132,11 +153,12 @@ module MCPClient
   # @param read_timeout [Integer] Read timeout in seconds (default: 30)
   # @param retries [Integer] Number of retry attempts on transient errors (default: 3)
   # @param retry_backoff [Integer] Backoff delay in seconds (default: 1)
+  # @param ssl_verify [Boolean] Enable SSL certificate verification (default: true)
   # @param name [String, nil] Optional name for this server
   # @param logger [Logger, nil] Optional logger for server operations
   # @return [Hash] server configuration
   def self.streamable_http_config(base_url:, endpoint: '/rpc', headers: {}, read_timeout: 30, retries: 3,
-                                  retry_backoff: 1, name: nil, logger: nil)
+                                  retry_backoff: 1, ssl_verify: true, name: nil, logger: nil)
     {
       type: 'streamable_http',
       base_url: base_url,
@@ -145,6 +167,7 @@ module MCPClient
       read_timeout: read_timeout,
       retries: retries,
       retry_backoff: retry_backoff,
+      ssl_verify: ssl_verify,
       name: name,
       logger: logger
     }

--- a/lib/mcp_client/config_parser.rb
+++ b/lib/mcp_client/config_parser.rb
@@ -181,9 +181,14 @@ module MCPClient
       headers = config['headers']
       headers = headers.is_a?(Hash) ? headers.transform_keys(&:to_s) : {}
 
+      # SSL verification is optional (defaults to true)
+      ssl_verify = config['ssl_verify']
+      ssl_verify = true if ssl_verify.nil?
+
       # Update clean config
       clean[:url] = source
       clean[:headers] = headers
+      clean[:ssl_verify] = ssl_verify
       true
     end
 
@@ -213,10 +218,15 @@ module MCPClient
       endpoint = config['endpoint']
       endpoint = endpoint.to_s if endpoint && !endpoint.is_a?(String)
 
+      # SSL verification is optional (defaults to true)
+      ssl_verify = config['ssl_verify']
+      ssl_verify = true if ssl_verify.nil?
+
       # Update clean config
       clean[:url] = source
       clean[:headers] = headers
       clean[:endpoint] = endpoint if endpoint
+      clean[:ssl_verify] = ssl_verify
       true
     end
 
@@ -246,10 +256,15 @@ module MCPClient
       endpoint = config['endpoint']
       endpoint = endpoint.to_s if endpoint && !endpoint.is_a?(String)
 
+      # SSL verification is optional (defaults to true)
+      ssl_verify = config['ssl_verify']
+      ssl_verify = true if ssl_verify.nil?
+
       # Update clean config
       clean[:url] = source
       clean[:headers] = headers
       clean[:endpoint] = endpoint if endpoint
+      clean[:ssl_verify] = ssl_verify
       true
     end
 

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -262,6 +262,13 @@ module MCPClient
         f.request :retry, max: @max_retries, interval: @retry_backoff, backoff_factor: 2
         f.options.open_timeout = @read_timeout
         f.options.timeout = @read_timeout
+
+        # Configure SSL verification if specified
+        if @ssl_verify_mode == false
+          f.ssl.verify = false
+          @logger&.warn("SSL verification disabled - this should only be used in development/testing")
+        end
+
         f.adapter Faraday.default_adapter
       end
     end

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -264,10 +264,12 @@ module MCPClient
         f.options.timeout = @read_timeout
 
         # Configure SSL verification if specified
-        @logger&.warn("SSL verification:  #{@ssl_verify_mode}")
+        if @ssl_verify_mode == false
+          f.ssl.verify = false
+          @logger&.warn("SSL verification disabled - this should only be used in development/testing")
+        end
 
         f.adapter Faraday.default_adapter
-        f.ssl.verify = false
       end
     end
 

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -264,12 +264,10 @@ module MCPClient
         f.options.timeout = @read_timeout
 
         # Configure SSL verification if specified
-        if @ssl_verify_mode == false
-          f.ssl.verify = false
-          @logger&.warn("SSL verification disabled - this should only be used in development/testing")
-        end
+        @logger&.warn("SSL verification:  #{@ssl_verify_mode}")
 
         f.adapter Faraday.default_adapter
+        f.ssl.verify = false
       end
     end
 

--- a/lib/mcp_client/oauth_client.rb
+++ b/lib/mcp_client/oauth_client.rb
@@ -17,6 +17,7 @@ module MCPClient
     # @option options [Integer] :read_timeout Read timeout in seconds (default: 30)
     # @option options [Integer] :retries Retry attempts on transient errors (default: 3)
     # @option options [Numeric] :retry_backoff Base delay for exponential backoff (default: 1)
+    # @option options [Boolean] :ssl_verify Enable SSL certificate verification (default: true)
     # @option options [String, nil] :name Optional name for this server
     # @option options [Logger, nil] :logger Optional logger
     # @option options [Object, nil] :storage Storage backend for OAuth tokens and client info
@@ -29,7 +30,8 @@ module MCPClient
         redirect_uri: opts[:redirect_uri],
         scope: opts[:scope],
         logger: opts[:logger],
-        storage: opts[:storage]
+        storage: opts[:storage],
+        ssl_verify: opts[:ssl_verify]
       )
 
       ServerHTTP.new(
@@ -39,6 +41,7 @@ module MCPClient
         read_timeout: opts[:read_timeout],
         retries: opts[:retries],
         retry_backoff: opts[:retry_backoff],
+        ssl_verify: opts[:ssl_verify],
         name: opts[:name],
         logger: opts[:logger],
         oauth_provider: oauth_provider
@@ -57,7 +60,8 @@ module MCPClient
         redirect_uri: opts[:redirect_uri],
         scope: opts[:scope],
         logger: opts[:logger],
-        storage: opts[:storage]
+        storage: opts[:storage],
+        ssl_verify: opts[:ssl_verify]
       )
 
       ServerStreamableHTTP.new(
@@ -67,6 +71,7 @@ module MCPClient
         read_timeout: opts[:read_timeout],
         retries: opts[:retries],
         retry_backoff: opts[:retry_backoff],
+        ssl_verify: opts[:ssl_verify],
         name: opts[:name],
         logger: opts[:logger],
         oauth_provider: oauth_provider
@@ -118,6 +123,7 @@ module MCPClient
         read_timeout: 30,
         retries: 3,
         retry_backoff: 1,
+        ssl_verify: true,
         name: nil,
         logger: nil,
         storage: nil

--- a/lib/mcp_client/server_factory.rb
+++ b/lib/mcp_client/server_factory.rb
@@ -56,6 +56,7 @@ module MCPClient
         ping: config[:ping] || 10,
         retries: config[:retries] || 0,
         retry_backoff: config[:retry_backoff] || 1,
+        ssl_verify: config[:ssl_verify] || true,
         name: config[:name],
         logger: logger
       )
@@ -75,6 +76,7 @@ module MCPClient
         read_timeout: config[:read_timeout] || 30,
         retries: config[:retries] || 3,
         retry_backoff: config[:retry_backoff] || 1,
+        ssl_verify: config[:ssl_verify] || true,
         name: config[:name],
         logger: logger
       )
@@ -94,6 +96,7 @@ module MCPClient
         read_timeout: config[:read_timeout] || 30,
         retries: config[:retries] || 3,
         retry_backoff: config[:retry_backoff] || 1,
+        ssl_verify: config[:ssl_verify] || true,
         name: config[:name],
         logger: logger
       )

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -44,6 +44,7 @@ module MCPClient
     # @option options [Integer] :read_timeout Read timeout in seconds (default: 30)
     # @option options [Integer] :retries Retry attempts on transient errors (default: 3)
     # @option options [Numeric] :retry_backoff Base delay for exponential backoff (default: 1)
+    # @option options [Boolean] :ssl_verify Enable SSL certificate verification (default: true)
     # @option options [String, nil] :name Optional name for this server
     # @option options [Logger, nil] :logger Optional logger
     # @option options [MCPClient::Auth::OAuthProvider, nil] :oauth_provider Optional OAuth provider
@@ -100,6 +101,7 @@ module MCPClient
       @http_conn = nil
       @session_id = nil
       @oauth_provider = opts[:oauth_provider]
+      @ssl_verify_mode = opts[:ssl_verify]
     end
 
     # Connect to the MCP server over HTTP
@@ -268,6 +270,7 @@ module MCPClient
         read_timeout: DEFAULT_READ_TIMEOUT,
         retries: DEFAULT_MAX_RETRIES,
         retry_backoff: 1,
+        ssl_verify: true,
         name: nil,
         logger: nil,
         oauth_provider: nil

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -55,7 +55,7 @@ module MCPClient
     # @param name [String, nil] optional name for this server
     # @param logger [Logger, nil] optional logger
     def initialize(base_url:, headers: {}, read_timeout: 30, ping: 10,
-                   retries: 0, retry_backoff: 1, name: nil, logger: nil)
+                   retries: 0, retry_backoff: 1, ssl_verify: true, name: nil, logger: nil)
       super(name: name)
       initialize_logger(logger)
       @max_retries = retries
@@ -92,6 +92,7 @@ module MCPClient
       # Time of last activity
       @last_activity_time = Time.now
       @activity_timer_thread = nil
+      @ssl_verify_mode = ssl_verify
     end
 
     # Stream tool call fallback for SSE transport (yields single result)

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -143,6 +143,13 @@ module MCPClient
           f.response :follow_redirects, limit: 3
           f.options.open_timeout = @read_timeout
           f.options.timeout = @read_timeout
+
+          # Configure SSL verification if specified
+          if @ssl_verify_mode == false
+            f.ssl.verify = false
+            @logger&.warn("SSL verification disabled - this should only be used in development/testing")
+          end
+
           f.adapter Faraday.default_adapter
         end
       end

--- a/lib/mcp_client/server_sse/reconnect_monitor.rb
+++ b/lib/mcp_client/server_sse/reconnect_monitor.rb
@@ -192,6 +192,13 @@ module MCPClient
           f.options.timeout = nil
           f.request :retry, max: @max_retries, interval: @retry_backoff, backoff_factor: 2
           f.response :follow_redirects, limit: 3
+
+          # Configure SSL verification if specified
+          if @ssl_verify_mode == false
+            f.ssl.verify = false
+            @logger&.warn("SSL verification disabled - this should only be used in development/testing")
+          end
+
           f.adapter Faraday.default_adapter
         end
 

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -95,6 +95,7 @@ module MCPClient
       @session_id = nil
       @last_event_id = nil
       @oauth_provider = opts[:oauth_provider]
+      @ssl_verify_mode = opts[:ssl_verify]
     end
 
     # Connect to the MCP server over Streamable HTTP
@@ -269,6 +270,7 @@ module MCPClient
         read_timeout: DEFAULT_READ_TIMEOUT,
         retries: DEFAULT_MAX_RETRIES,
         retry_backoff: 1,
+        ssl_verify: true,
         name: nil,
         logger: nil,
         oauth_provider: nil

--- a/spec/lib/mcp_client/config_parser_spec.rb
+++ b/spec/lib/mcp_client/config_parser_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe MCPClient::ConfigParser do
           parser = described_class.new(path, logger: logger)
           result = parser.parse
 
-          expect(result['server1'].keys).to match_array(%i[type url headers name])
+          expect(result['server1'].keys).to match_array(%i[type url headers ssl_verify name])
           expect(result['server1']).not_to have_key(:comment)
           expect(result['server1']).not_to have_key(:description)
         end

--- a/spec/lib/mcp_client/mcp_client_spec.rb
+++ b/spec/lib/mcp_client/mcp_client_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe MCPClient do
       headers = { 'Authorization' => 'Bearer token' }
       cfg = MCPClient.sse_config(base_url: url, headers: headers)
       expect(cfg).to eq(type: 'sse', base_url: url, headers: headers, read_timeout: 30, ping: 10, retries: 0,
-                        retry_backoff: 1, name: nil, logger: nil)
+                        retry_backoff: 1, ssl_verify: true, name: nil, logger: nil)
     end
   end
 end

--- a/spec/lib/mcp_client/mcp_spec.rb
+++ b/spec/lib/mcp_client/mcp_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe MCPClient do
       headers = { 'Authorization' => 'Bearer token' }
       cfg = MCPClient.sse_config(base_url: url, headers: headers)
       expect(cfg).to eq(type: 'sse', base_url: url, headers: headers, read_timeout: 30, ping: 10, retries: 0,
-                        retry_backoff: 1, name: nil, logger: nil)
+                        retry_backoff: 1, ssl_verify: true, name: nil, logger: nil)
     end
 
     it 'builds an sse server config hash with custom parameters' do
@@ -39,7 +39,7 @@ RSpec.describe MCPClient do
       cfg = MCPClient.sse_config(base_url: url, headers: headers, read_timeout: 60, ping: 15, retries: 3,
                                  retry_backoff: 2)
       expect(cfg).to eq(type: 'sse', base_url: url, headers: headers, read_timeout: 60, ping: 15, retries: 3,
-                        retry_backoff: 2, name: nil, logger: nil)
+                        retry_backoff: 2, ssl_verify: true, name: nil, logger: nil)
     end
 
     it 'allows overriding the default ping value' do


### PR DESCRIPTION
This would allow to use mcp_client in development with self signed ssl certs. And I could get rid of things like this:

```
      mcp_config = MCPClient.stdio_config(
        command: "npx mcp-remote@latest https://localhost:3000/mcp/sse --allow-http --skip-browser-auth",
        env: { "NODE_TLS_REJECT_UNAUTHORIZED" => "0" },
        name: "my-app"
      )
```

and use this instead:

```
      mcp_config = MCPClient.sse_config(
        base_url: "https://localhost:3000/mcp/sse",
        headers: {},
        name: "my-app",
        read_timeout: 30,
        retries: 3,
        retry_backoff: 1,
        ssl_verify: false  <------ this
      )
```