### PR TITLE
Handle OAuth WWW-Authenticate challenges: 401 discovery, scope selection, 403 step-up

### DIFF
--- a/lib/mcp_client/auth.rb
+++ b/lib/mcp_client/auth.rb
@@ -290,13 +290,16 @@ module MCPClient
 
     # Protected resource metadata for authorization server discovery
     class ResourceMetadata
-      attr_reader :resource, :authorization_servers
+      attr_reader :resource, :authorization_servers, :scopes_supported
 
       # @param resource [String] Resource server identifier
       # @param authorization_servers [Array<String>] List of authorization server URLs
-      def initialize(resource:, authorization_servers:)
+      # @param scopes_supported [Array<String>, nil] Scopes the resource supports (RFC 9728);
+      #   per MCP, the default scope set when a challenge provides none
+      def initialize(resource:, authorization_servers:, scopes_supported: nil)
         @resource = resource
         @authorization_servers = authorization_servers
+        @scopes_supported = scopes_supported
       end
 
       # Convert to hash
@@ -304,8 +307,9 @@ module MCPClient
       def to_h
         {
           resource: @resource,
-          authorization_servers: @authorization_servers
-        }
+          authorization_servers: @authorization_servers,
+          scopes_supported: @scopes_supported
+        }.compact
       end
 
       # Create resource metadata from hash
@@ -314,7 +318,8 @@ module MCPClient
       def self.from_h(data)
         new(
           resource: data[:resource] || data['resource'],
-          authorization_servers: data[:authorization_servers] || data['authorization_servers']
+          authorization_servers: data[:authorization_servers] || data['authorization_servers'],
+          scopes_supported: data[:scopes_supported] || data['scopes_supported']
         )
       end
     end

--- a/lib/mcp_client/auth/oauth_provider.rb
+++ b/lib/mcp_client/auth/oauth_provider.rb
@@ -11,6 +11,18 @@ module MCPClient
     # Handles the complete OAuth flow including server discovery, client registration,
     # authorization, token exchange, and refresh
     class OAuthProvider
+      # One auth-param (name = token / quoted-string) as it appears in a
+      # WWW-Authenticate challenge (RFC 7235 §2.1, optional whitespace around
+      # '='). Mirrors HttpTransportBase::AUTH_PARAM so provider-side challenge
+      # parsing segments headers exactly like the transport does.
+      AUTH_PARAM = /[A-Za-z0-9._~+-]+\s*=\s*(?:"(?:[^"\\]|\\.)*"|[^,\s]*)/
+      # A run of comma/space separated auth-params anchored at the start of a
+      # string. The run ends before a token that is NOT followed by '=' — the
+      # auth-scheme introducing the next challenge — while commas inside quoted
+      # values are consumed by the quoted-string branch, not treated as
+      # boundaries. Mirrors HttpTransportBase::AUTH_PARAMS_RUN.
+      AUTH_PARAMS_RUN = /\A(?:[\s,]*#{AUTH_PARAM})*/
+
       # @!attribute [rw] redirect_uri
       #   @return [String] OAuth redirect URI
       # @!attribute [rw] scope
@@ -148,11 +160,18 @@ module MCPClient
         www_authenticate = response.headers['WWW-Authenticate'] || response.headers['www-authenticate']
         return nil unless www_authenticate
 
+        # Challenge parameters are read from the Bearer challenge's own
+        # segment only — never from the whole (possibly multi-challenge)
+        # header — so parameters belonging to Basic or another scheme cannot
+        # drive Bearer scope selection or resource metadata discovery. A
+        # header without a Bearer challenge carries no usable Bearer params.
+        bearer_params = bearer_challenge_segment(www_authenticate)
+
         # MCP 2025-11-25: "Clients MUST treat the scopes provided in the
         # challenge as authoritative for satisfying the current request" —
         # including resetting a previously challenged scope when the current
         # challenge carries none.
-        @challenge_scope = extract_challenge_param(www_authenticate, 'scope')
+        @challenge_scope = bearer_params && extract_challenge_param(bearer_params, 'scope')
 
         url = extract_resource_metadata_url(www_authenticate)
         return nil unless url
@@ -173,23 +192,45 @@ module MCPClient
 
       # Extract the protected-resource-metadata URL from a WWW-Authenticate header.
       # Per RFC 9728 the parameter is `resource_metadata`; a legacy `resource`
-      # parameter is accepted as a fallback for older servers.
+      # parameter is accepted as a fallback for older servers. Only the Bearer
+      # challenge's own segment is consulted, so a parameter belonging to
+      # another scheme's challenge can never drive discovery.
       # @param header [String] the WWW-Authenticate header value
       # @return [String, nil] the metadata URL if present
       def extract_resource_metadata_url(header)
+        params = bearer_challenge_segment(header)
+        return nil unless params
+
         # Auth-params may include optional whitespace around '=' (RFC 7235).
         # Quoted form: resource_metadata = "https://..."
-        if (m = header.match(/resource_metadata\s*=\s*"([^"]+)"/))
+        if (m = params.match(/resource_metadata\s*=\s*"([^"]+)"/))
           return m[1]
         end
 
         # Unquoted token form: resource_metadata = https://...
-        if (m = header.match(/resource_metadata\s*=\s*([^,\s]+)/))
+        if (m = params.match(/resource_metadata\s*=\s*([^,\s]+)/))
           return m[1]
         end
 
         # Legacy fallback: resource="https://..."
-        header.match(/resource\s*=\s*"([^"]+)"/)&.captures&.first
+        params.match(/resource\s*=\s*"([^"]+)"/)&.captures&.first
+      end
+
+      # Extract the Bearer challenge's own parameter segment from a (possibly
+      # multi-challenge) WWW-Authenticate header, so params belonging to other
+      # schemes (e.g. `Basic resource_metadata="...", Bearer realm="x"`) are
+      # never attributed to the Bearer challenge. Mirrors
+      # HttpTransportBase#bearer_challenge_segment.
+      # @param header [String, nil] the WWW-Authenticate header value
+      # @return [String, nil] the Bearer challenge's parameters (possibly
+      #   empty), or nil when the header has no Bearer challenge
+      def bearer_challenge_segment(header)
+        return nil unless header
+
+        match = header.match(/(?:\A|[\s,])Bearer(?=[\s,]|\z)/i)
+        return nil unless match
+
+        match.post_match[AUTH_PARAMS_RUN]
       end
 
       # Extract an auth-param value from a WWW-Authenticate header

--- a/lib/mcp_client/auth/oauth_provider.rb
+++ b/lib/mcp_client/auth/oauth_provider.rb
@@ -146,6 +146,12 @@ module MCPClient
         www_authenticate = response.headers['WWW-Authenticate'] || response.headers['www-authenticate']
         return nil unless www_authenticate
 
