### PR TITLE
Enforce protocol version negotiation: disconnect on unsupported versions

### DIFF
--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -137,9 +137,10 @@ module MCPClient
       result = send_jsonrpc_request(json_rpc_request)
       return unless result.is_a?(Hash)
 
+      # Disconnects if the server negotiated a version we cannot speak.
+      @protocol_version = validate_protocol_version!(result)
       @server_info = result['serverInfo']
       @capabilities = result['capabilities']
-      @protocol_version = result['protocolVersion']
     end
 
     # Send a JSON-RPC request to the server and wait for result

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -135,7 +135,10 @@ module MCPClient
       @logger.debug("Performing initialize RPC: #{json_rpc_request}")
 
       result = send_jsonrpc_request(json_rpc_request)
-      return unless result.is_a?(Hash)
+      unless result.is_a?(Hash)
+        raise MCPClient::Errors::ConnectionError,
+              "Server returned invalid initialize result: #{result.inspect}"
+      end
 
       # Disconnects if the server negotiated a version we cannot speak.
       @protocol_version = validate_protocol_version!(result)

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -90,6 +90,28 @@ module MCPClient
       }
     end
 
+    # Validate the protocol version the server negotiated in its initialize
+    # result. Per the MCP lifecycle, the server may answer with a different
+    # version than requested; if the client cannot support it, it MUST
+    # disconnect. Disconnects (via the transport's cleanup) and raises when
+    # the version is unsupported or absent.
+    # @param result [Hash] the initialize result
+    # @return [String] the negotiated protocol version
+    # @raise [MCPClient::Errors::ConnectionError] if the version is unsupported
+    def validate_protocol_version!(result)
+      version = result['protocolVersion']
+      return version if MCPClient::SUPPORTED_PROTOCOL_VERSIONS.include?(version)
+
+      begin
+        cleanup if respond_to?(:cleanup)
+      rescue StandardError => e
+        @logger.debug("Cleanup after protocol version mismatch failed: #{e.message}")
+      end
+      raise MCPClient::Errors::ConnectionError,
+            "Server negotiated unsupported protocol version #{version.inspect} " \
+            "(supported: #{MCPClient::SUPPORTED_PROTOCOL_VERSIONS.join(', ')}); disconnecting"
+    end
+
     # Process JSON-RPC response
     # @param response [Hash] the parsed JSON-RPC response
     # @return [Object] the result field from the response

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -69,6 +69,8 @@ module MCPClient
         result = send_jsonrpc_request(json_rpc_request)
         return unless result.is_a?(Hash)
 
+        # Disconnects if the server negotiated a version we cannot speak.
+        @protocol_version = validate_protocol_version!(result)
         @server_info = result['serverInfo']
         @capabilities = result['capabilities']
 

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -67,7 +67,10 @@ module MCPClient
         json_rpc_request = build_jsonrpc_request('initialize', initialization_params, request_id)
         @logger.debug("Performing initialize RPC: #{json_rpc_request}")
         result = send_jsonrpc_request(json_rpc_request)
-        return unless result.is_a?(Hash)
+        unless result.is_a?(Hash)
+          raise MCPClient::Errors::ConnectionError,
+                "Server returned invalid initialize result: #{result.inspect}"
+        end
 
         # Disconnects if the server negotiated a version we cannot speak.
         @protocol_version = validate_protocol_version!(result)

--- a/lib/mcp_client/server_stdio/json_rpc_transport.rb
+++ b/lib/mcp_client/server_stdio/json_rpc_transport.rb
@@ -35,8 +35,10 @@ module MCPClient
           raise MCPClient::Errors::ConnectionError, "Initialize failed: #{err['message']}"
         end
 
-        # Store server info and capabilities
+        # Store negotiated protocol version, server info and capabilities.
+        # Disconnects if the server negotiated a version we cannot speak.
         result = res['result'] || {}
+        @protocol_version = validate_protocol_version!(result)
         @server_info = result['serverInfo']
         @capabilities = result['capabilities']
 

--- a/lib/mcp_client/version.rb
+++ b/lib/mcp_client/version.rb
@@ -6,4 +6,9 @@ module MCPClient
 
   # MCP protocol version (date-based) - unified across all transports
   PROTOCOL_VERSION = '2025-11-25'
