### PR TITLE
fix(gemspec): declare base64 as a runtime dependency (Ruby 3.4+ LoadError)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
   remote: .
   specs:
     ruby-mcp-client (1.0.1)
+      base64 (~> 0.2)
       faraday (~> 2.0)
       faraday-follow_redirects (~> 0.3)
       faraday-retry (~> 2.0)

--- a/ruby-mcp-client.gemspec
+++ b/ruby-mcp-client.gemspec
@@ -17,6 +17,10 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.glob('lib/**/*.rb') + ['README.md', 'LICENSE']
   spec.required_ruby_version = '>= 3.2.0'
   spec.require_paths = ['lib']
+  # base64 is required by the OAuth/PKCE and content helpers. It became a
+  # bundled (non-default) gem in Ruby 3.4, so it must be declared explicitly
+  # or `require 'base64'` fails under Bundler on Ruby >= 3.4.
+  spec.add_dependency 'base64', '~> 0.2'
   # HTTP instrumentation
   spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'faraday-follow_redirects', '~> 0.3'

--- a/spec/gemspec_spec.rb
+++ b/spec/gemspec_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'ruby-mcp-client.gemspec' do
+  let(:gemspec) do
+    Gem::Specification.load(File.expand_path('../ruby-mcp-client.gemspec', __dir__))
+  end
+
+  it 'loads without error' do
+    expect(gemspec).to be_a(Gem::Specification)
+  end
+
+  # base64 became a bundled (non-default) gem in Ruby 3.4. The library requires
+  # it (OAuth/PKCE, audio and resource content helpers), so it must be a
+  # declared runtime dependency or `require 'base64'` fails under Bundler on
+  # Ruby >= 3.4.
+  it 'declares base64 as a runtime dependency' do
+    dep = gemspec.dependencies.find { |d| d.name == 'base64' }
+    expect(dep).not_to be_nil
+    expect(dep.type).to eq(:runtime)
+  end
+
+  it 'requires base64 at load time' do
+    expect { require 'base64' }.not_to raise_error
+    expect(defined?(Base64)).to eq('constant')
+  end
+end


### PR DESCRIPTION
## Problem

Three library files `require 'base64'`:

- `lib/mcp_client/auth.rb` (OAuth 2.1 / PKCE code verifier + challenge)
- `lib/mcp_client/audio_content.rb`
- `lib/mcp_client/resource_content.rb`

`base64` was a **default** gem through Ruby 3.3 but became a **bundled** (non-default) gem in **Ruby 3.4**. Under Bundler it is therefore no longer on the load path unless it is declared. The gemspec targets `>= 3.2.0` but does not list `base64`, so installing this gem on Ruby ≥ 3.4 makes `require 'base64'` raise `LoadError` the first time OAuth/PKCE or base64 content decoding runs.

## Fix

```ruby
spec.add_dependency 'base64', '~> 0.2'
```

Plus a `spec/gemspec_spec.rb` regression guard that asserts the dependency is declared and that `base64` loads. Lockfile updated.

## Compatibility

Purely additive — declares an already-used stdlib gem. No behavior change on Ruby 3.2/3.3 (where base64 is still default); fixes the load failure on 3.4+.

> Note: `logger` is likewise required throughout the library and is a candidate for the same treatment, but it remains a *default* gem in current Ruby, so it is out of scope here.

Full suite: `1249 examples, 0 failures`; RuboCop clean. Reviewed with `codex review` (no actionable findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)