### PR TITLE
feat(tasks)!: conform Tasks API to MCP 2025-11-25 (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- **Tasks API rewritten to conform to MCP 2025-11-25.** The previous implementation
+  targeted a `tasks/create` method that does not exist in the specification.
+  - Removed `Client#create_task`. To create a task, augment a `tools/call` via the new
+    `Client#call_tool_as_task(name, arguments, ttl:)`, which returns a `MCPClient::Task`.
+  - `MCPClient::Task` fields renamed and reduced to the spec set: `id`→`task_id`,
+    `state`→`status`; added `status_message`, `created_at`, `last_updated_at`, `ttl`,
+    `poll_interval`; removed `progress`, `total`, `message`, `result`, `progress_token`,
+    and `progress_percentage`. Statuses are now `working`, `input_required`,
+    `completed`, `failed`, `cancelled` (was `pending`/`running`/…).
+  - `Client#get_task` and `Client#cancel_task` now send the `taskId` parameter (was `id`)
+    and return a `Task` with the new field set.
+
+### New Features
+
+- `Client#call_tool_as_task` — create a task by augmenting `tools/call` (gated on the
+  server's `tasks.requests.tools.call` capability and the tool's `execution.taskSupport`).
+- `Client#get_task_result` (`tasks/result`) — retrieve the underlying task result.
+- `Client#list_tasks` (`tasks/list`, paginated).
+- Tool-level task negotiation: `Tool#task_support`, `#supports_task?`, `#task_required?`,
+  `#task_optional?`, `#task_forbidden?` (parsed from `execution.taskSupport`).
+- The client handles `notifications/tasks/status` server notifications. (It does not
+  declare a client `tasks` capability: that marks a task *receiver* for
+  sampling/elicitation, which is not implemented — the client is a task requestor for
+  `tools/call` only.)
+
 ## 1.0.1 (2026-03-22)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Implements **MCP 2025-11-25** specification:
 - **Sampling**: Server-requested LLM completions with modelPreferences
 - **Completion**: Autocomplete for prompts/resources with context
 - **Logging**: Server log messages with level filtering
-- **Tasks**: Structured task management with progress tracking
+- **Tasks**: Task-augmented `tools/call` — create with a `ttl`, poll `tasks/get`, retrieve via `tasks/result`, plus `tasks/list` and `tasks/cancel`
 - **Audio**: Audio content type support
 - **OAuth 2.1**: PKCE, server discovery, dynamic registration
 
@@ -197,6 +197,39 @@ client.on_notification do |server, method, params|
   if method == 'notifications/message'
     puts "[#{params['level']}] #{params['logger']}: #{params['data']}"
   end
+end
+```
+
+### Tasks (Long-running, task-augmented tools)
+
+A task-capable server (one advertising `tasks.requests.tools.call`) can run a tool
+whose `execution.taskSupport` is `optional` or `required` as a background task:
+the call returns immediately with a task handle, and the result is fetched later.
+
+```ruby
+tool = client.find_tool('long_job')
+tool.supports_task?   # execution.taskSupport is optional/required?
+
+# Create the task (returns immediately); ttl is the requested lifetime in ms
+task = client.call_tool_as_task('long_job', { input: 'data' }, ttl: 60_000)
+
+# Poll until the task reaches a terminal (or input-required) status,
+# honoring the server's suggested poll interval
+until task.terminal? || task.input_required?
+  sleep((task.poll_interval || 1000) / 1000.0)
+  task = client.get_task(task.task_id)   # tasks/get
+end
+
+# Retrieve the underlying result (e.g. a CallToolResult) via tasks/result
+result = client.get_task_result(task.task_id)
+
+# List and cancel tasks
+page = client.list_tasks               # { tasks: [...], next_cursor: ... }
+client.cancel_task(task.task_id)       # tasks/cancel
+
+# React to server-pushed status updates
+client.on_notification do |server, method, params|
+  puts "Task #{params['taskId']} -> #{params['status']}" if method == 'notifications/tasks/status'
 end
 ```
 

--- a/examples/mcp_2025_11_25_server.py
+++ b/examples/mcp_2025_11_25_server.py
@@ -8,7 +8,7 @@ A Python MCP server demonstrating ALL new MCP 2025-11-25 features:
 - Tool annotations (readOnlyHint, destructiveHint, idempotentHint, openWorldHint)
 - Completion with context parameter
 - ResourceLink in tool results
-- Task management (tasks/create, tasks/get, tasks/cancel)
+- Task-augmented tools/call (tasks/get, tasks/result, tasks/list, tasks/cancel)
 
 Transport: stdio (JSON-RPC over stdin/stdout)
 No external dependencies required (Python 3.7+ stdlib only).
@@ -26,6 +26,7 @@ import time
 import threading
 import uuid
 import math
+from datetime import datetime, timezone
 
 
 # ---------------------------------------------------------------------------
@@ -102,17 +103,26 @@ tasks = {}          # id -> task dict
 tasks_lock = threading.Lock()
 
 
-def create_task_record(task_id, method, params, progress_token=None):
+def _now_iso():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def create_task_record(task_id, tool_name, arguments, ttl=None):
+    """Create a task record in the MCP 2025-11-25 shape."""
+    now = _now_iso()
     task = {
-        "id": task_id,
-        "state": "pending",
-        "method": method,
-        "params": params,
-        "progressToken": progress_token,
-        "progress": None,
-        "total": None,
-        "message": "Task created",
-        "result": None,
+        # Spec Task fields
+        "taskId": task_id,
+        "status": "working",
+        "statusMessage": "Task created",
+        "createdAt": now,
+        "lastUpdatedAt": now,
+        "ttl": ttl,
+        "pollInterval": 500,
+        # Internal bookkeeping (not sent to the client)
+        "_tool_name": tool_name,
+        "_arguments": arguments,
+        "_result": None,
     }
     with tasks_lock:
         tasks[task_id] = task
@@ -120,57 +130,55 @@ def create_task_record(task_id, method, params, progress_token=None):
 
 
 def task_to_response(task):
-    """Return the public-facing task fields."""
-    result = {"id": task["id"], "state": task["state"]}
-    if task.get("progressToken"):
-        result["progressToken"] = task["progressToken"]
-    if task.get("progress") is not None:
-        result["progress"] = task["progress"]
-    if task.get("total") is not None:
-        result["total"] = task["total"]
-    if task.get("message"):
-        result["message"] = task["message"]
-    if task.get("result") is not None:
-        result["result"] = task["result"]
-    return result
+    """Return the flat, spec-shaped Task fields (GetTaskResult / CancelTaskResult)."""
+    response = {
+        "taskId": task["taskId"],
+        "status": task["status"],
+        "createdAt": task["createdAt"],
+        "lastUpdatedAt": task["lastUpdatedAt"],
+        "ttl": task.get("ttl"),
+    }
+    if task.get("statusMessage"):
+        response["statusMessage"] = task["statusMessage"]
+    if task.get("pollInterval") is not None:
+        response["pollInterval"] = task["pollInterval"]
+    return response
+
+
+def send_task_status(task):
+    """Emit a notifications/tasks/status (params are a flat Task)."""
+    send_notification("notifications/tasks/status", task_to_response(task))
 
 
 def run_task_in_background(task_id):
-    """Simulate long-running work for a task."""
-    # Brief delay so the create response is sent while task is still "pending"
-    time.sleep(0.1)
-    with tasks_lock:
-        task = tasks.get(task_id)
-        if not task:
-            return
-        task["state"] = "running"
-        task["total"] = 5
-        task["progress"] = 0
-        task["message"] = "Starting work..."
+    """Simulate long-running work for a task, then store its CallToolResult."""
+    time.sleep(0.1)  # let the CreateTaskResult response go out first
 
-    for step in range(1, 6):
+    for _ in range(5):
         time.sleep(0.3)
         with tasks_lock:
             task = tasks.get(task_id)
-            if not task or task["state"] == "cancelled":
+            if not task or task["status"] == "cancelled":
                 return
-            task["progress"] = step
-            task["message"] = f"Step {step} of 5"
-
-        # Send progress notification if we have a token
-        if task.get("progressToken"):
-            send_notification("notifications/progress", {
-                "progressToken": task["progressToken"],
-                "progress": step,
-                "total": 5,
-            })
+            task["lastUpdatedAt"] = _now_iso()
 
     with tasks_lock:
         task = tasks.get(task_id)
-        if task and task["state"] != "cancelled":
-            task["state"] = "completed"
-            task["message"] = "All steps done"
-            task["result"] = {"summary": "Background task finished successfully"}
+        if not task or task["status"] == "cancelled":
+            return
+        task["status"] = "completed"
+        task["statusMessage"] = "All steps done"
+        task["lastUpdatedAt"] = _now_iso()
+        # tasks/result returns exactly what tools/call would have returned
+        task["_result"] = {
+            "content": [
+                {"type": "text", "text": "Background task finished successfully"},
+            ],
+            "isError": False,
+        }
+        completed = dict(task)
+
+    send_task_status(completed)
 
 
 # ---------------------------------------------------------------------------
@@ -196,7 +204,11 @@ def handle_initialize(request_id, _params):
             "tools": {},
             "resources": {"listChanged": True},
             "completions": {},
-            "tasks": {},
+            "tasks": {
+                "list": {},
+                "cancel": {},
+                "requests": {"tools": {"call": {}}},
+            },
         },
         "serverInfo": {
             "name": "MCP 2025-11-25 Feature Demo",
@@ -313,6 +325,15 @@ def handle_tools_list(request_id, _params):
                 "openWorldHint": False,
             },
         },
+        {
+            "name": "background_work",
+            "description": "A long-running job — call it as a task (execution.taskSupport: optional)",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"input": {"type": "string", "description": "Job input"}},
+            },
+            "execution": {"taskSupport": "optional"},
+        },
     ]
     return make_result(request_id, {"tools": tools})
 
@@ -320,6 +341,22 @@ def handle_tools_list(request_id, _params):
 def handle_tools_call(request_id, params):
     tool_name = params.get("name")
     args = params.get("arguments", {})
+
+    # Task-augmented request: create a task and return a CreateTaskResult now;
+    # the actual result is retrieved later via tasks/result.
+    task_aug = params.get("task")
+    if task_aug is not None and tool_name == "background_work":
+        task_id = str(uuid.uuid4())
+        ttl = task_aug.get("ttl") if isinstance(task_aug, dict) else None
+        task = create_task_record(task_id, tool_name, args, ttl=ttl)
+        threading.Thread(target=run_task_in_background, args=(task_id,), daemon=True).start()
+        return make_result(request_id, {"task": task_to_response(task)})
+
+    if tool_name == "background_work":
+        # Synchronous fallback when not called as a task
+        return make_result(request_id, {
+            "content": [{"type": "text", "text": "Background task finished successfully"}],
+        })
 
     if tool_name == "get_audio":
         frequency = args.get("frequency", 440)
@@ -528,25 +565,8 @@ def handle_completion(request_id, params):
     })
 
 
-def handle_tasks_create(request_id, params):
-    task_id = str(uuid.uuid4())
-    method = params.get("method", "unknown")
-    task_params = params.get("params", {})
-    progress_token = params.get("progressToken")
-
-    task = create_task_record(task_id, method, task_params, progress_token)
-    # Snapshot response while still in "pending" state
-    response = make_result(request_id, task_to_response(task))
-
-    # Start background work (will transition to "running" after a brief delay)
-    thread = threading.Thread(target=run_task_in_background, args=(task_id,), daemon=True)
-    thread.start()
-
-    return response
-
-
 def handle_tasks_get(request_id, params):
-    task_id = params.get("id", "")
+    task_id = params.get("taskId", "")
     with tasks_lock:
         task = tasks.get(task_id)
     if not task:
@@ -554,17 +574,39 @@ def handle_tasks_get(request_id, params):
     return make_result(request_id, task_to_response(task))
 
 
-def handle_tasks_cancel(request_id, params):
-    task_id = params.get("id", "")
+def handle_tasks_result(request_id, params):
+    task_id = params.get("taskId", "")
     with tasks_lock:
         task = tasks.get(task_id)
         if not task:
             return make_error(request_id, -32602, f"Task not found: {task_id}")
-        if task["state"] in ("completed", "failed", "cancelled"):
+        if task["status"] != "completed":
             return make_error(request_id, -32602,
-                              f"Cannot cancel task in state '{task['state']}'")
-        task["state"] = "cancelled"
-        task["message"] = "Cancelled by client"
+                              f"Task '{task_id}' is not complete (status: {task['status']})")
+        result = dict(task["_result"] or {})
+    # tasks/result MUST carry the related-task metadata
+    result.setdefault("_meta", {})["io.modelcontextprotocol/related-task"] = {"taskId": task_id}
+    return make_result(request_id, result)
+
+
+def handle_tasks_list(request_id, _params):
+    with tasks_lock:
+        task_list = [task_to_response(t) for t in tasks.values()]
+    return make_result(request_id, {"tasks": task_list})
+
+
+def handle_tasks_cancel(request_id, params):
+    task_id = params.get("taskId", "")
+    with tasks_lock:
+        task = tasks.get(task_id)
+        if not task:
+            return make_error(request_id, -32602, f"Task not found: {task_id}")
+        if task["status"] in ("completed", "failed", "cancelled"):
+            return make_error(request_id, -32602,
+                              f"Cannot cancel task in terminal status '{task['status']}'")
+        task["status"] = "cancelled"
+        task["statusMessage"] = "Cancelled by client"
+        task["lastUpdatedAt"] = _now_iso()
     return make_result(request_id, task_to_response(task))
 
 
@@ -580,8 +622,9 @@ HANDLERS = {
     "resources/list": handle_resources_list,
     "resources/read": handle_resources_read,
     "completion/complete": handle_completion,
-    "tasks/create": handle_tasks_create,
     "tasks/get": handle_tasks_get,
+    "tasks/result": handle_tasks_result,
+    "tasks/list": handle_tasks_list,
     "tasks/cancel": handle_tasks_cancel,
     "ping": lambda rid, _p: make_result(rid, {}),
 }

--- a/examples/tasks_example.rb
+++ b/examples/tasks_example.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Example: task-augmented tools/call (MCP 2025-11-25 Tasks utility).
+#
+# A "task-capable" server advertises the tasks.requests.tools.call capability,
+# and a long-running tool declares execution.taskSupport of "optional" or
+# "required". Calling such a tool as a task returns immediately with a task
+# handle; the actual result is fetched later once the task is terminal.
+#
+# Run against a task-capable server, e.g.:
+#   MCP_SERVER_URL='https://example.com/mcp' \
+#   MCP_BEARER_TOKEN='your_token' ./examples/tasks_example.rb long_job
+
+require 'bundler/setup'
+require_relative '../lib/mcp_client'
+require 'logger'
+
+logger = Logger.new($stdout)
+logger.level = Logger::INFO
+
+server_url = ENV.fetch('MCP_SERVER_URL', 'https://example.com/mcp')
+bearer_token = ENV.fetch('MCP_BEARER_TOKEN', nil)
+tool_name = ARGV[0] || 'long_job'
+
+headers = {}
+headers['Authorization'] = "Bearer #{bearer_token}" if bearer_token
+
+client = MCPClient.create_client(
+  mcp_server_configs: [
+    MCPClient.streamable_http_config(base_url: server_url, headers: headers)
+  ],
+  logger: logger
+)
+
+# Surface server-pushed task status updates
+client.on_notification do |_server, method, params|
+  puts "  [notification] Task #{params['taskId']} -> #{params['status']}" if method == 'notifications/tasks/status'
+end
+
+begin
+  tool = client.find_tool(tool_name)
+  raise "Tool '#{tool_name}' not found on the server" unless tool
+
+  unless tool.supports_task?
+    raise "Tool '#{tool_name}' does not support task execution " \
+          "(execution.taskSupport = #{tool.task_support.inspect})"
+  end
+
+  puts "Creating a task for tool '#{tool_name}'..."
+  task = client.call_tool_as_task(tool_name, { 'input' => 'demo' }, ttl: 60_000)
+  puts "  created task #{task.task_id} (status: #{task.status})"
+
+  # Poll until the task finishes or asks for input, honoring the server's
+  # suggested poll interval (milliseconds).
+  until task.terminal? || task.input_required?
+    sleep((task.poll_interval || 1000) / 1000.0)
+    task = client.get_task(task.task_id)
+    puts "  status: #{task.status}"
+  end
+
+  if task.terminal? && task.status == 'completed'
+    result = client.get_task_result(task.task_id)
+    puts "Result: #{result.inspect}"
+  else
+    puts "Task ended in status: #{task.status}"
+  end
+
+  # List and (optionally) cancel outstanding tasks
+  page = client.list_tasks
+  puts "Server currently knows about #{page[:tasks].size} task(s)."
+rescue MCPClient::Errors::TaskError => e
+  warn "Task error: #{e.message}"
+rescue MCPClient::Errors::MCPError => e
+  warn "MCP error: #{e.message}"
+ensure
+  client.cleanup
+end

--- a/examples/test_mcp_2025_11_25.rb
+++ b/examples/test_mcp_2025_11_25.rb
@@ -289,40 +289,37 @@ begin
   puts
   puts '--- Task Management ---'
 
-  # Create a task
-  task = client.create_task('background_work', params: { input: 'test' }, progress_token: 'tok-1')
-  runner.assert('create_task returns a Task', task.is_a?(MCPClient::Task))
-  runner.assert('task has an id', !task.id.nil? && !task.id.empty?)
-  runner.assert('task initial state is pending', task.state == 'pending')
-  runner.assert('task has message', !task.message.nil?)
+  # Create a task by augmenting tools/call (background_work has taskSupport: optional)
+  task = client.call_tool_as_task('background_work', { input: 'test' }, ttl: 60_000)
+  runner.assert('call_tool_as_task returns a Task', task.is_a?(MCPClient::Task))
+  runner.assert('task has a task_id', !task.task_id.nil? && !task.task_id.empty?)
+  runner.assert('task initial status is working', task.status == 'working')
 
-  # Wait briefly then get task state (should be running or completed)
-  sleep 0.5
-  task_state = client.get_task(task.id)
-  runner.assert('get_task returns a Task', task_state.is_a?(MCPClient::Task))
-  runner.assert(
-    'task is running or completed after 0.5s',
-    %w[running completed].include?(task_state.state),
-    "state: #{task_state.state}"
-  )
+  # Poll until the task reaches a terminal status, honoring poll_interval
+  final = task
+  20.times do
+    break if final.terminal?
 
-  # Wait for completion
-  sleep 2.5
-  final_state = client.get_task(task.id)
-  runner.assert('task is completed after waiting', final_state.state == 'completed')
-  runner.assert('completed task has result', !final_state.result.nil?) if final_state.state == 'completed'
+    sleep((final.poll_interval || 500) / 1000.0)
+    final = client.get_task(task.task_id)
+  end
+  runner.assert('get_task returns a Task', final.is_a?(MCPClient::Task))
+  runner.assert('task is completed after waiting', final.status == 'completed', "status: #{final.status}")
+
+  # Retrieve the underlying result via tasks/result
+  if final.status == 'completed'
+    result = client.get_task_result(task.task_id)
+    runner.assert('get_task_result returns the underlying content', result['content'].is_a?(Array))
+  end
+
+  # tasks/list returns the tasks
+  listing = client.list_tasks
+  runner.assert('list_tasks returns tasks', listing[:tasks].any? { |t| t.task_id == task.task_id })
 
   # Create another task and cancel it quickly
-  cancel_task = client.create_task('cancel_test', params: {})
-  runner.assert('cancel test task created', cancel_task.is_a?(MCPClient::Task))
-
-  cancelled = client.cancel_task(cancel_task.id)
-  runner.assert('cancel_task returns a Task', cancelled.is_a?(MCPClient::Task))
-  runner.assert('cancelled task state is cancelled', cancelled.state == 'cancelled')
-
-  # Verify get on cancelled task
-  cancelled_get = client.get_task(cancel_task.id)
-  runner.assert('get_task on cancelled task returns cancelled', cancelled_get.state == 'cancelled')
+  cancel_target = client.call_tool_as_task('background_work', {})
+  cancelled = client.cancel_task(cancel_target.task_id)
+  runner.assert('cancel_task returns a cancelled Task', cancelled.status == 'cancelled')
 
   # Task error handling: get non-existent task
   begin

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -281,6 +281,7 @@ module MCPClient
 
       # Validate parameters against tool schema
       validate_params!(tool, parameters)
+      reject_task_required!(tool, tool_name)
 
       # Use the tool's associated server
       server = tool.server
@@ -426,6 +427,7 @@ module MCPClient
 
       # Validate parameters against tool schema
       validate_params!(tool, parameters)
+      reject_task_required!(tool, tool_name)
 
       # Use the tool's associated server
       server = tool.server
@@ -497,32 +499,59 @@ module MCPClient
       srv.complete(ref: ref, argument: argument, context: context)
     end
 
-    # Create a new task on a server (MCP 2025-11-25)
-    # Tasks represent long-running operations that can report progress
-    # @param method [String] the method to execute as a task
-    # @param params [Hash] parameters for the task method
-    # @param progress_token [String, nil] optional token for receiving progress notifications
-    # @param server [Integer, String, Symbol, MCPClient::ServerBase, nil] server selector
-    # @return [MCPClient::Task] the created task
-    # @raise [MCPClient::Errors::ServerNotFound] if no server is available
-    # @raise [MCPClient::Errors::TaskError] if task creation fails
-    def create_task(method, params: {}, progress_token: nil, server: nil)
-      srv = select_server(server)
-      rpc_params = { method: method, params: params }
-      rpc_params[:progressToken] = progress_token if progress_token
+    # Call a tool as a task (task-augmented tools/call, MCP 2025-11-25).
+    #
+    # Instead of blocking for the result, the server accepts the request and
+    # immediately returns a task handle; the actual result is retrieved later
+    # via {#get_task_result} once the task reaches a terminal status. The server
+    # must advertise the tasks.requests.tools.call capability, and the tool must
+    # declare execution.taskSupport of 'optional' or 'required'.
+    # @param tool_name [String] the name of the tool to call
+    # @param parameters [Hash] the parameters to pass to the tool
+    # @param ttl [Integer, nil] optional requested task lifetime in milliseconds
+    # @param server [String, Symbol, Integer, MCPClient::ServerBase, nil] optional server to use
+    # @return [MCPClient::Task] the created task (status typically 'working')
+    # @raise [MCPClient::Errors::ToolNotFound] if the tool is not found
+    # @raise [MCPClient::Errors::ValidationError] if required parameters are missing
+    # @raise [MCPClient::Errors::TaskError] if the server or tool does not support tasks, or creation fails
+    def call_tool_as_task(tool_name, parameters, ttl: nil, server: nil)
+      tool = resolve_tool(tool_name, server: server)
+      validate_params!(tool, parameters)
+
+      srv = tool.server
+      raise MCPClient::Errors::ServerNotFound, "No server found for tool '#{tool_name}'" unless srv
+
+      unless server_supports_task_tool_call?(srv)
+        raise MCPClient::Errors::TaskError,
+              'Server does not support task-augmented tools/call (no tasks.requests.tools.call capability)'
+      end
+      unless tool.supports_task?
+        raise MCPClient::Errors::TaskError,
+              "Tool '#{tool_name}' does not support task execution (execution.taskSupport is forbidden/unset)"
+      end
+
+      task_params = {}
+      task_params[:ttl] = ttl if ttl
+      # Keep _meta (string or symbol key) as a top-level request field rather
+      # than a tool argument, so request metadata is preserved and does not fail
+      # tool input-schema validation.
+      meta_key = [:_meta, '_meta'].find { |k| parameters.key?(k) }
+      arguments = meta_key ? parameters.reject { |k, _| k == meta_key } : parameters
+      rpc_params = { name: tool_name, arguments: arguments, task: task_params }
+      rpc_params[:_meta] = parameters[meta_key] if meta_key
 
       begin
-        result = srv.rpc_request('tasks/create', rpc_params)
-        MCPClient::Task.from_json(result, server: srv)
+        result = srv.rpc_request('tools/call', rpc_params)
+        MCPClient::Task.from_create_result(result, server: srv)
       rescue MCPClient::Errors::ServerError, MCPClient::Errors::TransportError, MCPClient::Errors::ConnectionError => e
-        raise MCPClient::Errors::TaskError, "Error creating task: #{e.message}"
+        raise MCPClient::Errors::TaskError, "Error creating task for tool '#{tool_name}': #{e.message}"
       end
     end
 
-    # Get the current state of a task (MCP 2025-11-25)
+    # Get the current state of a task (tasks/get, MCP 2025-11-25)
     # @param task_id [String] the ID of the task to query
     # @param server [Integer, String, Symbol, MCPClient::ServerBase, nil] server selector
-    # @return [MCPClient::Task] the task with current state
+    # @return [MCPClient::Task] the task with current status
     # @raise [MCPClient::Errors::ServerNotFound] if no server is available
     # @raise [MCPClient::Errors::TaskNotFound] if the task does not exist
     # @raise [MCPClient::Errors::TaskError] if retrieving the task fails
@@ -530,38 +559,75 @@ module MCPClient
       srv = select_server(server)
 
       begin
-        result = srv.rpc_request('tasks/get', { id: task_id })
+        result = srv.rpc_request('tasks/get', { taskId: task_id })
         MCPClient::Task.from_json(result, server: srv)
       rescue MCPClient::Errors::ServerError => e
-        if e.message.include?('not found') || e.message.include?('unknown task')
-          raise MCPClient::Errors::TaskNotFound, "Task '#{task_id}' not found"
-        end
-
-        raise MCPClient::Errors::TaskError, "Error getting task '#{task_id}': #{e.message}"
+        raise task_error_from(e, task_id, 'getting')
       rescue MCPClient::Errors::TransportError, MCPClient::Errors::ConnectionError => e
         raise MCPClient::Errors::TaskError, "Error getting task '#{task_id}': #{e.message}"
       end
     end
 
-    # Cancel a running task (MCP 2025-11-25)
+    # Retrieve the result of a completed task (tasks/result, MCP 2025-11-25).
+    # Returns exactly what the underlying request would have returned (e.g. a
+    # CallToolResult hash with 'content'/'isError'/'structuredContent'); it is
+    # NOT wrapped in a Task. Blocks on the server until the task is terminal.
+    # @param task_id [String] the ID of the task
+    # @param server [Integer, String, Symbol, MCPClient::ServerBase, nil] server selector
+    # @return [Object] the underlying task result
+    # @raise [MCPClient::Errors::TaskNotFound] if the task does not exist
+    # @raise [MCPClient::Errors::TaskError] if retrieval fails
+    def get_task_result(task_id, server: nil)
+      srv = select_server(server)
+
+      begin
+        srv.rpc_request('tasks/result', { taskId: task_id })
+      rescue MCPClient::Errors::ServerError => e
+        raise task_error_from(e, task_id, 'getting result for')
+      rescue MCPClient::Errors::TransportError, MCPClient::Errors::ConnectionError => e
+        raise MCPClient::Errors::TaskError, "Error getting result for task '#{task_id}': #{e.message}"
+      end
+    end
+
+    # List tasks known to a server (tasks/list, paginated, MCP 2025-11-25)
+    # @param cursor [String, nil] optional pagination cursor
+    # @param server [Integer, String, Symbol, MCPClient::ServerBase, nil] server selector
+    # @return [Hash] { tasks: Array<MCPClient::Task>, next_cursor: String, nil }
+    # @raise [MCPClient::Errors::TaskError] if listing fails
+    def list_tasks(cursor: nil, server: nil)
+      srv = select_server(server)
+      params = cursor ? { cursor: cursor } : {}
+
+      begin
+        result = srv.rpc_request('tasks/list', params) || {}
+        tasks = (result['tasks'] || []).map { |t| MCPClient::Task.from_json(t, server: srv) }
+        { tasks: tasks, next_cursor: result['nextCursor'] }
+      rescue MCPClient::Errors::ServerError, MCPClient::Errors::TransportError, MCPClient::Errors::ConnectionError => e
+        raise MCPClient::Errors::TaskError, "Error listing tasks: #{e.message}"
+      end
+    end
+
+    # Cancel a task (tasks/cancel, MCP 2025-11-25)
     # @param task_id [String] the ID of the task to cancel
     # @param server [Integer, String, Symbol, MCPClient::ServerBase, nil] server selector
-    # @return [MCPClient::Task] the task with updated (cancelled) state
+    # @return [MCPClient::Task] the task with updated (cancelled) status
     # @raise [MCPClient::Errors::ServerNotFound] if no server is available
     # @raise [MCPClient::Errors::TaskNotFound] if the task does not exist
-    # @raise [MCPClient::Errors::TaskError] if cancellation fails
+    # @raise [MCPClient::Errors::TaskError] if cancellation fails (including cancelling a terminal task)
     def cancel_task(task_id, server: nil)
       srv = select_server(server)
 
       begin
-        result = srv.rpc_request('tasks/cancel', { id: task_id })
+        result = srv.rpc_request('tasks/cancel', { taskId: task_id })
         MCPClient::Task.from_json(result, server: srv)
       rescue MCPClient::Errors::ServerError => e
-        if e.message.include?('not found') || e.message.include?('unknown task')
-          raise MCPClient::Errors::TaskNotFound, "Task '#{task_id}' not found"
+        # A terminal task cannot be cancelled (-32602); that is an error, not a
+        # missing task, so keep it as a TaskError.
+        if e.message.match?(/terminal/i)
+          raise MCPClient::Errors::TaskError, "Error cancelling task '#{task_id}': #{e.message}"
         end
 
-        raise MCPClient::Errors::TaskError, "Error cancelling task '#{task_id}': #{e.message}"
+        raise task_error_from(e, task_id, 'cancelling')
       rescue MCPClient::Errors::TransportError, MCPClient::Errors::ConnectionError => e
         raise MCPClient::Errors::TaskError, "Error cancelling task '#{task_id}': #{e.message}"
       end
@@ -601,6 +667,9 @@ module MCPClient
       when 'notifications/message'
         # MCP 2025-06-18: Handle logging messages from server
         handle_log_message(server_id, params)
+      when 'notifications/tasks/status'
+        # MCP 2025-11-25: task status update (params are a flat Task)
+        handle_task_status_notification(server_id, params)
       else
         # Log unknown notification types for debugging purposes
         logger.debug("[#{server_id}] Received unknown notification: #{method} - #{params}")
@@ -698,6 +767,91 @@ module MCPClient
       servers.find do |server|
         server.list_tools.any? { |t| t.name == tool.name }
       end
+    end
+
+    # Resolve a tool by name (optionally scoped to a server), raising the same
+    # not-found / ambiguity errors as call_tool.
+    # @param tool_name [String] the tool name
+    # @param server [String, Symbol, Integer, MCPClient::ServerBase, nil] optional server selector
+    # @return [MCPClient::Tool] the resolved tool
+    # @raise [MCPClient::Errors::ToolNotFound, MCPClient::Errors::AmbiguousToolName]
+    def resolve_tool(tool_name, server: nil)
+      tools = list_tools
+
+      if server
+        srv = select_server(server)
+        tool = tools.find { |t| t.name == tool_name && t.server == srv }
+        unless tool
+          raise MCPClient::Errors::ToolNotFound,
+                "Tool '#{tool_name}' not found on server '#{srv.name || srv.class.name}'"
+        end
+        return tool
+      end
+
+      matching_tools = tools.select { |t| t.name == tool_name }
+      if matching_tools.empty?
+        raise MCPClient::Errors::ToolNotFound, "Tool '#{tool_name}' not found"
+      elsif matching_tools.size > 1
+        server_names = matching_tools.map { |t| t.server&.name || 'unnamed' }
+        raise MCPClient::Errors::AmbiguousToolName,
+              "Multiple tools named '#{tool_name}' found across servers (#{server_names.join(', ')}). " \
+              "Please specify a server using the 'server' parameter."
+      end
+
+      matching_tools.first
+    end
+
+    # Reject a plain (synchronous) call for a tool whose execution.taskSupport is
+    # 'required'. A compliant server would reject a non-task-augmented tools/call
+    # for such a tool, so fail fast and point the caller at call_tool_as_task.
+    # @param tool [MCPClient::Tool] the resolved tool
+    # @param tool_name [String] the tool name (for the message)
+    # @raise [MCPClient::Errors::ToolCallError] if the tool requires task execution
+    def reject_task_required!(tool, tool_name)
+      return unless tool.task_required?
+
+      raise MCPClient::Errors::ToolCallError,
+            "Tool '#{tool_name}' requires task-augmented execution; call it with call_tool_as_task instead"
+    end
+
+    # Whether a server advertised support for task-augmented tools/call, i.e.
+    # capabilities.tasks.requests.tools.call.
+    # @param srv [MCPClient::ServerBase] the server
+    # @return [Boolean]
+    def server_supports_task_tool_call?(srv)
+      caps = srv.respond_to?(:capabilities) ? srv.capabilities : nil
+      return false unless caps.is_a?(Hash)
+
+      tasks = caps['tasks'] || caps[:tasks]
+      requests = tasks && (tasks['requests'] || tasks[:requests])
+      tools = requests && (requests['tools'] || requests[:tools])
+      call = tools && (tools['call'] || tools[:call])
+      !call.nil?
+    end
+
+    # Map a ServerError from a task operation to TaskNotFound or TaskError.
+    # @param error [MCPClient::Errors::ServerError] the server error
+    # @param task_id [String] the task id
+    # @param action [String] a verb phrase for the error message (e.g. 'getting')
+    # @return [MCPClient::Errors::TaskNotFound, MCPClient::Errors::TaskError]
+    def task_error_from(error, task_id, action)
+      if error.message.match?(/not found|unknown task|expired/i)
+        return MCPClient::Errors::TaskNotFound.new("Task '#{task_id}' not found")
+      end
+
+      MCPClient::Errors::TaskError.new("Error #{action} task '#{task_id}': #{error.message}")
+    end
+
+    # Handle a notifications/tasks/status notification (MCP 2025-11-25).
+    # The params are a flat Task.
+    # @param server_id [String] server identifier for the log prefix
+    # @param params [Hash] the flat task params
+    # @return [void]
+    def handle_task_status_notification(server_id, params)
+      task = MCPClient::Task.from_json(params)
+      logger.info("[#{server_id}] Task #{task.task_id} status: #{task.status}")
+    rescue StandardError => e
+      logger.debug("[#{server_id}] Failed to parse task status notification: #{e.message}")
     end
 
     # Generate a cache key for server-specific items

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -66,6 +66,11 @@ module MCPClient
         'elicitation' => {}, # MCP 2025-11-25: Support for server-initiated user interactions
         'roots' => { 'listChanged' => true }, # MCP 2025-11-25: Support for roots
         'sampling' => {} # MCP 2025-11-25: Support for server-initiated LLM sampling
+        # NOTE: we intentionally do NOT declare a client `tasks` capability. That
+        # capability marks the client as a RECEIVER of task-augmented
+        # sampling/elicitation requests, which is not implemented here — this
+        # client only acts as a task REQUESTOR for tools/call (see
+        # Client#call_tool_as_task), which requires no client-side declaration.
       }
 
       {

--- a/lib/mcp_client/task.rb
+++ b/lib/mcp_client/task.rb
@@ -1,65 +1,94 @@
 # frozen_string_literal: true
 
 module MCPClient
-  # Represents an MCP Task for long-running operations with progress tracking
-  # Tasks follow the MCP 2025-11-25 specification for structured task management
+  # Represents an MCP Task for long-running, task-augmented operations.
+  # Conforms to the MCP 2025-11-25 Tasks utility.
   #
-  # Task states: pending, running, completed, failed, cancelled
+  # Task statuses: working, input_required, completed, failed, cancelled.
+  # A task begins in `working`; completed/failed/cancelled are terminal.
   class Task
-    # Valid task states
-    VALID_STATES = %w[pending running completed failed cancelled].freeze
+    # Valid task statuses (MCP 2025-11-25)
+    VALID_STATUSES = %w[working input_required completed failed cancelled].freeze
 
-    attr_reader :id, :state, :progress_token, :progress, :total, :message, :result, :server
+    # Statuses from which a task will not transition further
+    TERMINAL_STATUSES = %w[completed failed cancelled].freeze
+
+    attr_reader :task_id, :status, :status_message, :created_at, :last_updated_at, :ttl, :poll_interval, :server
 
     # Create a new Task
-    # @param id [String] unique task identifier
-    # @param state [String] task state (pending, running, completed, failed, cancelled)
-    # @param progress_token [String, nil] optional token for tracking progress
-    # @param progress [Integer, nil] current progress value
-    # @param total [Integer, nil] total progress value
-    # @param message [String, nil] human-readable status message
-    # @param result [Object, nil] task result (when completed)
+    # @param task_id [String] unique task identifier
+    # @param status [String] task status (working, input_required, completed, failed, cancelled)
+    # @param status_message [String, nil] optional human-readable status detail
+    # @param created_at [String, nil] ISO 8601 creation timestamp
+    # @param last_updated_at [String, nil] ISO 8601 last-update timestamp
+    # @param ttl [Integer, nil] retention duration in milliseconds since creation (nil = unspecified)
+    # @param poll_interval [Integer, nil] suggested polling interval in milliseconds
     # @param server [MCPClient::ServerBase, nil] the server this task belongs to
-    def initialize(id:, state: 'pending', progress_token: nil, progress: nil, total: nil,
-                   message: nil, result: nil, server: nil)
-      validate_state!(state)
-      @id = id
-      @state = state
-      @progress_token = progress_token
-      @progress = progress
-      @total = total
-      @message = message
-      @result = result
+    def initialize(task_id:, status: 'working', status_message: nil, created_at: nil,
+                   last_updated_at: nil, ttl: nil, poll_interval: nil, server: nil)
+      validate_status!(status)
+      @task_id = task_id
+      @status = status
+      @status_message = status_message
+      @created_at = created_at
+      @last_updated_at = last_updated_at
+      @ttl = ttl
+      @poll_interval = poll_interval
       @server = server
     end
 
-    # Create a Task from a JSON hash
-    # @param json [Hash] the JSON hash with task fields
+    # Build a Task from a flat Task hash. This is the shape of GetTaskResult,
+    # CancelTaskResult, the items in a ListTasksResult, and the params of a
+    # notifications/tasks/status notification.
+    # @param json [Hash] the flat task hash
     # @param server [MCPClient::ServerBase, nil] optional server reference
     # @return [Task]
     def self.from_json(json, server: nil)
+      data = json || {}
       new(
-        id: json['id'] || json[:id],
-        state: json['state'] || json[:state] || 'pending',
-        progress_token: json['progressToken'] || json[:progressToken] || json[:progress_token],
-        progress: json['progress'] || json[:progress],
-        total: json['total'] || json[:total],
-        message: json['message'] || json[:message],
-        result: json.key?('result') ? json['result'] : json[:result],
+        task_id: extract_field(data, 'taskId', :task_id),
+        status: extract_field(data, 'status') || 'working',
+        status_message: extract_field(data, 'statusMessage', :status_message),
+        created_at: extract_field(data, 'createdAt', :created_at),
+        last_updated_at: extract_field(data, 'lastUpdatedAt', :last_updated_at),
+        ttl: extract_field(data, 'ttl'),
+        poll_interval: extract_field(data, 'pollInterval', :poll_interval),
         server: server
       )
     end
 
-    # Convert to JSON-serializable hash
+    # Build a Task from a CreateTaskResult, which wraps the task under `task`.
+    # @param result [Hash] the CreateTaskResult ({ 'task' => { ... } })
+    # @param server [MCPClient::ServerBase, nil] optional server reference
+    # @return [Task]
+    def self.from_create_result(result, server: nil)
+      task_data = (result && (result['task'] || result[:task])) || result
+      from_json(task_data, server: server)
+    end
+
+    # Read a value by camelCase string key, falling back to a snake_case symbol.
+    # Uses key? so an explicit null value is preserved (not treated as absent).
+    # @return [Object, nil]
+    def self.extract_field(data, str_key, sym_key = nil)
+      return data[str_key] if data.key?(str_key)
+      return data[str_key.to_sym] if data.key?(str_key.to_sym)
+      return data[sym_key] if sym_key && data.key?(sym_key)
+
+      nil
+    end
+    private_class_method :extract_field
+
+    # Convert to a spec-shaped, JSON-serializable hash
     # @return [Hash]
     def to_h
-      result = { 'id' => @id, 'state' => @state }
-      result['progressToken'] = @progress_token if @progress_token
-      result['progress'] = @progress if @progress
-      result['total'] = @total if @total
-      result['message'] = @message if @message
-      result['result'] = @result unless @result.nil?
-      result
+      # ttl is a REQUIRED Task field whose value may be null, so it is always
+      # included (even when nil). The other optional fields are omitted when nil.
+      hash = { 'taskId' => @task_id, 'status' => @status, 'ttl' => @ttl }
+      hash['statusMessage'] = @status_message if @status_message
+      hash['createdAt'] = @created_at if @created_at
+      hash['lastUpdatedAt'] = @last_updated_at if @last_updated_at
+      hash['pollInterval'] = @poll_interval if @poll_interval
+      hash
     end
 
     # Convert to JSON string
@@ -68,60 +97,63 @@ module MCPClient
       to_h.to_json(*)
     end
 
-    # Check if task is in a terminal state
+    # Whether the task is in a terminal status (completed, failed, cancelled)
     # @return [Boolean]
     def terminal?
-      %w[completed failed cancelled].include?(@state)
+      TERMINAL_STATUSES.include?(@status)
     end
 
-    # Check if task is still active (pending or running)
+    # Whether the task is still active (not terminal — working or input_required)
     # @return [Boolean]
     def active?
-      %w[pending running].include?(@state)
+      !terminal?
     end
 
-    # Calculate progress percentage
-    # @return [Float, nil] percentage (0.0-100.0) or nil if progress info unavailable
-    def progress_percentage
-      return nil unless @progress && @total&.positive?
+    # Whether the task is waiting for input (status input_required)
+    # @return [Boolean]
+    def input_required?
+      @status == 'input_required'
+    end
 
-      (@progress.to_f / @total * 100).round(2)
+    # Whether the task is still running (status working)
+    # @return [Boolean]
+    def working?
+      @status == 'working'
     end
 
     # Check equality
     def ==(other)
       return false unless other.is_a?(Task)
 
-      id == other.id && state == other.state
+      task_id == other.task_id && status == other.status
     end
 
     alias eql? ==
 
     def hash
-      [id, state].hash
+      [task_id, status].hash
     end
 
     # String representation
     def to_s
-      parts = ["Task[#{@id}]: #{@state}"]
-      parts << "(#{@progress}/#{@total})" if @progress && @total
-      parts << "- #{@message}" if @message
+      parts = ["Task[#{@task_id}]: #{@status}"]
+      parts << "- #{@status_message}" if @status_message
       parts.join(' ')
     end
 
     def inspect
-      "#<MCPClient::Task id=#{@id.inspect} state=#{@state.inspect}>"
+      "#<MCPClient::Task task_id=#{@task_id.inspect} status=#{@status.inspect}>"
     end
 
     private
 
-    # Validate task state
-    # @param state [String] the state to validate
-    # @raise [ArgumentError] if the state is not valid
-    def validate_state!(state)
-      return if VALID_STATES.include?(state)
+    # Validate task status
+    # @param status [String] the status to validate
+    # @raise [ArgumentError] if the status is not valid
+    def validate_status!(status)
+      return if VALID_STATUSES.include?(status)
 
-      raise ArgumentError, "Invalid task state: #{state.inspect}. Must be one of: #{VALID_STATES.join(', ')}"
+      raise ArgumentError, "Invalid task status: #{status.inspect}. Must be one of: #{VALID_STATUSES.join(', ')}"
     end
   end
 end

--- a/lib/mcp_client/tool.rb
+++ b/lib/mcp_client/tool.rb
@@ -17,7 +17,10 @@ module MCPClient
     #   @return [Hash, nil] optional annotations describing tool behavior (e.g., readOnly, destructive)
     # @!attribute [r] server
     #   @return [MCPClient::ServerBase, nil] the server this tool belongs to
-    attr_reader :name, :title, :description, :schema, :output_schema, :annotations, :server
+    # @!attribute [r] task_support
+    #   @return [String, nil] tool-level task negotiation (MCP 2025-11-25):
+    #     'forbidden' (default), 'optional', or 'required'; nil when not advertised
+    attr_reader :name, :title, :description, :schema, :output_schema, :annotations, :server, :task_support
 
     # Initialize a new Tool
     # @param name [String] the name of the tool
@@ -27,7 +30,9 @@ module MCPClient
     # @param output_schema [Hash, nil] optional JSON schema for structured tool outputs (MCP 2025-06-18)
     # @param annotations [Hash, nil] optional annotations describing tool behavior
     # @param server [MCPClient::ServerBase, nil] the server this tool belongs to
-    def initialize(name:, description:, schema:, title: nil, output_schema: nil, annotations: nil, server: nil)
+    # @param task_support [String, nil] execution.taskSupport value (MCP 2025-11-25)
+    def initialize(name:, description:, schema:, title: nil, output_schema: nil, annotations: nil, server: nil,
+                   task_support: nil)
       @name = name
       @title = title
       @description = description
@@ -35,6 +40,7 @@ module MCPClient
       @output_schema = output_schema
       @annotations = annotations
       @server = server
+      @task_support = task_support
     end
 
     # Create a Tool instance from JSON data
@@ -48,6 +54,8 @@ module MCPClient
       output_schema = data['outputSchema'] || data[:outputSchema]
       annotations = data['annotations'] || data[:annotations]
       title = data['title'] || data[:title]
+      execution = data['execution'] || data[:execution]
+      task_support = execution && (execution['taskSupport'] || execution[:taskSupport])
       new(
         name: data['name'] || data[:name],
         description: data['description'] || data[:description],
@@ -55,7 +63,8 @@ module MCPClient
         title: title,
         output_schema: output_schema,
         annotations: annotations,
-        server: server
+        server: server,
+        task_support: task_support
       )
     end
 
@@ -154,6 +163,31 @@ module MCPClient
     # @return [Boolean] true if the tool has an output schema defined
     def structured_output?
       !@output_schema.nil? && !@output_schema.empty?
+    end
+
+    # Whether task-augmented execution is allowed for this tool (MCP 2025-11-25).
+    # True when execution.taskSupport is 'optional' or 'required'.
+    # @return [Boolean]
+    def supports_task?
+      %w[optional required].include?(@task_support)
+    end
+
+    # Whether task-augmented execution is required for this tool
+    # @return [Boolean]
+    def task_required?
+      @task_support == 'required'
+    end
+
+    # Whether task-augmented execution is optional for this tool
+    # @return [Boolean]
+    def task_optional?
+      @task_support == 'optional'
+    end
+
+    # Whether task-augmented execution is forbidden (the default when unset)
+    # @return [Boolean]
+    def task_forbidden?
+      @task_support.nil? || @task_support == 'forbidden'
     end
 
     private

--- a/spec/lib/mcp_client/client_spec.rb
+++ b/spec/lib/mcp_client/client_spec.rb
@@ -934,222 +934,217 @@ RSpec.describe MCPClient::Client do
     end
   end
 
-  describe '#create_task' do
+  describe '#call_tool_as_task' do
     let(:client) { described_class.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }]) }
-    let(:task_result) do
-      { 'id' => 'task-123', 'state' => 'pending', 'progressToken' => 'pt-abc' }
+    let(:task_tool) do
+      MCPClient::Tool.from_json(
+        {
+          'name' => 'long_job',
+          'description' => 'A long job',
+          'inputSchema' => { 'type' => 'object', 'properties' => { 'input' => { 'type' => 'string' } } },
+          'execution' => { 'taskSupport' => 'optional' }
+        }, server: mock_server
+      )
     end
+    let(:create_result) do
+      { 'task' => { 'taskId' => 'task-x', 'status' => 'working', 'ttl' => 60_000,
+                    'createdAt' => '2025-11-25T10:00:00Z' } }
+    end
+    let(:task_caps) { { 'tasks' => { 'requests' => { 'tools' => { 'call' => {} } } } } }
 
     before do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/create', { method: 'longRunningOp', params: { input: 'data' }, progressToken: 'pt-abc' })
-        .and_return(task_result)
+      allow(mock_server).to receive(:list_tools).and_return([task_tool])
+      allow(mock_server).to receive(:capabilities).and_return(task_caps)
     end
 
-    it 'creates a task and returns a Task object' do
-      task = client.create_task('longRunningOp', params: { input: 'data' }, progress_token: 'pt-abc')
+    it 'augments tools/call with a task field and returns a Task from the CreateTaskResult' do
+      expect(mock_server).to receive(:rpc_request)
+        .with('tools/call', { name: 'long_job', arguments: { 'input' => 'x' }, task: { ttl: 60_000 } })
+        .and_return(create_result)
+
+      task = client.call_tool_as_task('long_job', { 'input' => 'x' }, ttl: 60_000)
       expect(task).to be_a(MCPClient::Task)
-      expect(task.id).to eq('task-123')
-      expect(task.state).to eq('pending')
-      expect(task.progress_token).to eq('pt-abc')
+      expect(task.task_id).to eq('task-x')
+      expect(task.status).to eq('working')
       expect(task.server).to eq(mock_server)
     end
 
-    it 'creates a task without progress token' do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/create', { method: 'simpleOp', params: {} })
-        .and_return({ 'id' => 'task-456', 'state' => 'pending' })
+    it 'sends an empty task object when no ttl is given' do
+      expect(mock_server).to receive(:rpc_request)
+        .with('tools/call', { name: 'long_job', arguments: {}, task: {} })
+        .and_return(create_result)
 
-      task = client.create_task('simpleOp')
-      expect(task.id).to eq('task-456')
-      expect(task.progress_token).to be_nil
+      client.call_tool_as_task('long_job', {})
     end
 
-    it 'raises TaskError on server error' do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/create', { method: 'failOp', params: {} })
-        .and_raise(MCPClient::Errors::ServerError.new('Internal error'))
+    it 'keeps a symbol _meta key as a top-level request field rather than inside arguments' do
+      expect(mock_server).to receive(:rpc_request)
+        .with('tools/call', { name: 'long_job', arguments: { 'input' => 'x' }, task: {}, _meta: { 'a' => 1 } })
+        .and_return(create_result)
 
-      expect do
-        client.create_task('failOp')
-      end.to raise_error(MCPClient::Errors::TaskError, /Error creating task/)
+      client.call_tool_as_task('long_job', { 'input' => 'x', _meta: { 'a' => 1 } })
     end
 
-    it 'raises TaskError on transport error' do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/create', { method: 'failOp', params: {} })
-        .and_raise(MCPClient::Errors::TransportError.new('Connection lost'))
+    it 'keeps a string "_meta" key as a top-level request field (e.g. from JSON)' do
+      expect(mock_server).to receive(:rpc_request)
+        .with('tools/call', { name: 'long_job', arguments: { 'input' => 'x' }, task: {}, _meta: { 'a' => 1 } })
+        .and_return(create_result)
 
-      expect do
-        client.create_task('failOp')
-      end.to raise_error(MCPClient::Errors::TaskError, /Error creating task/)
+      client.call_tool_as_task('long_job', { 'input' => 'x', '_meta' => { 'a' => 1 } })
     end
 
-    context 'with server selection' do
-      let(:mock_server2) { instance_double(MCPClient::ServerBase, name: 'server2') }
-      let(:multi_client) do
-        client = described_class.new(mcp_server_configs: [
-                                       { type: 'stdio', command: 'test1' },
-                                       { type: 'stdio', command: 'test2' }
-                                     ])
-        client.instance_variable_set(:@servers, [mock_server, mock_server2])
-        client
-      end
+    it 'raises TaskError and sends no request when the server lacks tasks.requests.tools.call' do
+      allow(mock_server).to receive(:capabilities).and_return({ 'tools' => {} })
+      expect(mock_server).not_to receive(:rpc_request)
 
-      before do
-        allow(mock_server2).to receive(:on_notification)
-        allow(mock_server2).to receive(:rpc_request)
-          .with('tasks/create', { method: 'op', params: {} })
-          .and_return({ 'id' => 'task-s2', 'state' => 'pending' })
-      end
+      expect { client.call_tool_as_task('long_job', {}) }
+        .to raise_error(MCPClient::Errors::TaskError, /does not support task-augmented/)
+    end
 
-      it 'creates a task on a specific server by name' do
-        task = multi_client.create_task('op', server: 'server2')
-        expect(task.id).to eq('task-s2')
-        expect(task.server).to eq(mock_server2)
-      end
+    it 'raises TaskError and sends no request when the tool does not support tasks' do
+      forbidden_tool = MCPClient::Tool.from_json(
+        { 'name' => 'long_job', 'description' => 'd', 'inputSchema' => {} }, server: mock_server
+      )
+      allow(mock_server).to receive(:list_tools).and_return([forbidden_tool])
+      expect(mock_server).not_to receive(:rpc_request)
+
+      expect { client.call_tool_as_task('long_job', {}) }
+        .to raise_error(MCPClient::Errors::TaskError, /does not support task execution/)
+    end
+
+    it 'validates parameters before issuing any request' do
+      required_tool = MCPClient::Tool.from_json(
+        {
+          'name' => 'long_job', 'description' => 'd',
+          'inputSchema' => { 'type' => 'object', 'required' => ['input'], 'properties' => {} },
+          'execution' => { 'taskSupport' => 'required' }
+        }, server: mock_server
+      )
+      allow(mock_server).to receive(:list_tools).and_return([required_tool])
+      expect(mock_server).not_to receive(:rpc_request)
+
+      expect { client.call_tool_as_task('long_job', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /Missing required parameters/)
+    end
+  end
+
+  describe '#call_tool with a task-required tool' do
+    let(:client) { described_class.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }]) }
+
+    it 'rejects a plain call and points the caller at call_tool_as_task' do
+      required_tool = MCPClient::Tool.from_json(
+        {
+          'name' => 'must_task', 'description' => 'd', 'inputSchema' => {},
+          'execution' => { 'taskSupport' => 'required' }
+        }, server: mock_server
+      )
+      allow(mock_server).to receive(:list_tools).and_return([required_tool])
+      expect(mock_server).not_to receive(:call_tool)
+
+      expect { client.call_tool('must_task', {}) }
+        .to raise_error(MCPClient::Errors::ToolCallError, /call_tool_as_task/)
     end
   end
 
   describe '#get_task' do
     let(:client) { described_class.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }]) }
-    let(:task_result) do
-      { 'id' => 'task-123', 'state' => 'running', 'progress' => 50, 'total' => 100, 'message' => 'Halfway' }
-    end
+    let(:task_result) { { 'taskId' => 'task-123', 'status' => 'working', 'pollInterval' => 5000 } }
 
     before do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/get', { id: 'task-123' })
-        .and_return(task_result)
+      allow(mock_server).to receive(:rpc_request).with('tasks/get', { taskId: 'task-123' }).and_return(task_result)
     end
 
-    it 'gets a task and returns a Task object' do
+    it 'sends taskId (not id) and returns a Task' do
       task = client.get_task('task-123')
       expect(task).to be_a(MCPClient::Task)
-      expect(task.id).to eq('task-123')
-      expect(task.state).to eq('running')
-      expect(task.progress).to eq(50)
-      expect(task.total).to eq(100)
-      expect(task.message).to eq('Halfway')
+      expect(task.task_id).to eq('task-123')
+      expect(task.status).to eq('working')
+      expect(task.poll_interval).to eq(5000)
       expect(task.server).to eq(mock_server)
     end
 
-    it 'raises TaskNotFound when task does not exist' do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/get', { id: 'nonexistent' })
-        .and_raise(MCPClient::Errors::ServerError.new('Task not found'))
-
-      expect do
-        client.get_task('nonexistent')
-      end.to raise_error(MCPClient::Errors::TaskNotFound, "Task 'nonexistent' not found")
-    end
-
-    it 'raises TaskNotFound for unknown task error' do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/get', { id: 'bad-id' })
-        .and_raise(MCPClient::Errors::ServerError.new('unknown task'))
-
-      expect do
-        client.get_task('bad-id')
-      end.to raise_error(MCPClient::Errors::TaskNotFound)
+    it 'raises TaskNotFound when the task does not exist' do
+      allow(mock_server).to receive(:rpc_request).with('tasks/get', { taskId: 'nope' })
+                                                 .and_raise(MCPClient::Errors::ServerError.new('Task not found'))
+      expect { client.get_task('nope') }.to raise_error(MCPClient::Errors::TaskNotFound)
     end
 
     it 'raises TaskError on other server errors' do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/get', { id: 'task-err' })
-        .and_raise(MCPClient::Errors::ServerError.new('Internal error'))
-
-      expect do
-        client.get_task('task-err')
-      end.to raise_error(MCPClient::Errors::TaskError, /Error getting task/)
+      allow(mock_server).to receive(:rpc_request).with('tasks/get', { taskId: 'e' })
+                                                 .and_raise(MCPClient::Errors::ServerError.new('Internal error'))
+      expect { client.get_task('e') }.to raise_error(MCPClient::Errors::TaskError, /Error getting task/)
     end
 
     it 'raises TaskError on transport error' do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/get', { id: 'task-err' })
-        .and_raise(MCPClient::Errors::TransportError.new('Connection lost'))
+      allow(mock_server).to receive(:rpc_request).with('tasks/get', { taskId: 'e' })
+                                                 .and_raise(MCPClient::Errors::TransportError.new('Connection lost'))
+      expect { client.get_task('e') }.to raise_error(MCPClient::Errors::TaskError)
+    end
+  end
 
-      expect do
-        client.get_task('task-err')
-      end.to raise_error(MCPClient::Errors::TaskError, /Error getting task/)
+  describe '#get_task_result' do
+    let(:client) { described_class.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }]) }
+
+    it 'returns the raw underlying result without wrapping it in a Task' do
+      call_tool_result = { 'content' => [{ 'type' => 'text', 'text' => 'done' }], 'isError' => false }
+      allow(mock_server).to receive(:rpc_request).with('tasks/result', { taskId: 't1' }).and_return(call_tool_result)
+
+      expect(client.get_task_result('t1')).to eq(call_tool_result)
+    end
+
+    it 'raises TaskNotFound when the task does not exist' do
+      allow(mock_server).to receive(:rpc_request).with('tasks/result', { taskId: 'nope' })
+                                                 .and_raise(MCPClient::Errors::ServerError.new('unknown task'))
+      expect { client.get_task_result('nope') }.to raise_error(MCPClient::Errors::TaskNotFound)
+    end
+  end
+
+  describe '#list_tasks' do
+    let(:client) { described_class.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }]) }
+
+    it 'lists tasks and returns Task objects with a next cursor' do
+      allow(mock_server).to receive(:rpc_request).with('tasks/list', {}).and_return(
+        { 'tasks' => [{ 'taskId' => 'a', 'status' => 'working' }, { 'taskId' => 'b', 'status' => 'completed' }],
+          'nextCursor' => 'page2' }
+      )
+
+      result = client.list_tasks
+      expect(result[:tasks].map(&:task_id)).to eq(%w[a b])
+      expect(result[:next_cursor]).to eq('page2')
+    end
+
+    it 'passes a cursor when given' do
+      expect(mock_server).to receive(:rpc_request).with('tasks/list', { cursor: 'c1' })
+                                                  .and_return({ 'tasks' => [] })
+      result = client.list_tasks(cursor: 'c1')
+      expect(result[:next_cursor]).to be_nil
     end
   end
 
   describe '#cancel_task' do
     let(:client) { described_class.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }]) }
-    let(:cancel_result) do
-      { 'id' => 'task-123', 'state' => 'cancelled', 'message' => 'Cancelled by user' }
-    end
 
     before do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/cancel', { id: 'task-123' })
-        .and_return(cancel_result)
+      allow(mock_server).to receive(:rpc_request).with('tasks/cancel', { taskId: 'task-123' })
+                                                 .and_return({ 'taskId' => 'task-123', 'status' => 'cancelled' })
     end
 
-    it 'cancels a task and returns updated Task object' do
+    it 'sends taskId and returns the cancelled Task' do
       task = client.cancel_task('task-123')
-      expect(task).to be_a(MCPClient::Task)
-      expect(task.id).to eq('task-123')
-      expect(task.state).to eq('cancelled')
-      expect(task.message).to eq('Cancelled by user')
-      expect(task.server).to eq(mock_server)
+      expect(task.task_id).to eq('task-123')
+      expect(task.status).to eq('cancelled')
     end
 
-    it 'raises TaskNotFound when task does not exist' do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/cancel', { id: 'nonexistent' })
-        .and_raise(MCPClient::Errors::ServerError.new('Task not found'))
-
-      expect do
-        client.cancel_task('nonexistent')
-      end.to raise_error(MCPClient::Errors::TaskNotFound, "Task 'nonexistent' not found")
+    it 'raises TaskError (not TaskNotFound) when cancelling a terminal task' do
+      terminal_error = MCPClient::Errors::ServerError.new('Task is in a terminal status')
+      allow(mock_server).to receive(:rpc_request).with('tasks/cancel', { taskId: 'done' }).and_raise(terminal_error)
+      expect { client.cancel_task('done') }.to raise_error(MCPClient::Errors::TaskError, /Error cancelling/)
     end
 
-    it 'raises TaskError on other server errors' do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/cancel', { id: 'task-err' })
-        .and_raise(MCPClient::Errors::ServerError.new('Cannot cancel completed task'))
-
-      expect do
-        client.cancel_task('task-err')
-      end.to raise_error(MCPClient::Errors::TaskError, /Error cancelling task/)
-    end
-
-    it 'raises TaskError on transport error' do
-      allow(mock_server).to receive(:rpc_request)
-        .with('tasks/cancel', { id: 'task-err' })
-        .and_raise(MCPClient::Errors::TransportError.new('Connection lost'))
-
-      expect do
-        client.cancel_task('task-err')
-      end.to raise_error(MCPClient::Errors::TaskError, /Error cancelling task/)
-    end
-
-    context 'with server selection' do
-      let(:mock_server2) { instance_double(MCPClient::ServerBase, name: 'server2') }
-      let(:multi_client) do
-        client = described_class.new(mcp_server_configs: [
-                                       { type: 'stdio', command: 'test1' },
-                                       { type: 'stdio', command: 'test2' }
-                                     ])
-        client.instance_variable_set(:@servers, [mock_server, mock_server2])
-        client
-      end
-
-      before do
-        allow(mock_server2).to receive(:on_notification)
-        allow(mock_server2).to receive(:rpc_request)
-          .with('tasks/cancel', { id: 'task-s2' })
-          .and_return({ 'id' => 'task-s2', 'state' => 'cancelled' })
-      end
-
-      it 'cancels a task on a specific server by name' do
-        task = multi_client.cancel_task('task-s2', server: 'server2')
-        expect(task.id).to eq('task-s2')
-        expect(task.state).to eq('cancelled')
-        expect(task.server).to eq(mock_server2)
-      end
+    it 'raises TaskNotFound when the task does not exist' do
+      allow(mock_server).to receive(:rpc_request).with('tasks/cancel', { taskId: 'nope' })
+                                                 .and_raise(MCPClient::Errors::ServerError.new('Task not found'))
+      expect { client.cancel_task('nope') }.to raise_error(MCPClient::Errors::TaskNotFound)
     end
   end
 

--- a/spec/lib/mcp_client/json_rpc_common_spec.rb
+++ b/spec/lib/mcp_client/json_rpc_common_spec.rb
@@ -144,6 +144,10 @@ RSpec.describe MCPClient::JsonRpcCommon do
         }
       )
     end
+
+    it 'does not declare a client tasks capability (requestor-only, not a task receiver)' do
+      expect(instance.initialization_params['capabilities']).not_to have_key('tasks')
+    end
   end
 
   describe '#process_jsonrpc_response' do

--- a/spec/lib/mcp_client/task_spec.rb
+++ b/spec/lib/mcp_client/task_spec.rb
@@ -4,302 +4,142 @@ require 'spec_helper'
 
 RSpec.describe MCPClient::Task do
   describe '#initialize' do
-    it 'creates a task with required attributes' do
-      task = described_class.new(id: 'task-123')
-      expect(task.id).to eq('task-123')
-      expect(task.state).to eq('pending')
-    end
-
-    it 'creates a task with all attributes' do
+    it 'creates a task with the given fields' do
       task = described_class.new(
-        id: 'task-123',
-        state: 'running',
-        progress_token: 'pt-456',
-        progress: 50,
-        total: 100,
-        message: 'Processing...',
-        result: { 'data' => 'value' }
+        task_id: 't1', status: 'working', status_message: 'in progress',
+        created_at: '2025-11-25T10:30:00Z', last_updated_at: '2025-11-25T10:40:00Z',
+        ttl: 30_000, poll_interval: 5000
       )
-      expect(task.id).to eq('task-123')
-      expect(task.state).to eq('running')
-      expect(task.progress_token).to eq('pt-456')
-      expect(task.progress).to eq(50)
-      expect(task.total).to eq(100)
-      expect(task.message).to eq('Processing...')
-      expect(task.result).to eq({ 'data' => 'value' })
+      expect(task.task_id).to eq('t1')
+      expect(task.status).to eq('working')
+      expect(task.status_message).to eq('in progress')
+      expect(task.created_at).to eq('2025-11-25T10:30:00Z')
+      expect(task.last_updated_at).to eq('2025-11-25T10:40:00Z')
+      expect(task.ttl).to eq(30_000)
+      expect(task.poll_interval).to eq(5000)
     end
 
-    it 'raises ArgumentError for invalid state' do
-      expect do
-        described_class.new(id: 'task-123', state: 'invalid')
-      end.to raise_error(ArgumentError, /Invalid task state/)
+    it 'defaults status to working' do
+      expect(described_class.new(task_id: 't1').status).to eq('working')
     end
 
-    it 'accepts all valid states' do
-      %w[pending running completed failed cancelled].each do |state|
-        task = described_class.new(id: 'task-123', state: state)
-        expect(task.state).to eq(state)
+    %w[working input_required completed failed cancelled].each do |status|
+      it "accepts the valid status #{status}" do
+        expect { described_class.new(task_id: 't1', status: status) }.not_to raise_error
       end
     end
 
-    it 'stores server reference' do
-      server = instance_double(MCPClient::ServerBase)
-      task = described_class.new(id: 'task-123', server: server)
-      expect(task.server).to eq(server)
+    %w[pending running unknown].each do |status|
+      it "rejects the invalid status #{status}" do
+        expect { described_class.new(task_id: 't1', status: status) }
+          .to raise_error(ArgumentError, /Invalid task status/)
+      end
     end
   end
 
   describe '.from_json' do
-    it 'parses JSON with string keys' do
-      json = {
-        'id' => 'task-abc',
-        'state' => 'running',
-        'progressToken' => 'pt-xyz',
-        'progress' => 25,
-        'total' => 100,
-        'message' => 'In progress',
-        'result' => { 'output' => 'data' }
-      }
-      task = described_class.from_json(json)
-
-      expect(task.id).to eq('task-abc')
-      expect(task.state).to eq('running')
-      expect(task.progress_token).to eq('pt-xyz')
-      expect(task.progress).to eq(25)
-      expect(task.total).to eq(100)
-      expect(task.message).to eq('In progress')
-      expect(task.result).to eq({ 'output' => 'data' })
+    it 'parses a flat GetTaskResult shape' do
+      task = described_class.from_json(
+        {
+          'taskId' => 't1', 'status' => 'working',
+          'createdAt' => '2025-11-25T10:30:00Z', 'lastUpdatedAt' => '2025-11-25T10:40:00Z',
+          'ttl' => 30_000, 'pollInterval' => 5000, 'statusMessage' => 'running'
+        }
+      )
+      expect(task.task_id).to eq('t1')
+      expect(task.status).to eq('working')
+      expect(task.created_at).to eq('2025-11-25T10:30:00Z')
+      expect(task.last_updated_at).to eq('2025-11-25T10:40:00Z')
+      expect(task.ttl).to eq(30_000)
+      expect(task.poll_interval).to eq(5000)
+      expect(task.status_message).to eq('running')
     end
 
-    it 'parses JSON with symbol keys' do
-      json = {
-        id: 'task-abc',
-        state: 'completed',
-        progressToken: 'pt-xyz',
-        progress: 100,
-        total: 100,
-        message: 'Done',
-        result: { 'output' => 'data' }
-      }
-      task = described_class.from_json(json)
+    it 'preserves a null ttl (key present, value null)' do
+      task = described_class.from_json({ 'taskId' => 't1', 'status' => 'working', 'ttl' => nil })
+      expect(task.ttl).to be_nil
+    end
+  end
 
-      expect(task.id).to eq('task-abc')
-      expect(task.state).to eq('completed')
-      expect(task.progress_token).to eq('pt-xyz')
+  describe '.from_create_result' do
+    it 'unwraps the task under the "task" key of a CreateTaskResult' do
+      task = described_class.from_create_result({ 'task' => { 'taskId' => 'x', 'status' => 'working',
+                                                              'ttl' => 60_000 } })
+      expect(task.task_id).to eq('x')
+      expect(task.status).to eq('working')
+      expect(task.ttl).to eq(60_000)
     end
 
-    it 'handles missing optional fields' do
-      json = { 'id' => 'task-abc' }
-      task = described_class.from_json(json)
+    it 'tolerates a flat result without a task wrapper' do
+      task = described_class.from_create_result({ 'taskId' => 'x', 'status' => 'working' })
+      expect(task.task_id).to eq('x')
+    end
+  end
 
-      expect(task.id).to eq('task-abc')
-      expect(task.state).to eq('pending')
-      expect(task.progress_token).to be_nil
-      expect(task.progress).to be_nil
-      expect(task.total).to be_nil
-      expect(task.message).to be_nil
-      expect(task.result).to be_nil
+  describe 'status predicates' do
+    def build(status)
+      described_class.new(task_id: 't', status: status)
     end
 
-    it 'accepts a server parameter' do
-      server = instance_double(MCPClient::ServerBase)
-      json = { 'id' => 'task-abc', 'state' => 'pending' }
-      task = described_class.from_json(json, server: server)
-
-      expect(task.server).to eq(server)
+    it '#terminal? is true only for completed/failed/cancelled' do
+      expect(build('completed').terminal?).to be true
+      expect(build('failed').terminal?).to be true
+      expect(build('cancelled').terminal?).to be true
+      expect(build('working').terminal?).to be false
+      expect(build('input_required').terminal?).to be false
     end
 
-    it 'handles snake_case progress_token key' do
-      json = { id: 'task-abc', progress_token: 'pt-xyz' }
-      task = described_class.from_json(json)
+    it '#active? is the inverse of terminal?' do
+      expect(build('working').active?).to be true
+      expect(build('input_required').active?).to be true
+      expect(build('completed').active?).to be false
+    end
 
-      expect(task.progress_token).to eq('pt-xyz')
+    it '#input_required? and #working? reflect the status' do
+      expect(build('input_required').input_required?).to be true
+      expect(build('working').working?).to be true
+      expect(build('working').input_required?).to be false
     end
   end
 
   describe '#to_h' do
-    it 'returns hash with required fields only' do
-      task = described_class.new(id: 'task-123', state: 'pending')
-      expect(task.to_h).to eq({ 'id' => 'task-123', 'state' => 'pending' })
+    it 'emits spec-shaped keys' do
+      task = described_class.new(task_id: 't1', status: 'working', ttl: 30_000, poll_interval: 5000)
+      expect(task.to_h).to eq('taskId' => 't1', 'status' => 'working', 'ttl' => 30_000, 'pollInterval' => 5000)
     end
 
-    it 'includes optional fields when present' do
-      task = described_class.new(
-        id: 'task-123',
-        state: 'running',
-        progress_token: 'pt-456',
-        progress: 50,
-        total: 100,
-        message: 'Working...',
-        result: { 'data' => 'value' }
-      )
-      hash = task.to_h
-
-      expect(hash['id']).to eq('task-123')
-      expect(hash['state']).to eq('running')
-      expect(hash['progressToken']).to eq('pt-456')
-      expect(hash['progress']).to eq(50)
-      expect(hash['total']).to eq(100)
-      expect(hash['message']).to eq('Working...')
-      expect(hash['result']).to eq({ 'data' => 'value' })
-    end
-
-    it 'excludes nil optional fields' do
-      task = described_class.new(id: 'task-123')
-      hash = task.to_h
-
-      expect(hash).not_to have_key('progressToken')
-      expect(hash).not_to have_key('progress')
-      expect(hash).not_to have_key('total')
-      expect(hash).not_to have_key('message')
-      expect(hash).not_to have_key('result')
+    it 'always includes ttl (a required Task field, value may be null)' do
+      task = described_class.new(task_id: 't1', status: 'working')
+      expect(task.to_h).to eq('taskId' => 't1', 'status' => 'working', 'ttl' => nil)
     end
   end
 
-  describe '#to_json' do
-    it 'serializes to JSON string' do
-      task = described_class.new(id: 'task-123', state: 'running', message: 'Working')
-      json = task.to_json
-      parsed = JSON.parse(json)
+  describe 'equality and representation' do
+    it 'considers tasks with the same id and status equal' do
+      a = described_class.new(task_id: 't1', status: 'working')
+      b = described_class.new(task_id: 't1', status: 'working')
+      expect(a).to eq(b)
+      expect(a.hash).to eq(b.hash)
+    end
 
-      expect(parsed['id']).to eq('task-123')
-      expect(parsed['state']).to eq('running')
-      expect(parsed['message']).to eq('Working')
+    it 'considers tasks with a different status not equal' do
+      a = described_class.new(task_id: 't1', status: 'working')
+      b = described_class.new(task_id: 't1', status: 'completed')
+      expect(a).not_to eq(b)
+    end
+
+    it '#to_s and #inspect show the id and status' do
+      task = described_class.new(task_id: 't1', status: 'working', status_message: 'busy')
+      expect(task.to_s).to include('t1', 'working', 'busy')
+      expect(task.inspect).to include('t1', 'working')
     end
   end
 
-  describe '#terminal?' do
-    it 'returns true for completed state' do
-      expect(described_class.new(id: 't', state: 'completed').terminal?).to be true
-    end
-
-    it 'returns true for failed state' do
-      expect(described_class.new(id: 't', state: 'failed').terminal?).to be true
-    end
-
-    it 'returns true for cancelled state' do
-      expect(described_class.new(id: 't', state: 'cancelled').terminal?).to be true
-    end
-
-    it 'returns false for pending state' do
-      expect(described_class.new(id: 't', state: 'pending').terminal?).to be false
-    end
-
-    it 'returns false for running state' do
-      expect(described_class.new(id: 't', state: 'running').terminal?).to be false
-    end
-  end
-
-  describe '#active?' do
-    it 'returns true for pending state' do
-      expect(described_class.new(id: 't', state: 'pending').active?).to be true
-    end
-
-    it 'returns true for running state' do
-      expect(described_class.new(id: 't', state: 'running').active?).to be true
-    end
-
-    it 'returns false for completed state' do
-      expect(described_class.new(id: 't', state: 'completed').active?).to be false
-    end
-
-    it 'returns false for failed state' do
-      expect(described_class.new(id: 't', state: 'failed').active?).to be false
-    end
-
-    it 'returns false for cancelled state' do
-      expect(described_class.new(id: 't', state: 'cancelled').active?).to be false
-    end
-  end
-
-  describe '#progress_percentage' do
-    it 'calculates percentage when progress and total are set' do
-      task = described_class.new(id: 't', state: 'running', progress: 25, total: 200)
-      expect(task.progress_percentage).to eq(12.5)
-    end
-
-    it 'returns 100.0 when progress equals total' do
-      task = described_class.new(id: 't', state: 'completed', progress: 100, total: 100)
-      expect(task.progress_percentage).to eq(100.0)
-    end
-
-    it 'returns nil when progress is nil' do
-      task = described_class.new(id: 't', state: 'running', total: 100)
-      expect(task.progress_percentage).to be_nil
-    end
-
-    it 'returns nil when total is nil' do
-      task = described_class.new(id: 't', state: 'running', progress: 50)
-      expect(task.progress_percentage).to be_nil
-    end
-
-    it 'returns nil when total is zero' do
-      task = described_class.new(id: 't', state: 'running', progress: 0, total: 0)
-      expect(task.progress_percentage).to be_nil
-    end
-  end
-
-  describe 'equality' do
-    it 'considers tasks with same id and state as equal' do
-      task1 = described_class.new(id: 'task-123', state: 'running')
-      task2 = described_class.new(id: 'task-123', state: 'running')
-
-      expect(task1).to eq(task2)
-      expect(task1.eql?(task2)).to be true
-      expect(task1.hash).to eq(task2.hash)
-    end
-
-    it 'considers tasks with different id as not equal' do
-      task1 = described_class.new(id: 'task-123', state: 'running')
-      task2 = described_class.new(id: 'task-456', state: 'running')
-
-      expect(task1).not_to eq(task2)
-    end
-
-    it 'considers tasks with different state as not equal' do
-      task1 = described_class.new(id: 'task-123', state: 'running')
-      task2 = described_class.new(id: 'task-123', state: 'completed')
-
-      expect(task1).not_to eq(task2)
-    end
-  end
-
-  describe '#to_s' do
-    it 'returns basic string for simple task' do
-      task = described_class.new(id: 'task-123', state: 'pending')
-      expect(task.to_s).to eq('Task[task-123]: pending')
-    end
-
-    it 'includes progress when available' do
-      task = described_class.new(id: 'task-123', state: 'running', progress: 50, total: 100)
-      expect(task.to_s).to eq('Task[task-123]: running (50/100)')
-    end
-
-    it 'includes message when available' do
-      task = described_class.new(id: 'task-123', state: 'running', message: 'Processing files')
-      expect(task.to_s).to eq('Task[task-123]: running - Processing files')
-    end
-
-    it 'includes both progress and message' do
-      task = described_class.new(id: 'task-123', state: 'running', progress: 3, total: 10, message: 'Step 3')
-      expect(task.to_s).to eq('Task[task-123]: running (3/10) - Step 3')
-    end
-  end
-
-  describe '#inspect' do
-    it 'returns a readable representation' do
-      task = described_class.new(id: 'task-123', state: 'running')
-      expect(task.inspect).to eq('#<MCPClient::Task id="task-123" state="running">')
-    end
-  end
-
-  describe 'VALID_STATES' do
-    it 'contains all expected states' do
-      expect(described_class::VALID_STATES).to eq(%w[pending running completed failed cancelled])
-    end
-
-    it 'is frozen' do
-      expect(described_class::VALID_STATES).to be_frozen
+  describe 'constants' do
+    it 'exposes the spec statuses' do
+      expect(described_class::VALID_STATUSES).to eq(%w[working input_required completed failed cancelled])
+      expect(described_class::VALID_STATUSES).to be_frozen
+      expect(described_class::TERMINAL_STATUSES).to eq(%w[completed failed cancelled])
     end
   end
 end


### PR DESCRIPTION
> **Breaking change** (maintainer-approved). The previous Tasks implementation targeted a `tasks/create` method that does not exist in the spec and used invented Task fields. This makes the requestor-side Tasks support conform to the [MCP 2025-11-25 Tasks utility](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks).

## What was wrong

- There is **no `tasks/create`** in the spec. Tasks are created by **augmenting** a request (here, `tools/call`) with a `task` field; the server returns a `CreateTaskResult` immediately and the result is fetched later.
- `MCPClient::Task` used invented fields (`id`/`state`/`progress`/`total`/`message`/`result`) and statuses (`pending`/`running`).
- `tasks/get`/`tasks/cancel` sent `id` instead of `taskId`.

## Changes

**`MCPClient::Task`** (breaking): fields are now `task_id`, `status`, `status_message`, `created_at`, `last_updated_at`, `ttl`, `poll_interval`. Statuses: `working`, `input_required`, `completed`, `failed`, `cancelled` (default `working`). `terminal?`/`active?`/`input_required?`/`working?`; `from_json` (flat) and `from_create_result` (unwraps `task`). `to_h` always includes `ttl` (a required field, may be null).

**`MCPClient::Client`**:
- Removed `create_task`. Added **`call_tool_as_task(name, args, ttl:)`** — augments `tools/call` with a `task` field and returns a `Task`. Gated on the server's `tasks.requests.tools.call` capability and the tool's `execution.taskSupport`; runs `validate_params!`; keeps `_meta` (string or symbol key) as a top-level request field.
- `get_task`/`cancel_task` now send `taskId`; cancelling a terminal task → `TaskError`.
- Added **`get_task_result`** (`tasks/result`, returns the raw underlying result), **`list_tasks`** (`tasks/list`, paginated), and `notifications/tasks/status` handling.
- `call_tool`/`call_tools`/`call_tool_streaming` now **fail fast for a `taskSupport: required` tool**, directing callers to `call_tool_as_task`.

**`Tool`**: parses `execution.taskSupport`; adds `supports_task?`/`task_required?`/`task_optional?`/`task_forbidden?`.

**Protocol**: the client does **not** declare a client `tasks` capability — that marks a task *receiver* (for sampling/elicitation), which isn't implemented; this client is a task *requestor* for `tools/call` only.

## Docs / examples

README Tasks section rewritten with the real flow; CHANGELOG documents the break + new features; new `examples/tasks_example.rb`. The bundled `examples/test_mcp_2025_11_25.rb` **and its Python demo server** were migrated to task-augmented `tools/call` — the example runs end-to-end (**55/55 assertions pass**), exercising create → poll `get_task` → `get_task_result` → `list_tasks` → `cancel_task` → not-found.

## Tests

`task_spec` and the client tasks specs rewritten. Full suite: `1235 examples, 0 failures`; RuboCop clean. Reviewed with `codex review` across several passes (capability over-claim, `_meta` handling, required-task enforcement, ttl serialization) — all addressed; final review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)