+
+  # Protocol revisions this client can speak, newest first. Used during
+  # version negotiation: if the server answers initialize with a version
+  # outside this set, the client must disconnect (MCP lifecycle).
+  SUPPORTED_PROTOCOL_VERSIONS = %w[2025-11-25 2025-06-18 2025-03-26 2024-11-05].freeze
 end

--- a/spec/integration/session_management_integration_spec.rb
+++ b/spec/integration/session_management_integration_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe 'Session Management Integration', type: :integration do
           .with(body: hash_including(method: 'initialize'))
           .to_return(
             status: 200,
-            body: { jsonrpc: '2.0', id: 1, result: {} }.to_json,
+            body: { jsonrpc: '2.0', id: 1, result: { protocolVersion: MCPClient::PROTOCOL_VERSION } }.to_json,
             headers: { 'Mcp-Session-Id' => 'invalid@session!' } # Invalid format
           )
 
@@ -212,7 +212,9 @@ RSpec.describe 'Session Management Integration', type: :integration do
           .with(body: hash_including(method: 'initialize'))
           .to_return(
             status: 200,
-            body: "event: message\nid: #{event_id}-init\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n",
+            body: "event: message\nid: #{event_id}-init\n" \
+                  "data: #{{ jsonrpc: '2.0', id: 1,
+                             result: { protocolVersion: MCPClient::PROTOCOL_VERSION } }.to_json}\n\n",
             headers: {
               'Mcp-Session-Id' => session_id,
               'Content-Type' => 'text/event-stream'
@@ -435,7 +437,7 @@ RSpec.describe 'Session Management Integration', type: :integration do
         stub_request(:post, "#{base_url}/rpc")
           .to_return(
             status: 200,
-            body: { jsonrpc: '2.0', id: 1, result: {} }.to_json,
+            body: { jsonrpc: '2.0', id: 1, result: { protocolVersion: MCPClient::PROTOCOL_VERSION } }.to_json,
             headers: { 'Mcp-Session-Id' => 'valid_session-123_abc' }
           )
 
@@ -446,7 +448,7 @@ RSpec.describe 'Session Management Integration', type: :integration do
         stub_request(:post, "#{base_url}/rpc")
           .to_return(
             status: 200,
-            body: { jsonrpc: '2.0', id: 2, result: {} }.to_json,
+            body: { jsonrpc: '2.0', id: 2, result: { protocolVersion: MCPClient::PROTOCOL_VERSION } }.to_json,
             headers: { 'Mcp-Session-Id' => 'invalid@session!' }
           )
 

--- a/spec/lib/mcp_client/logger_initialization_spec.rb
+++ b/spec/lib/mcp_client/logger_initialization_spec.rb
@@ -189,7 +189,8 @@ RSpec.describe 'Logger Initialization' do
         .to_return(
           status: 200,
           headers: { 'Content-Type' => 'application/json' },
-          body: { jsonrpc: '2.0', id: 1, result: { serverInfo: {}, capabilities: {} } }.to_json
+          body: { jsonrpc: '2.0', id: 1,
+                  result: { protocolVersion: MCPClient::PROTOCOL_VERSION, serverInfo: {}, capabilities: {} } }.to_json
         )
     end
 

--- a/spec/lib/mcp_client/protocol_version_negotiation_spec.rb
+++ b/spec/lib/mcp_client/protocol_version_negotiation_spec.rb
@@ -50,6 +50,19 @@ RSpec.describe 'Protocol version negotiation (MCP 2025-11-25)' do
       )
     end
 
+    it 'disconnects when the initialize result is not an object' do
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including('method' => 'initialize'))
+        .to_return(status: 200,
+                   body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"ok\"}\n\n",
+                   headers: { 'Content-Type' => 'text/event-stream' })
+      stub_request(:get, "#{base_url}#{endpoint}").to_return(status: 200, body: '')
+
+      expect { server.connect }.to raise_error(
+        MCPClient::Errors::ConnectionError, /initialize result/i
+      )
+    end
+
     it 'accepts a supported older version and records it' do
       stub_initialize({ protocolVersion: '2025-06-18', capabilities: {},
                         serverInfo: { name: 's', version: '1' } })

