### PR TITLE
docs: fix README OAuth snippet require and CHANGELOG method names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Full implementation of the **MCP 2025-11-25** specification, upgrading from 2025
 
 #### MCP 2025-06-18 Protocol Compliance (#62)
 - **Roots Support**: Define filesystem scope boundaries
-  - `client.set_roots([{ uri: 'file:///path', name: 'Root' }])`
+  - `client.roots = [{ uri: 'file:///path', name: 'Root' }]`
   - Sends `notifications/roots/list_changed` to servers
   - Handles `roots/list` requests from servers
 
@@ -69,7 +69,7 @@ Full implementation of the **MCP 2025-11-25** specification, upgrading from 2025
   - Returns completion values with pagination info
 
 - **Logging Support**: Server log messages
-  - `client.set_log_level(level)` method
+  - `client.log_level = level`
   - Handles `notifications/message` from servers
   - Maps MCP levels to Ruby Logger levels
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ See `examples/` for complete implementations:
 ## OAuth 2.1 Authentication
 
 ```ruby
+require 'mcp_client'
 require 'mcp_client/auth/browser_oauth'
 
 oauth = MCPClient::Auth::OAuthProvider.new(


### PR DESCRIPTION
## Problem

Two documentation inaccuracies that mislead readers or break copy-paste:

1. **README OAuth quick-start crashed verbatim.** The snippet did:
   ```ruby
   require 'mcp_client/auth/browser_oauth'
   # ...
   client = MCPClient::Client.new(...)   # NameError!
   ```
   Requiring only `mcp_client/auth/browser_oauth` loads `OAuthProvider`/`BrowserOAuth` but **not** `MCPClient::Client`, so running the example as written raised `NameError: uninitialized constant MCPClient::Client`.

2. **CHANGELOG referenced methods that never existed.** It documented `client.set_roots(...)` and `client.set_log_level(level)`, but the real API is the setters `client.roots = ...` and `client.log_level = ...`.

## Fix

- Add `require 'mcp_client'` to the README OAuth example (verified: `require 'mcp_client'` + `require 'mcp_client/auth/browser_oauth'` resolves `Client`, `OAuthProvider`, and `BrowserOAuth`).
- Correct the two CHANGELOG entries to the actual setter API.

Docs only — no code or behavior change.

> Note: a first pass also bumped `examples/README_ECHO_SERVER.md` / `STREAMABLE_HTTP_TESTING.md` from "MCP 2025-03-26" to "2025-11-25", but `codex review` correctly flagged that the streamable echo example still negotiates `2025-06-18` on the wire, so that bump would overclaim. Left out of this PR; the example implementation/version labels can be reconciled separately.

Reviewed with `codex review` (no actionable findings on the final diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)