### PR TITLE
fix(client): stop overwriting a caller-supplied logger's formatter

### DIFF
--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -27,9 +27,18 @@ module MCPClient
     # @param roots [Array<MCPClient::Root, Hash>, nil] optional list of roots (MCP 2025-06-18)
     # @param sampling_handler [Proc, nil] optional handler for sampling requests (MCP 2025-11-25)
     def initialize(mcp_server_configs: [], logger: nil, elicitation_handler: nil, roots: nil, sampling_handler: nil)
-      @logger = logger || Logger.new($stdout, level: Logger::WARN)
-      @logger.progname = self.class.name
-      @logger.formatter = proc { |severity, _datetime, progname, msg| "#{severity} [#{progname}] #{msg}\n" }
+      # Preserve a caller-supplied logger's formatter (only tag progname), and
+      # install the default formatter solely on a logger we create ourselves.
+      # Overwriting the formatter of an application's logger would silently
+      # reformat every log line it emits elsewhere.
+      if logger
+        @logger = logger
+        @logger.progname = self.class.name
+      else
+        @logger = Logger.new($stdout, level: Logger::WARN)
+        @logger.progname = self.class.name
+        @logger.formatter = proc { |severity, _datetime, progname, msg| "#{severity} [#{progname}] #{msg}\n" }
+      end
       @servers = mcp_server_configs.map do |config|
         @logger.debug("Creating server with config: #{config.inspect}")
         MCPClient::ServerFactory.create(config, logger: @logger)

--- a/spec/lib/mcp_client/logger_initialization_spec.rb
+++ b/spec/lib/mcp_client/logger_initialization_spec.rb
@@ -150,6 +150,36 @@ RSpec.describe 'Logger Initialization' do
     end
   end
 
+  describe 'MCPClient::Client logger handling' do
+    it 'preserves a caller-supplied logger formatter (does not reconfigure the app logger)' do
+      client = MCPClient::Client.new(logger: custom_logger)
+
+      logger = client.instance_variable_get(:@logger)
+      expect(logger).to eq(custom_logger)
+      expect(logger.formatter).to eq(custom_formatter)
+    end
+
+    it 'tags the caller-supplied logger progname without touching its level' do
+      custom_logger.level = Logger::ERROR
+      client = MCPClient::Client.new(logger: custom_logger)
+
+      logger = client.instance_variable_get(:@logger)
+      expect(logger.progname).to eq(MCPClient::Client.name)
+      expect(logger.level).to eq(Logger::ERROR)
+    end
+
+    it 'installs the default formatter only on a logger it creates' do
+      client = MCPClient::Client.new
+      logger = client.instance_variable_get(:@logger)
+
+      output = StringIO.new
+      logger.instance_variable_set(:@logdev, Logger::LogDevice.new(output))
+      logger.warn('hello')
+
+      expect(output.string).to match(/WARN \[#{MCPClient::Client.name}\] hello\n/)
+    end
+  end
+
   describe 'logger usage in server operations' do
     let(:server) { MCPClient::ServerHTTP.new(base_url: 'http://example.com', logger: custom_logger) }
 


### PR DESCRIPTION
## Problem

`MCPClient::Client#initialize` unconditionally set both `progname` **and** `formatter` on whatever logger it was handed:

```ruby
@logger = logger || Logger.new($stdout, level: Logger::WARN)
@logger.progname = self.class.name
@logger.formatter = proc { |severity, _datetime, progname, msg| "#{severity} [#{progname}] #{msg}\n" }
```

When an application passes in its own logger, the client **silently replaces that logger's formatter**, so every log line the application emits elsewhere in the process is reformatted into the MCP style. That's a surprising side effect for library code.

The server transports already handle this correctly — `ServerBase#initialize_logger` preserves a caller-supplied formatter and only tags `progname` (there's an existing test asserting exactly that).

## Fix

Align `Client` with the server behavior:
- **caller-supplied logger** → set `progname` only; preserve the formatter (and level)
- **self-created logger** → apply the default pretty formatter, as before

## Compatibility

The default (no-logger) experience is unchanged. Applications that pass a logger keep their own formatting instead of having it overwritten — which is the fix. Public API and signatures are unchanged.

## Tests

Added `MCPClient::Client` examples to `logger_initialization_spec.rb`:
- preserves a caller-supplied formatter
- tags progname without changing the logger's level
- installs the default formatter only on a logger it creates

Full suite: `1249 examples, 0 failures`; RuboCop clean. Reviewed with `codex review` (no actionable findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)