### PR TITLE
Fix elicitation compliance: JSON-RPC responses, mode negotiation, error semantics

### DIFF
--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -938,19 +938,21 @@ module MCPClient
     # @param params [Hash] the elicitation parameters
     # @return [Hash] the elicitation response
     def handle_elicitation_request(_request_id, params)
+      mode = params['mode'] || 'form'
+      # MCP 2025-11-25: requests with a mode not declared in client
+      # capabilities MUST be rejected with -32602 (Invalid params). This check
+      # precedes everything else — an undeclared mode is -32602 even when no
+      # handler is configured.
+      unless SUPPORTED_ELICITATION_MODES.include?(mode)
+        @logger.warn("Rejecting elicitation request with unsupported mode '#{mode}'")
+        return jsonrpc_error_result(-32_602, "Elicitation mode '#{mode}' is not supported")
+      end
+
       # Without a handler there is no user to interact with: answer with a
       # JSON-RPC error rather than fabricating a user "decline".
       unless @elicitation_handler
         @logger.warn('Received elicitation request but no elicitation handler is configured')
         return jsonrpc_error_result(-32_601, 'Elicitation not supported: no elicitation handler configured')
-      end
-
-      mode = params['mode'] || 'form'
-      # MCP 2025-11-25: requests with a mode not declared in client
-      # capabilities MUST be rejected with -32602 (Invalid params).
-      unless SUPPORTED_ELICITATION_MODES.include?(mode)
-        @logger.warn("Rejecting elicitation request with unsupported mode '#{mode}'")
-        return jsonrpc_error_result(-32_602, "Elicitation mode '#{mode}' is not supported")
       end
 
       message = params['message']
@@ -1033,27 +1035,19 @@ module MCPClient
     # @param params [Hash] original request params (for schema validation)
     # @return [Hash] formatted response
     def format_elicitation_response(result, params)
-      response = case result
-                 when Hash
-                   if result['action']
-                     normalised_action_response(result)
-                   elsif result[:action]
-                     {
-                       'action' => result[:action].to_s,
-                       'content' => result[:content]
-                     }.compact.then { |payload| normalised_action_response(payload) }
-                   else
-                     { 'action' => 'accept', 'content' => result }
-                   end
-                 when nil
-                   { 'action' => 'cancel' }
-                 else
-                   { 'action' => 'accept', 'content' => result }
-                 end
+      response = normalize_elicitation_result(result)
 
-      # Per the ElicitResult schema, content is only present for form mode
-      # accepts; it is omitted for out-of-band (url) mode responses.
-      response.delete('content') if (params['mode'] || 'form') == 'url'
+      # Per the ElicitResult schema, content is only present when the action
+      # is accept and the mode was form; it is omitted for decline/cancel and
+      # for out-of-band (url) mode responses.
+      response.delete('content') if response['action'] != 'accept' || (params['mode'] || 'form') == 'url'
+
+      # ElicitResult.content is an object mapping property names to primitive
+      # values — a scalar cannot be transmitted.
+      if response.key?('content') && !response['content'].is_a?(Hash)
+        @logger.warn("Elicitation handler returned non-object content (#{response['content'].class})")
+        return jsonrpc_error_result(-32_603, 'Elicitation content must be an object of primitive values')
+      end
 
       # Validate content against schema for form mode accept responses; do not
       # transmit content that violates the requestedSchema (spec SHOULD).
@@ -1064,6 +1058,25 @@ module MCPClient
       end
 
       response
+    end
+
+    # Normalize a handler's return value into a string-keyed ElicitResult
+    # shape, so mixed or symbol keys cannot bypass content handling.
+    # @param result [Object] handler result
+    # @return [Hash] normalized response with string keys
+    def normalize_elicitation_result(result)
+      case result
+      when Hash
+        action = result['action'] || result[:action]
+        return { 'action' => 'accept', 'content' => result } unless action
+
+        content = result.key?('content') || result.key?(:content) ? (result['content'] || result[:content]) : nil
+        normalised_action_response({ 'action' => action.to_s, 'content' => content }.compact)
+      when nil
+        { 'action' => 'cancel' }
+      else
+        { 'action' => 'accept', 'content' => result }
+      end
     end
 
     # Validate elicitation response content against the requestedSchema

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -6,6 +6,10 @@ module MCPClient
   # MCP Client for integrating with the Model Context Protocol
   # This is the main entry point for using MCP tools
   class Client
+    # Elicitation modes implemented by this client (MCP 2025-11-25).
+    # Requests with a mode outside this set are rejected with -32602.
+    SUPPORTED_ELICITATION_MODES = %w[form url].freeze
+
     # @!attribute [r] servers
     #   @return [Array<MCPClient::ServerBase>] list of servers
     # @!attribute [r] tool_cache
@@ -934,13 +938,21 @@ module MCPClient
     # @param params [Hash] the elicitation parameters
     # @return [Hash] the elicitation response
     def handle_elicitation_request(_request_id, params)
