### PR TITLE
fix(stdio): drain subprocess stderr to prevent deadlock

### DIFF
--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -21,6 +21,14 @@ module MCPClient
     # Timeout in seconds for responses
     READ_TIMEOUT = 15
 
+    # Chunk size (bytes) used when draining the subprocess stderr pipe
+    STDERR_READ_CHUNK_SIZE = 8192
+
+    # Maximum bytes buffered for a single unterminated stderr line before it is
+    # flushed. Bounds memory when a server writes to stderr without newlines
+    # (e.g. progress output using carriage returns).
+    STDERR_MAX_LINE_SIZE = 64 * 1024
+
     # Initialize a new ServerStdio instance
     # @param command [String, Array] the stdio command to launch the MCP JSON-RPC server
     #   For improved security, passing an Array is recommended to avoid shell injection issues
@@ -49,6 +57,8 @@ module MCPClient
       @elicitation_request_callback = nil # MCP 2025-06-18
       @roots_list_request_callback = nil # MCP 2025-06-18
       @sampling_request_callback = nil # MCP 2025-11-25
+      @reader_thread = nil
+      @stderr_thread = nil
     end
 
     # Server info from the initialize response
@@ -88,6 +98,36 @@ module MCPClient
         end
       rescue StandardError
         # Reader thread aborted unexpectedly
+      end
+    end
+
+    # Spawn a thread to continuously drain the subprocess stderr.
+    #
+    # The child's stderr pipe has a fixed OS buffer (typically 64KB). If it is
+    # never read, a server that logs verbosely to stderr eventually blocks on
+    # write once the buffer fills, which stalls the whole subprocess (it stops
+    # producing stdout / reading stdin) and deadlocks the client. Draining
+    # stderr keeps the pipe empty; lines are surfaced at debug level.
+    #
+    # Reads happen in bounded chunks (not IO#each_line) so that a server which
+    # writes to stderr without newline delimiters cannot make the client buffer
+    # a single "line" without limit: any pending fragment larger than
+    # STDERR_MAX_LINE_SIZE is flushed rather than retained.
+    # @return [Thread] the stderr reader thread
+    def start_stderr_reader
+      @stderr_thread = Thread.new do
+        buffer = +''
+        loop do
+          buffer << @stderr.readpartial(STDERR_READ_CHUNK_SIZE)
+          flush_stderr_lines(buffer)
+          flush_stderr_overflow(buffer)
+        end
+      rescue IOError
+        # EOFError (a subclass of IOError) on EOF, or IOError on close;
+        # emit any trailing partial line before exiting
+        @logger.debug("[stderr] #{buffer.chomp}") if buffer && !buffer.empty?
+      rescue StandardError
+        # reader aborted unexpectedly; nothing actionable
       end
     end
 
@@ -573,6 +613,27 @@ module MCPClient
       @logger.error("Error sending message: #{e.message}")
     end
 
+    # Emit and remove all newline-terminated lines from the stderr buffer.
+    # @param buffer [String] mutable buffer of accumulated stderr bytes
+    # @return [void]
+    def flush_stderr_lines(buffer)
+      while (newline_index = buffer.index("\n"))
+        line = buffer.slice!(0, newline_index + 1)
+        @logger.debug("[stderr] #{line.chomp}")
+      end
+    end
+
+    # Flush an unterminated stderr fragment that has grown past the size cap,
+    # so a newline-less stderr stream cannot buffer without bound.
+    # @param buffer [String] mutable buffer of accumulated stderr bytes
+    # @return [void]
+    def flush_stderr_overflow(buffer)
+      return if buffer.bytesize <= STDERR_MAX_LINE_SIZE
+
+      @logger.debug("[stderr] #{buffer}")
+      buffer.clear
+    end
+
     # Clean up the server connection
     # Closes all stdio handles and terminates any running processes and threads
     # @return [void]
@@ -587,10 +648,11 @@ module MCPClient
         @wait_thread.join(1)
       end
       @reader_thread&.kill
+      @stderr_thread&.kill
     rescue StandardError
       # Clean up resources during unexpected termination
     ensure
-      @stdin = @stdout = @stderr = @wait_thread = @reader_thread = nil
+      @stdin = @stdout = @stderr = @wait_thread = @reader_thread = @stderr_thread = nil
     end
   end
 end

--- a/lib/mcp_client/server_stdio/json_rpc_transport.rb
+++ b/lib/mcp_client/server_stdio/json_rpc_transport.rb
@@ -16,6 +16,7 @@ module MCPClient
 
         connect
         start_reader
+        start_stderr_reader
         perform_initialize
 
         @initialized = true

--- a/spec/lib/mcp_client/server_stdio_spec.rb
+++ b/spec/lib/mcp_client/server_stdio_spec.rb
@@ -208,6 +208,7 @@ RSpec.describe MCPClient::ServerStdio do
       @stderr = double('stderr', close: nil, closed?: false)
       @wait_thread = double('wait_thread', pid: 12_345, alive?: true, join: nil)
       @reader_thread = double('reader_thread', kill: nil)
+      @stderr_thread = double('stderr_thread', kill: nil)
 
       allow(Open3).to receive(:popen3).and_return([@stdin, @stdout, @stderr, @wait_thread])
       allow(Process).to receive(:kill)
