### PR TITLE
fix(oauth): RFC 8414/9728 compliant authorization server discovery

### DIFF
--- a/OAUTH.md
+++ b/OAUTH.md
@@ -62,9 +62,20 @@ token = oauth_provider.complete_authorization_flow(code, state)
 
 The implementation follows the standard OAuth 2.1 authorization code flow with PKCE:
 
-1. **Server Discovery**: Discover authorization server via `.well-known/oauth-protected-resource`
-   - Uses the origin (scheme + host + port) of the MCP server URL for discovery
-   - Example: `https://api.example.com/mcp/path?query=123` → `https://api.example.com/.well-known/oauth-protected-resource`
+1. **Server Discovery**: Protected Resource Metadata is authoritative (RFC 9728). On a `401` the client
+   parses the `resource_metadata` parameter from the `WWW-Authenticate` header (a legacy `resource`
+   parameter is accepted as a fallback); otherwise it probes the `.well-known` URLs in priority order.
+   - **Protected Resource Metadata (RFC 9728 §3.1)** is path-aware: the well-known segment is inserted
+     between host and path, then a root fallback is tried.
+     - Example: `https://api.example.com/mcp` →
+       `https://api.example.com/.well-known/oauth-protected-resource/mcp`, then
+       `https://api.example.com/.well-known/oauth-protected-resource`
+   - **Authorization Server Metadata (RFC 8414 §3.1 + OpenID Connect Discovery)**: for an issuer with a
+     path, the well-known segment is *inserted* (not appended); both `oauth-authorization-server` and
+     `openid-configuration` forms are tried in priority order.
+   - The discovered protected-resource `resource` is validated against the server host (confused-deputy
+     protection), and every authorization-server endpoint must use HTTPS (localhost is allowed for
+     local development).
 2. **Client Registration**: Automatically register OAuth client if dynamic registration is supported
 3. **Authorization**: Redirect user to authorization server with PKCE parameters
 4. **Token Exchange**: Exchange authorization code for access token using PKCE verifier
