### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.1.0 (2026-07-04)
 
 ### Breaking Changes
 
@@ -28,6 +28,48 @@
   declare a client `tasks` capability: that marks a task *receiver* for
   sampling/elicitation, which is not implemented — the client is a task requestor for
   `tools/call` only.)
+- **Automatic pagination**: `list_tools` and `list_prompts` now follow the server's
+  `nextCursor` and return the complete set across all pages, with a per-call safety
+  bound and an identical-cursor loop guard. No manual cursor handling is required (#148).
+
+### Bug Fixes
+
+- **Tool annotations**: corrected `readOnlyHint`/`destructiveHint` defaults to match the
+  MCP 2025-11-25 `ToolAnnotations` schema — an un-annotated tool is treated as writable,
+  potentially destructive, and open-world (#140).
+- **Ping utility**: the stdio and SSE transports now respond to a server-initiated `ping`
+  with an empty result (#141).
+- **stdio deadlock**: drain the subprocess's stderr so a server that writes heavily to
+  stderr can no longer block the pipe (#142).
+- **MCP lifecycle**: HTTP and Streamable HTTP transports now send
+  `notifications/initialized` after `initialize`, as the specification requires (#143).
+- **stdio memory leak**: bound the pending-response map so responses to abandoned
+  requests can no longer accumulate (#144).
+- **Logger**: stop overwriting a caller-supplied logger's formatter (#145).
+- **Ruby 3.4+**: declare `base64` as a runtime dependency to avoid a `LoadError` (#146).
+- **Retry safety**: application-level `ServerError`s are no longer retried; only transport
+  errors and transient HTTP 5xx responses (`TransientServerError`) are retried, so
+  non-idempotent requests are not executed twice (#149).
+- **SSE reconnection**: repaired the auto-reconnect path that could never fire because the
+  monitor thread killed itself (#150).
+- **OAuth discovery**: authorization-server and protected-resource metadata discovery now
+  follows RFC 8414 and RFC 9728 (#151).
+
+### Examples & Tooling
+
+- Added `examples/run_all_examples.sh`, a pre-release harness that boots each example's
+  server, runs every example, and reports PASS/FAIL/SKIP, plus an `examples/README.md`
+  index. Fixed stale examples (removed the retired Playwright `browser_install` call,
+  robust first-tool selection in `streamable_http_example.rb`, updated the Gemini model)
+  and wired the Zapier/OAuth examples through a gitignored `examples/secrets.env` (#153).
+
+### Documentation
+
+- Fixed the README OAuth snippet `require` and corrected method names in the changelog (#147).
+
+### Dependencies
+
+- Bumped `faraday` to 2.14.3, plus routine development-dependency updates.
 
 ## 1.0.1 (2026-03-22)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    ruby-mcp-client (1.0.1)
+    ruby-mcp-client (1.1.0)
       base64 (~> 0.2)
       faraday (~> 2.0)
       faraday-follow_redirects (~> 0.3)

--- a/lib/mcp_client/version.rb
+++ b/lib/mcp_client/version.rb
@@ -2,7 +2,7 @@
 
 module MCPClient
   # Current version of the MCP client gem
-  VERSION = '1.0.1'
+  VERSION = '1.1.0'
 
   # MCP protocol version (date-based) - unified across all transports
   PROTOCOL_VERSION = '2025-11-25'


### PR DESCRIPTION
## Release 1.1.0

Bumps `MCPClient::VERSION` to **1.1.0** and finalizes `CHANGELOG.md` for everything merged since 1.0.1. (Gemfile.lock reflects the version bump.)

### Highlights

**Breaking**
- Tasks API rewritten to conform to MCP 2025-11-25 (`create_task` removed → `call_tool_as_task`; `Task` fields/statuses renamed; `get_task`/`cancel_task` now send `taskId`). See the changelog for the full migration notes. (#152)

**New**
- Task-augmented `tools/call`: `call_tool_as_task`, `get_task_result`, `list_tasks`, tool-level task negotiation, and `notifications/tasks/status` handling (#152)
- Automatic pagination for `list_tools` / `list_prompts` (auto-follows `nextCursor`) (#148)

**Bug fixes**
- Tool annotation defaults per MCP 2025-11-25 (#140) · ping response (#141) · stdio stderr-drain deadlock (#142) · `notifications/initialized` lifecycle (#143) · stdio pending-response memory leak (#144) · logger formatter (#145) · `base64` runtime dep for Ruby 3.4+ (#146) · non-idempotent retry safety (#149) · SSE auto-reconnect (#150) · RFC 8414/9728 OAuth discovery (#151)

**Examples & tooling**
- `examples/run_all_examples.sh` pre-release runner + `examples/README.md`; fixes to `json_input`, `streamable_http`, `gemini`, and the Zapier/OAuth examples via a gitignored `examples/secrets.env` (#153)

### Verification
- Full suite: **1320 examples, 0 failures**
- RuboCop: clean (110 files)
- `gem build` produces `ruby-mcp-client-1.1.0.gem`

After merge: tag `1.1.0` and publish the gem / GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KeNTP3mpe9RqF4FeScsv9R