@@ -217,6 +218,7 @@ RSpec.describe MCPClient::ServerStdio do
       server.instance_variable_set(:@stderr, @stderr)
       server.instance_variable_set(:@wait_thread, @wait_thread)
       server.instance_variable_set(:@reader_thread, @reader_thread)
+      server.instance_variable_set(:@stderr_thread, @stderr_thread)
     end
 
     it 'closes the streams' do
@@ -237,6 +239,11 @@ RSpec.describe MCPClient::ServerStdio do
       server.cleanup
     end
 
+    it 'kills the stderr reader thread' do
+      expect(@stderr_thread).to receive(:kill)
+      server.cleanup
+    end
+
     it 'handles already closed streams' do
       allow(@stdin).to receive(:closed?).and_return(true)
       expect(@stdin).not_to receive(:close)
@@ -250,6 +257,65 @@ RSpec.describe MCPClient::ServerStdio do
       expect(server.instance_variable_get(:@stderr)).to be_nil
       expect(server.instance_variable_get(:@wait_thread)).to be_nil
       expect(server.instance_variable_get(:@reader_thread)).to be_nil
+      expect(server.instance_variable_get(:@stderr_thread)).to be_nil
+    end
+  end
+
+  describe '#start_stderr_reader' do
+    it 'continuously drains the subprocess stderr so its pipe buffer cannot fill and deadlock' do
+      stderr = StringIO.new("line one\nline two\n")
+      server.instance_variable_set(:@stderr, stderr)
+      logger = server.instance_variable_get(:@logger)
+      allow(logger).to receive(:debug)
+
+      server.start_stderr_reader
+      server.instance_variable_get(:@stderr_thread).join(2)
+
+      expect(logger).to have_received(:debug).with('[stderr] line one')
+      expect(logger).to have_received(:debug).with('[stderr] line two')
+    end
+
+    it 'does not raise when the stderr stream is closed underneath it' do
+      reader, writer = IO.pipe
+      server.instance_variable_set(:@stderr, reader)
+      server.start_stderr_reader
+      writer.close
+      thread = server.instance_variable_get(:@stderr_thread)
+      expect { thread.join(2) }.not_to raise_error
+      reader.close unless reader.closed?
+    end
+
+    it 'flushes a trailing partial line (no newline) when the stream closes' do
+      reader, writer = IO.pipe
+      server.instance_variable_set(:@stderr, reader)
+      logger = server.instance_variable_get(:@logger)
+      allow(logger).to receive(:debug)
+
+      server.start_stderr_reader
+      writer.write('progress without newline')
+      writer.close
+      server.instance_variable_get(:@stderr_thread).join(2)
+
+      expect(logger).to have_received(:debug).with('[stderr] progress without newline')
+      reader.close unless reader.closed?
+    end
+
+    it 'bounds an unterminated stderr line instead of buffering it without limit' do
+      reader, writer = IO.pipe
+      server.instance_variable_set(:@stderr, reader)
+      logger = server.instance_variable_get(:@logger)
+      allow(logger).to receive(:debug)
+
+      server.start_stderr_reader
+      # Write more than STDERR_MAX_LINE_SIZE bytes with no newline delimiter.
+      writer.write('x' * (described_class::STDERR_MAX_LINE_SIZE + 1024))
+      writer.close
+      server.instance_variable_get(:@stderr_thread).join(2)
+
+      # The oversize fragment is flushed rather than retained; at least one
+      # debug line is emitted and the reader does not hang.
+      expect(logger).to have_received(:debug).at_least(:once)
+      reader.close unless reader.closed?
     end
   end
 


### PR DESCRIPTION
## Problem

`ServerStdio#connect` launches the child with `Open3.popen3`, which returns a **stderr** pipe in addition to stdin/stdout — but only **stdout** was ever read (`start_reader`). The stderr pipe has a fixed OS buffer (typically ~64KB). A server that logs verbosely to stderr fills that buffer and then **blocks on write**. A blocked write stalls the whole subprocess: it stops producing stdout and stops reading stdin, so the client deadlocks waiting for responses that never arrive.

This is easy to hit with real servers (many MCP servers log diagnostics to stderr).

## Fix

Add a dedicated stderr reader thread (`start_stderr_reader`), started alongside the stdout reader in `ensure_initialized`. It continuously drains stderr and surfaces lines at **debug** level, keeping the OS pipe empty. The thread is killed and cleared in `cleanup` exactly like the stdout reader.

Reads use bounded `readpartial` chunks rather than `IO#each_line`, and any unterminated fragment larger than `STDERR_MAX_LINE_SIZE` (64KB) is flushed instead of retained — so a server that writes to stderr **without newline delimiters** (e.g. carriage-return progress output) can't make the client buffer a single "line" without limit.

## Compatibility

Additive. New thread + lifecycle only; no public API or message-handling changes. stderr content is emitted at debug level (previously discarded).

## Tests

- Line draining, trailing-partial-line flush on close, oversize-line bounding, stream-close safety, and `cleanup` killing the thread
- Full suite: `1251 examples, 0 failures`; RuboCop clean
- Reviewed with `codex review` (raised a bounded-read concern → addressed with `readpartial` + max-line cap; re-review clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)