### PR TITLE
fix(sse): repair dead-code auto-reconnection (monitor thread self-kill)

### DIFF
--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -405,28 +405,42 @@ module MCPClient
         @sse_connected = false
         @initialized = false # Reset initialization state for reconnection
 
+        # Reset the SSE parse buffer so a reconnect never inherits a leftover
+        # partial event from the previous connection.
+        @buffer = ''
+
         # Log cleanup for debugging
         @logger.debug('Cleaning up SSE connection')
 
         # Store threads locally to avoid race conditions
         sse_thread = @sse_thread
+
+        # The activity monitor drives reconnection, and reconnection calls this
+        # method FROM that thread. Killing the current thread here would abort
+        # the reconnect before connect() runs (the historical dead-code bug), so
+        # never kill/clear the activity thread when we are running on it. Leaving
+        # @activity_timer_thread referenced also makes start_activity_monitor
+        # short-circuit, preventing a duplicate monitor after reconnect.
         activity_thread = @activity_timer_thread
+        kill_activity_thread = activity_thread && activity_thread != Thread.current
 
         # Clear thread references first
         @sse_thread = nil
-        @activity_timer_thread = nil
+        @activity_timer_thread = nil if kill_activity_thread
 
-        # Kill threads outside the critical section
+        # Kill threads
         begin
           sse_thread&.kill
         rescue StandardError => e
           @logger.debug("Error killing SSE thread: #{e.message}")
         end
 
-        begin
-          activity_thread&.kill
-        rescue StandardError => e
-          @logger.debug("Error killing activity thread: #{e.message}")
+        if kill_activity_thread
+          begin
+            activity_thread.kill
+          rescue StandardError => e
+            @logger.debug("Error killing activity thread: #{e.message}")
+          end
         end
 
         if @http_client

--- a/lib/mcp_client/server_sse/reconnect_monitor.rb
+++ b/lib/mcp_client/server_sse/reconnect_monitor.rb
@@ -88,6 +88,10 @@ module MCPClient
 
             cleanup
 
+            # Clear any stale auth error from the previous connection so it does
+            # not spuriously abort this reconnect via wait_for_connection.
+            @mutex.synchronize { @auth_error = nil }
+
             connect
             @logger.info('Successfully reconnected after ping failures')
 

--- a/spec/lib/mcp_client/server_sse_spec.rb
+++ b/spec/lib/mcp_client/server_sse_spec.rb
@@ -438,6 +438,31 @@ RSpec.describe MCPClient::ServerSSE do
       expect(server.instance_variable_get(:@initialized)).to be false
     end
 
+    it 'resets the SSE parse buffer so a reconnect does not inherit a partial event' do
+      server.instance_variable_set(:@buffer, 'data: {"jso')
+      server.cleanup
+      expect(server.instance_variable_get(:@buffer)).to eq('')
+    end
+
+    it 'does NOT kill the activity monitor thread when called on that same thread' do
+      # Reconnection drives cleanup from the activity monitor thread; killing the
+      # current thread there is the historical dead-code bug.
+      ran_to_completion = false
+
+      monitor = Thread.new do
+        server.instance_variable_set(:@activity_timer_thread, Thread.current)
+        server.instance_variable_set(:@connection_established, true)
+        server.cleanup
+        ran_to_completion = true # unreachable if cleanup killed this thread
+      end
+      monitor.join(2)
+
+      # If cleanup had killed the current thread, ran_to_completion stays false
+      expect(ran_to_completion).to be true
+      # The reference is preserved so start_activity_monitor won't spawn a duplicate
+      expect(server.instance_variable_get(:@activity_timer_thread)).to eq(monitor)
+    end
+
     it 'sets flags before closing threads' do
       # Create mock threads
       sse_thread = double('sse_thread')
@@ -660,6 +685,57 @@ RSpec.describe MCPClient::ServerSSE do
       expect(server.instance_variable_get(:@consecutive_ping_failures)).to eq(0)
       # And reset the reconnect attempt counter
       expect(server.instance_variable_get(:@reconnect_attempts)).to eq(0)
