### PR TITLE
Document Armorer Guard stdio proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,18 @@ end
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home"]
     },
+    "guarded_filesystem": {
+      "type": "stdio",
+      "command": "armorer-guard",
+      "args": [
+        "mcp-proxy",
+        "--",
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/home"
+      ]
+    },
     "api": {
       "type": "streamable_http",
       "url": "https://api.example.com/mcp",
@@ -270,6 +282,11 @@ end
   }
 }
 ```
+
+The `guarded_filesystem` example wraps a local stdio server with
+[Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard), which inspects
+MCP tool-call arguments locally for prompt injection, credential leakage,
+exfiltration risk, and dangerous actions before forwarding safe calls.
 
 ## AI Integration Examples
 


### PR DESCRIPTION
Adds an optional server definition example showing how to wrap a local stdio MCP server with `armorer-guard mcp-proxy -- ...`.

This keeps the existing `mcpServers` JSON format and gives Ruby MCP Client users a local guardrail for prompt injection, credential leakage, exfiltration risk, and dangerous tool-call checks before requests reach the underlying server.