--- a/spec/lib/mcp_client/protocol_version_negotiation_spec.rb
+++ b/spec/lib/mcp_client/protocol_version_negotiation_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2025-11-25 version negotiation (basic/lifecycle + InitializeResult
+# schema): the server responds with the protocol version it wants to use —
+# "If the client cannot support this version, it MUST disconnect."
+RSpec.describe 'Protocol version negotiation (MCP 2025-11-25)' do
+  it 'defines the set of supported protocol versions, including the current one' do
+    expect(MCPClient::SUPPORTED_PROTOCOL_VERSIONS).to include(MCPClient::PROTOCOL_VERSION)
+  end
+
+  def init_sse_body(result)
+    "event: message\ndata: #{JSON.generate(jsonrpc: '2.0', id: 1, result: result)}\n\n"
+  end
+
+  describe MCPClient::ServerStreamableHTTP do
+    let(:base_url) { 'https://example.com' }
+    let(:endpoint) { '/rpc' }
+    let(:server) { described_class.new(base_url: base_url, endpoint: endpoint, name: 'ver-test') }
+
+    after { server.cleanup }
+
+    def stub_initialize(result)
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including('method' => 'initialize'))
+        .to_return(status: 200, body: init_sse_body(result),
+                   headers: { 'Content-Type' => 'text/event-stream' })
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including('method' => 'notifications/initialized'))
+        .to_return(status: 202, body: '')
+      stub_request(:get, "#{base_url}#{endpoint}").to_return(status: 200, body: '')
+    end
+
+    it 'disconnects when the server negotiates an unsupported version' do
+      stub_initialize({ protocolVersion: '1999-01-01', capabilities: {},
+                        serverInfo: { name: 's', version: '1' } })
+
+      expect { server.connect }.to raise_error(
+        MCPClient::Errors::ConnectionError, /protocol version.*1999-01-01/i
+      )
+    end
+
+    it 'disconnects when the initialize result carries no protocol version' do
+      stub_initialize({ capabilities: {}, serverInfo: { name: 's', version: '1' } })
+
+      expect { server.connect }.to raise_error(
+        MCPClient::Errors::ConnectionError, /protocol version/i
+      )
+    end
+
+    it 'accepts a supported older version and records it' do
+      stub_initialize({ protocolVersion: '2025-06-18', capabilities: {},
+                        serverInfo: { name: 's', version: '1' } })
+
+      expect(server.connect).to be true
+      expect(server.instance_variable_get(:@protocol_version)).to eq('2025-06-18')
+    end
+  end
+
+  describe MCPClient::ServerStdio do
+    let(:server) { described_class.new(command: 'echo test') }
+
+    it 'disconnects when the server negotiates an unsupported version' do
+      allow(server).to receive(:next_id).and_return(1)
+      allow(server).to receive(:send_request)
+      allow(server).to receive(:wait_response).and_return(
+        { 'result' => { 'protocolVersion' => '1999-01-01', 'capabilities' => {} } }
+      )
+      expect(server).to receive(:cleanup)
+
+      expect { server.send(:perform_initialize) }.to raise_error(
+        MCPClient::Errors::ConnectionError, /protocol version.*1999-01-01/i
+      )
+    end
+
+    it 'records a supported negotiated version' do
+      allow(server).to receive(:next_id).and_return(1)
+      allow(server).to receive(:send_request)
+      allow(server).to receive(:wait_response).and_return(
+        { 'result' => { 'protocolVersion' => '2024-11-05', 'capabilities' => {},
+                        'serverInfo' => { 'name' => 's' } } }
+      )
+      server.instance_variable_set(:@stdin, double('stdin', puts: nil))
+
+      server.send(:perform_initialize)
+
+      expect(server.instance_variable_get(:@protocol_version)).to eq('2024-11-05')
+    end
+  end
+
+  describe MCPClient::ServerSSE do
+    let(:server) { described_class.new(base_url: 'https://example.com/sse') }
+
+    it 'disconnects when the server negotiates an unsupported version' do
+      allow(server).to receive(:send_jsonrpc_request).and_return(
+        { 'protocolVersion' => '1999-01-01', 'capabilities' => {} }
+      )
+      expect(server).to receive(:cleanup)
+
+      expect { server.send(:perform_initialize) }.to raise_error(
+        MCPClient::Errors::ConnectionError, /protocol version.*1999-01-01/i
+      )
+    end
+
+    it 'records a supported negotiated version' do
+      allow(server).to receive(:send_jsonrpc_request).and_return(
+        { 'protocolVersion' => '2024-11-05', 'capabilities' => {},
+          'serverInfo' => { 'name' => 's' } }
+      )
+      allow(server).to receive(:post_json_rpc_request)
+      allow(server).to receive(:sleep)
+
+      server.send(:perform_initialize)
+
+      expect(server.instance_variable_get(:@protocol_version)).to eq('2024-11-05')
+    end
+  end
+end