+        # MCP 2025-11-25: "Clients MUST treat the scopes provided in the
+        # challenge as authoritative for satisfying the current request."
+        if (challenge_scope = extract_challenge_param(www_authenticate, 'scope'))
+          @challenge_scope = challenge_scope
+        end
+
         url = extract_resource_metadata_url(www_authenticate)
         return nil unless url
 
@@ -179,7 +185,42 @@ module MCPClient
         header.match(/resource\s*=\s*"([^"]+)"/)&.captures&.first
       end
 
+      # Extract an auth-param value from a WWW-Authenticate header
+      # (quoted or unquoted form, optional whitespace around '=').
+      # @param header [String] the WWW-Authenticate header value
+      # @param name [String] the auth-param name
+      # @return [String, nil] the parameter value if present
+      def extract_challenge_param(header, name)
+        if (m = header.match(/#{Regexp.escape(name)}\s*=\s*"([^"]*)"/))
+          return m[1]
+        end
+
+        header.match(/#{Regexp.escape(name)}\s*=\s*([^,\s]+)/)&.captures&.first
+      end
+
+      # Scope requested by the most recent WWW-Authenticate challenge.
+      # @return [String, nil]
+      attr_reader :challenge_scope
+
       private
+
+      # Resolve the scope for authorization/registration requests using the
+      # MCP 2025-11-25 scope selection strategy: the challenge's scope
+      # parameter is authoritative; then an explicitly configured scope
+      # (:all resolves to the AS-advertised scope list); then the Protected
+      # Resource Metadata's scopes_supported; otherwise omit scope entirely.
+      # @return [String, nil]
+      def resolved_scope
+        return @challenge_scope if @challenge_scope && !@challenge_scope.empty?
+        return supported_scopes.join(' ') if scope == :all
+        return scope if scope
+
+        prm = @challenge_resource_metadata || @resource_metadata
+        prm_scopes = prm&.scopes_supported
+        return prm_scopes.join(' ') if prm_scopes && !prm_scopes.empty?
+
+        nil
+      end
 
       # Normalize server URL to canonical form
       # @param url [String] Server URL
@@ -571,7 +612,11 @@ module MCPClient
         end
 
         data = JSON.parse(response.body)
-        ResourceMetadata.from_h(data)
+        metadata = ResourceMetadata.from_h(data)
+        # Retain the most recently fetched PRM so scope resolution can fall
+        # back to its scopes_supported (MCP scope selection priority 2).
+        @resource_metadata = metadata
+        metadata
       rescue JSON::ParserError => e
         raise MCPClient::Errors::ConnectionError, "Invalid resource metadata JSON: #{e.message}"
       rescue Faraday::Error => e
@@ -628,8 +673,6 @@ module MCPClient
       # @raise [MCPClient::Errors::ConnectionError] if registration fails
       def register_client(server_metadata)
         logger.debug("Registering OAuth client at: #{server_metadata.registration_endpoint}")
-
-        resolved_scope = scope == :all ? supported_scopes.join(' ') : scope
 
         metadata = ClientMetadata.new(
           redirect_uris: [redirect_uri],
@@ -705,8 +748,6 @@ module MCPClient
       def build_authorization_url(server_metadata, client_info, pkce, state)
         # Use the redirect_uri that was actually registered
         registered_redirect_uri = client_info.metadata.redirect_uris.first
-
-        resolved_scope = scope == :all ? supported_scopes.join(' ') : scope
 
         params = {
           response_type: 'code',

--- a/lib/mcp_client/auth/oauth_provider.rb
+++ b/lib/mcp_client/auth/oauth_provider.rb
@@ -227,10 +227,14 @@ module MCPClient
       def bearer_challenge_segment(header)
         return nil unless header
 
-        match = header.match(/(?:\A|[\s,])Bearer(?=[\s,]|\z)/i)
+        # Locate the Bearer scheme token only OUTSIDE quoted strings: a
+        # quoted value such as realm="prefix Bearer x" must not anchor the
+        # segment.
+        masked = header.gsub(/"(?:\\.|[^"\\])*"/) { |q| "\"#{' ' * (q.length - 2)}\"" }
+        match = masked.match(/(?:\A|[\s,])Bearer(?=[\s,]|\z)/i)
         return nil unless match
 
-        match.post_match[AUTH_PARAMS_RUN]
+        header[match.end(0)..][AUTH_PARAMS_RUN]
       end
 
       # Extract an auth-param value from a WWW-Authenticate header

--- a/lib/mcp_client/auth/oauth_provider.rb
+++ b/lib/mcp_client/auth/oauth_provider.rb
@@ -43,8 +43,10 @@ module MCPClient
         @http_client = create_http_client
         # Protected resource metadata learned from a 401 WWW-Authenticate
         # challenge, reused by discovery so a challenge-advertised metadata URL
-        # is not re-derived (and possibly missed).
+        # is not re-derived (and possibly missed). The URL itself is retained
+        # separately so a failed fetch is retried authoritatively by discovery.
         @challenge_resource_metadata = nil
+        @challenge_metadata_url = nil
       end
 
       # @param url [String] Server URL to normalize
@@ -350,8 +352,11 @@ module MCPClient
       # @raise [MCPClient::Errors::ConnectionError] if discovery fails
       def discover_authorization_server
         # A fresh 401 challenge is authoritative and overrides any cached
-        # (possibly stale or direct-discovered) authorization server metadata.
-        cached = storage.get_server_metadata(server_url) unless @challenge_resource_metadata
+        # (possibly stale or direct-discovered) authorization server metadata —
+        # whether the challenge-advertised PRM was already fetched or only its
+        # URL is pending (e.g. the initial fetch failed and must be retried).
+        challenge_pending = @challenge_resource_metadata || @challenge_metadata_url
+        cached = storage.get_server_metadata(server_url) unless challenge_pending
         if cached
           # Validate the cached entry before use so a persisted/older cache with
           # an HTTP endpoint or without S256 is still rejected.
@@ -384,6 +389,7 @@ module MCPClient
 
         storage.set_server_metadata(server_url, server_metadata)
         @challenge_resource_metadata = nil # consumed
+        @challenge_metadata_url = nil # consumed
         server_metadata
       end
 
@@ -426,9 +432,7 @@ module MCPClient
         # once PRM IS found it is authoritative: any subsequent failure must be a
         # hard error, never a silent fallback to an authorization server the PRM
         # did not advertise.
-        candidate_urls = ([@challenge_metadata_url] + protected_resource_metadata_urls(server_url)).compact.uniq
-        resource_metadata = @challenge_resource_metadata ||
-                            fetch_first_resource_metadata(candidate_urls)
+        resource_metadata = challenge_or_well_known_resource_metadata
         return nil unless resource_metadata
 
         validate_resource_matches!(resource_metadata)
@@ -447,6 +451,25 @@ module MCPClient
         end
 
         server_metadata
+      end
+
+      # Resolve the Protected Resource Metadata for discovery.
+      #
+      # MCP 2025-11-25 MUST: use the resource metadata URL from the parsed
+      # WWW-Authenticate headers when present; otherwise fall back to the
+      # well-known URIs. A challenge-advertised URL is therefore authoritative:
+      # it is fetched strictly, and any failure (including a 404) raises rather
+      # than falling through to constructed well-known candidates the challenge
+      # superseded.
+      # @return [ResourceMetadata, nil] metadata, or nil when no PRM exists at
+      #   the speculative well-known URLs (permitting the direct-AS fallback)
+      # @raise [MCPClient::Errors::ConnectionError] if the challenge-advertised
+      #   URL cannot be fetched, or a well-known candidate exists but is invalid
+      def challenge_or_well_known_resource_metadata
+        return @challenge_resource_metadata if @challenge_resource_metadata
+        return fetch_resource_metadata(@challenge_metadata_url, strict: true) if @challenge_metadata_url
+
+        fetch_first_resource_metadata(protected_resource_metadata_urls(server_url))
       end
 
       # Legacy/self-hosted discovery: treat the MCP server ORIGIN as its own

--- a/lib/mcp_client/auth/oauth_provider.rb
+++ b/lib/mcp_client/auth/oauth_provider.rb
@@ -147,13 +147,18 @@ module MCPClient
         return nil unless www_authenticate
 
         # MCP 2025-11-25: "Clients MUST treat the scopes provided in the
-        # challenge as authoritative for satisfying the current request."
-        if (challenge_scope = extract_challenge_param(www_authenticate, 'scope'))
-          @challenge_scope = challenge_scope
-        end
+        # challenge as authoritative for satisfying the current request" —
+        # including resetting a previously challenged scope when the current
+        # challenge carries none.
+        @challenge_scope = extract_challenge_param(www_authenticate, 'scope')
 
         url = extract_resource_metadata_url(www_authenticate)
         return nil unless url
+
+        # Remember the advertised URL even if the fetch below fails, so a
+        # later discovery retries it instead of probing well-known URIs the
+        # challenge already superseded.
+        @challenge_metadata_url = url
 
         # This URL was explicitly advertised by the 401 challenge, so a 404 is a
         # misconfiguration to surface (strict), not a speculative miss to skip.
@@ -191,11 +196,11 @@ module MCPClient
       # @param name [String] the auth-param name
       # @return [String, nil] the parameter value if present
       def extract_challenge_param(header, name)
-        if (m = header.match(/#{Regexp.escape(name)}\s*=\s*"([^"]*)"/))
+        if (m = header.match(/(?:^|[\s,])#{Regexp.escape(name)}\s*=\s*"([^"]*)"/i))
           return m[1]
         end
 
-        header.match(/#{Regexp.escape(name)}\s*=\s*([^,\s]+)/)&.captures&.first
+        header.match(/(?:^|[\s,])#{Regexp.escape(name)}\s*=\s*([^,\s]+)/i)&.captures&.first
       end
 
       # Scope requested by the most recent WWW-Authenticate challenge.
@@ -212,8 +217,13 @@ module MCPClient
       # @return [String, nil]
       def resolved_scope
         return @challenge_scope if @challenge_scope && !@challenge_scope.empty?
-        return supported_scopes.join(' ') if scope == :all
-        return scope if scope
+
+        if scope == :all
+          all_scopes = supported_scopes
+          return all_scopes.join(' ') unless all_scopes.empty?
+        elsif scope
+          return scope
+        end
 
         prm = @challenge_resource_metadata || @resource_metadata
         prm_scopes = prm&.scopes_supported
@@ -416,8 +426,9 @@ module MCPClient
         # once PRM IS found it is authoritative: any subsequent failure must be a
         # hard error, never a silent fallback to an authorization server the PRM
         # did not advertise.
+        candidate_urls = ([@challenge_metadata_url] + protected_resource_metadata_urls(server_url)).compact.uniq
         resource_metadata = @challenge_resource_metadata ||
-                            fetch_first_resource_metadata(protected_resource_metadata_urls(server_url))
+                            fetch_first_resource_metadata(candidate_urls)
         return nil unless resource_metadata
 
         validate_resource_matches!(resource_metadata)

--- a/lib/mcp_client/errors.rb
+++ b/lib/mcp_client/errors.rb
@@ -30,6 +30,25 @@ module MCPClient
     # Raised when there's a connection error with an MCP server
     class ConnectionError < MCPError; end
 
+    # Raised for an HTTP 403 with a WWW-Authenticate insufficient_scope
+    # challenge (MCP 2025-11-25 / SEP-835). Exposes the challenge parameters
+    # so hosts can run a step-up authorization flow with the required scopes.
+    class InsufficientScopeError < ConnectionError
+      # @return [String, nil] the scopes required by the server's challenge
+      attr_reader :scope
+      # @return [String, nil] the challenge's human-readable error description
+      attr_reader :error_description
+
+      # @param message [String] error message
+      # @param scope [String, nil] scopes from the challenge's scope parameter
+      # @param error_description [String, nil] challenge error_description
+      def initialize(message, scope: nil, error_description: nil)
+        super(message)
+        @scope = scope
+        @error_description = error_description
+      end
+    end
+
     # Raised when the MCP server returns an error response
     class ServerError < MCPError; end
 

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -9,6 +9,10 @@ module MCPClient
   module HttpTransportBase
     include JsonRpcCommon
 
+    # Lightweight response wrapper for Faraday exception payloads (Hashes),
+    # so the exception path and the default path share one challenge pipeline.
+    NormalizedResponse = Struct.new(:status, :headers)
+
     # Generic JSON-RPC request: send method with params and return result
     # @param method [String] JSON-RPC method name
     # @param params [Hash] parameters for the request
@@ -212,22 +216,30 @@ module MCPClient
       # Default: no additional handling
     end
 
-    # Handle authentication errors
+    # Handle authentication errors raised by user-configured raise_error
+    # middleware; routes through the same challenge pipeline as the default
+    # response path.
     # @param error [Faraday::UnauthorizedError, Faraday::ForbiddenError] Auth error
-    # @raise [MCPClient::Errors::ConnectionError] Connection error
+    # @raise [MCPClient::Errors::InsufficientScopeError, MCPClient::Errors::ConnectionError]
     def handle_auth_error(error)
-      # Handle OAuth authorization challenges
-      if error.response && @oauth_provider
-        resource_metadata = @oauth_provider.handle_unauthorized_response(error.response)
-        if resource_metadata
-          @logger.debug('Received OAuth challenge, discovered resource metadata')
-          # Re-raise the error to trigger OAuth flow in calling code
-          raise MCPClient::Errors::ConnectionError, "OAuth authorization required: HTTP #{error.response[:status]}"
-        end
+      response = normalize_error_response(error.response)
+      if response
+        process_authorization_challenge(response)
+        raise_authorization_error(response)
       end
 
-      error_status = error.response ? error.response[:status] : 'unknown'
-      raise MCPClient::Errors::ConnectionError, "Authorization failed: HTTP #{error_status}"
+      raise MCPClient::Errors::ConnectionError, 'Authorization failed: HTTP unknown'
+    end
+
+    # @param raw [Faraday::Response, Hash, nil] an exception's response payload
+    # @return [#status, nil] a response-like object with #status and #headers
+    def normalize_error_response(raw)
+      return nil unless raw
+      return raw if raw.respond_to?(:status) && raw.respond_to?(:headers)
+
+      status = raw[:status] || raw['status']
+      headers = raw[:headers] || raw['headers'] || {}
+      NormalizedResponse.new(status, headers)
     end
 
     # Handle HTTP error responses
@@ -281,9 +293,9 @@ module MCPClient
     def raise_authorization_error(response)
       header = www_authenticate_header(response)
 
-      if response.status == 403 && header&.match?(/error\s*=\s*"?insufficient_scope"?/)
-        scope = header[/scope\s*=\s*"([^"]*)"/, 1] || header[/scope\s*=\s*([^,\s"]+)/, 1]
-        description = header[/error_description\s*=\s*"([^"]*)"/, 1]
+      if response.status == 403 && insufficient_scope_challenge?(header)
+        scope = header[/(?:^|[\s,])scope\s*=\s*"([^"]*)"/i, 1] || header[/(?:^|[\s,])scope\s*=\s*([^,\s"]+)/i, 1]
+        description = header[/(?:^|[\s,])error_description\s*=\s*"([^"]*)"/i, 1]
         raise MCPClient::Errors::InsufficientScopeError.new(
           "Authorization failed: HTTP 403 insufficient_scope#{" (required scopes: #{scope})" if scope}",
           scope: scope, error_description: description
@@ -291,6 +303,17 @@ module MCPClient
       end
 
       raise MCPClient::Errors::ConnectionError, "Authorization failed: HTTP #{response.status}"
+    end
+
+    # A Bearer challenge whose error auth-param is exactly insufficient_scope
+    # (RFC 6750 / SEP-835); prefixed schemes or extended tokens do not match.
+    # @param header [String, nil] the WWW-Authenticate header value
+    # @return [Boolean]
+    def insufficient_scope_challenge?(header)
+      return false unless header
+
+      header.match?(/\bBearer\b/i) &&
+        header.match?(/(?:^|[\s,])error\s*=\s*"?insufficient_scope"?(?![\w-])/i)
     end
 
     # @param response [Faraday::Response] an HTTP response

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -13,6 +13,15 @@ module MCPClient
     # so the exception path and the default path share one challenge pipeline.
     NormalizedResponse = Struct.new(:status, :headers)
 
+    # One auth-param (name = token / quoted-string) as it appears in a
+    # WWW-Authenticate challenge (RFC 7235 §2.1, optional whitespace around '=').
+    AUTH_PARAM = /[A-Za-z0-9._~+-]+\s*=\s*(?:"(?:[^"\\]|\\.)*"|[^,\s]*)/
+    # A run of comma/space separated auth-params anchored at the start of a
+    # string. The run ends before a token that is NOT followed by '=' — the
+    # auth-scheme introducing the next challenge — while commas inside quoted
+    # values are consumed by the quoted-string branch, not treated as boundaries.
+    AUTH_PARAMS_RUN = /\A(?:[\s,]*#{AUTH_PARAM})*/
+
     # Generic JSON-RPC request: send method with params and return result
     # @param method [String] JSON-RPC method name
     # @param params [Hash] parameters for the request
@@ -291,11 +300,12 @@ module MCPClient
     # @param response [Faraday::Response] the 401/403 response
     # @raise [MCPClient::Errors::InsufficientScopeError, MCPClient::Errors::ConnectionError]
     def raise_authorization_error(response)
-      header = www_authenticate_header(response)
+      challenge = bearer_challenge_segment(www_authenticate_header(response))
 
-      if response.status == 403 && insufficient_scope_challenge?(header)
-        scope = header[/(?:^|[\s,])scope\s*=\s*"([^"]*)"/i, 1] || header[/(?:^|[\s,])scope\s*=\s*([^,\s"]+)/i, 1]
-        description = header[/(?:^|[\s,])error_description\s*=\s*"([^"]*)"/i, 1]
+      if response.status == 403 && insufficient_scope_challenge?(challenge)
+        scope = challenge[/(?:^|[\s,])scope\s*=\s*"([^"]*)"/i, 1] ||
+                challenge[/(?:^|[\s,])scope\s*=\s*([^,\s"]+)/i, 1]
+        description = challenge[/(?:^|[\s,])error_description\s*=\s*"([^"]*)"/i, 1]
         raise MCPClient::Errors::InsufficientScopeError.new(
           "Authorization failed: HTTP 403 insufficient_scope#{" (required scopes: #{scope})" if scope}",
           scope: scope, error_description: description
@@ -305,15 +315,31 @@ module MCPClient
       raise MCPClient::Errors::ConnectionError, "Authorization failed: HTTP #{response.status}"
     end
 
-    # A Bearer challenge whose error auth-param is exactly insufficient_scope
-    # (RFC 6750 / SEP-835); prefixed schemes or extended tokens do not match.
+    # Extract the Bearer challenge's own parameter segment from a (possibly
+    # multi-challenge) WWW-Authenticate header, so params belonging to other
+    # schemes (e.g. `Basic error="insufficient_scope", Bearer realm="x"`) are
+    # never attributed to the Bearer challenge.
     # @param header [String, nil] the WWW-Authenticate header value
-    # @return [Boolean]
-    def insufficient_scope_challenge?(header)
-      return false unless header
+    # @return [String, nil] the Bearer challenge's parameters (possibly empty),
+    #   or nil when the header has no Bearer challenge
+    def bearer_challenge_segment(header)
+      return nil unless header
 
-      header.match?(/\bBearer\b/i) &&
-        header.match?(/(?:^|[\s,])error\s*=\s*"?insufficient_scope"?(?![\w-])/i)
+      match = header.match(/(?:\A|[\s,])Bearer(?=[\s,]|\z)/i)
+      return nil unless match
+
+      match.post_match[AUTH_PARAMS_RUN]
+    end
+
+    # The Bearer challenge segment carries an error auth-param that is exactly
+    # insufficient_scope (RFC 6750 / SEP-835); prefixed or extended tokens
+    # (e.g. insufficient_scope.extra) do not match.
+    # @param challenge [String, nil] the Bearer challenge segment
+    # @return [Boolean]
+    def insufficient_scope_challenge?(challenge)
+      return false unless challenge
+
+      challenge.match?(/(?:^|[\s,])error\s*=\s*"?insufficient_scope"?(?![\w.-])/i)
     end
 
     # @param response [Faraday::Response] an HTTP response

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -325,10 +325,13 @@ module MCPClient
     def bearer_challenge_segment(header)
       return nil unless header
 
-      match = header.match(/(?:\A|[\s,])Bearer(?=[\s,]|\z)/i)
+      # Locate the Bearer scheme token only OUTSIDE quoted strings: a quoted
+      # value such as realm="prefix Bearer x" must not anchor the segment.
+      masked = header.gsub(/"(?:\\.|[^"\\])*"/) { |q| "\"#{' ' * (q.length - 2)}\"" }
+      match = masked.match(/(?:\A|[\s,])Bearer(?=[\s,]|\z)/i)
       return nil unless match
 
-      match.post_match[AUTH_PARAMS_RUN]
+      header[match.end(0)..][AUTH_PARAMS_RUN]
     end
 
     # The Bearer challenge segment carries an error auth-param that is exactly

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -241,7 +241,11 @@ module MCPClient
 
       case response.status
       when 401, 403
-        raise MCPClient::Errors::ConnectionError, "Authorization failed: HTTP #{response.status}"
+        # MCP 2025-11-25: clients MUST parse WWW-Authenticate headers on 401
+        # responses and use the advertised resource metadata; the challenge's
+        # scope parameter is authoritative for the next authorization.
+        process_authorization_challenge(response)
+        raise_authorization_error(response)
       when 400..499
         # Deterministic client errors: the request was processed/rejected and
         # will not succeed on retry, so raise a plain (non-retryable) ServerError.
@@ -253,6 +257,48 @@ module MCPClient
       else
         raise MCPClient::Errors::ServerError, "HTTP error: #{response.status}#{reason_text}"
       end
+    end
+
+    # Surface a 401/403 WWW-Authenticate challenge to the OAuth provider so
+    # the advertised resource metadata and challenge scope are captured before
+    # the error propagates. Discovery failures must not mask the original
+    # authorization error.
+    # @param response [Faraday::Response] the 401/403 response
+    # @return [void]
+    def process_authorization_challenge(response)
+      return unless @oauth_provider && response.respond_to?(:headers)
+
+      @oauth_provider.handle_unauthorized_response(response)
+    rescue StandardError => e
+      @logger.debug("OAuth challenge processing failed: #{e.message}")
+    end
+
+    # Raise the appropriate error for a 401/403: an insufficient_scope 403
+    # challenge (SEP-835) raises InsufficientScopeError exposing the required
+    # scopes so hosts can run a step-up authorization flow.
+    # @param response [Faraday::Response] the 401/403 response
+    # @raise [MCPClient::Errors::InsufficientScopeError, MCPClient::Errors::ConnectionError]
+    def raise_authorization_error(response)
+      header = www_authenticate_header(response)
+
+      if response.status == 403 && header&.match?(/error\s*=\s*"?insufficient_scope"?/)
+        scope = header[/scope\s*=\s*"([^"]*)"/, 1] || header[/scope\s*=\s*([^,\s"]+)/, 1]
+        description = header[/error_description\s*=\s*"([^"]*)"/, 1]
+        raise MCPClient::Errors::InsufficientScopeError.new(
+          "Authorization failed: HTTP 403 insufficient_scope#{" (required scopes: #{scope})" if scope}",
+          scope: scope, error_description: description
+        )
+      end
+
+      raise MCPClient::Errors::ConnectionError, "Authorization failed: HTTP #{response.status}"
+    end
+
+    # @param response [Faraday::Response] an HTTP response
+    # @return [String, nil] the WWW-Authenticate header value, if any
+    def www_authenticate_header(response)
+      return nil unless response.respond_to?(:headers) && response.headers
+
+      response.headers['WWW-Authenticate'] || response.headers['www-authenticate']
     end
 
     # Get or create HTTP connection

--- a/spec/lib/mcp_client/http_transport_base_spec.rb
+++ b/spec/lib/mcp_client/http_transport_base_spec.rb
@@ -338,6 +338,7 @@ RSpec.describe MCPClient::HttpTransportBase do
 
     before do
       allow(response).to receive(:respond_to?).with(:reason_phrase).and_return(true)
+      allow(response).to receive(:respond_to?).with(:headers).and_return(true)
       allow(response).to receive(:reason_phrase).and_return('Test Error')
     end
 
@@ -346,6 +347,7 @@ RSpec.describe MCPClient::HttpTransportBase do
         [401, 403].each do |status|
           it "raises ConnectionError for HTTP #{status}" do
             allow(response).to receive(:status).and_return(status)
+            allow(response).to receive(:headers).and_return({})
 
             expect do
               transport.test_handle_http_error_response(response)

--- a/spec/lib/mcp_client/oauth_challenge_handling_spec.rb
+++ b/spec/lib/mcp_client/oauth_challenge_handling_spec.rb
@@ -368,4 +368,27 @@ RSpec.describe 'OAuth challenge handling (MCP 2025-11-25)' do
       expect(metadata.to_h[:scopes_supported]).to eq(%w[mcp:tools mcp:resources])
     end
   end
+
+  describe 'quoted-string masking in Bearer segment location' do
+    it 'does not anchor on a Bearer token embedded in a quoted value (transport)' do
+      server = MCPClient::ServerHTTP.new(base_url: base_url, endpoint: '/rpc')
+      header = 'Basic realm="prefix Bearer scope=basic:only", Bearer realm="mcp"'
+      response = Struct.new(:status, :headers).new(403, { 'WWW-Authenticate' => header })
+
+      expect { server.send(:raise_authorization_error, response) }
+        .to raise_error(MCPClient::Errors::ConnectionError) do |e|
+          expect(e).not_to be_a(MCPClient::Errors::InsufficientScopeError)
+        end
+    end
+
+    it 'does not capture scope from a quoted value preceding the real Bearer challenge (provider)' do
+      provider = MCPClient::Auth::OAuthProvider.new(server_url: base_url)
+      header = 'Basic realm="prefix Bearer scope=evil:scope", Bearer realm="mcp"'
+      response = instance_double(Faraday::Response, headers: { 'WWW-Authenticate' => header })
+
+      provider.handle_unauthorized_response(response)
+
+      expect(provider.challenge_scope).to be_nil
+    end
+  end
 end

--- a/spec/lib/mcp_client/oauth_challenge_handling_spec.rb
+++ b/spec/lib/mcp_client/oauth_challenge_handling_spec.rb
@@ -208,6 +208,59 @@ RSpec.describe 'OAuth challenge handling (MCP 2025-11-25)' do
     end
   end
 
+  describe 'provider-side Bearer-segment parameter extraction' do
+    let(:provider) { MCPClient::Auth::OAuthProvider.new(server_url: base_url) }
+
+    def response_with(header)
+      instance_double(Faraday::Response, headers: { 'WWW-Authenticate' => header })
+    end
+
+    it 'does not let another scheme\'s resource_metadata drive discovery or scope' do
+      provider.instance_variable_set(:@challenge_scope, 'old:scope')
+      header = 'Basic resource_metadata="https://evil.example/prm", Bearer realm="mcp"'
+
+      expect(provider.handle_unauthorized_response(response_with(header))).to be_nil
+
+      expect(a_request(:get, 'https://evil.example/prm')).not_to have_been_made
+      expect(provider.instance_variable_get(:@challenge_metadata_url)).to be_nil
+      expect(provider.challenge_scope).to be_nil
+    end
+
+    it 'does not capture a scope parameter carried by a non-Bearer challenge' do
+      header = 'Basic scope="basic:only", Bearer realm="mcp"'
+
+      provider.handle_unauthorized_response(response_with(header))
+
+      expect(provider.challenge_scope).to be_nil
+    end
+
+    it 'treats a header without a Bearer challenge as carrying no usable parameters' do
+      provider.instance_variable_set(:@challenge_scope, 'old:scope')
+      header = 'Basic resource_metadata="https://evil.example/prm", scope="basic:only"'
+
+      expect(provider.handle_unauthorized_response(response_with(header))).to be_nil
+
+      expect(a_request(:get, 'https://evil.example/prm')).not_to have_been_made
+      expect(provider.challenge_scope).to be_nil
+    end
+
+    it 'still drives discovery and scope from a normal Bearer challenge' do
+      stub_request(:get, "#{base_url}/.well-known/oauth-protected-resource")
+        .to_return(
+          status: 200,
+          headers: { 'Content-Type' => 'application/json' },
+          body: { resource: base_url, authorization_servers: ['https://auth.example.com'] }.to_json
+        )
+      header = "Bearer resource_metadata=\"#{base_url}/.well-known/oauth-protected-resource\", scope=\"mcp:tools\""
+
+      metadata = provider.handle_unauthorized_response(response_with(header))
+
+      expect(metadata).to be_a(MCPClient::Auth::ResourceMetadata)
+      expect(metadata.authorization_servers).to include('https://auth.example.com')
+      expect(provider.challenge_scope).to eq('mcp:tools')
+    end
+  end
+
   describe 'challenge-advertised metadata URL authority' do
     let(:provider) { MCPClient::Auth::OAuthProvider.new(server_url: base_url) }
     let(:challenge_url) { "#{base_url}/.well-known/oauth-protected-resource/tenant" }

--- a/spec/lib/mcp_client/oauth_challenge_handling_spec.rb
+++ b/spec/lib/mcp_client/oauth_challenge_handling_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2025-11-25 authorization (basic/authorization.mdx):
+# - "MCP clients MUST be able to parse WWW-Authenticate headers and respond
+#   appropriately to HTTP 401 Unauthorized responses" — and MUST use the
+#   resource metadata URL from the parsed header when present.
+# - "Clients MUST treat the scopes provided in the challenge as authoritative
+#   for satisfying the current request" (scope selection priority 1); the
+#   fallback is scopes_supported from the Protected Resource Metadata.
+# - SEP-835: clients SHOULD respond to 403 insufficient_scope challenges with
+#   a step-up authorization flow — which requires the challenge parameters to
+#   be surfaced, not swallowed.
+RSpec.describe 'OAuth challenge handling (MCP 2025-11-25)' do
+  let(:base_url) { 'https://mcp.example.com' }
+
+  describe 'transport 401 handling (default configuration)' do
+    it 'passes the WWW-Authenticate challenge to the OAuth provider before raising' do
+      provider = instance_double(MCPClient::Auth::OAuthProvider)
+      allow(provider).to receive(:apply_authorization)
+      allow(provider).to receive(:handle_unauthorized_response)
+
+      server = MCPClient::ServerHTTP.new(base_url: base_url, endpoint: '/rpc', oauth_provider: provider)
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+
+      stub_request(:post, "#{base_url}/rpc").to_return(
+        status: 401,
+        headers: { 'WWW-Authenticate' =>
+          'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"' },
+        body: ''
+      )
+
+      expect { server.rpc_request('tools/list', {}) }.to raise_error(MCPClient::Errors::ConnectionError)
+      expect(provider).to have_received(:handle_unauthorized_response) do |response|
+        expect(response.headers['WWW-Authenticate']).to include('resource_metadata')
+      end
+    end
+  end
+
+  describe '403 insufficient_scope step-up (SEP-835)' do
+    it 'raises InsufficientScopeError exposing the challenged scopes' do
+      server = MCPClient::ServerHTTP.new(base_url: base_url, endpoint: '/rpc')
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+
+      stub_request(:post, "#{base_url}/rpc").to_return(
+        status: 403,
+        headers: { 'WWW-Authenticate' =>
+          'Bearer error="insufficient_scope", scope="files:write admin", error_description="Need more scopes"' },
+        body: ''
+      )
+
+      expect { server.rpc_request('tools/call', {}) }.to raise_error(MCPClient::Errors::InsufficientScopeError) do |e|
+        expect(e.scope).to eq('files:write admin')
+        expect(e.error_description).to eq('Need more scopes')
+        expect(e).to be_a(MCPClient::Errors::ConnectionError)
+      end
+    end
+  end
+
+  describe MCPClient::Auth::OAuthProvider do
+    let(:provider) { described_class.new(server_url: base_url) }
+
+    it 'captures the challenge scope parameter as authoritative' do
+      stub_request(:get, 'https://mcp.example.com/.well-known/oauth-protected-resource')
+        .to_return(
+          status: 200,
+          headers: { 'Content-Type' => 'application/json' },
+          body: { resource: base_url, authorization_servers: ['https://auth.example.com'] }.to_json
+        )
+
+      response = instance_double(
+        Faraday::Response,
+        headers: {
+          'WWW-Authenticate' =>
+            'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource", ' \
+            'scope="mcp:tools mcp:resources"'
+        }
+      )
+      provider.handle_unauthorized_response(response)
+
+      expect(provider.challenge_scope).to eq('mcp:tools mcp:resources')
+    end
+
+    it 'captures the challenge scope even without a resource_metadata parameter' do
+      response = instance_double(
+        Faraday::Response,
+        headers: { 'WWW-Authenticate' => 'Bearer scope="mcp:tools"' }
+      )
+      provider.handle_unauthorized_response(response)
+
+      expect(provider.challenge_scope).to eq('mcp:tools')
+    end
+
+    describe 'scope resolution priority' do
+      it 'prefers the challenge scope over everything else' do
+        provider.scope = 'configured:scope'
+        provider.instance_variable_set(:@challenge_scope, 'challenge:scope')
+
+        expect(provider.send(:resolved_scope)).to eq('challenge:scope')
+      end
+
+      it 'falls back to the configured scope when there is no challenge' do
+        provider.scope = 'configured:scope'
+
+        expect(provider.send(:resolved_scope)).to eq('configured:scope')
+      end
+
+      it 'falls back to Protected Resource Metadata scopes_supported' do
+        prm = MCPClient::Auth::ResourceMetadata.new(
+          resource: base_url,
+          authorization_servers: ['https://auth.example.com'],
+          scopes_supported: %w[mcp:tools mcp:resources]
+        )
+        provider.instance_variable_set(:@resource_metadata, prm)
+
+        expect(provider.send(:resolved_scope)).to eq('mcp:tools mcp:resources')
+      end
+
+      it 'omits the scope entirely when nothing is defined' do
+        expect(provider.send(:resolved_scope)).to be_nil
+      end
+    end
+  end
+
+  describe MCPClient::Auth::ResourceMetadata do
+    it 'parses and round-trips scopes_supported from RFC 9728 metadata' do
+      metadata = described_class.from_h(
+        'resource' => base_url,
+        'authorization_servers' => ['https://auth.example.com'],
+        'scopes_supported' => %w[mcp:tools mcp:resources]
+      )
+
+      expect(metadata.scopes_supported).to eq(%w[mcp:tools mcp:resources])
+      expect(metadata.to_h[:scopes_supported]).to eq(%w[mcp:tools mcp:resources])
+    end
+  end
+end

--- a/spec/lib/mcp_client/oauth_challenge_handling_spec.rb
+++ b/spec/lib/mcp_client/oauth_challenge_handling_spec.rb
@@ -173,6 +173,109 @@ RSpec.describe 'OAuth challenge handling (MCP 2025-11-25)' do
       expect { server.send(:raise_authorization_error, response_with(header)) }
         .to raise_error(MCPClient::Errors::InsufficientScopeError) { |e| expect(e.scope).to eq('right') }
     end
+
+    it 'does not misclassify when a preceding non-Bearer challenge carries error=insufficient_scope' do
+      header = 'Basic error="insufficient_scope", Bearer realm="x"'
+      expect { server.send(:raise_authorization_error, response_with(header)) }
+        .to raise_error(MCPClient::Errors::ConnectionError) do |e|
+          expect(e).not_to be_a(MCPClient::Errors::InsufficientScopeError)
+        end
+    end
+
+    it 'does not misclassify when a trailing non-Bearer challenge carries error=insufficient_scope' do
+      header = 'Bearer realm="r", Basic error="insufficient_scope"'
+      expect { server.send(:raise_authorization_error, response_with(header)) }
+        .to raise_error(MCPClient::Errors::ConnectionError) do |e|
+          expect(e).not_to be_a(MCPClient::Errors::InsufficientScopeError)
+        end
+    end
+
+    it 'does not treat an extended error token such as insufficient_scope.extra as a match' do
+      expect { server.send(:raise_authorization_error, response_with('Bearer error="insufficient_scope.extra"')) }
+        .to raise_error(MCPClient::Errors::ConnectionError) do |e|
+          expect(e).not_to be_a(MCPClient::Errors::InsufficientScopeError)
+        end
+    end
+
+    it 'extracts scope and error_description only from the Bearer challenge segment' do
+      header = 'Basic realm="b", scope="basic:only", error_description="basic reason", ' \
+               'Bearer error="insufficient_scope", scope="mcp:tools", error_description="Bearer reason"'
+      expect { server.send(:raise_authorization_error, response_with(header)) }
+        .to raise_error(MCPClient::Errors::InsufficientScopeError) do |e|
+          expect(e.scope).to eq('mcp:tools')
+          expect(e.error_description).to eq('Bearer reason')
+        end
+    end
+  end
+
+  describe 'challenge-advertised metadata URL authority' do
+    let(:provider) { MCPClient::Auth::OAuthProvider.new(server_url: base_url) }
+    let(:challenge_url) { "#{base_url}/.well-known/oauth-protected-resource/tenant" }
+    let(:prm_body) do
+      { resource: base_url, authorization_servers: ['https://auth.example.com'] }.to_json
+    end
+    let(:as_metadata_body) do
+      { issuer: 'https://auth.example.com',
+        authorization_endpoint: 'https://auth.example.com/authorize',
+        token_endpoint: 'https://auth.example.com/token',
+        code_challenge_methods_supported: ['S256'] }.to_json
+    end
+
+    def challenge_response
+      instance_double(
+        Faraday::Response,
+        headers: { 'WWW-Authenticate' => "Bearer resource_metadata=\"#{challenge_url}\"" }
+      )
+    end
+
+    it 'retries the advertised URL strictly on discovery with no well-known fallback when it 404s' do
+      stub_request(:get, challenge_url).to_return(status: 404)
+      # Well-known candidates that MUST NOT be consulted while the challenge URL stands.
+      fallback = stub_request(:get, "#{base_url}/.well-known/oauth-protected-resource")
+                 .to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: prm_body)
+      stub_request(:get, 'https://auth.example.com/.well-known/oauth-authorization-server')
+        .to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: as_metadata_body)
+
+      expect { provider.handle_unauthorized_response(challenge_response) }
+        .to raise_error(MCPClient::Errors::ConnectionError)
+
+      expect { provider.send(:discover_authorization_server) }
+        .to raise_error(MCPClient::Errors::ConnectionError, /404/)
+      expect(fallback).not_to have_been_requested
+    end
+
+    it 'bypasses cached authorization server metadata while a challenge metadata URL is pending' do
+      cached = MCPClient::Auth::ServerMetadata.new(
+        issuer: 'https://stale.example.com',
+        authorization_endpoint: 'https://stale.example.com/authorize',
+        token_endpoint: 'https://stale.example.com/token',
+        code_challenge_methods_supported: ['S256']
+      )
+      provider.storage.set_server_metadata(provider.server_url, cached)
+      stub_request(:get, challenge_url).to_return(status: 404)
+
+      expect { provider.handle_unauthorized_response(challenge_response) }
+        .to raise_error(MCPClient::Errors::ConnectionError)
+
+      expect { provider.send(:discover_authorization_server) }
+        .to raise_error(MCPClient::Errors::ConnectionError, /404/)
+    end
+
+    it 'consumes the challenge metadata URL after successful discovery' do
+      stub_request(:get, challenge_url)
+        .to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: prm_body)
+      as_stub = stub_request(:get, 'https://auth.example.com/.well-known/oauth-authorization-server')
+                .to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: as_metadata_body)
+
+      provider.handle_unauthorized_response(challenge_response)
+
+      expect(provider.send(:discover_authorization_server).issuer).to eq('https://auth.example.com')
+      # The challenge URL was consumed: a later discovery serves the cache
+      # instead of re-fetching challenge or authorization server metadata.
+      expect(provider.send(:discover_authorization_server).issuer).to eq('https://auth.example.com')
+      expect(as_stub).to have_been_requested.once
+      expect(a_request(:get, challenge_url)).to have_been_made.once
+    end
   end
 
   describe 'challenge scope lifecycle' do