-      # If no handler is configured, decline the request
+      # Without a handler there is no user to interact with: answer with a
+      # JSON-RPC error rather than fabricating a user "decline".
       unless @elicitation_handler
-        @logger.warn('Received elicitation request but no handler configured, declining')
-        return { 'action' => 'decline' }
+        @logger.warn('Received elicitation request but no elicitation handler is configured')
+        return jsonrpc_error_result(-32_601, 'Elicitation not supported: no elicitation handler configured')
       end
 
       mode = params['mode'] || 'form'
+      # MCP 2025-11-25: requests with a mode not declared in client
+      # capabilities MUST be rejected with -32602 (Invalid params).
+      unless SUPPORTED_ELICITATION_MODES.include?(mode)
+        @logger.warn("Rejecting elicitation request with unsupported mode '#{mode}'")
+        return jsonrpc_error_result(-32_602, "Elicitation mode '#{mode}' is not supported")
+      end
+
       message = params['message']
 
       begin
@@ -954,8 +966,17 @@ module MCPClient
       rescue StandardError => e
         @logger.error("Elicitation handler error: #{e.message}")
         @logger.debug(e.backtrace.join("\n"))
-        { 'action' => 'decline' }
+        jsonrpc_error_result(-32_603, "Elicitation handler error: #{e.message}")
       end
+    end
+
+    # Build an error-shaped handler result that transports turn into a
+    # JSON-RPC error response (mirroring the sampling error path).
+    # @param code [Integer] JSON-RPC error code
+    # @param message [String] error message
+    # @return [Hash] error result
+    def jsonrpc_error_result(code, message)
+      { 'error' => { 'code' => code, 'message' => message } }
     end
 
     # Handle form mode elicitation (MCP 2025-11-25)
@@ -1030,8 +1051,17 @@ module MCPClient
                    { 'action' => 'accept', 'content' => result }
                  end
 
-      # Validate content against schema for form mode accept responses
-      validate_elicitation_content(response, params)
+      # Per the ElicitResult schema, content is only present for form mode
+      # accepts; it is omitted for out-of-band (url) mode responses.
+      response.delete('content') if (params['mode'] || 'form') == 'url'
+
+      # Validate content against schema for form mode accept responses; do not
+      # transmit content that violates the requestedSchema (spec SHOULD).
+      errors = validate_elicitation_content(response, params)
+      unless errors.empty?
+        @logger.warn("Elicitation content validation failed: #{errors.join('; ')}")
+        return jsonrpc_error_result(-32_603, "Elicitation content failed schema validation: #{errors.join('; ')}")
+      end
 
       response
     end
@@ -1039,20 +1069,17 @@ module MCPClient
     # Validate elicitation response content against the requestedSchema
     # @param response [Hash] the formatted response
     # @param params [Hash] original request params
-    # @return [void]
+    # @return [Array<String>] validation errors (empty when conforming or not applicable)
     def validate_elicitation_content(response, params)
-      return unless response['action'] == 'accept' && response['content'].is_a?(Hash)
+      return [] unless response['action'] == 'accept' && response['content'].is_a?(Hash)
 
       mode = params['mode'] || 'form'
-      return unless mode == 'form'
+      return [] unless mode == 'form'
 
       schema = params['requestedSchema'] || params['schema']
-      return unless schema.is_a?(Hash)
+      return [] unless schema.is_a?(Hash)
 
-      errors = ElicitationValidator.validate_content(response['content'], schema)
-      return if errors.empty?
-
-      @logger.warn("Elicitation content validation warnings: #{errors.join('; ')}")
+      ElicitationValidator.validate_content(response['content'], schema)
     end
 
     # Ensure the action value conforms to MCP spec (accept, decline, cancel)

--- a/lib/mcp_client/elicitation_validator.rb
+++ b/lib/mcp_client/elicitation_validator.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'uri'
+require 'date'
+require 'time'
+
 module MCPClient
   # Validates elicitation schemas and content per MCP 2025-11-25 spec.
   # Schemas are restricted to flat objects with primitive property types:
@@ -197,7 +201,46 @@ module MCPClient
         errors << "Field '#{field}' must be at most #{prop['maxLength']} characters"
       end
 
+      errors.concat(validate_string_format(field, value, prop['format']))
+
       errors
