### PR TITLE
fix(http): send notifications/initialized after initialize (MCP lifecycle MUST)

### DIFF
--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -448,6 +448,25 @@ module MCPClient
 
     private
 
+    # Perform the MCP initialize handshake, then announce readiness.
+    #
+    # The base handshake sends the initialize request and captures
+    # serverInfo/capabilities. Per the MCP lifecycle the client MUST send an
+    # `initialized` notification after a successful initialize before issuing
+    # any other requests; the plain HTTP transport previously skipped it.
+    # @return [void]
+    # @raise [MCPClient::Errors::TransportError] if the notification fails to send
+    def perform_initialize
+      super
+
+      notification = build_jsonrpc_notification('notifications/initialized', {})
+      begin
+        send_http_request(notification)
+      rescue MCPClient::Errors::ServerError, MCPClient::Errors::ConnectionError, Faraday::ConnectionFailed => e
+        raise MCPClient::Errors::TransportError, "Failed to send initialized notification: #{e.message}"
+      end
+    end
+
     # Default options for server initialization
     # @return [Hash] Default options
     def default_options

--- a/spec/integration/server_http_integration_spec.rb
+++ b/spec/integration/server_http_integration_spec.rb
@@ -92,6 +92,8 @@ RSpec.describe 'HTTP Transport Integration', type: :integration do
           case body['method']
           when 'initialize'
             { status: 200, body: initialize_response.to_json, headers: { 'Content-Type' => 'application/json' } }
+          when 'notifications/initialized'
+            { status: 202, body: '' }
           when 'tools/list'
             { status: 200, body: tools_response.to_json, headers: { 'Content-Type' => 'application/json' } }
           when 'tools/call'
@@ -123,7 +125,8 @@ RSpec.describe 'HTTP Transport Integration', type: :integration do
       expect(result['content'].first['text']).to include('Weather in San Francisco')
 
       # Verify all expected requests were made
-      expect(WebMock).to have_requested(:post, "#{base_url}#{endpoint}").times(3)
+      # 4 POSTs: initialize, initialized notification, tools/list, tools/call
+      expect(WebMock).to have_requested(:post, "#{base_url}#{endpoint}").times(4)
     end
 
     it 'sends correct headers in all requests' do
@@ -133,7 +136,8 @@ RSpec.describe 'HTTP Transport Integration', type: :integration do
 
       # Verify all requests were made to the correct endpoint
       # Headers verification is covered in unit tests
-      expect(WebMock).to have_requested(:post, "#{base_url}#{endpoint}").times(3)
+      # 4 POSTs: initialize, initialized notification, tools/list, tools/call
+      expect(WebMock).to have_requested(:post, "#{base_url}#{endpoint}").times(4)
     end
 
     it 'handles streaming tool calls' do
@@ -201,6 +205,10 @@ RSpec.describe 'HTTP Transport Integration', type: :integration do
         stub_request(:post, "#{base_url}#{endpoint}")
           .with(body: hash_including(method: 'tools/list'))
           .to_return(status: 200, body: 'invalid json response')
+
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .with(body: hash_including(method: 'notifications/initialized'))
+          .to_return(status: 202, body: '')
       end
 
       it 'raises TransportError for invalid JSON' do
@@ -245,6 +253,10 @@ RSpec.describe 'HTTP Transport Integration', type: :integration do
             }.to_json,
             headers: { 'Content-Type' => 'application/json' }
           )
+
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .with(body: hash_including(method: 'notifications/initialized'))
+          .to_return(status: 202, body: '')
       end
 
       it 'raises ToolCallError with wrapped error message' do
@@ -273,6 +285,11 @@ RSpec.describe 'HTTP Transport Integration', type: :integration do
       stub_request(:post, "#{base_url}#{endpoint}")
         .with(body: hash_including(method: 'notification'))
         .to_return(status: 200, body: '')
+
+      # initialized notification sent during connect (MCP lifecycle MUST)
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including(method: 'notifications/initialized'))
+        .to_return(status: 202, body: '')
     end
 
     it 'sends notifications without expecting responses' do
@@ -346,6 +363,11 @@ RSpec.describe 'HTTP Transport Integration', type: :integration do
           status: 200,
           body: { jsonrpc: '2.0', id: 1, result: 'pong' }.to_json
         )
+
+      # initialized notification sent during connect (MCP lifecycle MUST)
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including(method: 'notifications/initialized'))
+        .to_return(status: 202, body: '')
     end
 
     it 'handles concurrent requests correctly' do

--- a/spec/integration/session_management_integration_spec.rb
+++ b/spec/integration/session_management_integration_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe 'Session Management Integration', type: :integration do
             headers: { 'Mcp-Session-Id' => session_id }
           )
 
