### PR TITLE
fix(tool): correct readOnlyHint/destructiveHint annotation defaults per MCP 2025-11-25

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,12 @@ end
 tool = client.find_tool('delete_user')
 
 # Hint-style annotations (MCP 2025-11-25)
-tool.read_only_hint?      # Defaults to true; tool does not modify environment
-tool.destructive_hint?    # Defaults to false; tool may perform destructive updates
-tool.idempotent_hint?     # Defaults to false; repeated calls have no additional effect
+# Defaults follow the MCP ToolAnnotations schema: when a hint is absent the
+# client assumes the less-safe value, so an un-annotated tool is treated as
+# writable, potentially destructive, and open-world.
+tool.read_only_hint?      # Defaults to false; tool may modify its environment
+tool.destructive_hint?    # Defaults to true; tool may perform destructive updates
+tool.idempotent_hint?     # Defaults to false; repeated calls may have additional effects
 tool.open_world_hint?     # Defaults to true; tool may interact with external entities
 
 # Legacy annotations

--- a/lib/mcp_client/tool.rb
+++ b/lib/mcp_client/tool.rb
@@ -114,21 +114,25 @@ module MCPClient
 
     # Check the readOnlyHint annotation (MCP 2025-11-25)
     # When true, the tool does not modify its environment.
-    # @return [Boolean] defaults to true when not specified
+    # Per the MCP ToolAnnotations schema the default is false, i.e. a tool
+    # without this hint is assumed to potentially modify its environment.
+    # @return [Boolean] defaults to false when not specified
     def read_only_hint?
-      return true unless @annotations
+      return false unless @annotations
 
-      fetch_annotation_hint('readOnlyHint', :readOnlyHint, true)
+      fetch_annotation_hint('readOnlyHint', :readOnlyHint, false)
     end
 
     # Check the destructiveHint annotation (MCP 2025-11-25)
     # When true, the tool may perform destructive updates.
-    # Only meaningful when readOnlyHint is false.
-    # @return [Boolean] defaults to false when not specified
+    # Only meaningful when readOnlyHint is false. Per the MCP ToolAnnotations
+    # schema the default is true, i.e. a non-read-only tool without this hint
+    # is assumed to be potentially destructive.
+    # @return [Boolean] defaults to true when not specified
     def destructive_hint?
-      return false unless @annotations
+      return true unless @annotations
 
-      fetch_annotation_hint('destructiveHint', :destructiveHint, false)
+      fetch_annotation_hint('destructiveHint', :destructiveHint, true)
     end
 
     # Check the idempotentHint annotation (MCP 2025-11-25)

--- a/spec/lib/mcp_client/tool_spec.rb
+++ b/spec/lib/mcp_client/tool_spec.rb
@@ -314,13 +314,13 @@ RSpec.describe MCPClient::Tool do
 
   describe 'MCP 2025-11-25 annotation hints' do
     describe '#read_only_hint?' do
-      it 'defaults to true when no annotations' do
-        expect(tool.read_only_hint?).to be true
+      it 'defaults to false when no annotations (MCP ToolAnnotations default)' do
+        expect(tool.read_only_hint?).to be false
       end
 
-      it 'defaults to true when annotations exist but readOnlyHint is not set' do
+      it 'defaults to false when annotations exist but readOnlyHint is not set' do
         t = described_class.new(name: 't', description: 'd', schema: {}, annotations: {})
-        expect(t.read_only_hint?).to be true
+        expect(t.read_only_hint?).to be false
       end
 
       it 'returns true when readOnlyHint is true (string key)' do
@@ -343,13 +343,13 @@ RSpec.describe MCPClient::Tool do
     end
 
     describe '#destructive_hint?' do
-      it 'defaults to false when no annotations' do
-        expect(tool.destructive_hint?).to be false
+      it 'defaults to true when no annotations (MCP ToolAnnotations default)' do
+        expect(tool.destructive_hint?).to be true
       end
 
-      it 'defaults to false when annotations exist but destructiveHint is not set' do
+      it 'defaults to true when annotations exist but destructiveHint is not set' do
         t = described_class.new(name: 't', description: 'd', schema: {}, annotations: {})
-        expect(t.destructive_hint?).to be false
+        expect(t.destructive_hint?).to be true
       end
 
       it 'returns false when destructiveHint is false (string key)' do


### PR DESCRIPTION
## Problem

`MCPClient::Tool` exposes the MCP 2025-11-25 annotation hints, but two of the four defaults were inverted relative to the [`ToolAnnotations` schema](https://modelcontextprotocol.io/specification/2025-11-25/schema):

| hint | spec default | before | after |
|------|-------------|--------|-------|
| `readOnlyHint` | **false** | `true` ❌ | `false` ✅ |
| `destructiveHint` | **true** | `false` ❌ | `true` ✅ |
| `idempotentHint` | false | false ✅ | false |
| `openWorldHint` | true | true ✅ | true |

An un-annotated tool was therefore reported as **read-only** and **non-destructive** — the *safe* interpretation the spec deliberately avoids. A host that decides whether to auto-approve a tool from `read_only_hint?` / `destructive_hint?` would treat an unannotated (and potentially dangerous) tool as safe to run without confirmation.

## Fix

- `read_only_hint?` now defaults to `false`
- `destructive_hint?` now defaults to `true`
- Explicit annotation values are unchanged (they already win over the default via `fetch_annotation_hint`).

## Compatibility

Public API is unchanged — same methods, same signatures. Only the default return value for tools that omit the hint changes, bringing it in line with the spec. Tools that send explicit annotations (including the bundled `examples/mcp_2025_11_25_server.py`) are unaffected.

## Tests / docs

- Updated `spec/lib/mcp_client/tool_spec.rb` default-value expectations
- Updated the README annotation defaults table
- Full suite: `1246 examples, 0 failures`; RuboCop clean
- Reviewed with `codex review` (no actionable findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)