+    end
+
+    # Validate a string value against the schema's format constraint.
+    # The MCP elicitation schema supports email, uri, date, and date-time.
+    # @param field [String] field name
+    # @param value [String] the value
+    # @param format [String, nil] declared format
+    # @return [Array<String>] validation errors
+    def self.validate_string_format(field, value, format)
+      valid = case format
+              when 'email' then value.match?(URI::MailTo::EMAIL_REGEXP)
+              when 'uri' then valid_uri?(value)
+              when 'date' then parseable?(Date, value)
+              when 'date-time' then parseable?(Time, value)
+              else true # No format declared, or an unknown format: not validated
+              end
+
+      valid ? [] : ["Field '#{field}' must be a valid #{format}"]
+    end
+
+    # @param value [String] candidate URI
+    # @return [Boolean] whether the value is an absolute URI
+    def self.valid_uri?(value)
+      uri = URI.parse(value)
+      !uri.scheme.nil?
+    rescue URI::InvalidURIError
+      false
+    end
+
+    # @param klass [Class] Date or Time
+    # @param value [String] candidate ISO 8601 value
+    # @return [Boolean] whether the value parses
+    def self.parseable?(klass, value)
+      klass.iso8601(value)
+      true
+    rescue ArgumentError
+      false
     end
 
     # Validate a number value against its property schema.

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -73,7 +73,9 @@ module MCPClient
     # @return [Hash] the initialization parameters
     def initialization_params
       capabilities = {
-        'elicitation' => {}, # MCP 2025-11-25: Support for server-initiated user interactions
+        # MCP 2025-11-25: server-initiated user interactions; both defined
+        # modes are implemented (an empty object would mean form-only).
+        'elicitation' => { 'form' => {}, 'url' => {} },
         'roots' => { 'listChanged' => true }, # MCP 2025-11-25: Support for roots
         'sampling' => {} # MCP 2025-11-25: Support for server-initiated LLM sampling
         # NOTE: we intentionally do NOT declare a client `tasks` capability. That

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -527,10 +527,11 @@ module MCPClient
     # @param params [Hash] the elicitation parameters
     # @return [void]
     def handle_elicitation_create(request_id, params)
-      # If no callback is registered, decline the request
+      # Without a callback there is no user to interact with: answer with a
+      # JSON-RPC error rather than fabricating a user "decline".
       unless @elicitation_request_callback
-        @logger.warn('Received elicitation request but no callback registered, declining')
-        send_elicitation_response(request_id, { 'action' => 'decline' })
+        @logger.warn('Received elicitation request but no callback registered')
+        send_error_response(request_id, -32_601, 'Elicitation not supported: no handler configured')
         return
       end
 
@@ -628,6 +629,14 @@ module MCPClient
     # @param result [Hash] the elicitation result (action and optional content)
     # @return [void]
     def send_elicitation_response(request_id, result)
+      # Error-shaped results become JSON-RPC error responses (e.g. -32602 for
+      # an undeclared elicitation mode), mirroring the sampling error path.
+      if result.is_a?(Hash) && result['error']
+        send_error_response(request_id, result['error']['code'] || -32_603,
+                            result['error']['message'] || 'Elicitation error')
+        return
+      end
+
       ensure_initialized
 
       response = {

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -524,10 +524,11 @@ module MCPClient
     # @param params [Hash] the elicitation parameters
     # @return [void]
     def handle_elicitation_create(request_id, params)
-      # If no callback is registered, decline the request
+      # Without a callback there is no user to interact with: answer with a
+      # JSON-RPC error rather than fabricating a user "decline".
       unless @elicitation_request_callback
-        @logger.warn('Received elicitation request but no callback registered, declining')
-        send_elicitation_response(request_id, { 'action' => 'decline' })
+        @logger.warn('Received elicitation request but no callback registered')
+        send_error_response(request_id, -32_601, 'Elicitation not supported: no handler configured')
         return
       end
 
@@ -613,6 +614,14 @@ module MCPClient
     # @param result [Hash] the elicitation result (action and optional content)
     # @return [void]
     def send_elicitation_response(request_id, result)
+      # Error-shaped results become JSON-RPC error responses (e.g. -32602 for
+      # an undeclared elicitation mode), mirroring the sampling error path.
+      if result.is_a?(Hash) && result['error']
+        send_error_response(request_id, result['error']['code'] || -32_603,
+                            result['error']['message'] || 'Elicitation error')
+        return
+      end
+
       response = {
         'jsonrpc' => '2.0',
         'id' => request_id,

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -872,18 +872,16 @@ module MCPClient
       send_error_response(request_id, -32_603, "Internal error: #{e.message}")
     end
 
-    # Handle elicitation/create request from server (MCP 2025-06-18)
-    # @param request_id [String, Integer] the JSON-RPC request ID (used as elicitationId)
+    # Handle elicitation/create request from server (MCP 2025-11-25)
+    # @param request_id [String, Integer] the JSON-RPC request ID
     # @param params [Hash] the elicitation parameters
     # @return [void]
     def handle_elicitation_create(request_id, params)
-      # The request_id is the elicitationId per MCP spec
-      elicitation_id = request_id
-
-      # If no callback is registered, decline the request
+      # Without a callback there is no user to interact with: answer with a
+      # JSON-RPC error rather than fabricating a user "decline".
       unless @elicitation_request_callback
-        @logger.warn('Received elicitation request but no callback registered, declining')
-        send_elicitation_response(elicitation_id, { 'action' => 'decline' })
+        @logger.warn('Received elicitation request but no callback registered')
+        send_error_response(request_id, -32_601, 'Elicitation not supported: no handler configured')
         return
       end
 
@@ -891,7 +889,7 @@ module MCPClient
       result = @elicitation_request_callback.call(request_id, params)
 
       # Send the response back to the server
-      send_elicitation_response(elicitation_id, result)
+      send_elicitation_response(request_id, result)
     end
 
     # Handle roots/list request from server (MCP 2025-06-18)
@@ -972,29 +970,29 @@ module MCPClient
       @logger.error("Error sending sampling response: #{e.message}")
     end
 
-    # Send elicitation response back to server via HTTP POST (MCP 2025-06-18)
-    # For streamable HTTP, this is sent as a JSON-RPC request (not response)
-    # because HTTP is unidirectional.
-    # @param elicitation_id [String] the elicitation ID from the server
+    # Send elicitation response back to server via HTTP POST (MCP 2025-11-25)
+    # The reply to a server's elicitation/create request is a standard
+    # JSON-RPC response echoing the request id, POSTed like every other
+    # response on this transport.
+    # @param request_id [String, Integer] the JSON-RPC request ID
     # @param result [Hash] the elicitation result (action and optional content)
     # @return [void]
-    def send_elicitation_response(elicitation_id, result)
-      params = {
-        'elicitationId' => elicitation_id,
-        'action' => result['action']
-      }
+    def send_elicitation_response(request_id, result)
+      # Error-shaped results become JSON-RPC error responses (e.g. -32602 for
+      # an undeclared elicitation mode), mirroring the sampling error path.
+      if result.is_a?(Hash) && result['error']
+        send_error_response(request_id, result['error']['code'] || -32_603,
+                            result['error']['message'] || 'Elicitation error')
+        return
+      end
 
-      # Only include content if present (typically for 'accept' action)
-      params['content'] = result['content'] if result['content']
-
-      request = {
+      response = {
         'jsonrpc' => '2.0',
-        'method' => 'elicitation/response',
-        'params' => params
+        'id' => request_id,
+        'result' => result
       }
 
-      # Send as a JSON-RPC request via HTTP POST
-      post_jsonrpc_response(request)
+      post_jsonrpc_response(response)
     rescue StandardError => e
       @logger.error("Error sending elicitation response: #{e.message}")
     end

--- a/spec/lib/mcp_client/client_elicitation_spec.rb
+++ b/spec/lib/mcp_client/client_elicitation_spec.rb
@@ -130,19 +130,19 @@ RSpec.describe MCPClient::Client, 'Elicitation (MCP 2025-06-18)' do
     end
 
     context 'when no elicitation handler is configured' do
-      it 'declines the request' do
+      it 'returns a -32601 error instead of fabricating a decline' do
         client = described_class.new
 
         result = client.send(:handle_elicitation_request, request_id, params)
 
-        expect(result).to eq({ 'action' => 'decline' })
+        expect(result['error']).to include('code' => -32_601)
       end
 
       it 'logs a warning' do
         client = described_class.new
         logger = client.instance_variable_get(:@logger)
 
-        expect(logger).to receive(:warn).with('Received elicitation request but no handler configured, declining')
+        expect(logger).to receive(:warn).with('Received elicitation request but no elicitation handler is configured')
 
         client.send(:handle_elicitation_request, request_id, params)
       end
@@ -211,12 +211,12 @@ RSpec.describe MCPClient::Client, 'Elicitation (MCP 2025-06-18)' do
         end
       end
 
-      it 'catches the exception and declines' do
+      it 'catches the exception and returns a -32603 internal error' do
         client = described_class.new(elicitation_handler: error_handler)
 
         result = client.send(:handle_elicitation_request, request_id, params)
 
-        expect(result).to eq({ 'action' => 'decline' })
+        expect(result['error']).to include('code' => -32_603)
       end
 
       it 'logs the error' do

--- a/spec/lib/mcp_client/elicitation_compliance_spec.rb
+++ b/spec/lib/mcp_client/elicitation_compliance_spec.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2025-11-25 elicitation compliance (client/elicitation.mdx):
+# - Replies to elicitation/create MUST be JSON-RPC responses carrying an
+#   ElicitResult (or a JSON-RPC error), on every transport.
+# - "Server sends an elicitation/create request with a mode not declared in
+#   client capabilities: -32602 (Invalid params)" (client MUST).
+# - Internal failures must not be misreported as the user action "decline".
+# - URL-mode results omit the content field (ElicitResult schema).
+# - Clients SHOULD validate responses against the provided schema.
+RSpec.describe 'Elicitation compliance (MCP 2025-11-25)' do
+  describe MCPClient::Client do
+    let(:params) do
+      {
+        'message' => 'Enter your name:',
+        'requestedSchema' => {
+          'type' => 'object',
+          'properties' => { 'name' => { 'type' => 'string' } }
+        }
+      }
+    end
+
+    context 'when the server requests an undeclared or unknown mode' do
+      it 'returns a -32602 Invalid params error' do
+        client = described_class.new(elicitation_handler: ->(_m, _s) { { 'action' => 'accept' } })
+
+        result = client.send(:handle_elicitation_request, 1, params.merge('mode' => 'voice'))
+
+        expect(result['error']).to include('code' => -32_602)
+        expect(result['error']['message']).to match(/mode/i)
+        expect(result).not_to have_key('action')
+      end
+    end
+
+    context 'when no elicitation handler is configured' do
+      it 'returns a -32601 error instead of fabricating a user decline' do
+        client = described_class.new
+
+        result = client.send(:handle_elicitation_request, 1, params)
+
+        expect(result['error']).to include('code' => -32_601)
+        expect(result).not_to have_key('action')
+      end
+    end
+
+    context 'when the elicitation handler raises' do
+      it 'returns a -32603 internal error instead of fabricating a user decline' do
+        handler = ->(_m, _s) { raise StandardError, 'boom' }
+        client = described_class.new(elicitation_handler: handler)
+
+        result = client.send(:handle_elicitation_request, 1, params)
+
+        expect(result['error']).to include('code' => -32_603)
+        expect(result).not_to have_key('action')
+      end
+    end
+
+    context 'with a URL mode accept' do
+      it 'omits the content field per the ElicitResult schema' do
+        handler = ->(_m, _p) { { 'action' => 'accept', 'content' => { 'stray' => 'data' } } }
+        client = described_class.new(elicitation_handler: handler)
+
+        url_params = {
+          'mode' => 'url',
+          'message' => 'Visit to authorize',
+          'url' => 'https://example.com/auth',
+          'elicitationId' => 'elic-1'
+        }
+        result = client.send(:handle_elicitation_request, 2, url_params)
+
+        expect(result['action']).to eq('accept')
+        expect(result).not_to have_key('content')
+      end
+    end
+
+    context 'when the handler returns content violating the requestedSchema' do
+      it 'returns a -32603 error instead of transmitting invalid content' do
+        handler = ->(_m, _s) { { 'name' => 123 } }
+        client = described_class.new(elicitation_handler: handler)
+
+        result = client.send(:handle_elicitation_request, 3, params)
+
+        expect(result['error']).to include('code' => -32_603)
+        expect(result['error']['message']).to match(/schema|validation/i)
+      end
+    end
+
+    context 'when the handler returns conforming content' do
+      it 'returns the accept result unchanged' do
+        handler = ->(_m, _s) { { 'name' => 'Alice' } }
+        client = described_class.new(elicitation_handler: handler)
+
+        result = client.send(:handle_elicitation_request, 4, params)
+
+        expect(result).to eq({ 'action' => 'accept', 'content' => { 'name' => 'Alice' } })
+      end
+    end
+  end
+
+  describe MCPClient::ElicitationValidator do
+    def schema_for(prop)
+      { 'type' => 'object', 'properties' => { 'value' => prop } }
+    end
+
+    it 'flags a string that violates the email format' do
+      errors = described_class.validate_content(
+        { 'value' => 'not-an-email' }, schema_for({ 'type' => 'string', 'format' => 'email' })
+      )
+      expect(errors).not_to be_empty
+    end
+
+    it 'accepts a valid email format value' do
+      errors = described_class.validate_content(
+        { 'value' => 'user@example.com' }, schema_for({ 'type' => 'string', 'format' => 'email' })
+      )
+      expect(errors).to be_empty
+    end
+
+    it 'flags a string that violates the uri format' do
+      errors = described_class.validate_content(
+        { 'value' => 'not a uri' }, schema_for({ 'type' => 'string', 'format' => 'uri' })
+      )
+      expect(errors).not_to be_empty
+    end
+
+    it 'flags a string that violates the date format' do
+      errors = described_class.validate_content(
+        { 'value' => '2026-13-45' }, schema_for({ 'type' => 'string', 'format' => 'date' })
+      )
+      expect(errors).not_to be_empty
+    end
+
+    it 'accepts a valid date-time format value' do
+      errors = described_class.validate_content(
+        { 'value' => '2026-07-20T12:34:56Z' }, schema_for({ 'type' => 'string', 'format' => 'date-time' })
+      )
+      expect(errors).to be_empty
+    end
+  end
+
+  describe 'declared elicitation capability' do
+    it 'declares both supported modes (form and url)' do
+      server = MCPClient::ServerStdio.new(command: 'echo test')
+      params = server.send(:initialization_params)
+
+      expect(params['capabilities']['elicitation']).to eq({ 'form' => {}, 'url' => {} })
+    end
+  end
+
+  describe MCPClient::ServerStreamableHTTP, 'wire format' do
+    let(:base_url) { 'https://example.com' }
+    let(:endpoint) { '/rpc' }
+
+    let(:server) do
+      described_class.new(base_url: base_url, endpoint: endpoint, name: 'elic-wire-test')
+    end
+
+    after { server.cleanup }
+
+    before do
+      server.instance_variable_set(:@session_id, 'test-session-123')
+    end
+
+    it 'replies to elicitation/create with a standard JSON-RPC response' do
+      server.send(:on_elicitation_request) do |_req_id, _params|
+        { 'action' => 'accept', 'content' => { 'name' => 'Alice' } }
+      end
+
+      response_stub = stub_request(:post, "#{base_url}#{endpoint}")
+                      .with(
+                        body: {
+                          'jsonrpc' => '2.0',
+                          'id' => 456,
+                          'result' => { 'action' => 'accept', 'content' => { 'name' => 'Alice' } }
+                        }.to_json
+                      )
+                      .to_return(status: 200, body: '')
+
+      request = {
+        'jsonrpc' => '2.0',
+        'id' => 456,
+        'method' => 'elicitation/create',
+        'params' => { 'message' => 'Enter your name:' }
+      }
+      server.send(:handle_server_message, JSON.generate(request))
+
+      deadline = Time.now + 2
+      sleep 0.05 until response_stub.to_s.include?('was requested 1 time') || Time.now > deadline
+
+      expect(response_stub).to have_been_requested.once
+    end
+
+    it 'replies with a JSON-RPC error when the callback yields an error result' do
+      server.send(:on_elicitation_request) do |_req_id, _params|
+        { 'error' => { 'code' => -32_602, 'message' => "Elicitation mode 'voice' is not supported" } }
+      end
+
+      error_stub = stub_request(:post, "#{base_url}#{endpoint}")
+                   .with(
+                     body: hash_including(
+                       'jsonrpc' => '2.0',
+                       'id' => 457,
+                       'error' => hash_including('code' => -32_602)
+                     )
+                   )
+                   .to_return(status: 200, body: '')
+
+      request = {
+        'jsonrpc' => '2.0',
+        'id' => 457,
+        'method' => 'elicitation/create',
+        'params' => { 'mode' => 'voice', 'message' => 'Speak now' }
+      }
+      server.send(:handle_server_message, JSON.generate(request))
+
+      deadline = Time.now + 2
+      sleep 0.05 until error_stub.to_s.include?('was requested 1 time') || Time.now > deadline
+
+      expect(error_stub).to have_been_requested.once
+    end
+  end
+
+  describe 'error results on stdio and SSE transports' do
+    it 'stdio sends a JSON-RPC error response for an error-shaped elicitation result' do
+      server = MCPClient::ServerStdio.new(command: 'echo test')
+      expect(server).to receive(:send_message).with(
+        hash_including('jsonrpc' => '2.0', 'id' => 9, 'error' => hash_including('code' => -32_602))
+      )
+
+      server.send(:send_elicitation_response, 9, { 'error' => { 'code' => -32_602, 'message' => 'bad mode' } })
+    end
+
+    it 'SSE sends a JSON-RPC error response for an error-shaped elicitation result' do
+      server = MCPClient::ServerSSE.new(base_url: 'https://example.com/sse')
+      expect(server).to receive(:send_error_response).with(9, -32_602, 'bad mode')
+
+      server.send(:send_elicitation_response, 9, { 'error' => { 'code' => -32_602, 'message' => 'bad mode' } })
+    end
+  end
+end

--- a/spec/lib/mcp_client/elicitation_compliance_spec.rb
+++ b/spec/lib/mcp_client/elicitation_compliance_spec.rb
@@ -88,6 +88,52 @@ RSpec.describe 'Elicitation compliance (MCP 2025-11-25)' do
       end
     end
 
+    context 'when the server requests an unknown mode and no handler is configured' do
+      it 'returns -32602 (mode check precedes handler check)' do
+        client = described_class.new
+
+        result = client.send(:handle_elicitation_request, 1, params.merge('mode' => 'voice'))
+
+        expect(result['error']).to include('code' => -32_602)
+      end
+    end
+
+    context 'when the handler returns scalar content' do
+      it 'returns -32603 instead of sending non-object content' do
+        handler = ->(_m, _s) { 'yes' }
+        client = described_class.new(elicitation_handler: handler)
+
+        result = client.send(:handle_elicitation_request, 5, params)
+
+        expect(result['error']).to include('code' => -32_603)
+      end
+    end
+
+    context 'when the handler uses symbol keys in URL mode' do
+      it 'still omits the content field' do
+        handler = ->(_m, _p) { { action: :accept, content: { 'stray' => 'data' } } }
+        client = described_class.new(elicitation_handler: handler)
+
+        url_params = { 'mode' => 'url', 'message' => 'Visit', 'url' => 'https://e.com', 'elicitationId' => 'e2' }
+        result = client.send(:handle_elicitation_request, 6, url_params)
+
+        expect(result['action']).to eq('accept')
+        expect(result).not_to have_key('content')
+        expect(result).not_to have_key(:content)
+      end
+    end
+
+    context 'when the handler attaches content to a decline' do
+      it 'strips content (only accept results carry content)' do
+        handler = ->(_m, _s) { { 'action' => 'decline', 'content' => { 'name' => 'x' } } }
+        client = described_class.new(elicitation_handler: handler)
+
+        result = client.send(:handle_elicitation_request, 7, params)
+
+        expect(result).to eq({ 'action' => 'decline' })
+      end
+    end
+
     context 'when the handler returns conforming content' do
       it 'returns the accept result unchanged' do
         handler = ->(_m, _s) { { 'name' => 'Alice' } }

--- a/spec/lib/mcp_client/json_rpc_common_spec.rb
+++ b/spec/lib/mcp_client/json_rpc_common_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe MCPClient::JsonRpcCommon do
       expect(params).to include(
         'protocolVersion' => MCPClient::PROTOCOL_VERSION,
         'capabilities' => {
-          'elicitation' => {}, # MCP 2025-11-25
+          'elicitation' => { 'form' => {}, 'url' => {} }, # MCP 2025-11-25
           'roots' => { 'listChanged' => true }, # MCP 2025-11-25
           'sampling' => {} # MCP 2025-11-25
         },

--- a/spec/lib/mcp_client/server_sse_elicitation_spec.rb
+++ b/spec/lib/mcp_client/server_sse_elicitation_spec.rb
@@ -114,15 +114,16 @@ RSpec.describe MCPClient::ServerSSE, 'Elicitation (MCP 2025-06-18)' do
     end
 
     context 'when no callback is registered' do
-      it 'sends decline response' do
-        expect(server).to receive(:send_elicitation_response).with(request_id, { 'action' => 'decline' })
+      it 'sends a -32601 error response' do
+        expect(server).to receive(:send_error_response)
+          .with(request_id, -32_601, 'Elicitation not supported: no handler configured')
         server.handle_elicitation_create(request_id, params)
       end
 
       it 'logs a warning' do
-        allow(server).to receive(:send_elicitation_response)
+        allow(server).to receive(:send_error_response)
         logger = server.instance_variable_get(:@logger)
-        expect(logger).to receive(:warn).with('Received elicitation request but no callback registered, declining')
+        expect(logger).to receive(:warn).with('Received elicitation request but no callback registered')
         server.handle_elicitation_create(request_id, params)
       end
     end

--- a/spec/lib/mcp_client/server_stdio_elicitation_spec.rb
+++ b/spec/lib/mcp_client/server_stdio_elicitation_spec.rb
@@ -121,15 +121,16 @@ RSpec.describe MCPClient::ServerStdio, 'Elicitation (MCP 2025-06-18)' do
     end
 
     context 'when no callback is registered' do
-      it 'sends decline response' do
-        expect(server).to receive(:send_elicitation_response).with(request_id, { 'action' => 'decline' })
+      it 'sends a -32601 error response' do
+        expect(server).to receive(:send_error_response)
+          .with(request_id, -32_601, 'Elicitation not supported: no handler configured')
         server.handle_elicitation_create(request_id, params)
       end
 
       it 'logs a warning' do
-        allow(server).to receive(:send_elicitation_response)
+        allow(server).to receive(:send_error_response)
         logger = server.instance_variable_get(:@logger)
-        expect(logger).to receive(:warn).with('Received elicitation request but no callback registered, declining')
+        expect(logger).to receive(:warn).with('Received elicitation request but no callback registered')
         server.handle_elicitation_create(request_id, params)
       end
     end

--- a/spec/lib/mcp_client/server_streamable_http_elicitation_spec.rb
+++ b/spec/lib/mcp_client/server_streamable_http_elicitation_spec.rb
@@ -112,15 +112,16 @@ RSpec.describe MCPClient::ServerStreamableHTTP, 'Elicitation (MCP 2025-06-18)' d
     end
 
     context 'when no callback is registered' do
-      it 'sends decline response' do
-        expect(server).to receive(:send_elicitation_response).with(request_id, { 'action' => 'decline' })
+      it 'sends a -32601 error response' do
+        expect(server).to receive(:send_error_response)
+          .with(request_id, -32_601, 'Elicitation not supported: no handler configured')
         server.send(:handle_elicitation_create, request_id, params)
       end
 
       it 'logs a warning' do
-        allow(server).to receive(:send_elicitation_response)
+        allow(server).to receive(:send_error_response)
         logger = server.instance_variable_get(:@logger)
-        expect(logger).to receive(:warn).with('Received elicitation request but no callback registered, declining')
+        expect(logger).to receive(:warn).with('Received elicitation request but no callback registered')
         server.send(:handle_elicitation_create, request_id, params)
       end
     end
@@ -156,19 +157,14 @@ RSpec.describe MCPClient::ServerStreamableHTTP, 'Elicitation (MCP 2025-06-18)' d
     let(:request_id) { 123 }
     let(:result) { { 'action' => 'accept', 'content' => { 'name' => 'John' } } }
 
-    it 'sends JSON-RPC request via HTTP POST' do
-      # Elicitation responses are sent as JSON-RPC requests, not responses
-      expected_request = {
+    it 'sends a standard JSON-RPC response via HTTP POST' do
+      expected_response = {
         'jsonrpc' => '2.0',
-        'method' => 'elicitation/response',
-        'params' => {
-          'elicitationId' => request_id,
-          'action' => result['action'],
-          'content' => result['content']
-        }
+        'id' => request_id,
+        'result' => result
       }
 
-      expect(server).to receive(:post_jsonrpc_response).with(expected_request)
+      expect(server).to receive(:post_jsonrpc_response).with(expected_response)
       server.send(:send_elicitation_response, request_id, result)
     end
   end
@@ -394,7 +390,7 @@ RSpec.describe MCPClient::ServerStreamableHTTP, 'Elicitation (MCP 2025-06-18)' d
         user_response
       end
 
-      # Stub HTTP POST for response (sent as JSON-RPC request, not response)
+      # Stub HTTP POST for the standard JSON-RPC response
       response_stub = stub_request(:post, "#{base_url}#{endpoint}")
                       .with(
                         headers: {
@@ -403,12 +399,8 @@ RSpec.describe MCPClient::ServerStreamableHTTP, 'Elicitation (MCP 2025-06-18)' d
                         },
                         body: {
                           'jsonrpc' => '2.0',
-                          'method' => 'elicitation/response',
-                          'params' => {
-                            'elicitationId' => 456,
-                            'action' => user_response['action'],
-                            'content' => user_response['content']
-                          }
+                          'id' => 456,
+                          'result' => user_response
                         }.to_json
                       )
                       .to_return(status: 200, body: '')
@@ -438,16 +430,15 @@ RSpec.describe MCPClient::ServerStreamableHTTP, 'Elicitation (MCP 2025-06-18)' d
       expect(response_stub).to have_been_requested.once
     end
 
-    it 'handles decline response' do
-      # No callback registered, should auto-decline
+    it 'answers with a -32601 error when no callback is registered' do
       response_stub = stub_request(:post, "#{base_url}#{endpoint}")
                       .with(
                         body: {
                           'jsonrpc' => '2.0',
-                          'method' => 'elicitation/response',
-                          'params' => {
-                            'elicitationId' => 789,
-                            'action' => 'decline'
+                          'id' => 789,
+                          'error' => {
+                            'code' => -32_601,
+                            'message' => 'Elicitation not supported: no handler configured'
                           }
                         }.to_json
                       )


### PR DESCRIPTION
## What

Four elicitation fixes against [MCP 2025-11-25 client/elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation):

### 1. Streamable HTTP: reply with a real JSON-RPC response (MUST)

The transport answered a server's `elicitation/create` request with an invented message: `{"jsonrpc":"2.0","method":"elicitation/response","params":{"elicitationId":<the JSON-RPC id>,...}}` — no `id`, no `result`, and a method that exists nowhere in the spec. A compliant server never receives a response to its request (it hangs until timeout) and additionally gets an unknown-method notification it can only ignore. The sibling `roots/list` and `sampling/createMessage` reply paths in the same class already POSTed proper responses; elicitation now does the same: `{"jsonrpc":"2.0","id":<request id>,"result":{...ElicitResult...}}`.

### 2. Mode negotiation (MUST)

> "Server sends an `elicitation/create` request with a mode not declared in client capabilities: `-32602` (Invalid params)"

Previously **any** unknown mode string was silently processed as form mode, and the declared capability was the bare `'elicitation' => {}` — which the spec defines as *form-only*, making the gem's implemented URL-mode handling unreachable via compliant servers. Now:
- capability declares both implemented modes: `{'form' => {}, 'url' => {}}`;
- undeclared/unknown modes are rejected with `-32602` on every transport.

### 3. Truthful error semantics

Internal failures were misreported as user actions — a handler exception or missing handler produced `{'action' => 'decline'}`, which the spec defines as "User explicitly declined the request" and tells servers to act on. Now: handler exception → `-32603` Internal error; no handler → `-32601`; error-shaped results flow through each transport's `send_elicitation_response` into a JSON-RPC error response, mirroring the existing sampling error path.

### 4. Validation (SHOULD)

> "Clients SHOULD validate all responses against the provided schema"

Validation was warn-only — content violating the `requestedSchema` was logged and then transmitted anyway. Now non-conforming form accepts return `-32603` with the validation errors instead of sending invalid content, and the validator checks the spec's string `format` constraints (`email`, `uri`, `date`, `date-time`) which were previously ignored. URL-mode accepts omit `content` per the `ElicitResult` schema ("Omitted for out-of-band mode responses").

## Tests

- New `spec/lib/mcp_client/elicitation_compliance_spec.rb` (16 examples: client-level error codes, mode rejection, URL-mode content omission, validation enforcement, format checks, capability shape, and wire-level Streamable HTTP request/response + error cycles). 13 failed before the fix.
- Existing tests that encoded the old behavior updated (auto-decline expectations, `elicitation/response` wire stubs, capability shape).
- Full suite: 1336 examples, 0 failures; RuboCop clean.

Part of an MCP 2025-11-25 compliance audit of this gem against the official spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)