+        # Step 1b: initialized notification (MCP lifecycle MUST)
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .with(body: hash_including(method: 'notifications/initialized'))
+          .to_return(status: 202, body: '')
+
         # Step 2: Tools list request with session header
         stub_request(:post, "#{base_url}#{endpoint}")
           .with(
@@ -102,7 +107,8 @@ RSpec.describe 'Session Management Integration', type: :integration do
         expect(http_server.instance_variable_get(:@session_id)).to be_nil
 
         # Verify all expected requests were made
-        expect(WebMock).to have_requested(:post, "#{base_url}#{endpoint}").times(3)
+        # 4 POSTs: initialize, initialized notification, tools/list, tools/call
+        expect(WebMock).to have_requested(:post, "#{base_url}#{endpoint}").times(4)
         expect(WebMock).to have_requested(:delete, "#{base_url}#{endpoint}").once
       end
 
@@ -119,6 +125,11 @@ RSpec.describe 'Session Management Integration', type: :integration do
             }.to_json,
             headers: {} # No session ID provided
           )
+
+        # initialized notification (MCP lifecycle MUST)
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .with(body: hash_including(method: 'notifications/initialized'))
+          .to_return(status: 202, body: '')
 
         # Tools list without session header
         stub_request(:post, "#{base_url}#{endpoint}")
@@ -150,6 +161,11 @@ RSpec.describe 'Session Management Integration', type: :integration do
             body: { jsonrpc: '2.0', id: 1, result: {} }.to_json,
             headers: { 'Mcp-Session-Id' => 'invalid@session!' } # Invalid format
           )
+
+        # initialized notification (MCP lifecycle MUST)
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .with(body: hash_including(method: 'notifications/initialized'))
+          .to_return(status: 202, body: '')
 
         expect(http_server.connect).to be true
         expect(http_server.instance_variable_get(:@session_id)).to be_nil

--- a/spec/lib/mcp_client/server_http_spec.rb
+++ b/spec/lib/mcp_client/server_http_spec.rb
@@ -67,6 +67,10 @@ RSpec.describe MCPClient::ServerHTTP do
                               }),
           headers: { 'Content-Type' => 'application/json' }
         )
+      # Lifecycle: client MUST send an initialized notification after initialize
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including(method: 'notifications/initialized'))
+        .to_return(status: 202, body: '')
 
       server.connect
 
@@ -126,12 +130,22 @@ RSpec.describe MCPClient::ServerHTTP do
           body: initialize_response.to_json,
           headers: { 'Content-Type' => 'application/json' }
         )
+      # Lifecycle: client MUST send an initialized notification after initialize
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including(method: 'notifications/initialized'))
+        .to_return(status: 202, body: '')
     end
 
     it 'successfully connects and initializes' do
       expect(server.connect).to be true
       expect(server.server_info).to eq({ 'name' => 'test-server', 'version' => '1.0.0' })
       expect(server.capabilities).to eq({ 'tools' => {} })
+    end
+
+    it 'sends the initialized notification after initialize (MCP lifecycle MUST)' do
+      server.connect
+      expect(WebMock).to have_requested(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including('method' => 'notifications/initialized'))
     end
 
     it 'sets connection state correctly' do
@@ -586,6 +600,10 @@ RSpec.describe MCPClient::ServerHTTP do
       before do
         server.instance_variable_set(:@connection_established, true)
         server.instance_variable_set(:@initialized, true)
+        # Lifecycle: perform_initialize also emits an initialized notification
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .with(body: hash_including(method: 'notifications/initialized'))
+          .to_return(status: 202, body: '')
       end
 
       it 'captures valid session ID from initialize response' do
@@ -658,6 +676,9 @@ RSpec.describe MCPClient::ServerHTTP do
             status: 200,
             body: { jsonrpc: '2.0', id: 1, result: {} }.to_json
           )
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .with(body: hash_including(method: 'notifications/initialized'))
+          .to_return(status: 202, body: '')
 
         server.send(:perform_initialize)
         expect(WebMock).to(have_requested(:post, "#{base_url}#{endpoint}")


### PR DESCRIPTION
## Problem

The [MCP lifecycle](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle) states:

> After successful initialization, the client **MUST** send an `initialized` notification to indicate it is ready to begin normal operations.

`ServerStreamableHTTP` overrides `perform_initialize` to send this notification, but the **plain HTTP** transport (`ServerHTTP`) did not — and the shared `HttpTransportBase#perform_initialize` only sends the `initialize` request. So `ServerHTTP` completed the handshake having sent *only* `initialize`, never `notifications/initialized`.

A spec-conformant server that withholds normal operations until it receives `notifications/initialized` would stall every `ServerHTTP` session.

## Fix

Override `ServerHTTP#perform_initialize` to call `super` (which sends `initialize` and captures serverInfo/capabilities/session id) and then POST the `notifications/initialized` notification — mirroring `ServerStreamableHTTP`. A send failure is wrapped in `TransportError`, consistent with the streamable transport.

## Compatibility

Additive on the wire (one extra notification POST after initialize, which the spec requires). No public API change. The notification carries the session and protocol-version headers already captured during initialize.

## Tests

- New positive spec: the notification is sent during `connect`
- Existing `ServerHTTP` unit specs and the HTTP/session integration specs updated to stub and count the additional notification POST
- Full suite: `1247 examples, 0 failures`; RuboCop clean
- Reviewed with `codex review` (no actionable findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)