--- a/spec/lib/mcp_client/server_http_spec.rb
+++ b/spec/lib/mcp_client/server_http_spec.rb
@@ -640,7 +640,7 @@ RSpec.describe MCPClient::ServerHTTP do
           .with(body: hash_including(method: 'initialize'))
           .to_return(
             status: 200,
-            body: { jsonrpc: '2.0', id: 1, result: {} }.to_json,
+            body: { jsonrpc: '2.0', id: 1, result: { protocolVersion: MCPClient::PROTOCOL_VERSION } }.to_json,
             headers: { 'Mcp-Session-Id' => 'valid-session-123' }
           )
 
@@ -653,7 +653,7 @@ RSpec.describe MCPClient::ServerHTTP do
           .with(body: hash_including(method: 'initialize'))
           .to_return(
             status: 200,
-            body: { jsonrpc: '2.0', id: 1, result: {} }.to_json,
+            body: { jsonrpc: '2.0', id: 1, result: { protocolVersion: MCPClient::PROTOCOL_VERSION } }.to_json,
             headers: { 'Mcp-Session-Id' => 'invalid@session!' }
           )
 
@@ -666,7 +666,7 @@ RSpec.describe MCPClient::ServerHTTP do
           .with(body: hash_including(method: 'initialize'))
           .to_return(
             status: 200,
-            body: { jsonrpc: '2.0', id: 1, result: {} }.to_json,
+            body: { jsonrpc: '2.0', id: 1, result: { protocolVersion: MCPClient::PROTOCOL_VERSION } }.to_json,
             headers: {}
           )
 
@@ -703,7 +703,7 @@ RSpec.describe MCPClient::ServerHTTP do
           .with(body: hash_including(method: 'initialize'))
           .to_return(
             status: 200,
-            body: { jsonrpc: '2.0', id: 1, result: {} }.to_json
+            body: { jsonrpc: '2.0', id: 1, result: { protocolVersion: MCPClient::PROTOCOL_VERSION } }.to_json
           )
         stub_request(:post, "#{base_url}#{endpoint}")
           .with(body: hash_including(method: 'notifications/initialized'))