--- a/spec/lib/mcp_client/oauth_challenge_handling_spec.rb
+++ b/spec/lib/mcp_client/oauth_challenge_handling_spec.rb
@@ -126,6 +126,80 @@ RSpec.describe 'OAuth challenge handling (MCP 2025-11-25)' do
     end
   end
 
+  describe 'exception-path (raise_error middleware) parity' do
+    it 'routes Hash-shaped exception responses through the same challenge pipeline' do
+      provider = instance_double(MCPClient::Auth::OAuthProvider)
+      allow(provider).to receive(:handle_unauthorized_response)
+
+      server = MCPClient::ServerHTTP.new(base_url: base_url, endpoint: '/rpc', oauth_provider: provider)
+      error = Faraday::ForbiddenError.new(
+        nil,
+        { status: 403,
+          headers: { 'www-authenticate' =>
+            'Bearer error="insufficient_scope", scope="mcp:admin"' },
+          body: '' }
+      )
+
+      expect { server.send(:handle_auth_error, error) }.to raise_error(
+        MCPClient::Errors::InsufficientScopeError
+      ) do |e|
+        expect(e.scope).to eq('mcp:admin')
+      end
+      expect(provider).to have_received(:handle_unauthorized_response) do |response|
+        expect(response.headers['www-authenticate']).to include('insufficient_scope')
+      end
+    end
+  end
+
+  describe 'challenge parsing robustness' do
+    let(:server) { MCPClient::ServerHTTP.new(base_url: base_url, endpoint: '/rpc') }
+
+    def response_with(header, status: 403)
+      Struct.new(:status, :headers).new(status, { 'WWW-Authenticate' => header })
+    end
+
+    it 'ignores non-Bearer challenges' do
+      expect { server.send(:raise_authorization_error, response_with('Basic error="insufficient_scope"')) }
+        .to raise_error(MCPClient::Errors::ConnectionError) { |e| expect(e).not_to be_a(MCPClient::Errors::InsufficientScopeError) }
+    end
+
+    it 'does not treat a prefixed error token as insufficient_scope' do
+      expect { server.send(:raise_authorization_error, response_with('Bearer error="insufficient_scope_extra"')) }
+        .to raise_error(MCPClient::Errors::ConnectionError) { |e| expect(e).not_to be_a(MCPClient::Errors::InsufficientScopeError) }
+    end
+
+    it 'does not capture a prefixed scope parameter' do
+      header = 'Bearer error="insufficient_scope", previous_scope="wrong", scope="right"'
+      expect { server.send(:raise_authorization_error, response_with(header)) }
+        .to raise_error(MCPClient::Errors::InsufficientScopeError) { |e| expect(e.scope).to eq('right') }
+    end
+  end
+
+  describe 'challenge scope lifecycle' do
+    let(:provider) { MCPClient::Auth::OAuthProvider.new(server_url: base_url) }
+
+    it 'clears the previous challenge scope when a new challenge carries none' do
+      provider.instance_variable_set(:@challenge_scope, 'old:scope')
+      response = instance_double(Faraday::Response, headers: { 'WWW-Authenticate' => 'Bearer realm="mcp"' })
+
+      provider.handle_unauthorized_response(response)
+
+      expect(provider.challenge_scope).to be_nil
+    end
+
+    it 'falls back to PRM scopes when :all resolves to an empty AS scope list' do
+      provider.scope = :all
+      allow(provider).to receive(:supported_scopes).and_return([])
+      prm = MCPClient::Auth::ResourceMetadata.new(
+        resource: base_url, authorization_servers: ['https://auth.example.com'],
+        scopes_supported: %w[mcp:tools]
+      )
+      provider.instance_variable_set(:@resource_metadata, prm)
+
+      expect(provider.send(:resolved_scope)).to eq('mcp:tools')
+    end
+  end
+
   describe MCPClient::Auth::ResourceMetadata do
     it 'parses and round-trips scopes_supported from RFC 9728 metadata' do
       metadata = described_class.from_h(


### PR DESCRIPTION
## What

Three authorization fixes against [MCP 2025-11-25 basic/authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization):

### 1. Make 401 `WWW-Authenticate` discovery reachable (MUST)

> "MCP clients **MUST** be able to parse `WWW-Authenticate` headers and respond appropriately to HTTP 401 Unauthorized responses" — using "the resource metadata URL from the parsed `WWW-Authenticate` headers when present".

`OAuthProvider#handle_unauthorized_response` implements the parsing correctly, but the only transport wiring that called it lived behind `Faraday::UnauthorizedError`/`ForbiddenError` rescues — exceptions Faraday only raises when the `:raise_error` middleware is registered, which no transport does. On the actual default path, `handle_http_error_response` raised a plain `ConnectionError` with the header discarded, so a server advertising its Protected Resource Metadata **only** via the header (one of the two mechanisms the spec lets servers choose) could never be discovered. The 401/403 error path now passes the response to the OAuth provider (failures logged, never masking the original error) before raising.

### 2. Spec-compliant scope selection

> "Clients **MUST** treat the scopes provided in the challenge as authoritative for satisfying the current request." Fallback (SHOULD): "use all scopes defined in `scopes_supported` from the Protected Resource Metadata document, omitting the `scope` parameter if `scopes_supported` is undefined."

Neither source existed: the challenge's `scope` parameter was never parsed, and `ResourceMetadata` dropped `scopes_supported` entirely (a host could never see it through this library). Now: the provider captures `challenge_scope` from every challenge (exposed publicly), `ResourceMetadata` parses/round-trips `scopes_supported`, and authorization/registration resolve scope by the spec's priority — challenge scope → configured scope (`:all` keeps its documented AS-metadata behavior) → PRM `scopes_supported` → omit.

### 3. SEP-835 step-up authorization enabled

> "Clients **SHOULD** respond to these errors by requesting a new access token with an increased set of scopes via a step-up authorization flow..."

A 403 `insufficient_scope` challenge was swallowed into `"Authorization failed: HTTP 403"` — the required scopes were unknowable, making step-up impossible for both the library and the host. Now it raises the new `MCPClient::Errors::InsufficientScopeError` (subclass of `ConnectionError`, so existing rescues keep working) exposing `scope` and `error_description`; combined with the captured `challenge_scope`, the next `start_authorization_flow` automatically requests the challenged scopes.

## Tests

New `spec/lib/mcp_client/oauth_challenge_handling_spec.rb` (9 examples: wire-level 401 → provider handoff, 403 insufficient_scope → typed error with scopes, challenge-scope capture with/without resource_metadata, full scope-resolution priority ladder, RFC 9728 `scopes_supported` round-trip). All 9 failed before the fix. Full suite: 1329 examples, 0 failures; RuboCop clean.

Part of an MCP 2025-11-25 compliance audit of this gem against the official spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)