+    end
+
+    it 'reconnects without the monitor thread killing itself (regression)' do
+      server.instance_variable_set(:@consecutive_ping_failures, 3)
+      server.instance_variable_set(:@reconnect_attempts, 0)
+      server.instance_variable_set(:@max_ping_failures, 3)
+      server.instance_variable_set(:@max_reconnect_attempts, 5)
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@sse_connected, true)
+      allow(server).to receive(:sleep)
+
+      connect_called = false
+      allow(server).to receive(:connect) do
+        connect_called = true
+        server.instance_variable_set(:@connection_established, true)
+        true
+      end
+      # NOTE: cleanup is NOT stubbed — the real cleanup runs, exercising the
+      # self-kill guard that made reconnection dead code before this fix.
+
+      completed = false
+      monitor = Thread.new do
+        server.instance_variable_set(:@activity_timer_thread, Thread.current)
+        server.send(:attempt_reconnection)
+        completed = true
+      end
+      monitor.join(3)
+
+      expect(connect_called).to be true
+      expect(completed).to be true # would be false if cleanup killed this thread
+      expect(server.instance_variable_get(:@consecutive_ping_failures)).to eq(0)
+      expect(server.instance_variable_get(:@reconnect_attempts)).to eq(0)
+    end
+
+    it 'clears a stale auth error before reconnecting' do
+      server.instance_variable_set(:@consecutive_ping_failures, 3)
+      server.instance_variable_set(:@reconnect_attempts, 0)
+      server.instance_variable_set(:@max_ping_failures, 3)
+      server.instance_variable_set(:@max_reconnect_attempts, 5)
+      server.instance_variable_set(:@auth_error, 'Authorization failed: stale token')
+      allow(server).to receive(:cleanup)
+      allow(server).to receive(:sleep)
+
+      auth_error_at_connect = :unset
+      allow(server).to receive(:connect) do
+        auth_error_at_connect = server.instance_variable_get(:@auth_error)
+        true
+      end
+
+      server.send(:attempt_reconnection)
+      expect(auth_error_at_connect).to be_nil
     end
   end
 


### PR DESCRIPTION
## Problem

`ServerSSE`'s activity monitor runs `attempt_reconnection` **on `@activity_timer_thread`**. After `@max_ping_failures` consecutive ping failures it called `cleanup`, whose `activity_thread.kill` — with `activity_thread == @activity_timer_thread == Thread.current` — was effectively **`Thread.current.kill`**. The monitor thread terminated itself before `connect()` on the next line ever ran.

The result: **automatic reconnection was unreachable dead code.** A dropped SSE stream was never re-established; the success log, counter resets, and `connect` were all after the self-kill point. No existing test caught it because the reconnect specs stub `cleanup`/`connect`.

## Fix

- **`cleanup` never kills or clears the activity thread when it *is* the current thread** — a thread must not kill itself mid-cleanup. Keeping the reference in place also makes `start_activity_monitor` short-circuit, so `connect()` doesn't spawn a *duplicate* monitor after reconnect. Cleanup from any other thread is unchanged (kills + nils it, as before).
- **`cleanup` resets `@buffer`** so a reconnect can't inherit a leftover partial SSE event from the previous connection.
- **`attempt_reconnection` clears a stale `@auth_error` before `connect`**, so an old auth failure can't spuriously abort a valid reconnect via `wait_for_connection`.

## Compatibility

No public API change. Normal `cleanup` (from the main thread, or a test with a thread double) behaves exactly as before — the guard only differs when cleanup is invoked *from* the monitor thread it would otherwise kill.

> **Out of scope:** `Last-Event-ID` resumption. This is the *legacy* HTTP+SSE transport, whose connection is established via an `endpoint` control event. A resumable server honoring `Last-Event-ID` may skip that event on reconnect and stall `wait_for_connection` — `codex review` flagged exactly this regression on a first pass. Resumability belongs to the Streamable HTTP transport and is deliberately left out.

## Tests

- Reconnection actually runs on the monitor thread **without self-killing** (the core regression — the thread survives and `connect` is called).
- `cleanup` does not kill the current thread but still kills other threads.
- `@buffer` is reset on cleanup.
- A stale `@auth_error` is cleared before reconnect.

Full suite: `1250 examples, 0 failures`; RuboCop clean. Reviewed with `codex review` (final pass: no actionable findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)