--- a/spec/lib/mcp_client/server_streamable_http_spec.rb
+++ b/spec/lib/mcp_client/server_streamable_http_spec.rb
@@ -1029,7 +1029,7 @@ RSpec.describe MCPClient::ServerStreamableHTTP do
           .with(body: hash_including(method: 'initialize'))
           .to_return(
             status: 200,
-            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n",
+            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"#{MCPClient::PROTOCOL_VERSION}\"}}\n\n",
             headers: {
               'Mcp-Session-Id' => 'valid-streamable-session-456',
               'Content-Type' => 'text/event-stream'
@@ -1075,7 +1075,7 @@ RSpec.describe MCPClient::ServerStreamableHTTP do
           .with(body: hash_including(method: 'initialize'))
           .to_return(
             status: 200,
-            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n",
+            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"#{MCPClient::PROTOCOL_VERSION}\"}}\n\n",
             headers: {
               'Mcp-Session-Id' => 'invalid@session$format!',
               'Content-Type' => 'text/event-stream'
@@ -1099,7 +1099,7 @@ RSpec.describe MCPClient::ServerStreamableHTTP do
           .with(body: hash_including(method: 'initialize'))
           .to_return(
             status: 200,
-            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n",
+            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"#{MCPClient::PROTOCOL_VERSION}\"}}\n\n",
             headers: { 'Content-Type' => 'text/event-stream' }
           )
 
@@ -1164,7 +1164,7 @@ RSpec.describe MCPClient::ServerStreamableHTTP do
           .with(body: hash_including(method: 'initialize'))
           .to_return(
             status: 200,
-            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n",
+            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"#{MCPClient::PROTOCOL_VERSION}\"}}\n\n",
             headers: { 'Content-Type' => 'text/event-stream' }
           )
 
@@ -1372,7 +1372,7 @@ RSpec.describe MCPClient::ServerStreamableHTTP do
         stub_request(:post, "#{base_url}#{endpoint}")
           .to_return(
             status: 200,
-            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n",
+            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"#{MCPClient::PROTOCOL_VERSION}\"}}\n\n",
             headers: {
               'Mcp-Session-Id' => 'valid_session-123_abc',
               'Content-Type' => 'text/event-stream'
@@ -1387,7 +1387,7 @@ RSpec.describe MCPClient::ServerStreamableHTTP do
         stub_request(:post, "#{base_url}#{endpoint}")
           .to_return(
             status: 200,
-            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n",
+            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"#{MCPClient::PROTOCOL_VERSION}\"}}\n\n",
             headers: {
               'Mcp-Session-Id' => 'invalid/session@123!',
               'Content-Type' => 'text/event-stream'

--- a/spec/support/fake_filesystem_mcp_server.rb
+++ b/spec/support/fake_filesystem_mcp_server.rb
@@ -287,7 +287,11 @@ while (line = $stdin.gets)
   id = msg['id']
   case msg['method']
   when 'initialize'
-    send_response(id, {})
+    send_response(id, {
+                    'protocolVersion' => '2025-11-25',
+                    'capabilities' => { 'tools' => {} },
+                    'serverInfo' => { 'name' => 'fake-filesystem', 'version' => '1.0.0' }
+                  })
   when 'tools/list'
     send_response(id, { 'tools' => TOOLS })
   when 'tools/call'


### PR DESCRIPTION
## What

Implements the version-negotiation MUST from the MCP lifecycle ([basic/lifecycle — Version Negotiation](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#version-negotiation), `InitializeResult.protocolVersion` in the official schema):

> "The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it **MUST** disconnect."

No transport performed any check:

- **stdio** and **legacy SSE** never even read `result['protocolVersion']` — the negotiated version was discarded with no public accessor, so a host couldn't perform the check either.
- **HTTP / Streamable HTTP** stored it without comparison and then dutifully echoed the unvalidated value in the `MCP-Protocol-Version` header.

A server negotiating e.g. `1999-01-01` (or omitting the field entirely) silently continued the session under 2025-11-25 semantics.

## How

- New `MCPClient::SUPPORTED_PROTOCOL_VERSIONS = %w[2025-11-25 2025-06-18 2025-03-26 2024-11-05]` in `version.rb`.
- Shared `JsonRpcCommon#validate_protocol_version!`: returns the negotiated version when supported; otherwise runs the transport's `cleanup` (disconnect) and raises `ConnectionError` naming the offending version.
- Called from every transport's `perform_initialize`; stdio and SSE now also record `@protocol_version` (needed for the `MCP-Protocol-Version` header work on the legacy SSE transport, tracked separately).

## Tests

- New `spec/lib/mcp_client/protocol_version_negotiation_spec.rb` (8 examples across Streamable HTTP wire level, stdio, and SSE: unsupported version → disconnect+raise, missing version → raise, supported older version → accepted and recorded). 7 failed before the fix.
- Existing stubs that answered `initialize` with an empty result (non-compliant per the `InitializeResult` schema, which requires `protocolVersion`) now include one — including the fake stdio filesystem server used by the integration suite.
- Full suite: 1328 examples, 0 failures; RuboCop clean.

Part of an MCP 2025-11-25 compliance audit of this gem against the official spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)