### PR TITLE
fix(retry): stop retrying application-level errors (non-idempotent safety)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,18 @@ client = MCPClient.create_client(
 client = MCPClient.create_client(server_definition_file: 'servers.json')
 ```
 
+### Retries
+
+The `retries:` option controls automatic retry with exponential backoff. Only
+failures where the request most likely did **not** complete at the server are
+retried: transport/network errors and HTTP **5xx** responses. Application-level
+failures — a JSON-RPC error response or an HTTP **4xx** — are **never** retried,
+because the server already processed or rejected the request and re-sending
+would risk re-executing a non-idempotent `tools/call`. Retryable server failures
+raise `MCPClient::Errors::TransientServerError`, a subclass of
+`MCPClient::Errors::ServerError`, so existing `rescue ServerError` handlers are
+unaffected.
+
 ### Faraday Customization
 
 ```ruby

--- a/lib/mcp_client/errors.rb
+++ b/lib/mcp_client/errors.rb
@@ -33,6 +33,15 @@ module MCPClient
     # Raised when the MCP server returns an error response
     class ServerError < MCPError; end
 
+    # Raised for a server-side failure that is plausibly transient and safe to
+    # retry — chiefly HTTP 5xx responses, where the request likely did not
+    # complete at the application layer. It is a subclass of ServerError so that
+    # existing `rescue MCPClient::Errors::ServerError` handlers keep catching it,
+    # while the retry logic can single it out. Application-level failures
+    # (JSON-RPC error responses, HTTP 4xx) use plain ServerError and are NOT
+    # retried, since the server already processed/rejected the request.
+    class TransientServerError < ServerError; end
+
     # Raised when there's an error in the MCP server transport
     class TransportError < MCPError; end
 

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -243,9 +243,13 @@ module MCPClient
       when 401, 403
         raise MCPClient::Errors::ConnectionError, "Authorization failed: HTTP #{response.status}"
       when 400..499
+        # Deterministic client errors: the request was processed/rejected and
+        # will not succeed on retry, so raise a plain (non-retryable) ServerError.
         raise MCPClient::Errors::ServerError, "Client error: HTTP #{response.status}#{reason_text}"
       when 500..599
-        raise MCPClient::Errors::ServerError, "Server error: HTTP #{response.status}#{reason_text}"
+        # Server-side failures are plausibly transient: raise the retryable
+        # subclass so with_retry can re-attempt them.
+        raise MCPClient::Errors::TransientServerError, "Server error: HTTP #{response.status}#{reason_text}"
       else
         raise MCPClient::Errors::ServerError, "HTTP error: #{response.status}#{reason_text}"
       end

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -3,16 +3,26 @@
 module MCPClient
   # Shared retry/backoff logic for JSON-RPC transports
   module JsonRpcCommon
-    # Execute the block with retry/backoff for transient errors
+    # Execute the block with retry/backoff for transient errors only.
+    #
+    # Retries genuinely transient failures where the request most likely did not
+    # complete at the server: transport/network errors (TransportError, IOError,
+    # Errno::ETIMEDOUT/ECONNRESET/EPIPE) and TransientServerError (HTTP 5xx).
+    #
+    # It deliberately does NOT retry a plain ServerError. A plain ServerError is
+    # raised for a JSON-RPC error response or an HTTP 4xx — cases where the
+    # server received and processed (or deterministically rejected) the request.
+    # Re-sending those would silently re-execute a non-idempotent operation
+    # (e.g. a tools/call), which JSON-RPC provides no way to make safe.
     # @yield block to execute
     # @return [Object] result of block
-    # @raise original exception if max retries exceeded
+    # @raise original exception if max retries exceeded or the error is not retryable
     def with_retry
       attempts = 0
       begin
         yield
-      rescue MCPClient::Errors::ServerError, MCPClient::Errors::TransportError, IOError, Errno::ETIMEDOUT,
-             Errno::ECONNRESET => e
+      rescue MCPClient::Errors::TransientServerError, MCPClient::Errors::TransportError, IOError,
+             Errno::ETIMEDOUT, Errno::ECONNRESET, Errno::EPIPE => e
         attempts += 1
         if attempts <= @max_retries
           delay = @retry_backoff * (2**(attempts - 1))

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -126,7 +126,10 @@ module MCPClient
           record_activity
 
           unless response.success?
-            raise MCPClient::Errors::ServerError, "Server returned error: #{response.status} #{response.reason_phrase}"
+            # 5xx failures are plausibly transient (retryable); 4xx and other
+            # statuses are deterministic and raise a plain (non-retryable) error.
+            error_class = (500..599).cover?(response.status) ? MCPClient::Errors::TransientServerError : MCPClient::Errors::ServerError
+            raise error_class, "Server returned error: #{response.status} #{response.reason_phrase}"
           end
 
           response

--- a/spec/lib/mcp_client/http_transport_base_spec.rb
+++ b/spec/lib/mcp_client/http_transport_base_spec.rb
@@ -363,17 +363,35 @@ RSpec.describe MCPClient::HttpTransportBase do
               transport.test_handle_http_error_response(response)
             end.to raise_error(MCPClient::Errors::ServerError, /Client error.*#{status}.*Test Error/)
           end
+
+          it "raises a NON-retryable (plain) ServerError for HTTP #{status}" do
+            allow(response).to receive(:status).and_return(status)
+
+            begin
+              transport.test_handle_http_error_response(response)
+            rescue MCPClient::Errors::ServerError => e
+              expect(e).not_to be_a(MCPClient::Errors::TransientServerError)
+            end
+          end
         end
       end
 
       context 'with server errors' do
         [500, 502, 503, 504].each do |status|
-          it "raises ServerError for HTTP #{status}" do
+          it "raises a retryable TransientServerError for HTTP #{status}" do
             allow(response).to receive(:status).and_return(status)
 
             expect do
               transport.test_handle_http_error_response(response)
-            end.to raise_error(MCPClient::Errors::ServerError, /Server error.*#{status}.*Test Error/)
+            end.to raise_error(MCPClient::Errors::TransientServerError, /Server error.*#{status}.*Test Error/)
+          end
+
+          it "TransientServerError for HTTP #{status} is still a ServerError (backward compatible)" do
+            allow(response).to receive(:status).and_return(status)
+
+            expect do
+              transport.test_handle_http_error_response(response)
+            end.to raise_error(MCPClient::Errors::ServerError)
           end
         end
       end
@@ -400,6 +418,50 @@ RSpec.describe MCPClient::HttpTransportBase do
             transport.test_handle_http_error_response(response)
           end.to raise_error(MCPClient::Errors::ServerError, /Server error.*500$/)
         end
+      end
+    end
+
+    describe '#rpc_request retry behavior' do
+      before { transport.retry_backoff = 0.01 }
+
+      it 'does NOT re-send a request that failed with a plain ServerError' do
+        # A JSON-RPC error response or HTTP 4xx means the server already
+        # processed the request; retrying would re-execute a non-idempotent call.
+        calls = 0
+        allow(transport).to receive(:send_jsonrpc_request) do
+          calls += 1
+          raise MCPClient::Errors::ServerError, 'tool failed'
+        end
+
+        expect { transport.rpc_request('tools/call', { name: 't' }) }
+          .to raise_error(MCPClient::Errors::ServerError, 'tool failed')
+        expect(calls).to eq(1)
+      end
+
+      it 'retries a TransientServerError (HTTP 5xx) and can then succeed' do
+        calls = 0
+        allow(transport).to receive(:send_jsonrpc_request) do
+          calls += 1
+          raise MCPClient::Errors::TransientServerError, 'Server error: HTTP 503' if calls < 3
+
+          'ok'
+        end
+
+        expect(transport.rpc_request('tools/call', {})).to eq('ok')
+        expect(calls).to eq(3)
+      end
+
+      it 'retries a transient transport (network) error and can then succeed' do
+        calls = 0
+        allow(transport).to receive(:send_jsonrpc_request) do
+          calls += 1
+          raise MCPClient::Errors::TransportError, 'connection reset' if calls < 2
+
+          'ok'
+        end
+
+        expect(transport.rpc_request('tools/call', {})).to eq('ok')
+        expect(calls).to eq(2)
       end
     end
   end

--- a/spec/lib/mcp_client/json_rpc_common_spec.rb
+++ b/spec/lib/mcp_client/json_rpc_common_spec.rb
@@ -57,6 +57,62 @@ RSpec.describe MCPClient::JsonRpcCommon do
 
       expect(attempts).to eq(3) # Initial + 2 retries
     end
+
+    it 'does NOT retry a plain ServerError (application-level failure)' do
+      attempts = 0
+
+      expect do
+        instance.with_retry do
+          attempts += 1
+          raise MCPClient::Errors::ServerError, 'JSON-RPC error'
+        end
+      end.to raise_error(MCPClient::Errors::ServerError, 'JSON-RPC error')
+
+      # A plain ServerError means the server already processed the request, so
+      # it must be raised immediately without re-execution.
+      expect(attempts).to eq(1)
+    end
+
+    it 'DOES retry a TransientServerError (HTTP 5xx) up to max_retries' do
+      attempts = 0
+
+      expect do
+        instance.with_retry do
+          attempts += 1
+          raise MCPClient::Errors::TransientServerError, 'Server error: HTTP 503'
+        end
+      end.to raise_error(MCPClient::Errors::TransientServerError, 'Server error: HTTP 503')
+
+      expect(attempts).to eq(3) # Initial + 2 retries
+    end
+
+    it 'retries a TransientServerError and can then succeed' do
+      attempts = 0
+
+      result = instance.with_retry do
+        attempts += 1
+        raise MCPClient::Errors::TransientServerError, 'Server error: HTTP 502' if attempts < 2
+
+        'recovered'
+      end
+
+      expect(attempts).to eq(2)
+      expect(result).to eq('recovered')
+    end
+
+    it 'retries Errno::EPIPE (broken pipe)' do
+      attempts = 0
+
+      result = instance.with_retry do
+        attempts += 1
+        raise Errno::EPIPE if attempts < 2
+
+        'recovered'
+      end
+
+      expect(attempts).to eq(2)
+      expect(result).to eq('recovered')
+    end
   end
 
   describe '#ping' do

--- a/spec/lib/mcp_client/server_sse/json_rpc_transport_spec.rb
+++ b/spec/lib/mcp_client/server_sse/json_rpc_transport_spec.rb
@@ -69,6 +69,33 @@ RSpec.describe MCPClient::ServerSSE::JsonRpcTransport do
     end
   end
 
+  describe '#post_json_rpc_request error classification' do
+    before do
+      transport.instance_variable_set(:@mutex, Mutex.new)
+      transport.instance_variable_set(:@rpc_conn, double('conn'))
+    end
+
+    it 'raises a retryable TransientServerError for a 5xx response' do
+      resp = instance_double(Faraday::Response, status: 503, reason_phrase: 'Service Unavailable', success?: false)
+      allow(transport).to receive(:send_http_request).and_return(resp)
+
+      expect { transport.send(:post_json_rpc_request, { id: 1 }) }
+        .to raise_error(MCPClient::Errors::TransientServerError, /Server returned error: 503/)
+    end
+
+    it 'raises a plain (non-retryable) ServerError for a 4xx response' do
+      resp = instance_double(Faraday::Response, status: 400, reason_phrase: 'Bad Request', success?: false)
+      allow(transport).to receive(:send_http_request).and_return(resp)
+
+      begin
+        transport.send(:post_json_rpc_request, { id: 1 })
+      rescue MCPClient::Errors::ServerError => e
+        expect(e).not_to be_a(MCPClient::Errors::TransientServerError)
+        expect(e.message).to match(/Server returned error: 400/)
+      end
+    end
+  end
+
   describe '#parse_direct_response' do
     it 'parses JSON and returns result key' do
       resp = double('resp', body: '{"result":{"ok":true}}')


### PR DESCRIPTION
## Problem

`with_retry` (`json_rpc_common.rb`) rescued plain `MCPClient::Errors::ServerError` and retried it up to `@max_retries`. But `ServerError` is raised in two very different situations:

- **Transport-level, plausibly transient** — HTTP **5xx**.
- **Application-level, already processed** — a **JSON-RPC error response** (`process_jsonrpc_response`) or an HTTP **4xx** (`handle_http_error_response`).

For the second group the server *received and processed (or deterministically rejected)* the request. Retrying re-sent it, so a non-idempotent `tools/call` that returned a JSON-RPC error — or hit a 400/500 — was silently **re-executed** up to 3 times on the HTTP transports (`retries: 3` default). JSON-RPC provides no way to make that safe.

## Fix

Split transient from application-level failures:

- New **`MCPClient::Errors::TransientServerError < ServerError`**. HTTP 5xx (and SSE 5xx) now raise it — plausibly transient, request likely didn't complete at the app layer.
- **`with_retry` retries only** `TransientServerError` and genuine transport/network errors (`TransportError`, `IOError`, `Errno::ETIMEDOUT/ECONNRESET/EPIPE`). A **plain `ServerError`** — a JSON-RPC error response or an HTTP **4xx** — is raised immediately and **never retried**.

## Compatibility

`TransientServerError` **is a subclass of `ServerError`**, so every existing `rescue MCPClient::Errors::ServerError` and `raise_error(ServerError)` still matches, and all error message strings are byte-identical. `faraday-retry` already does not retry POST, so HTTP-level double-sends were never a factor.

The one observable change is the intended fix: with `retries > 0`, a JSON-RPC error / 4xx is no longer resubmitted. HTTP 5xx retry behavior is preserved.

## Tests

- `with_retry` retries `TransientServerError` and `Errno::EPIPE`, but invokes the block exactly once for a plain `ServerError`.
- `handle_http_error_response`: 5xx → `TransientServerError` (still a `ServerError`, message unchanged); 4xx → plain `ServerError` (asserted *not* transient).
- SSE `post_json_rpc_request`: 5xx → `TransientServerError`, 4xx → plain `ServerError`.
- `rpc_request` does not re-send after a plain `ServerError`; does retry 5xx/transport errors.

Full suite: `1263 examples, 0 failures`; RuboCop clean. README documents the retry semantics. Reviewed with `codex review` (no actionable findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)