### PR TITLE
Attach OAuth authorization to every Streamable HTTP request

### DIFF
--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -59,6 +59,8 @@ module MCPClient
           @headers.each { |k, v| req.headers[k] = v }
           req.headers['Mcp-Session-Id'] = @session_id
           req.headers['Mcp-Protocol-Version'] = @protocol_version if @protocol_version
+          # MCP: authorization MUST be included in every HTTP request
+          @oauth_provider&.apply_authorization(req)
         end
 
         if response.success?

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -722,6 +722,8 @@ module MCPClient
       @headers.each { |k, v| req.headers[k] = v }
       req.headers['Mcp-Session-Id'] = @session_id if @session_id
       req.headers['Mcp-Protocol-Version'] = @protocol_version if @protocol_version
+      # MCP: authorization MUST be included in every HTTP request
+      @oauth_provider&.apply_authorization(req)
     end
 
     # Process event chunks from the server
@@ -833,6 +835,8 @@ module MCPClient
           @headers.each { |k, v| req.headers[k] = v }
           req.headers['Mcp-Session-Id'] = @session_id if @session_id
           req.headers['Mcp-Protocol-Version'] = @protocol_version if @protocol_version
+          # MCP: authorization MUST be included in every HTTP request
+          @oauth_provider&.apply_authorization(req)
           req.body = pong_response.to_json
         end
 
@@ -1034,6 +1038,8 @@ module MCPClient
           @headers.each { |k, v| req.headers[k] = v }
           req.headers['Mcp-Session-Id'] = @session_id if @session_id
           req.headers['Mcp-Protocol-Version'] = @protocol_version if @protocol_version
+          # MCP: authorization MUST be included in every HTTP request
+          @oauth_provider&.apply_authorization(req)
           req.body = json_body
         end
 

--- a/spec/lib/mcp_client/oauth_token_all_requests_spec.rb
+++ b/spec/lib/mcp_client/oauth_token_all_requests_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2025-11-25 basic/authorization — Access Token Usage:
+# "Note that authorization MUST be included in every HTTP request from
+# client to server, even if they are part of the same logical session."
+RSpec.describe 'OAuth token on every Streamable HTTP request (MCP 2025-11-25)' do
+  let(:base_url) { 'https://mcp.example.com' }
+  let(:endpoint) { '/rpc' }
+
+  # A minimal OAuth provider that stamps a recognizable Authorization header
+  let(:oauth_provider) do
+    provider = instance_double(MCPClient::Auth::OAuthProvider)
+    allow(provider).to receive(:apply_authorization) do |req|
+      req.headers['Authorization'] = 'Bearer audit-token'
+    end
+    provider
+  end
+
+  let(:server) do
+    MCPClient::ServerStreamableHTTP.new(
+      base_url: base_url, endpoint: endpoint, name: 'auth-test', oauth_provider: oauth_provider
+    )
+  end
+
+  after { server.cleanup }
+
+  it 'sends the token on the GET events stream' do
+    get_stub = stub_request(:get, "#{base_url}#{endpoint}")
+               .with(headers: { 'Authorization' => 'Bearer audit-token' })
+               .to_return(status: 200, body: '', headers: { 'Content-Type' => 'text/event-stream' })
+
+    server.instance_variable_set(:@connection_established, true)
+    server.send(:start_events_connection)
+    deadline = Time.now + 2
+    sleep 0.05 until get_stub.to_s.include?('was requested') || Time.now > deadline
+
+    expect(get_stub).to have_been_requested.at_least_once
+  end
+
+  it 'sends the token on the session termination DELETE' do
+    server.instance_variable_set(:@session_id, 'sess-123')
+    delete_stub = stub_request(:delete, "#{base_url}#{endpoint}")
+                  .with(headers: { 'Authorization' => 'Bearer audit-token' })
+                  .to_return(status: 200, body: '')
+
+    expect(server.terminate_session).to be true
+    expect(delete_stub).to have_been_requested.once
+  end
+
+  it 'sends the token on pong responses to server pings' do
+    pong_stub = stub_request(:post, "#{base_url}#{endpoint}")
+                .with(headers: { 'Authorization' => 'Bearer audit-token' },
+                      body: hash_including('id' => 'ping-9'))
+                .to_return(status: 200, body: '')
+
+    server.send(:handle_ping_request, 'ping-9')
+    deadline = Time.now + 2
+    sleep 0.05 until pong_stub.to_s.include?('was requested') || Time.now > deadline
+
+    expect(pong_stub).to have_been_requested.once
+  end
+
+  it 'sends the token on responses to server-initiated requests' do
+    response_stub = stub_request(:post, "#{base_url}#{endpoint}")
+                    .with(headers: { 'Authorization' => 'Bearer audit-token' },
+                          body: hash_including('id' => 42))
+                    .to_return(status: 200, body: '')
+
+    server.send(:post_jsonrpc_response, { 'jsonrpc' => '2.0', 'id' => 42, 'result' => { 'roots' => [] } })
+    deadline = Time.now + 2
+    sleep 0.05 until response_stub.to_s.include?('was requested') || Time.now > deadline
+
+    expect(response_stub).to have_been_requested.once
+  end
+
+  it 'sends the token on the plain HTTP transport DELETE as well' do
+    http_server = MCPClient::ServerHTTP.new(base_url: base_url, endpoint: endpoint, oauth_provider: oauth_provider)
+    http_server.instance_variable_set(:@session_id, 'sess-456')
+    delete_stub = stub_request(:delete, "#{base_url}#{endpoint}")
+                  .with(headers: { 'Authorization' => 'Bearer audit-token' })
+                  .to_return(status: 200, body: '')
+
+    expect(http_server.terminate_session).to be true
+    expect(delete_stub).to have_been_requested.once
+  end
+end


### PR DESCRIPTION
## What

Implements the per-request token MUST from [MCP 2025-11-25 basic/authorization — Access Token Usage](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#access-token-usage):

> "Note that authorization **MUST** be included in every HTTP request from client to server, even if they are part of the same logical session."

The Bearer token was only applied on the primary POST path. Four request paths hand-assembled their headers and sent **no** `Authorization`, so against an OAuth-protected server:

| Path | Consequence |
|---|---|
| GET events stream | 401 → events thread reconnect-loops forever; server-initiated requests/notifications never arrive |
| Session-termination DELETE (shared with plain HTTP transport) | 401 → session never terminated server-side |
| Pong responses to server pings | 401 → server sees its pings time out |
| POSTed responses to server-initiated elicitation/roots/sampling requests | 401 → server sees its requests time out |

All four now apply `@oauth_provider&.apply_authorization(req)` alongside the session and protocol-version headers.

## Tests

New `spec/lib/mcp_client/oauth_token_all_requests_spec.rb` — 5 wire-level examples asserting the Authorization header on the GET stream, both transports' DELETE, pong POSTs, and server-request response POSTs. All 5 failed before the fix. Full suite: 1325 examples, 0 failures; RuboCop clean.

Part of an MCP 2025-11-25 compliance audit of this gem against the official spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)