### PR TITLE
fix(stdio): bound the pending-response map to prevent a memory leak

### DIFF
--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -46,6 +46,9 @@ module MCPClient
       @cond = ConditionVariable.new
       @next_id = 1
       @pending = {}
+      # Ids of requests awaiting a response; used to drop late/unsolicited
+      # responses so @pending cannot grow without bound on a long-lived session
+      @awaiting = {}
       @initialized = false
       @server_info = nil
       @capabilities = nil
@@ -156,8 +159,15 @@ module MCPClient
       return unless id
 
       @mutex.synchronize do
-        @pending[id] = msg
-        @cond.broadcast
+        # Only retain a response that corresponds to an outstanding request.
+        # Late responses (arriving after the caller timed out) and unsolicited
+        # responses are dropped so @pending cannot grow without bound.
+        if @awaiting.key?(id)
+          @pending[id] = msg
+          @cond.broadcast
+        else
+          @logger.debug("Discarding response for unknown or expired request id=#{id}")
+        end
       end
     rescue JSON::ParserError
       # Skip non-JSONRPC lines in the output stream
@@ -667,6 +677,11 @@ module MCPClient
     rescue StandardError
       # Clean up resources during unexpected termination
     ensure
+      # Release any buffered responses / awaiting markers
+      @mutex.synchronize do
+        @pending.clear
+        @awaiting.clear
+      end
       @stdin = @stdout = @stderr = @wait_thread = @reader_thread = @stderr_thread = nil
     end
   end

--- a/lib/mcp_client/server_stdio/json_rpc_transport.rb
+++ b/lib/mcp_client/server_stdio/json_rpc_transport.rb
@@ -45,12 +45,15 @@ module MCPClient
         @stdin.puts(notif.to_json)
       end
 
-      # Generate a new unique request ID
+      # Generate a new unique request ID and mark it as awaiting a response.
+      # Registering the id before the request is sent lets the reader thread
+      # distinguish expected responses from late/unsolicited ones.
       # @return [Integer] a unique request ID
       def next_id
         @mutex.synchronize do
           id = @next_id
           @next_id += 1
+          @awaiting[id] = true
           id
         end
       end
@@ -63,6 +66,10 @@ module MCPClient
         @logger.debug("Sending JSONRPC request: #{req.to_json}")
         @stdin.puts(req.to_json)
       rescue StandardError => e
+        # A request that failed to send will never receive a response, so drop
+        # its awaiting marker; otherwise a broken transport (e.g. the server
+        # exited) would leak an entry per retry/attempt into @awaiting.
+        @mutex.synchronize { @awaiting.delete(req['id']) } if req.is_a?(Hash) && req['id']
         raise MCPClient::Errors::TransportError, "Failed to send JSONRPC request: #{e.message}"
       end
 
@@ -79,8 +86,10 @@ module MCPClient
 
             @cond.wait(@mutex, remaining)
           end
-          msg = @pending[id]
-          @pending[id] = nil
+          # Remove the response and the awaiting marker on both success and
+          # timeout so neither @pending nor @awaiting accumulates entries.
+          msg = @pending.delete(id)
+          @awaiting.delete(id)
           raise MCPClient::Errors::TransportError, "Timeout waiting for JSONRPC response id=#{id}" unless msg
 
           msg

--- a/spec/lib/mcp_client/server_stdio/json_rpc_transport_spec.rb
+++ b/spec/lib/mcp_client/server_stdio/json_rpc_transport_spec.rb
@@ -8,13 +8,14 @@ RSpec.describe MCPClient::ServerStdio::JsonRpcTransport do
     Class.new do
       include MCPClient::ServerStdio::JsonRpcTransport
 
-      attr_accessor :stdin, :mutex, :cond, :pending,
+      attr_accessor :stdin, :mutex, :cond, :pending, :awaiting,
                     :logger, :max_retries, :retry_backoff, :read_timeout
 
       def initialize
         @mutex = Mutex.new
         @cond = ConditionVariable.new
         @pending = {}
+        @awaiting = {}
         @next_id = 1
         @logger = Logger.new(StringIO.new)
         @stdin = StringIO.new

--- a/spec/lib/mcp_client/server_stdio_elicitation_spec.rb
+++ b/spec/lib/mcp_client/server_stdio_elicitation_spec.rb
@@ -262,6 +262,8 @@ RSpec.describe MCPClient::ServerStdio, 'Elicitation (MCP 2025-06-18)' do
 
     context 'with response (has id, no method)' do
       it 'stores in pending responses' do
