### PR TITLE
fix(stdio,sse): respond to server-initiated ping with empty result (MCP ping utility)

### DIFF
--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -476,6 +476,8 @@ module MCPClient
       @logger.debug("Received server request: #{method} (id: #{request_id})")
 
       case method
+      when 'ping'
+        handle_ping(request_id)
       when 'elicitation/create'
         handle_elicitation_create(request_id, params)
       when 'roots/list'
@@ -489,6 +491,21 @@ module MCPClient
     rescue StandardError => e
       @logger.error("Error handling server request: #{e.message}")
       send_error_response(request_id, -32_603, "Internal error: #{e.message}")
+    end
+
+    # Handle a server-initiated ping request (MCP ping utility)
+    # The receiver MUST respond promptly with an empty result.
+    # @param request_id [String, Integer] the JSON-RPC request ID
+    # @return [void]
+    def handle_ping(request_id)
+      response = {
+        'jsonrpc' => '2.0',
+        'id' => request_id,
+        'result' => {}
+      }
+      post_jsonrpc_response(response)
+    rescue StandardError => e
+      @logger.error("Error sending ping response: #{e.message}")
     end
 
     # Handle elicitation/create request from server (MCP 2025-06-18)

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -427,6 +427,8 @@ module MCPClient
       @logger.debug("Received server request: #{method} (id: #{request_id})")
 
       case method
+      when 'ping'
+        handle_ping(request_id)
       when 'elicitation/create'
         handle_elicitation_create(request_id, params)
       when 'roots/list'
@@ -440,6 +442,19 @@ module MCPClient
     rescue StandardError => e
       @logger.error("Error handling server request: #{e.message}")
       send_error_response(request_id, -32_603, "Internal error: #{e.message}")
+    end
+
+    # Handle a server-initiated ping request (MCP ping utility)
+    # The receiver MUST respond promptly with an empty result.
+    # @param request_id [String, Integer] the JSON-RPC request ID
+    # @return [void]
+    def handle_ping(request_id)
+      response = {
+        'jsonrpc' => '2.0',
+        'id' => request_id,
+        'result' => {}
+      }
+      send_message(response)
     end
 
     # Handle elicitation/create request from server (MCP 2025-06-18)

--- a/spec/lib/mcp_client/server_sse_elicitation_spec.rb
+++ b/spec/lib/mcp_client/server_sse_elicitation_spec.rb
@@ -51,6 +51,22 @@ RSpec.describe MCPClient::ServerSSE, 'Elicitation (MCP 2025-06-18)' do
       end
     end
 
+    context 'when method is ping' do
+      let(:message) do
+        {
+          'id' => request_id,
+          'method' => 'ping',
+          'params' => {}
+        }
+      end
+
+      it 'responds with an empty result (MCP ping utility)' do
+        expected_response = { 'jsonrpc' => '2.0', 'id' => request_id, 'result' => {} }
+        expect(server).to receive(:post_jsonrpc_response).with(expected_response)
+        server.handle_server_request(message)
+      end
+    end
+
     context 'when method is unknown' do
       let(:message) do
         {

--- a/spec/lib/mcp_client/server_stdio_elicitation_spec.rb
+++ b/spec/lib/mcp_client/server_stdio_elicitation_spec.rb
@@ -57,6 +57,23 @@ RSpec.describe MCPClient::ServerStdio, 'Elicitation (MCP 2025-06-18)' do
       end
     end
 
+    context 'when method is ping' do
+      let(:message) do
+        {
+          'id' => request_id,
+          'method' => 'ping',
+          'params' => {}
+        }
+      end
+
+      it 'responds with an empty result (MCP ping utility)' do
+        server.handle_server_request(message)
+        expect(stdin_mock.string).to include('"id":123')
+        expect(stdin_mock.string).to include('"result":{}')
+        expect(stdin_mock.string).not_to include('error')
+      end
+    end
+
     context 'when method is unknown' do
       let(:message) do
         {


### PR DESCRIPTION
## Problem

The [MCP ping utility](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/ping) states:

> The receiver **MUST** respond promptly with an empty response:
> ```json
> { "jsonrpc": "2.0", "id": "123", "result": {} }
> ```

Either party may send `ping`. When a **server** pings the client over **stdio** or **SSE**, the request (method `ping`, with an `id`) was routed through `handle_server_request`, which had no `ping` branch and fell through to:

```ruby
send_error_response(request_id, -32_601, "Method not found: #{method}")
```

So the client answered a spec-mandated ping with JSON-RPC error **-32601**. A server using ping for keepalive would treat the client as unresponsive and could consider the connection stale and tear it down.

Streamable HTTP already intercepts `ping` in `handle_server_message`, so only stdio and SSE were affected.

## Fix

- `ServerStdio#handle_server_request` — handle `ping` → empty `result` written to the child's stdin
- `ServerSSE#handle_server_request` — handle `ping` → empty `result` POSTed back to the server
- Added a `handle_ping` helper on each transport

## Compatibility

Purely additive: a new `when 'ping'` branch and a new `handle_ping` method on each transport. No public API or existing behavior changes; unknown methods still return -32601.

## Tests

- New ping specs for stdio and SSE `handle_server_request`
- Full suite: `1248 examples, 0 failures`; RuboCop clean
- Reviewed with `codex review` (no actionable findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)