@@ -177,7 +188,8 @@ metadata = MCPClient::Auth::ServerMetadata.new(
   issuer: 'https://auth.example.com',
   authorization_endpoint: 'https://auth.example.com/authorize',
   token_endpoint: 'https://auth.example.com/token',
-  registration_endpoint: 'https://auth.example.com/register'
+  registration_endpoint: 'https://auth.example.com/register',
+  code_challenge_methods_supported: ['S256'] # advertised PKCE methods (RFC 8414)
 )
 ```
 
@@ -204,12 +216,17 @@ end
 
 This implementation follows OAuth 2.1 security best practices:
 
-- **PKCE is mandatory** for all authorization code flows
+- **PKCE is mandatory** for all authorization code flows. The client uses `S256` and **verifies the
+  authorization server's `code_challenge_methods_supported`**: it refuses to proceed if the server
+  explicitly advertises methods without `S256`, and warns (but proceeds) if the field is omitted.
 - **State parameter** is used to prevent CSRF attacks
-- **Resource parameter** (RFC 8707) ensures token audience binding
-- **Token validation** ensures tokens are used only with intended servers
+- **Resource parameter** (RFC 8707) ensures token audience binding — sent in both the authorization
+  and token requests as the canonical server URI
+- **Confused-deputy protection**: the protected-resource metadata `resource` is validated against the
+  server host before its advertised authorization server is trusted
+- **HTTPS is enforced** on all discovered authorization-server endpoints (authorization, token, and
+  registration), with a `localhost`/`127.0.0.1` exception for local development
 - **Secure token storage** guidelines should be followed
-- **HTTPS is required** for all OAuth endpoints
 
 ## Examples
 

--- a/lib/mcp_client/auth.rb
+++ b/lib/mcp_client/auth.rb
@@ -225,7 +225,8 @@ module MCPClient
     # OAuth authorization server metadata
     class ServerMetadata
       attr_reader :issuer, :authorization_endpoint, :token_endpoint, :registration_endpoint,
-                  :scopes_supported, :response_types_supported, :grant_types_supported
+                  :scopes_supported, :response_types_supported, :grant_types_supported,
+                  :code_challenge_methods_supported
 
       # @param issuer [String] Issuer identifier URL
       # @param authorization_endpoint [String] Authorization endpoint URL
@@ -234,8 +235,10 @@ module MCPClient
       # @param scopes_supported [Array<String>, nil] Supported OAuth scopes
       # @param response_types_supported [Array<String>, nil] Supported response types
       # @param grant_types_supported [Array<String>, nil] Supported grant types
+      # @param code_challenge_methods_supported [Array<String>, nil] Supported PKCE code challenge methods (RFC 8414)
       def initialize(issuer:, authorization_endpoint:, token_endpoint:, registration_endpoint: nil,
-                     scopes_supported: nil, response_types_supported: nil, grant_types_supported: nil)
+                     scopes_supported: nil, response_types_supported: nil, grant_types_supported: nil,
+                     code_challenge_methods_supported: nil)
         @issuer = issuer
         @authorization_endpoint = authorization_endpoint
         @token_endpoint = token_endpoint
@@ -243,6 +246,7 @@ module MCPClient
         @scopes_supported = scopes_supported
         @response_types_supported = response_types_supported
         @grant_types_supported = grant_types_supported
+        @code_challenge_methods_supported = code_challenge_methods_supported
       end
 
       # Check if dynamic client registration is supported
@@ -261,7 +265,8 @@ module MCPClient
           registration_endpoint: @registration_endpoint,
           scopes_supported: @scopes_supported,
           response_types_supported: @response_types_supported,
-          grant_types_supported: @grant_types_supported
+          grant_types_supported: @grant_types_supported,
+          code_challenge_methods_supported: @code_challenge_methods_supported
         }.compact
       end
 
@@ -276,7 +281,9 @@ module MCPClient
           registration_endpoint: data[:registration_endpoint] || data['registration_endpoint'],
           scopes_supported: data[:scopes_supported] || data['scopes_supported'],
           response_types_supported: data[:response_types_supported] || data['response_types_supported'],
-          grant_types_supported: data[:grant_types_supported] || data['grant_types_supported']
+          grant_types_supported: data[:grant_types_supported] || data['grant_types_supported'],
+          code_challenge_methods_supported: data[:code_challenge_methods_supported] ||
+            data['code_challenge_methods_supported']
         )
       end
     end

--- a/lib/mcp_client/auth/oauth_provider.rb
+++ b/lib/mcp_client/auth/oauth_provider.rb
@@ -41,6 +41,10 @@ module MCPClient
         self.storage = storage || MemoryStorage.new
         @extra_client_metadata = client_metadata
         @http_client = create_http_client
+        # Protected resource metadata learned from a 401 WWW-Authenticate
+        # challenge, reused by discovery so a challenge-advertised metadata URL
+        # is not re-derived (and possibly missed).
+        @challenge_resource_metadata = nil
       end
 
       # @param url [String] Server URL to normalize
@@ -142,12 +146,37 @@ module MCPClient
         www_authenticate = response.headers['WWW-Authenticate'] || response.headers['www-authenticate']
         return nil unless www_authenticate
 
-        # Parse WWW-Authenticate header to extract resource metadata URL
-        # Format: Bearer resource="https://example.com/.well-known/oauth-protected-resource"
-        if (match = www_authenticate.match(/resource="([^"]+)"/))
-          resource_metadata_url = match[1]
-          fetch_resource_metadata(resource_metadata_url)
+        url = extract_resource_metadata_url(www_authenticate)
+        return nil unless url
+
+        # This URL was explicitly advertised by the 401 challenge, so a 404 is a
+        # misconfiguration to surface (strict), not a speculative miss to skip.
+        metadata = fetch_resource_metadata(url, strict: true)
+        # Reuse this challenge-advertised metadata during the subsequent OAuth
+        # flow instead of re-deriving (and possibly missing) the well-known URL.
+        @challenge_resource_metadata = metadata
+        metadata
+      end
+
+      # Extract the protected-resource-metadata URL from a WWW-Authenticate header.
+      # Per RFC 9728 the parameter is `resource_metadata`; a legacy `resource`
+      # parameter is accepted as a fallback for older servers.
+      # @param header [String] the WWW-Authenticate header value
+      # @return [String, nil] the metadata URL if present
+      def extract_resource_metadata_url(header)
+        # Auth-params may include optional whitespace around '=' (RFC 7235).
+        # Quoted form: resource_metadata = "https://..."
+        if (m = header.match(/resource_metadata\s*=\s*"([^"]+)"/))
+          return m[1]
         end
+
+        # Unquoted token form: resource_metadata = https://...
+        if (m = header.match(/resource_metadata\s*=\s*([^,\s]+)/))
+          return m[1]
+        end
+
+        # Legacy fallback: resource="https://..."
+        header.match(/resource\s*=\s*"([^"]+)"/)&.captures&.first
       end
 
       private
@@ -213,6 +242,55 @@ module MCPClient
           (uri.scheme == 'https' && uri.port == 443)
       end
 
+      # Build the scheme://host[:port] origin for a parsed URI.
+      # @param uri [URI] Parsed URI
+      # @return [String] origin string
+      def origin_of(uri)
+        origin = "#{uri.scheme}://#{uri.host}"
+        origin += ":#{uri.port}" if uri.port && !default_port?(uri)
+        origin
+      end
+
+      # Protected Resource Metadata well-known URLs to try, in priority order
+      # (RFC 9728 §3.1). When the resource identifier has a path, the well-known
+      # segment is inserted between the host and the path; a root-level URL is
+      # always tried as a fallback.
+      # @param server_url [String] the MCP server (protected resource) URL
+      # @return [Array<String>] ordered candidate URLs
+      def protected_resource_metadata_urls(server_url)
+        uri = URI.parse(server_url)
+        origin = origin_of(uri)
+        path = uri.path.to_s
+
+        urls = []
+        urls << "#{origin}/.well-known/oauth-protected-resource#{path}" unless path.empty? || path == '/'
+        urls << "#{origin}/.well-known/oauth-protected-resource"
+        urls.uniq
+      end
+
+      # Authorization Server Metadata well-known URLs to try, in priority order
+      # (RFC 8414 §3.1 path-insertion plus OpenID Connect Discovery). When the
+      # issuer has a path, the well-known segment is INSERTED between host and
+      # path (not appended); the OIDC path-append form is also tried.
+      # @param issuer [String] the authorization server issuer URL
+      # @return [Array<String>] ordered candidate URLs
+      def authorization_server_metadata_urls(issuer)
+        uri = URI.parse(issuer)
+        origin = origin_of(uri)
+        path = uri.path.to_s
+
+        urls = []
+        if path.empty? || path == '/'
+          urls << "#{origin}/.well-known/oauth-authorization-server"
+          urls << "#{origin}/.well-known/openid-configuration"
+        else
+          urls << "#{origin}/.well-known/oauth-authorization-server#{path}"
+          urls << "#{origin}/.well-known/openid-configuration#{path}"
+          urls << "#{origin}#{path}/.well-known/openid-configuration"
+        end
+        urls.uniq
+      end
+
       # Discover authorization server metadata
       # Tries multiple discovery patterns:
       # 1. oauth-authorization-server (MCP spec pattern - server is its own auth server)
@@ -220,62 +298,273 @@ module MCPClient
       # @return [ServerMetadata] Authorization server metadata
       # @raise [MCPClient::Errors::ConnectionError] if discovery fails
       def discover_authorization_server
-        # Try to get from storage first
-        if (cached = storage.get_server_metadata(server_url))
+        # A fresh 401 challenge is authoritative and overrides any cached
+        # (possibly stale or direct-discovered) authorization server metadata.
+        cached = storage.get_server_metadata(server_url) unless @challenge_resource_metadata
+        if cached
+          # Validate the cached entry before use so a persisted/older cache with
+          # an HTTP endpoint or without S256 is still rejected.
+          validate_server_metadata!(cached)
           return cached
         end
 
-        server_metadata = nil
+        discover_and_cache_authorization_server
+      end
 
-        # Primary discovery: oauth-authorization-server (MCP spec pattern)
-        # Used by servers that are both resource and authorization server
-        begin
-          discovery_url = build_discovery_url(server_url, :authorization_server)
-          logger.debug("Attempting OAuth discovery: #{discovery_url}")
-          server_metadata = fetch_server_metadata(discovery_url)
-        rescue MCPClient::Errors::ConnectionError => e
-          logger.debug("oauth-authorization-server discovery failed: #{e.message}")
-        end
+      # Discover authorization server metadata, validate it, and cache it.
+      # @return [ServerMetadata]
+      # @raise [MCPClient::Errors::ConnectionError] if discovery or validation fails
+      def discover_and_cache_authorization_server
+        previous = storage.get_server_metadata(server_url)
 
-        # Fallback discovery: oauth-protected-resource (delegation pattern)
-        # Used by resource servers that delegate to external authorization servers
-        unless server_metadata
-          begin
-            discovery_url = build_discovery_url(server_url, :protected_resource)
-            logger.debug("Attempting OAuth discovery: #{discovery_url}")
-
-            resource_metadata = fetch_resource_metadata(discovery_url)
-            auth_server_url = resource_metadata.authorization_servers.first
-
-            if auth_server_url
-              server_metadata = fetch_server_metadata("#{auth_server_url}/.well-known/oauth-authorization-server")
-            end
-          rescue MCPClient::Errors::ConnectionError => e
-            logger.debug("oauth-protected-resource discovery failed: #{e.message}")
-          end
-        end
+        # RFC 9728: Protected Resource Metadata is authoritative — try it first,
+        # then fall back to treating the MCP server origin as its own AS.
+        server_metadata = discover_via_protected_resource || discover_via_direct_authorization_server
 
         unless server_metadata
           raise MCPClient::Errors::ConnectionError,
-                'OAuth discovery failed: no valid endpoints found'
+                'OAuth discovery failed: no valid authorization server metadata found'
         end
 
-        # Cache the metadata
+        # Validate BEFORE caching so invalid metadata is never persisted.
+        validate_server_metadata!(server_metadata)
+
+        invalidate_client_info_on_as_change(previous, server_metadata)
+
         storage.set_server_metadata(server_url, server_metadata)
+        @challenge_resource_metadata = nil # consumed
+        server_metadata
+      end
+
+      # When a 401 challenge changes the authorization server, per-AS state cached
+      # under this server_url becomes invalid: a client_id registered with the
+      # previous AS would fail as invalid_client, and memoized scopes belong to
+      # the old AS. Discard both so the new flow re-registers and re-discovers.
+      # @param previous [ServerMetadata, nil] previously cached AS metadata
+      # @param current [ServerMetadata] newly discovered AS metadata
+      def invalidate_client_info_on_as_change(previous, current)
+        return unless previous && previous.issuer != current.issuer
+
+        logger.debug('Authorization server changed; discarding client and scopes from the previous AS')
+
+        # Prefer an explicit delete; fall back to the always-available
+        # set_client_info(nil) so custom storage backends are handled too.
+        if storage.respond_to?(:delete_client_info)
+          storage.delete_client_info(server_url)
+        else
+          storage.set_client_info(server_url, nil)
+        end
+
+        @supported_scopes = nil
+      end
+
+      # Apply the PKCE-support and HTTPS-endpoint checks to server metadata.
+      # @param server_metadata [ServerMetadata]
+      # @raise [MCPClient::Errors::ConnectionError] if a check fails
+      def validate_server_metadata!(server_metadata)
+        verify_pkce_support!(server_metadata)
+        enforce_https_endpoints!(server_metadata)
+      end
+
+      # PRM-first discovery: fetch Protected Resource Metadata and then the
+      # authorization server it advertises.
+      # @return [ServerMetadata, nil] AS metadata, or nil if no PRM document exists
+      # @raise [MCPClient::Errors::ConnectionError] if PRM is malformed or mismatched
+      def discover_via_protected_resource
+        # A missing PRM document (return nil) permits the direct-AS fallback. But
+        # once PRM IS found it is authoritative: any subsequent failure must be a
+        # hard error, never a silent fallback to an authorization server the PRM
+        # did not advertise.
+        resource_metadata = @challenge_resource_metadata ||
+                            fetch_first_resource_metadata(protected_resource_metadata_urls(server_url))
+        return nil unless resource_metadata
+
+        validate_resource_matches!(resource_metadata)
+
+        auth_server_url = Array(resource_metadata.authorization_servers).first
+        unless auth_server_url
+          raise MCPClient::Errors::ConnectionError,
+                'Protected resource metadata does not advertise any authorization_servers'
+        end
+
+        server_metadata = fetch_first_server_metadata(authorization_server_metadata_urls(auth_server_url))
+        unless server_metadata
+          raise MCPClient::Errors::ConnectionError,
+                "Authorization server advertised by protected resource metadata (#{auth_server_url}) " \
+                'could not be discovered'
+        end
 
         server_metadata
       end
 
-      # Fetch resource metadata from URL
+      # Legacy/self-hosted discovery: treat the MCP server ORIGIN as its own
+      # authorization server issuer.
+      # @return [ServerMetadata, nil]
+      def discover_via_direct_authorization_server
+        origin = origin_of(URI.parse(server_url))
+        fetch_first_server_metadata(authorization_server_metadata_urls(origin))
+      end
+
+      # Fetch the first Protected Resource Metadata document that resolves.
+      #
+      # PRM is authoritative: a candidate that genuinely does not exist (HTTP
+      # 404) is skipped so the next candidate is tried, but a candidate that
+      # exists yet is malformed or errors (bad JSON, 5xx, network failure) is a
+      # HARD failure — it must not silently fall through to a root PRM or the
+      # direct-AS path, which could point at a different authorization server.
+      # @param urls [Array<String>] candidate URLs
+      # @return [ResourceMetadata, nil]
+      def fetch_first_resource_metadata(urls)
+        urls.each do |url|
+          md = fetch_resource_metadata(url) # returns nil only for a 404 (absent); raises otherwise
+          return md if md
+        end
+        nil
+      end
+
+      # Fetch the first Authorization Server Metadata document that resolves.
+      # The oauth-authorization-server and openid-configuration forms are
+      # genuine alternatives, so any failing candidate is skipped to try the next.
+      # @param urls [Array<String>] candidate URLs
+      # @return [ServerMetadata, nil]
+      def fetch_first_server_metadata(urls)
+        urls.each do |url|
+          md = try_fetch_server_metadata(url)
+          return md if md
+        end
+        nil
+      end
+
+      # Non-raising server-metadata fetch used while iterating candidates.
+      def try_fetch_server_metadata(url)
+        fetch_server_metadata(url)
+      rescue MCPClient::Errors::ConnectionError => e
+        logger.debug("Authorization server metadata candidate failed (#{url}): #{e.message}")
+        nil
+      end
+
+      # Verify the authorization server supports PKCE S256 (RFC 8414 / MCP).
+      # Refuses when S256 is explicitly not offered; warns (and proceeds, since
+      # the client always uses S256) when the field is not advertised at all.
+      # @param server_metadata [ServerMetadata]
+      # @raise [MCPClient::Errors::ConnectionError] if S256 is explicitly unsupported
+      def verify_pkce_support!(server_metadata)
+        methods = server_metadata.code_challenge_methods_supported
+        if methods.nil?
+          logger.warn(
+            'Authorization server metadata omits code_challenge_methods_supported; ' \
+            'proceeding with PKCE S256'
+          )
+        elsif !methods.include?('S256')
+          raise MCPClient::Errors::ConnectionError,
+                'Authorization server does not support PKCE S256 ' \
+                '(code_challenge_methods_supported does not include "S256")'
+        end
+      end
+
+      # Require HTTPS for all discovered authorization server endpoints, with a
+      # localhost exception for local development.
+      # @param server_metadata [ServerMetadata]
+      def enforce_https_endpoints!(server_metadata)
+        enforce_https!(server_metadata.authorization_endpoint, 'authorization endpoint')
+        enforce_https!(server_metadata.token_endpoint, 'token endpoint')
+        return unless server_metadata.registration_endpoint
+
+        enforce_https!(server_metadata.registration_endpoint, 'registration endpoint')
+      end
+
+      # @param url [String, nil] endpoint URL
+      # @param label [String] human-readable endpoint name for errors
+      # @raise [MCPClient::Errors::ConnectionError] if the URL is not HTTPS (non-localhost)
+      def enforce_https!(url, label)
+        return if url.nil?
+
+        uri = URI.parse(url)
+        return if uri.scheme == 'https'
+        # Dev exception is only for plain HTTP on a loopback host — not any other
+        # scheme (e.g. ftp://localhost). Use #hostname (not #host) so an IPv6
+        # loopback like http://[::1]:9292 matches without the surrounding brackets.
+        return if uri.scheme == 'http' && %w[localhost 127.0.0.1 ::1].include?(uri.hostname)
+
+        raise MCPClient::Errors::ConnectionError, "OAuth #{label} must use HTTPS: #{url}"
+      rescue URI::InvalidURIError
+        raise MCPClient::Errors::ConnectionError, "OAuth #{label} is not a valid URL: #{url}"
+      end
+
+      # Validate the PRM `resource` identifies this server (RFC 9728 confused
+      # deputy protection). Path/canonicalization differences on the same host
+      # are tolerated; a different host is rejected.
+      # @param resource_metadata [ResourceMetadata]
+      # @raise [MCPClient::Errors::ConnectionError] on host mismatch
+      def validate_resource_matches!(resource_metadata)
+        # RFC 9728 requires `resource`; without it the confused-deputy check is
+        # impossible, so a PRM that omits it must be rejected (not trusted).
+        if resource_metadata.resource.nil?
+          raise MCPClient::Errors::ConnectionError,
+                'Protected resource metadata is missing the required "resource" identifier'
+        end
+
+        # Require an EXACT canonical match (scheme/host/port/path). A same-host
+        # match is not enough: a host that serves multiple resources/tenants
+        # must not have one tenant's PRM trusted for another.
+        advertised = resource_identity(resource_metadata.resource)
+        expected = resource_identity(server_url)
+        return if advertised == expected
+
+        raise MCPClient::Errors::ConnectionError,
+              "Protected resource metadata resource (#{resource_metadata.resource}) " \
+              "does not match the server URL (#{server_url})"
+      end
+
+      # Canonical resource identity (scheme, host, port, path, query) used for
+      # the confused-deputy comparison. The query is included because the
+      # `resource` parameter sent in the authorization and token requests is the
+      # full server URL (some servers distinguish resources by query, e.g.
+      # ?serverId=a vs ?serverId=b); only the fragment is ignored. Rejects a
+      # non-absolute URL, since the value is untrusted server input.
+      # @param url [String] a resource URL
+      # @return [String] canonical identity string
+      # @raise [MCPClient::Errors::ConnectionError] if the URL is not an absolute URI
+      def resource_identity(url)
+        uri = URI.parse(url)
+        unless uri.scheme && uri.host
+          raise MCPClient::Errors::ConnectionError, "Invalid resource URL (must be absolute): #{url}"
+        end
+
+        scheme = uri.scheme.downcase
+        host = uri.host.downcase
+        port = uri.port
+        port = nil if (scheme == 'http' && port == 80) || (scheme == 'https' && port == 443)
+        path = uri.path.to_s
+        path = '' if path == '/'
+        path = path.chomp('/') while path.end_with?('/')
+        query = uri.query ? "?#{uri.query}" : ''
+
+        "#{scheme}://#{host}#{":#{port}" if port}#{path}#{query}"
+      rescue URI::InvalidURIError
+        raise MCPClient::Errors::ConnectionError, "Invalid resource URL: #{url}"
+      end
+
+      # Fetch resource metadata from URL.
+      #
+      # Returns nil when the document is genuinely absent (HTTP 404) so a
+      # discovery loop can try the next candidate. Any other failure — a
+      # non-404 error status, malformed JSON, or a network error — raises,
+      # because PRM is authoritative and such a response must not be silently
+      # skipped in favor of a different authorization server.
       # @param url [String] Resource metadata URL
-      # @return [ResourceMetadata] Resource metadata
-      # @raise [MCPClient::Errors::ConnectionError] if fetch fails
-      def fetch_resource_metadata(url)
+      # @param strict [Boolean] when true, a 404 raises instead of returning nil
+      #   (used for a URL explicitly advertised by a 401 challenge)
+      # @return [ResourceMetadata, nil] metadata, or nil if a speculative URL returns 404
+      # @raise [MCPClient::Errors::ConnectionError] on any non-404 failure, or on 404 when strict
+      def fetch_resource_metadata(url, strict: false)
         logger.debug("Fetching resource metadata from: #{url}")
 
         response = @http_client.get(url) do |req|
           req.headers['Accept'] = 'application/json'
         end
+
+        return nil if response.status == 404 && !strict
 
         unless response.success?
           raise MCPClient::Errors::ConnectionError, "Failed to fetch resource metadata: HTTP #{response.status}"
@@ -610,6 +899,10 @@ module MCPClient
 
         def set_client_info(server_url, client_info)
           @client_infos[server_url] = client_info
+        end
+
+        def delete_client_info(server_url)
+          @client_infos.delete(server_url)
         end
 
         def get_server_metadata(server_url)

--- a/spec/lib/mcp_client/auth/oauth_provider_spec.rb
+++ b/spec/lib/mcp_client/auth/oauth_provider_spec.rb
@@ -85,6 +85,364 @@ RSpec.describe MCPClient::Auth::OAuthProvider do
     end
   end
 
+  describe 'RFC-compliant discovery' do
+    describe '#protected_resource_metadata_urls (RFC 9728 path-aware)' do
+      it 'inserts the well-known segment before the path, then falls back to root' do
+        p = described_class.new(server_url: 'https://ex.com/public/mcp')
+        expect(p.send(:protected_resource_metadata_urls, p.server_url)).to eq(
+          [
+            'https://ex.com/.well-known/oauth-protected-resource/public/mcp',
+            'https://ex.com/.well-known/oauth-protected-resource'
+          ]
+        )
+      end
+
+      it 'returns only the root URL for a path-less server' do
+        p = described_class.new(server_url: 'https://ex.com')
+        expect(p.send(:protected_resource_metadata_urls, p.server_url))
+          .to eq(['https://ex.com/.well-known/oauth-protected-resource'])
+      end
+    end
+
+    describe '#authorization_server_metadata_urls (RFC 8414 path-insertion + OIDC)' do
+      let(:p) { described_class.new(server_url: server_url) }
+
+      it 'path-inserts oauth + OIDC and appends OIDC for an issuer with a path' do
+        expect(p.send(:authorization_server_metadata_urls, 'https://auth.example.com/tenant1')).to eq(
+          [
+            'https://auth.example.com/.well-known/oauth-authorization-server/tenant1',
+            'https://auth.example.com/.well-known/openid-configuration/tenant1',
+            'https://auth.example.com/tenant1/.well-known/openid-configuration'
+          ]
+        )
+      end
+
+      it 'tries oauth then OIDC for a path-less issuer' do
+        expect(p.send(:authorization_server_metadata_urls, 'https://auth.example.com')).to eq(
+          [
+            'https://auth.example.com/.well-known/oauth-authorization-server',
+            'https://auth.example.com/.well-known/openid-configuration'
+          ]
+        )
+      end
+    end
+
+    describe '#extract_resource_metadata_url (WWW-Authenticate)' do
+      let(:p) { described_class.new(server_url: server_url) }
+
+      it 'parses the quoted resource_metadata parameter' do
+        header = 'Bearer resource_metadata="https://mcp.example.com/meta", scope="files:read"'
+        expect(p.send(:extract_resource_metadata_url, header)).to eq('https://mcp.example.com/meta')
+      end
+
+      it 'parses the unquoted resource_metadata parameter' do
+        header = 'Bearer resource_metadata=https://mcp.example.com/meta'
+        expect(p.send(:extract_resource_metadata_url, header)).to eq('https://mcp.example.com/meta')
+      end
+
+      it 'falls back to the legacy resource parameter' do
+        header = 'Bearer resource="https://mcp.example.com/legacy"'
+        expect(p.send(:extract_resource_metadata_url, header)).to eq('https://mcp.example.com/legacy')
+      end
+
+      it 'tolerates whitespace around the parameter equals sign' do
+        header = 'Bearer resource_metadata = "https://mcp.example.com/meta"'
+        expect(p.send(:extract_resource_metadata_url, header)).to eq('https://mcp.example.com/meta')
+      end
+    end
+
+    describe '#verify_pkce_support!' do
+      def metadata(methods)
+        MCPClient::Auth::ServerMetadata.new(
+          issuer: 'https://a', authorization_endpoint: 'https://a/auth',
+          token_endpoint: 'https://a/token', code_challenge_methods_supported: methods
+        )
+      end
+
+      it 'raises when S256 is explicitly not offered' do
+        expect { oauth_provider.send(:verify_pkce_support!, metadata(['plain'])) }
+          .to raise_error(MCPClient::Errors::ConnectionError, /PKCE S256/)
+      end
+
+      it 'passes when S256 is offered' do
+        expect { oauth_provider.send(:verify_pkce_support!, metadata(['S256'])) }.not_to raise_error
+      end
+
+      it 'warns but proceeds when not advertised' do
+        expect(logger).to receive(:warn).with(/omits code_challenge_methods_supported/)
+        oauth_provider.send(:verify_pkce_support!, metadata(nil))
+      end
+    end
+
+    describe '#enforce_https!' do
+      it 'rejects a non-localhost http endpoint' do
+        expect { oauth_provider.send(:enforce_https!, 'http://evil.com/token', 'token endpoint') }
+          .to raise_error(MCPClient::Errors::ConnectionError, /must use HTTPS/)
+      end
+
+      it 'allows https endpoints' do
+        expect { oauth_provider.send(:enforce_https!, 'https://auth.example.com/token', 'token endpoint') }
+          .not_to raise_error
+      end
+
+      it 'allows http on localhost for local development' do
+        expect { oauth_provider.send(:enforce_https!, 'http://localhost:9292/token', 'token endpoint') }
+          .not_to raise_error
+      end
+
+      it 'allows http on an IPv6 loopback endpoint' do
+        expect { oauth_provider.send(:enforce_https!, 'http://[::1]:9292/token', 'token endpoint') }
+          .not_to raise_error
+      end
+
+      it 'rejects a non-http scheme even on a loopback host' do
+        expect { oauth_provider.send(:enforce_https!, 'ftp://localhost/token', 'token endpoint') }
+          .to raise_error(MCPClient::Errors::ConnectionError, /must use HTTPS/)
+      end
+    end
+
+    describe '#validate_resource_matches!' do
+      def resource_metadata(resource)
+        MCPClient::Auth::ResourceMetadata.new(resource: resource, authorization_servers: ['https://auth.example.com'])
+      end
+
+      it 'accepts an exact canonical resource match' do
+        expect { oauth_provider.send(:validate_resource_matches!, resource_metadata('https://mcp.example.com')) }
+          .not_to raise_error
+      end
+
+      it 'ignores a trailing slash on an exact match' do
+        expect { oauth_provider.send(:validate_resource_matches!, resource_metadata('https://mcp.example.com/')) }
+          .not_to raise_error
+      end
+
+      it 'treats the query as part of the resource identity' do
+        q_provider = described_class.new(server_url: 'https://mcp.example.com/mcp?serverId=a', logger: logger)
+        expect do
+          q_provider.send(:validate_resource_matches!, resource_metadata('https://mcp.example.com/mcp?serverId=b'))
+        end.to raise_error(MCPClient::Errors::ConnectionError, /does not match/)
+      end
+
+      it 'rejects a different resource host (confused deputy protection)' do
+        expect { oauth_provider.send(:validate_resource_matches!, resource_metadata('https://other.com')) }
+          .to raise_error(MCPClient::Errors::ConnectionError, /does not match/)
+      end
+
+      it 'rejects a same-host but different-path resource (multi-tenant safety)' do
+        tenant_provider = described_class.new(server_url: 'https://api.example.com/tenant-b/mcp', logger: logger)
+        expect do
+          tenant_provider.send(:validate_resource_matches!, resource_metadata('https://api.example.com/tenant-a/mcp'))
+        end.to raise_error(MCPClient::Errors::ConnectionError, /does not match/)
+      end
+
+      it 'rejects protected resource metadata that omits the required resource identifier' do
+        expect { oauth_provider.send(:validate_resource_matches!, resource_metadata(nil)) }
+          .to raise_error(MCPClient::Errors::ConnectionError, /missing the required "resource"/)
+      end
+
+      it 'raises a ConnectionError (not NoMethodError) for a non-absolute resource value' do
+        expect { oauth_provider.send(:validate_resource_matches!, resource_metadata('mcp.example.com')) }
+          .to raise_error(MCPClient::Errors::ConnectionError, /must be absolute/)
+      end
+    end
+
+    describe '#fetch_resource_metadata (404 handling)' do
+      let(:http_client) { instance_double('Faraday::Connection') }
+
+      before { oauth_provider.instance_variable_set(:@http_client, http_client) }
+
+      def response(status, body = '{}')
+        instance_double('Faraday::Response', status: status, success?: (200..299).cover?(status), body: body)
+      end
+
+      it 'returns nil for a speculative well-known 404 (non-strict)' do
+        allow(http_client).to receive(:get).and_return(response(404))
+        expect(oauth_provider.send(:fetch_resource_metadata, 'https://x.example.com/meta')).to be_nil
+      end
+
+      it 'raises for a 404 on an explicitly-advertised challenge URL (strict)' do
+        allow(http_client).to receive(:get).and_return(response(404))
+        expect { oauth_provider.send(:fetch_resource_metadata, 'https://x.example.com/meta', strict: true) }
+          .to raise_error(MCPClient::Errors::ConnectionError, /HTTP 404/)
+      end
+    end
+
+    describe '#discover_authorization_server (PRM-first)' do
+      let(:storage_instance) { MCPClient::Auth::OAuthProvider::MemoryStorage.new }
+      let(:provider) do
+        described_class.new(server_url: 'https://mcp.example.com/mcp', logger: logger, storage: storage_instance)
+      end
+      let(:resource_meta) do
+        MCPClient::Auth::ResourceMetadata.new(
+          resource: 'https://mcp.example.com/mcp', authorization_servers: ['https://auth.example.com']
+        )
+      end
+
+      def server_meta(methods)
+        MCPClient::Auth::ServerMetadata.new(
+          issuer: 'https://auth.example.com',
+          authorization_endpoint: 'https://auth.example.com/authorize',
+          token_endpoint: 'https://auth.example.com/token',
+          code_challenge_methods_supported: methods
+        )
+      end
+
+      it 'follows PRM to the authorization server, verifies S256, and caches' do
+        allow(provider).to receive(:fetch_resource_metadata).and_return(resource_meta)
+        allow(provider).to receive(:fetch_server_metadata).and_return(server_meta(['S256']))
+
+        result = provider.send(:discover_authorization_server)
+        expect(result.token_endpoint).to eq('https://auth.example.com/token')
+        expect(storage_instance.get_server_metadata('https://mcp.example.com/mcp')).not_to be_nil
+      end
+
+      it 'refuses an authorization server that does not support PKCE S256' do
+        allow(provider).to receive(:fetch_resource_metadata).and_return(resource_meta)
+        allow(provider).to receive(:fetch_server_metadata).and_return(server_meta(['plain']))
+
+        expect { provider.send(:discover_authorization_server) }
+          .to raise_error(MCPClient::Errors::ConnectionError, /PKCE S256/)
+      end
+
+      it 'falls back to direct AS discovery when no PRM document exists (404)' do
+        # fetch_resource_metadata returns nil for a genuine 404 (absent candidate)
+        allow(provider).to receive(:fetch_resource_metadata).and_return(nil)
+        allow(provider).to receive(:fetch_server_metadata).and_return(server_meta(['S256']))
+
+        result = provider.send(:discover_authorization_server)
+        expect(result.token_endpoint).to eq('https://auth.example.com/token')
+      end
+
+      it 'hard-fails (no fallback) when a PRM candidate exists but is malformed or errors' do
+        # A non-404 failure (malformed JSON / 5xx) at a PRM URL must not fall
+        # through to root PRM or direct-AS discovery.
+        allow(provider).to receive(:fetch_resource_metadata)
+          .and_raise(MCPClient::Errors::ConnectionError, 'Invalid resource metadata JSON')
+        # If a fallback were (wrongly) taken, this would let discovery succeed:
+        allow(provider).to receive(:fetch_server_metadata).and_return(server_meta(['S256']))
+
+        expect { provider.send(:discover_authorization_server) }
+          .to raise_error(MCPClient::Errors::ConnectionError, /Invalid resource metadata JSON/)
+      end
+
+      it 'hard-fails (no origin fallback) when PRM is found but its advertised AS is unreachable' do
+        allow(provider).to receive(:fetch_resource_metadata).and_return(resource_meta)
+        # The AS advertised by the authoritative PRM cannot be loaded
+        allow(provider).to receive(:fetch_server_metadata)
+          .and_raise(MCPClient::Errors::ConnectionError, 'HTTP 500')
+
+        expect { provider.send(:discover_authorization_server) }
+          .to raise_error(MCPClient::Errors::ConnectionError, /could not be discovered/)
+      end
+
+      it 'validates a cached metadata entry (rejects a cached AS lacking S256)' do
+        storage_instance.set_server_metadata('https://mcp.example.com/mcp', server_meta(['plain']))
+
+        expect { provider.send(:discover_authorization_server) }
+          .to raise_error(MCPClient::Errors::ConnectionError, /PKCE S256/)
+      end
+
+      it 'reuses protected resource metadata learned from a 401 challenge' do
+        provider.instance_variable_set(:@challenge_resource_metadata, resource_meta)
+        # No PRM well-known fetch should be needed; only the AS lookup runs
+        expect(provider).not_to receive(:fetch_resource_metadata)
+        allow(provider).to receive(:fetch_server_metadata).and_return(server_meta(['S256']))
+
+        result = provider.send(:discover_authorization_server)
+        expect(result.token_endpoint).to eq('https://auth.example.com/token')
+      end
+
+      it 'lets a 401 challenge override stale cached AS metadata' do
+        # A previously direct-discovered AS is cached...
+        stale = MCPClient::Auth::ServerMetadata.new(
+          issuer: 'https://stale.example.com',
+          authorization_endpoint: 'https://stale.example.com/authorize',
+          token_endpoint: 'https://stale.example.com/token',
+          code_challenge_methods_supported: ['S256']
+        )
+        storage_instance.set_server_metadata('https://mcp.example.com/mcp', stale)
+
+        # ...but a fresh 401 challenge points at the authoritative PRM/AS
+        provider.instance_variable_set(:@challenge_resource_metadata, resource_meta)
+        allow(provider).to receive(:fetch_server_metadata).and_return(server_meta(['S256']))
+
+        result = provider.send(:discover_authorization_server)
+        expect(result.token_endpoint).to eq('https://auth.example.com/token')
+      end
+
+      it 'discards a cached client registered with the previous AS when the AS changes' do
+        stale = MCPClient::Auth::ServerMetadata.new(
+          issuer: 'https://stale.example.com',
+          authorization_endpoint: 'https://stale.example.com/authorize',
+          token_endpoint: 'https://stale.example.com/token',
+          code_challenge_methods_supported: ['S256']
+        )
+        storage_instance.set_server_metadata('https://mcp.example.com/mcp', stale)
+        storage_instance.set_client_info('https://mcp.example.com/mcp', double('old-client'))
+
+        provider.instance_variable_set(:@challenge_resource_metadata, resource_meta)
+        allow(provider).to receive(:fetch_server_metadata).and_return(server_meta(['S256']))
+
+        provider.send(:discover_authorization_server)
+        expect(storage_instance.get_client_info('https://mcp.example.com/mcp')).to be_nil
+      end
+
+      it 'does not persist AS metadata that fails validation' do
+        allow(provider).to receive(:fetch_resource_metadata).and_return(resource_meta)
+        allow(provider).to receive(:fetch_server_metadata).and_return(server_meta(['plain']))
+
+        expect { provider.send(:discover_authorization_server) }
+          .to raise_error(MCPClient::Errors::ConnectionError, /PKCE S256/)
+        expect(storage_instance.get_server_metadata('https://mcp.example.com/mcp')).to be_nil
+      end
+
+      it 'resets memoized supported_scopes when the AS changes' do
+        stale = MCPClient::Auth::ServerMetadata.new(
+          issuer: 'https://stale.example.com', authorization_endpoint: 'https://stale.example.com/authorize',
+          token_endpoint: 'https://stale.example.com/token', code_challenge_methods_supported: ['S256']
+        )
+        storage_instance.set_server_metadata('https://mcp.example.com/mcp', stale)
+        provider.instance_variable_set(:@supported_scopes, ['old:scope'])
+        provider.instance_variable_set(:@challenge_resource_metadata, resource_meta)
+        allow(provider).to receive(:fetch_server_metadata).and_return(server_meta(['S256']))
+
+        provider.send(:discover_authorization_server)
+        expect(provider.instance_variable_get(:@supported_scopes)).to be_nil
+      end
+
+      it 'clears client info via set_client_info(nil) for storage without delete_client_info' do
+        # A minimal custom storage that intentionally does NOT implement
+        # delete_client_info (only the documented get/set interface).
+        storage_class = Class.new do
+          def initialize(stale)
+            @server_metadata = stale
+            @client_info = :registered_with_old_as
+          end
+
+          def get_server_metadata(_url) = @server_metadata
+          def set_server_metadata(_url, meta) = (@server_metadata = meta)
+          def get_client_info(_url) = @client_info
+          def set_client_info(_url, info) = (@client_info = info)
+          # deliberately no delete_client_info
+        end
+
+        stale = MCPClient::Auth::ServerMetadata.new(
+          issuer: 'https://stale.example.com', authorization_endpoint: 'https://stale.example.com/authorize',
+          token_endpoint: 'https://stale.example.com/token', code_challenge_methods_supported: ['S256']
+        )
+        custom_storage = storage_class.new(stale)
+        custom_provider = described_class.new(
+          server_url: 'https://mcp.example.com/mcp', logger: logger, storage: custom_storage
+        )
+        custom_provider.instance_variable_set(:@challenge_resource_metadata, resource_meta)
+        allow(custom_provider).to receive(:fetch_server_metadata).and_return(server_meta(['S256']))
+
+        custom_provider.send(:discover_authorization_server)
+        expect(custom_storage.get_client_info(nil)).to be_nil
+      end
+    end
+  end
+
   describe '#access_token' do
     context 'when no token is stored' do
       before do


### PR DESCRIPTION
## Problem

OAuth discovery deviated from the [MCP 2025-11-25 authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) and its RFCs:

- **WWW-Authenticate** was parsed for the nonstandard `resource=` parameter instead of RFC 9728's `resource_metadata`.
- **Protected Resource Metadata** discovery dropped the URL path and probed only the origin, and PRM was a *fallback* rather than authoritative.
- **Authorization Server Metadata** discovery appended the well-known suffix after the issuer path (instead of RFC 8414 §3.1 path-insertion), tried a single candidate, and had no OpenID Connect Discovery fallback.
- No PKCE-support check, no HTTPS enforcement, no confused-deputy validation of the PRM `resource`.

## Fix (all backward compatible — public `OAuthProvider` API unchanged)

- **RFC 9728 WWW-Authenticate**: parse `resource_metadata` (quoted + unquoted, whitespace-tolerant); keep legacy `resource=` as a fallback. Metadata learned from a 401 challenge is reused by discovery (and overrides a stale cache).
- **PRM is authoritative & path-aware (RFC 9728 §3.1)**: insert the well-known segment before the path, then a root fallback. A genuinely-absent candidate (404) is skipped, but a *malformed/erroring* PRM is a hard failure (no silent fallback to a different AS). A challenge-advertised URL is fetched strictly (404 raises). PRM without a `resource` is rejected.
- **AS metadata (RFC 8414 §3.1 + OIDC)**: path-insertion (not append), plus `openid-configuration`, tried in priority order.
- **PKCE**: verify `code_challenge_methods_supported` — refuse when S256 is explicitly absent; warn (and proceed with S256) when the field is omitted.
- **HTTPS enforced** on authorization/token/registration endpoints (plain-`http` loopback exception for local dev only).
- **Confused-deputy protection**: the PRM `resource` must be an **exact canonical match** (scheme/host/port/path/query; fragment ignored) of the server URL — a same-host different-tenant PRM is rejected.
- **Cache hygiene**: cached AS metadata is validated before use; validation failures are never persisted; when a challenge changes the AS, the stale `client_info` (and memoized scopes) are discarded so re-registration targets the new AS. The RFC 8707 `resource` parameter was already sent in both requests and is unchanged.

## Follow-up (out of scope)

The default HTTP transport does not install Faraday `raise_error`, so `handle_unauthorized_response` (the RFC 9728 challenge parser) is only reached on the `handle_auth_error` path — a **pre-existing** wiring limitation, not introduced here. Routing a normal 401 through the challenge parser is a transport concern best handled separately.

## Tests

61 OAuth examples covering path-aware PRM/AS URLs, `resource_metadata` parsing (+ legacy/whitespace), PKCE refusal/warn, HTTPS + non-http-loopback enforcement, exact resource-identity matching (incl. multi-tenant + query), PRM-first discovery with direct-AS fallback, malformed-PRM hard-fail, strict-vs-speculative 404, and cache invalidation on AS change (incl. custom storage). Full suite: `1283 examples, 0 failures`; RuboCop clean. OAUTH.md updated. Reviewed with `codex review` across ~10 passes; all actionable findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)