+        # Mark the id as awaited so the reader retains the response
+        server.instance_variable_set(:@awaiting, { 123 => true })
         message = {
           'id' => 123,
           'result' => { 'success' => true }

--- a/spec/lib/mcp_client/server_stdio_spec.rb
+++ b/spec/lib/mcp_client/server_stdio_spec.rb
@@ -373,10 +373,17 @@ RSpec.describe MCPClient::ServerStdio do
     end
 
     describe '#handle_line' do
-      it 'parses JSON and stores response by ID' do
+      it 'parses JSON and stores a response for an awaited ID' do
+        server.instance_variable_set(:@awaiting, { 1 => true })
         response = { 'jsonrpc' => '2.0', 'id' => 1, 'result' => 'success' }
         server.send(:handle_line, response.to_json)
         expect(server.instance_variable_get(:@pending)[1]).to eq(response)
+      end
+
+      it 'drops a response whose ID is not awaited (late or unsolicited)' do
+        response = { 'jsonrpc' => '2.0', 'id' => 999, 'result' => 'stale' }
+        server.send(:handle_line, response.to_json)
+        expect(server.instance_variable_get(:@pending)).to be_empty
       end
 
       it 'ignores responses without an ID' do
@@ -387,6 +394,52 @@ RSpec.describe MCPClient::ServerStdio do
 
       it 'ignores non-JSON lines' do
         expect { server.send(:handle_line, 'not json') }.not_to raise_error
+      end
+    end
+
+    describe 'pending-response map bounding' do
+      it 'removes the awaiting marker and buffered response once consumed' do
+        server.instance_variable_set(:@awaiting, { 1 => true })
+        server.instance_variable_set(:@pending, { 1 => { 'result' => 'ok' } })
+
+        expect(server.send(:wait_response, 1)).to eq({ 'result' => 'ok' })
+        expect(server.instance_variable_get(:@pending)).to be_empty
+        expect(server.instance_variable_get(:@awaiting)).to be_empty
+      end
+
+      it 'clears the awaiting marker on timeout so a late response is dropped' do
+        server.instance_variable_set(:@awaiting, { 1 => true })
+        # Shorten the instance timeout so the wait returns promptly
+        server.instance_variable_set(:@read_timeout, 0.1)
+
+        expect { server.send(:wait_response, 1) }.to raise_error(MCPClient::Errors::TransportError, /Timeout/)
+        expect(server.instance_variable_get(:@awaiting)).to be_empty
+
+        # A response that arrives after the timeout is discarded, not buffered
+        late = { 'jsonrpc' => '2.0', 'id' => 1, 'result' => 'late' }
+        server.send(:handle_line, late.to_json)
+        expect(server.instance_variable_get(:@pending)).to be_empty
+      end
+
+      it 'drops the awaiting marker when the request fails to send' do
+        broken = StringIO.new
+        allow(broken).to receive(:puts).and_raise(IOError, 'broken pipe')
+        server.instance_variable_set(:@stdin, broken)
+
+        id = server.send(:next_id)
+        req = { 'jsonrpc' => '2.0', 'id' => id, 'method' => 'ping', 'params' => {} }
+        expect { server.send(:send_request, req) }.to raise_error(MCPClient::Errors::TransportError)
+        expect(server.instance_variable_get(:@awaiting)).to be_empty
+      end
+
+      it 'does not accumulate entries across many sequential requests' do
+        100.times do |i|
+          id = server.send(:next_id)
+          server.send(:handle_line, { 'jsonrpc' => '2.0', 'id' => id, 'result' => i }.to_json)
+          server.send(:wait_response, id)
+        end
+        expect(server.instance_variable_get(:@pending)).to be_empty
+        expect(server.instance_variable_get(:@awaiting)).to be_empty
       end
     end
   end


### PR DESCRIPTION
## Problem

`ServerStdio` correlates requests and responses through the `@pending` hash, but it was never pruned:

- `wait_response` "consumed" a response with `@pending[id] = nil` instead of deleting it, leaving a dead entry behind for **every** request. Over a long-lived stdio session `@pending` grew without bound.
- A response arriving **after** its caller timed out — or any unsolicited response — was stored by `handle_line` and never removed.

## Fix

Track outstanding request ids in an `@awaiting` map so the reader can tell expected responses from stale ones:

- `next_id` registers the id **before** the request is sent (avoids a race where the response arrives before registration).
- `handle_line` only buffers a response whose id is still awaited; late/unsolicited responses are dropped (logged at debug).
- `wait_response` deletes both the buffered response and the awaiting marker **on success and on timeout**.
- `send_request` clears the marker if the write fails (so a broken transport can't leak an entry per retry).
- `cleanup` clears both maps.

Net effect: `@pending` and `@awaiting` stay bounded by the number of *concurrently outstanding* requests instead of growing with total request count.

## Compatibility

Internal bookkeeping only — no public API or wire-behavior change. Correlation semantics are unchanged for the normal request/response path.

## Tests

- Consumed responses leave both maps empty; 100 sequential requests don't accumulate
- Late/unsolicited responses are dropped
- Timeout clears the awaiting marker; a subsequent late response is discarded
- Send failure clears the awaiting marker
- Full suite: `1251 examples, 0 failures`; RuboCop clean
- Reviewed with `codex review` — it caught a send-failure leak and a slow-timeout test in the first pass; both fixed, re-review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)