### PR TITLE
Refuse authorization when PKCE support cannot be verified

### DIFF
--- a/lib/mcp_client/auth/oauth_provider.rb
+++ b/lib/mcp_client/auth/oauth_provider.rb
@@ -444,17 +444,18 @@ module MCPClient
       end
 
       # Verify the authorization server supports PKCE S256 (RFC 8414 / MCP).
-      # Refuses when S256 is explicitly not offered; warns (and proceeds, since
-      # the client always uses S256) when the field is not advertised at all.
+      # Per MCP 2025-11-25, "If code_challenge_methods_supported is absent,
+      # the authorization server does not support PKCE and MCP clients MUST
+      # refuse to proceed" — absence is a hard stop, not a warning, because
+      # proceeding would defeat the authorization-code downgrade protection.
       # @param server_metadata [ServerMetadata]
-      # @raise [MCPClient::Errors::ConnectionError] if S256 is explicitly unsupported
+      # @raise [MCPClient::Errors::ConnectionError] if PKCE S256 support cannot be verified
       def verify_pkce_support!(server_metadata)
         methods = server_metadata.code_challenge_methods_supported
         if methods.nil?
-          logger.warn(
-            'Authorization server metadata omits code_challenge_methods_supported; ' \
-            'proceeding with PKCE S256'
-          )
+          raise MCPClient::Errors::ConnectionError,
+                'Authorization server metadata omits code_challenge_methods_supported; ' \
+                'the server does not support PKCE and the client must refuse to proceed'
         elsif !methods.include?('S256')
           raise MCPClient::Errors::ConnectionError,
                 'Authorization server does not support PKCE S256 ' \

--- a/spec/lib/mcp_client/auth/oauth_provider_spec.rb
+++ b/spec/lib/mcp_client/auth/oauth_provider_spec.rb
@@ -168,9 +168,9 @@ RSpec.describe MCPClient::Auth::OAuthProvider do
         expect { oauth_provider.send(:verify_pkce_support!, metadata(['S256'])) }.not_to raise_error
       end
 
-      it 'warns but proceeds when not advertised' do
-        expect(logger).to receive(:warn).with(/omits code_challenge_methods_supported/)
-        oauth_provider.send(:verify_pkce_support!, metadata(nil))
+      it 'refuses to proceed when not advertised (MCP: absence means no PKCE support)' do
+        expect { oauth_provider.send(:verify_pkce_support!, metadata(nil)) }
+          .to raise_error(MCPClient::Errors::ConnectionError, /code_challenge_methods_supported/)
       end
     end
 
@@ -610,7 +610,8 @@ RSpec.describe MCPClient::Auth::OAuthProvider do
         authorization_endpoint: 'https://mcp.example.com/authorize',
         token_endpoint: 'https://mcp.example.com/token',
         registration_endpoint: 'https://mcp.example.com/register',
-        scopes_supported: %w[read write admin]
+        scopes_supported: %w[read write admin],
+        code_challenge_methods_supported: ['S256']
       )
     end
 


### PR DESCRIPTION
## What

Implements the PKCE verification MUST from [MCP 2025-11-25 basic/authorization — Security Considerations](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#security-considerations):

> "If `code_challenge_methods_supported` is absent, the authorization server does not support PKCE and MCP clients **MUST** refuse to proceed." (The OIDC-discovery variant of the same rule is equally explicit.)

`verify_pkce_support!` already refused when the field was present without `S256`, but when the field was **absent entirely** it logged a warning and continued the flow. That defeats the downgrade protection the requirement exists for: an AS that doesn't understand `code_challenge` silently ignores it, leaving the authorization code unprotected. Both discovery document types flow through this same validation, so the fix covers both MUSTs.

Absence now raises `ConnectionError`, mirroring the existing S256-missing branch.

## Tests

The warn-and-proceed test now asserts the refusal; the `scope: :all` fixtures gained `code_challenge_methods_supported: ['S256']` (they modeled a non-PKCE server, which is exactly what must now be rejected). Full suite: 1320 examples, 0 failures; RuboCop clean.

Part of an MCP 2025-11-25 compliance audit of this gem against the official spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)