### PR TITLE
Implement SEP-1699 resumability: retry directive, GET-based resumption, cursor placement

### DIFF
--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -728,22 +728,20 @@ module MCPClient
     end
 
     # Wait for a response replayed after the POST stream was closed before
-    # delivering it (SEP-1699 polling pattern). Issues a dedicated HTTP GET
-    # carrying the disconnected stream's Last-Event-ID cursor — the general
-    # events stream (opened without that cursor) cannot receive the replay.
+    # delivering it (SEP-1699 polling pattern). A dedicated worker issues
+    # HTTP GETs carrying the disconnected stream's Last-Event-ID cursor — the
+    # general events stream (opened without that cursor) cannot receive the
+    # replay.
     # @param request_id [Integer, String] id of the outstanding request
     # @param cursor [String] last event id received on the closed stream
+    # @param retry_ms [Integer, nil] retry directive received on the closed
+    #   stream itself (not the shared events-stream directive)
     # @return [Hash, nil] the replayed JSON-RPC response, or nil on timeout
-    def resume_response_via_get(request_id, cursor)
+    def resume_response_via_get(request_id, cursor, retry_ms = nil)
       queue = Thread::Queue.new
       @mutex.synchronize { @pending_stream_responses[request_id] = queue }
 
-      # SEP-1699: the client MUST respect the server's retry directive before
-      # attempting to reconnect.
-      retry_ms = @sse_retry_ms
-      sleep(retry_ms / 1000.0) if retry_ms&.positive?
-
-      resume_thread = Thread.new { issue_resumption_get(cursor) }
+      resume_thread = Thread.new { run_resumption_loop(request_id, cursor, retry_ms) }
       begin
         queue.pop(timeout: @read_timeout)
       ensure
@@ -753,12 +751,41 @@ module MCPClient
       end
     end
 
-    # One-shot GET with the given cursor; complete SSE events are dispatched
-    # through the standard server-message path, which routes replayed
-    # responses to their registered waiters.
-    # @param cursor [String] Last-Event-ID value for the resumption request
+    # Reconnecting worker for SEP-1699 resumption. The server MAY close a
+    # resumed stream again before returning the response (polling pattern),
+    # so each iteration issues a GET with the CURRENT cursor until the
+    # overall read timeout elapses or the waiter has been served. `id:`
+    # fields received on the resumed stream advance the cursor and `retry:`
+    # fields update the delay honored before the next reconnect (zero is a
+    # valid immediate-reconnect directive).
+    # @param request_id [Integer, String] id of the outstanding request
+    # @param cursor [String] Last-Event-ID cursor from the closed stream
+    # @param retry_ms [Integer, nil] retry directive from the closed stream
     # @return [void]
-    def issue_resumption_get(cursor)
+    def run_resumption_loop(request_id, cursor, retry_ms)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @read_timeout
+      state = { cursor: cursor, retry_ms: retry_ms }
+      # SEP-1699: the client MUST respect the server's retry directive before
+      # attempting to reconnect.
+      delay = retry_ms ? retry_ms / 1000.0 : 0
+
+      loop do
+        sleep(delay) if delay.positive?
+        issue_resumption_get(state)
+        break unless @mutex.synchronize { @pending_stream_responses.key?(request_id) }
+        break if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+        delay = state[:retry_ms] ? state[:retry_ms] / 1000.0 : SSE_RECONNECT_DELAY
+      end
+    end
+
+    # One GET with the current cursor; complete SSE events are dispatched
+    # through the standard server-message path, which routes replayed
+    # responses to their registered waiters. `id:` and `retry:` fields
+    # received on this stream update the resumption state live.
+    # @param state [Hash] mutable resumption state (:cursor, :retry_ms)
+    # @return [void]
+    def issue_resumption_get(state)
       conn = Faraday.new(url: @base_url) do |f|
         f.options.open_timeout = 10
         f.options.timeout = @read_timeout
@@ -768,26 +795,60 @@ module MCPClient
       buffer = +''
       conn.get(@endpoint) do |req|
         apply_events_headers(req)
-        req.headers['Last-Event-ID'] = cursor
+        req.headers['Last-Event-ID'] = state[:cursor]
         req.options.on_data = proc do |chunk, _bytes|
           buffer << chunk
-          while (idx = buffer.index("\n\n"))
-            event_text = buffer.slice!(0, idx + 2)
-            data_lines = event_text.lines.filter_map { |l| l.sub(/\Adata:\s*/, '').chomp if l.start_with?('data:') }
-            handle_server_message(data_lines.join("\n")) unless data_lines.empty?
-          end
+          process_resumption_buffer(buffer, state)
         end
       end
     rescue StandardError => e
       @logger.debug("Resumption GET failed: #{e.message}")
     end
 
+    # Extract complete SSE events (terminated by a blank line, LF or CRLF)
+    # from the resumption buffer and handle each of them.
+    # @param buffer [String] mutable stream buffer
+    # @param state [Hash] mutable resumption state (:cursor, :retry_ms)
+    # @return [void]
+    def process_resumption_buffer(buffer, state)
+      while (separator = buffer.match(/\r\n\r\n|\n\n/))
+        event_text = buffer.slice!(0, separator.end(0))
+        handle_resumption_event(event_text, state)
+      end
+    end
+
+    # Parse one SSE event received on a resumption stream: track `id:` lines
+    # (advancing the cursor used by the next reconnect) and `retry:` lines
+    # (updating the reconnect delay; zero is valid), then dispatch any data.
+    # @param event_text [String] one complete SSE event, separator included
+    # @param state [Hash] mutable resumption state (:cursor, :retry_ms)
+    # @return [void]
+    def handle_resumption_event(event_text, state)
+      data_lines = []
+      event_text.each_line do |raw_line|
+        line = raw_line.chomp
+        if line.start_with?('data:')
+          data_lines << line.sub(/\Adata:\s*/, '')
+        elsif line.start_with?('id:')
+          id = line.sub(/\Aid:\s*/, '').strip
+          state[:cursor] = id unless id.empty?
+        elsif line.start_with?('retry:')
+          raw = line.sub(/\Aretry:\s*/, '').strip
+          state[:retry_ms] = raw.to_i if raw.match?(/\A\d+\z/)
+        end
+      end
+      handle_server_message(data_lines.join("\n")) unless data_lines.empty?
+    end
+
     # Deliver a response replayed on the events stream to a waiting request.
+    # The pending entry is removed on delivery so resumption workers can see
+    # that their waiter has been served.
     # @param message [Hash] a JSON-RPC response message
     # @return [void]
     def deliver_stream_response(message)
       queue = @mutex.synchronize do
-        @pending_stream_responses[message['id']] || @pending_stream_responses[message['id'].to_s]
+        key = [message['id'], message['id'].to_s].find { |k| @pending_stream_responses.key?(k) }
+        @pending_stream_responses.delete(key) unless key.nil?
       end
       queue << message if queue
     end

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -111,6 +111,8 @@ module MCPClient
       @http_conn = nil
       @session_id = nil
       @last_event_id = nil
+      @sse_retry_ms = nil
+      @pending_stream_responses = {}
       @oauth_provider = opts[:oauth_provider]
 
       # SSE events connection state
@@ -397,23 +399,20 @@ module MCPClient
       super
 
       # Add session and protocol version headers for non-initialize requests
-      if request['method'] != 'initialize'
-        if @session_id
-          req.headers['Mcp-Session-Id'] = @session_id
-          @logger.debug("Adding session header: Mcp-Session-Id: #{@session_id}")
-        end
+      return unless request['method'] != 'initialize'
 
-        if @protocol_version
-          req.headers['Mcp-Protocol-Version'] = @protocol_version
-          @logger.debug("Adding protocol version header: Mcp-Protocol-Version: #{@protocol_version}")
-        end
+      if @session_id
+        req.headers['Mcp-Session-Id'] = @session_id
+        @logger.debug("Adding session header: Mcp-Session-Id: #{@session_id}")
       end
 
-      # Add Last-Event-ID header for resumability (if available)
-      return unless @last_event_id
+      return unless @protocol_version
 
-      req.headers['Last-Event-ID'] = @last_event_id
-      @logger.debug("Adding Last-Event-ID header: #{@last_event_id}")
+      req.headers['Mcp-Protocol-Version'] = @protocol_version
+      @logger.debug("Adding protocol version header: Mcp-Protocol-Version: #{@protocol_version}")
+
+      # NOTE: Last-Event-ID is deliberately NOT sent on POSTs — per SEP-1699,
+      # resumption is always via HTTP GET with Last-Event-ID.
     end
 
     # Override handle_successful_response to capture session ID
@@ -478,6 +477,9 @@ module MCPClient
         @events_connection = nil
         @session_id = nil
         @last_event_id = nil
+        @sse_retry_ms = nil
+        @pending_stream_responses.each_value(&:close)
+        @pending_stream_responses.clear
 
         # Clear cached data
         @tools = nil
@@ -688,7 +690,7 @@ module MCPClient
         break unless @mutex.synchronize { @connection_established }
 
         @logger.info('Events connection closed, reconnecting...')
-        sleep reconnect_delay
+        sleep events_reconnect_delay(reconnect_delay)
         reconnect_delay = [reconnect_delay * 2, SSE_MAX_RECONNECT_DELAY].min
 
       # Intentional shutdown
@@ -697,23 +699,58 @@ module MCPClient
         break unless @mutex.synchronize { @connection_established }
 
         @logger.debug('Events connection timed out after inactivity, reconnecting...')
-        sleep reconnect_delay
+        sleep events_reconnect_delay(reconnect_delay)
       rescue Faraday::ConnectionFailed => e
         break unless @mutex.synchronize { @connection_established }
 
         @logger.warn("Events connection failed: #{e.message}, retrying in #{reconnect_delay}s...")
-        sleep reconnect_delay
+        sleep events_reconnect_delay(reconnect_delay)
         reconnect_delay = [reconnect_delay * 2, SSE_MAX_RECONNECT_DELAY].min
       rescue StandardError => e
         break unless @mutex.synchronize { @connection_established }
 
         @logger.error("Unexpected error in events connection: #{e.class} - #{e.message}")
         @logger.debug(e.backtrace.join("\n")) if @logger.level <= Logger::DEBUG
-        sleep reconnect_delay
+        sleep events_reconnect_delay(reconnect_delay)
         reconnect_delay = [reconnect_delay * 2, SSE_MAX_RECONNECT_DELAY].min
       end
     ensure
       @logger.info('Events connection thread terminated')
+    end
+
+    # Reconnect delay for the events stream: the server's SSE retry directive
+    # (in ms) when present, otherwise the caller's backoff value.
+    # @param fallback_seconds [Numeric] exponential-backoff fallback
+    # @return [Numeric] delay in seconds
+    def events_reconnect_delay(fallback_seconds)
+      retry_ms = @sse_retry_ms
+      retry_ms&.positive? ? retry_ms / 1000.0 : fallback_seconds
+    end
+
+    # Wait for a response replayed on the GET events stream after the POST
+    # stream was closed before delivering it (SEP-1699 polling pattern).
+    # @param request_id [Integer, String] id of the outstanding request
+    # @return [Hash, nil] the replayed JSON-RPC response, or nil on timeout
+    def resume_response_via_get(request_id)
+      queue = Thread::Queue.new
+      @mutex.synchronize { @pending_stream_responses[request_id] = queue }
+
+      begin
+        start_events_connection unless @events_thread&.alive?
+        queue.pop(timeout: @read_timeout)
+      ensure
+        @mutex.synchronize { @pending_stream_responses.delete(request_id) }
+      end
+    end
+
+    # Deliver a response replayed on the events stream to a waiting request.
+    # @param message [Hash] a JSON-RPC response message
+    # @return [void]
+    def deliver_stream_response(message)
+      queue = @mutex.synchronize do
+        @pending_stream_responses[message['id']] || @pending_stream_responses[message['id'].to_s]
+      end
+      queue << message if queue
     end
 
     # Apply headers for events connection
@@ -722,6 +759,10 @@ module MCPClient
       @headers.each { |k, v| req.headers[k] = v }
       req.headers['Mcp-Session-Id'] = @session_id if @session_id
       req.headers['Mcp-Protocol-Version'] = @protocol_version if @protocol_version
+      # SEP-1699: resumption is via GET with the Last-Event-ID cursor, so the
+      # server can replay messages missed since the last received event.
+      last_event_id = @mutex.synchronize { @last_event_id }
+      req.headers['Last-Event-ID'] = last_event_id if last_event_id
     end
 
     # Process event chunks from the server
@@ -779,8 +820,10 @@ module MCPClient
           event[:id] = line[3..].strip
           @last_event_id = event[:id]
         elsif line.start_with?('retry:')
-          # Server can suggest reconnection delay (in milliseconds)
+          # SEP-1699: the client MUST respect the server's retry directive
+          # (milliseconds) when reconnecting.
           retry_ms = line[6..].strip.to_i
+          @sse_retry_ms = retry_ms if retry_ms.positive?
           @logger.debug("Server suggested retry delay: #{retry_ms}ms") if @logger.level <= Logger::DEBUG
         end
       end
@@ -819,6 +862,10 @@ module MCPClient
       elsif message['method'] && !message.key?('id')
         # Handle server notifications (messages without id)
         @notification_callback&.call(message['method'], message['params'])
+      elsif message.key?('id')
+        # A response replayed on the events stream after its POST stream was
+        # closed before delivery (SEP-1699 resumption)
+        deliver_stream_response(message)
       end
     end
 

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -724,23 +724,62 @@ module MCPClient
     # @return [Numeric] delay in seconds
     def events_reconnect_delay(fallback_seconds)
       retry_ms = @sse_retry_ms
-      retry_ms&.positive? ? retry_ms / 1000.0 : fallback_seconds
+      retry_ms ? retry_ms / 1000.0 : fallback_seconds
     end
 
-    # Wait for a response replayed on the GET events stream after the POST
-    # stream was closed before delivering it (SEP-1699 polling pattern).
+    # Wait for a response replayed after the POST stream was closed before
+    # delivering it (SEP-1699 polling pattern). Issues a dedicated HTTP GET
+    # carrying the disconnected stream's Last-Event-ID cursor — the general
+    # events stream (opened without that cursor) cannot receive the replay.
     # @param request_id [Integer, String] id of the outstanding request
+    # @param cursor [String] last event id received on the closed stream
     # @return [Hash, nil] the replayed JSON-RPC response, or nil on timeout
-    def resume_response_via_get(request_id)
+    def resume_response_via_get(request_id, cursor)
       queue = Thread::Queue.new
       @mutex.synchronize { @pending_stream_responses[request_id] = queue }
 
+      # SEP-1699: the client MUST respect the server's retry directive before
+      # attempting to reconnect.
+      retry_ms = @sse_retry_ms
+      sleep(retry_ms / 1000.0) if retry_ms&.positive?
+
+      resume_thread = Thread.new { issue_resumption_get(cursor) }
       begin
-        start_events_connection unless @events_thread&.alive?
         queue.pop(timeout: @read_timeout)
       ensure
         @mutex.synchronize { @pending_stream_responses.delete(request_id) }
+        resume_thread.kill
+        resume_thread.join(1)
       end
+    end
+
+    # One-shot GET with the given cursor; complete SSE events are dispatched
+    # through the standard server-message path, which routes replayed
+    # responses to their registered waiters.
+    # @param cursor [String] Last-Event-ID value for the resumption request
+    # @return [void]
+    def issue_resumption_get(cursor)
+      conn = Faraday.new(url: @base_url) do |f|
+        f.options.open_timeout = 10
+        f.options.timeout = @read_timeout
+        f.adapter :net_http
+      end
+
+      buffer = +''
+      conn.get(@endpoint) do |req|
+        apply_events_headers(req)
+        req.headers['Last-Event-ID'] = cursor
+        req.options.on_data = proc do |chunk, _bytes|
+          buffer << chunk
+          while (idx = buffer.index("\n\n"))
+            event_text = buffer.slice!(0, idx + 2)
+            data_lines = event_text.lines.filter_map { |l| l.sub(/\Adata:\s*/, '').chomp if l.start_with?('data:') }
+            handle_server_message(data_lines.join("\n")) unless data_lines.empty?
+          end
+        end
+      end
+    rescue StandardError => e
+      @logger.debug("Resumption GET failed: #{e.message}")
     end
 
     # Deliver a response replayed on the events stream to a waiting request.
@@ -821,10 +860,10 @@ module MCPClient
           @last_event_id = event[:id]
         elsif line.start_with?('retry:')
           # SEP-1699: the client MUST respect the server's retry directive
-          # (milliseconds) when reconnecting.
-          retry_ms = line[6..].strip.to_i
-          @sse_retry_ms = retry_ms if retry_ms.positive?
-          @logger.debug("Server suggested retry delay: #{retry_ms}ms") if @logger.level <= Logger::DEBUG
+          # (milliseconds) when reconnecting; zero is a valid directive.
+          raw = line[6..].strip
+          @sse_retry_ms = raw.to_i if raw.match?(/\A\d+\z/)
+          @logger.debug("Server suggested retry delay: #{raw}ms") if @logger.level <= Logger::DEBUG
         end
       end
 

--- a/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
+++ b/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
@@ -87,8 +87,11 @@ module MCPClient
       # @raise [MCPClient::Errors::ServerError] when resumption fails
       # @raise [MCPClient::Errors::TransportError] when no cursor was received
       def resume_or_fail(events, request_id)
-        if request_id && events.any? { |e| e[:id] && !e[:id].empty? }
-          resumed = resume_response_via_get(request_id)
+        cursor = events.reverse.find { |e| e[:id] && !e[:id].empty? }&.dig(:id)
+        if request_id && cursor
+          # Resume with THIS stream's cursor (event ids are per-stream), not
+          # the shared @last_event_id which a concurrent stream may have moved.
+          resumed = resume_response_via_get(request_id, cursor)
           return resumed if resumed
 
           # Non-retryable: the request may already be executing server-side,
@@ -124,8 +127,8 @@ module MCPClient
             current_event[:id] = line.sub(/^id:\s*/, '').strip
           elsif line.start_with?('retry:')
             # SEP-1699: the client MUST respect the server's retry directive
-            retry_ms = line.sub(/^retry:\s*/, '').strip.to_i
-            @sse_retry_ms = retry_ms if retry_ms.positive?
+            raw = line.sub(/^retry:\s*/, '').strip
+            @sse_retry_ms = raw.to_i if raw.match?(/\A\d+\z/)
           end
         end
 

--- a/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
+++ b/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
@@ -61,7 +61,7 @@ module MCPClient
       # @return [Hash] the parsed JSON-RPC response
       # @raise [MCPClient::Errors::TransportError] if no response is found
       def parse_sse_response(sse_body, request_id = nil)
-        events = extract_sse_events(sse_body)
+        events, retry_ms = extract_sse_events(sse_body)
 
         raise MCPClient::Errors::TransportError, 'No data found in SSE response' if events.empty?
 
@@ -74,7 +74,7 @@ module MCPClient
                 'Invalid JSON response from server: SSE stream contained no valid JSON-RPC response'
         end
 
-        resume_or_fail(events, request_id)
+        resume_or_fail(events, request_id, retry_ms)
       end
 
       # SEP-1699 polling pattern: the server MAY close the POST stream before
@@ -83,15 +83,17 @@ module MCPClient
       # non-idempotent) request.
       # @param events [Array<Hash>] parsed SSE events
       # @param request_id [Integer, String, nil] id of the originating request
+      # @param retry_ms [Integer, nil] retry directive received on THIS stream
       # @return [Hash] the replayed JSON-RPC response
       # @raise [MCPClient::Errors::ServerError] when resumption fails
       # @raise [MCPClient::Errors::TransportError] when no cursor was received
-      def resume_or_fail(events, request_id)
+      def resume_or_fail(events, request_id, retry_ms = nil)
         cursor = events.reverse.find { |e| e[:id] && !e[:id].empty? }&.dig(:id)
         if request_id && cursor
-          # Resume with THIS stream's cursor (event ids are per-stream), not
-          # the shared @last_event_id which a concurrent stream may have moved.
-          resumed = resume_response_via_get(request_id, cursor)
+          # Resume with THIS stream's cursor and retry directive (both are
+          # per-stream), not the shared @last_event_id / @sse_retry_ms which a
+          # concurrent stream may have moved between parsing and resumption.
+          resumed = resume_response_via_get(request_id, cursor, retry_ms)
           return resumed if resumed
 
           # Non-retryable: the request may already be executing server-side,
@@ -107,9 +109,11 @@ module MCPClient
       # field has the default type "message" per the SSE specification; events
       # carrying only an id (priming events) are kept so their id is tracked.
       # @param sse_body [String] the SSE formatted response body
-      # @return [Array<Hash>] parsed events
+      # @return [Array(Array<Hash>, Integer, nil)] parsed events and the last
+      #   retry directive (ms) received on this stream, if any
       def extract_sse_events(sse_body)
         events = []
+        retry_ms = nil
         current_event = { type: 'message', data_lines: [], id: nil }
 
         sse_body.lines.each do |line|
@@ -126,15 +130,20 @@ module MCPClient
           elsif line.start_with?('id:')
             current_event[:id] = line.sub(/^id:\s*/, '').strip
           elsif line.start_with?('retry:')
-            # SEP-1699: the client MUST respect the server's retry directive
+            # SEP-1699: the client MUST respect the server's retry directive.
+            # Track it locally for this stream's resumption; the shared ivar is
+            # only a hint for the general events loop.
             raw = line.sub(/^retry:\s*/, '').strip
-            @sse_retry_ms = raw.to_i if raw.match?(/\A\d+\z/)
+            if raw.match?(/\A\d+\z/)
+              retry_ms = raw.to_i
+              @sse_retry_ms = retry_ms
+            end
           end
         end
 
         # Handle last event if no trailing empty line
         events << current_event if sse_event_present?(current_event)
-        events
+        [events, retry_ms]
       end
 
       # @param event [Hash] a parsed SSE event

--- a/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
+++ b/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
@@ -66,7 +66,38 @@ module MCPClient
         raise MCPClient::Errors::TransportError, 'No data found in SSE response' if events.empty?
 
         responses, saw_invalid_json = route_sse_events(events)
-        select_sse_response(responses, saw_invalid_json, request_id)
+        matched = select_sse_response(responses, request_id)
+        return matched if matched
+
+        if saw_invalid_json
+          raise MCPClient::Errors::TransportError,
+                'Invalid JSON response from server: SSE stream contained no valid JSON-RPC response'
+        end
+
+        resume_or_fail(events, request_id)
+      end
+
+      # SEP-1699 polling pattern: the server MAY close the POST stream before
+      # delivering the response. When a cursor was received, resume via HTTP
+      # GET with Last-Event-ID instead of re-POSTing the (possibly
+      # non-idempotent) request.
+      # @param events [Array<Hash>] parsed SSE events
+      # @param request_id [Integer, String, nil] id of the originating request
+      # @return [Hash] the replayed JSON-RPC response
+      # @raise [MCPClient::Errors::ServerError] when resumption fails
+      # @raise [MCPClient::Errors::TransportError] when no cursor was received
+      def resume_or_fail(events, request_id)
+        if request_id && events.any? { |e| e[:id] && !e[:id].empty? }
+          resumed = resume_response_via_get(request_id)
+          return resumed if resumed
+
+          # Non-retryable: the request may already be executing server-side,
+          # so a blind re-POST could run a non-idempotent operation twice.
+          raise MCPClient::Errors::ServerError,
+                'SSE stream closed before delivering the response and resumption via GET failed'
+        end
+
+        raise MCPClient::Errors::TransportError, 'No JSON-RPC response found in SSE response'
       end
 
       # Split an SSE body into events. An event without an explicit `event:`
@@ -91,6 +122,10 @@ module MCPClient
             current_event[:data_lines] << line.sub(/^data:\s*/, '').strip
           elsif line.start_with?('id:')
             current_event[:id] = line.sub(/^id:\s*/, '').strip
+          elsif line.start_with?('retry:')
+            # SEP-1699: the client MUST respect the server's retry directive
+            retry_ms = line.sub(/^retry:\s*/, '').strip.to_i
+            @sse_retry_ms = retry_ms if retry_ms.positive?
           end
         end
 
@@ -152,11 +187,9 @@ module MCPClient
 
       # Choose the JSON-RPC response answering the originating request.
       # @param responses [Array<Hash>] response candidates from the stream
-      # @param saw_invalid_json [Boolean] whether any event contained invalid JSON
       # @param request_id [Integer, String, nil] id of the originating request
-      # @return [Hash] the selected response
-      # @raise [MCPClient::Errors::TransportError] if no response is found
-      def select_sse_response(responses, saw_invalid_json, request_id)
+      # @return [Hash, nil] the selected response, if any
+      def select_sse_response(responses, request_id)
         matched = if request_id.nil?
                     responses.first
                   else
@@ -171,14 +204,7 @@ module MCPClient
           )
         end
 
-        return matched if matched
-
-        if saw_invalid_json
-          raise MCPClient::Errors::TransportError,
-                'Invalid JSON response from server: SSE stream contained no valid JSON-RPC response'
-        end
-
-        raise MCPClient::Errors::TransportError, 'No JSON-RPC response found in SSE response'
+        matched
       end
     end
   end

--- a/spec/integration/session_management_integration_spec.rb
+++ b/spec/integration/session_management_integration_spec.rb
@@ -240,10 +240,7 @@ RSpec.describe 'Session Management Integration', type: :integration do
         stub_request(:post, "#{base_url}#{endpoint}")
           .with(
             body: hash_including(method: 'tools/list'),
-            headers: {
-              'Mcp-Session-Id' => session_id,
-              'Last-Event-ID' => "#{event_id}-init"
-            }
+            headers: { 'Mcp-Session-Id' => session_id }
           )
           .to_return(
             status: 200,
@@ -256,10 +253,7 @@ RSpec.describe 'Session Management Integration', type: :integration do
         stub_request(:post, "#{base_url}#{endpoint}")
           .with(
             body: hash_including(method: 'tools/call'),
-            headers: {
-              'Mcp-Session-Id' => session_id,
-              'Last-Event-ID' => "#{event_id}-tools"
-            }
+            headers: { 'Mcp-Session-Id' => session_id }
           )
           .to_return(
             status: 200,
@@ -380,30 +374,34 @@ RSpec.describe 'Session Management Integration', type: :integration do
     end
 
     context 'resumability scenarios' do
-      it 'continues from last event ID after reconnection' do
+      it 'resumes via GET with Last-Event-ID after reconnection (SEP-1699)' do
         # Set up state as if we had a previous session
         streamable_server.instance_variable_set(:@session_id, session_id)
         streamable_server.instance_variable_set(:@last_event_id, 'previous-event-123')
         streamable_server.instance_variable_set(:@connection_established, true)
         streamable_server.instance_variable_set(:@initialized, true)
 
-        # Server should replay from the last event ID
+        # Resumption is always via HTTP GET carrying the cursor; POSTs carry
+        # only session/protocol headers
+        req = Struct.new(:headers).new({})
+        streamable_server.send(:apply_events_headers, req)
+        expect(req.headers['Last-Event-ID']).to eq('previous-event-123')
+        expect(req.headers['Mcp-Session-Id']).to eq(session_id)
+
+        captured = []
         stub_request(:post, "#{base_url}#{endpoint}")
-          .with(
-            headers: {
-              'Mcp-Session-Id' => session_id,
-              'Last-Event-ID' => 'previous-event-123'
-            }
-          )
-          .to_return(
-            status: 200,
-            body: "event: message\nid: resumed-event-124\n" \
-                  "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n",
-            headers: { 'Content-Type' => 'text/event-stream' }
-          )
+          .with(headers: { 'Mcp-Session-Id' => session_id })
+          .to_return do |request|
+            captured << request
+            { status: 200,
+              body: "event: message\nid: resumed-event-124\n" \
+                    "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n",
+              headers: { 'Content-Type' => 'text/event-stream' } }
+          end
 
         result = streamable_server.send(:request_tools_list)
         expect(result).to eq([])
+        expect(captured.first.headers).not_to have_key('Last-Event-Id')
         expect(streamable_server.instance_variable_get(:@last_event_id)).to eq('resumed-event-124')
       end
     end

--- a/spec/lib/mcp_client/server_streamable_http_spec.rb
+++ b/spec/lib/mcp_client/server_streamable_http_spec.rb
@@ -1258,52 +1258,31 @@ RSpec.describe MCPClient::ServerStreamableHTTP do
       end
     end
 
-    describe 'Last-Event-ID header injection' do
+    describe 'Last-Event-ID header placement (SEP-1699)' do
       before do
         server.instance_variable_set(:@last_event_id, 'last-event-456')
       end
 
-      it 'includes Last-Event-ID header when available' do
+      it 'does not attach Last-Event-ID to JSON-RPC POSTs' do
+        captured = []
         stub_request(:post, "#{base_url}#{endpoint}")
-          .with(
-            headers: { 'Last-Event-ID' => 'last-event-456' },
-            body: hash_including(method: 'tools/list')
-          )
-          .to_return(
-            status: 200,
-            body: "event: message\nid: event-457\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n",
-            headers: { 'Content-Type' => 'text/event-stream' }
-          )
+          .with(body: hash_including(method: 'tools/list'))
+          .to_return do |request|
+            captured << request
+            { status: 200,
+              body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n",
+              headers: { 'Content-Type' => 'text/event-stream' } }
+          end
 
         server.send(:request_tools_list)
-        expect(WebMock).to have_requested(:post, "#{base_url}#{endpoint}")
-          .with(headers: { 'Last-Event-ID' => 'last-event-456' })
+        expect(captured.first.headers).not_to have_key('Last-Event-Id')
       end
 
-      it 'includes both session and Last-Event-ID headers when both present' do
-        server.instance_variable_set(:@session_id, 'session-123')
-        server.instance_variable_set(:@last_event_id, 'event-789')
+      it 'attaches Last-Event-ID to the GET events request (resumption is always via GET)' do
+        req = Struct.new(:headers).new({})
+        server.send(:apply_events_headers, req)
 
-        stub_request(:post, "#{base_url}#{endpoint}")
-          .with(
-            headers: {
-              'Mcp-Session-Id' => 'session-123',
-              'Last-Event-ID' => 'event-789'
-            },
-            body: hash_including(method: 'tools/list')
-          )
-          .to_return(
-            status: 200,
-            body: "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n",
-            headers: { 'Content-Type' => 'text/event-stream' }
-          )
-
-        server.send(:request_tools_list)
-        expect(WebMock).to have_requested(:post, "#{base_url}#{endpoint}")
-          .with(headers: {
-                  'Mcp-Session-Id' => 'session-123',
-                  'Last-Event-ID' => 'event-789'
-                })
+        expect(req.headers['Last-Event-ID']).to eq('last-event-456')
       end
     end
 

--- a/spec/lib/mcp_client/streamable_resumability_spec.rb
+++ b/spec/lib/mcp_client/streamable_resumability_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2025-11-25 Streamable HTTP — Resumability and Redelivery (SEP-1699):
+# - "If the client wishes to resume after a disconnection ... it SHOULD issue
+#   an HTTP GET to the MCP endpoint, and include the Last-Event-ID header" —
+#   "Resumption is always via HTTP GET with Last-Event-ID", regardless of how
+#   the original stream was initiated.
+# - "The client MUST respect the retry field, waiting the given number of
+#   milliseconds before attempting to reconnect."
+# - After a server-initiated close, the client SHOULD poll by reconnecting —
+#   not re-POST the original (possibly non-idempotent) request.
+RSpec.describe 'Streamable HTTP resumability (SEP-1699)' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+  let(:server) do
+    MCPClient::ServerStreamableHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0,
+                                        read_timeout: 2, name: 'resume-test')
+  end
+
+  after { server.cleanup }
+
+  def init_body
+    "event: message\ndata: #{JSON.generate(
+      jsonrpc: '2.0', id: 1,
+      result: { protocolVersion: MCPClient::PROTOCOL_VERSION, capabilities: {},
+                serverInfo: { name: 's', version: '1' } }
+    )}\n\n"
+  end
+
+  def stub_connect!(get_body: '')
+    stub_request(:post, "#{base_url}#{endpoint}")
+      .with(body: hash_including('method' => 'initialize'))
+      .to_return(status: 200, body: init_body, headers: { 'Content-Type' => 'text/event-stream' })
+    stub_request(:post, "#{base_url}#{endpoint}")
+      .with(body: hash_including('method' => 'notifications/initialized'))
+      .to_return(status: 202, body: '')
+    stub_request(:get, "#{base_url}#{endpoint}")
+      .to_return(status: 200, body: get_body, headers: { 'Content-Type' => 'text/event-stream' })
+  end
+
+  describe 'Last-Event-ID placement' do
+    it 'is not attached to JSON-RPC POSTs' do
+      stub_connect!
+      server.connect
+      server.instance_variable_set(:@last_event_id, 'evt-7')
+
+      post_requests = []
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including('method' => 'tools/list'))
+        .to_return do |request|
+          post_requests << request
+          { status: 200,
+            body: "event: message\ndata: #{JSON.generate(jsonrpc: '2.0', id: 2, result: { tools: [] })}\n\n",
+            headers: { 'Content-Type' => 'text/event-stream' } }
+        end
+
+      server.rpc_request('tools/list', {})
+
+      expect(post_requests.first.headers).not_to have_key('Last-Event-Id')
+      expect(post_requests.first.headers).not_to have_key('Last-Event-ID')
+    end
+
+    it 'is attached to the GET events request when a cursor exists' do
+      server.instance_variable_set(:@last_event_id, 'evt-9')
+      req = Struct.new(:headers).new({})
+      server.send(:apply_events_headers, req)
+
+      expect(req.headers['Last-Event-ID']).to eq('evt-9')
+    end
+  end
+
+  describe 'retry directive' do
+    it 'records the retry field from the GET events stream' do
+      server.send(:parse_and_handle_event, "retry: 250\ndata: \n")
+
+      expect(server.instance_variable_get(:@sse_retry_ms)).to eq(250)
+    end
+
+    it 'records the retry field from a POST SSE response' do
+      body = "retry: 5000\nevent: message\ndata: #{JSON.generate(jsonrpc: '2.0', id: 3, result: {})}\n\n"
+      server.send(:parse_sse_response, body, 3)
+
+      expect(server.instance_variable_get(:@sse_retry_ms)).to eq(5000)
+    end
+
+    it 'uses the server retry directive as the reconnect delay' do
+      server.instance_variable_set(:@sse_retry_ms, 250)
+      expect(server.send(:events_reconnect_delay, 4)).to eq(0.25)
+    end
+
+    it 'falls back to the caller delay without a directive' do
+      expect(server.send(:events_reconnect_delay, 4)).to eq(4)
+    end
+  end
+
+  describe 'polling pattern: stream closed before the response' do
+    it 'resumes via GET with Last-Event-ID instead of re-POSTing' do
+      # POST answers with a priming event (id, no data) and a fast retry
+      # directive, then the stream ends — the SEP-1699 polling pattern.
+      post_stub = stub_request(:post, "#{base_url}#{endpoint}")
+                  .with(body: hash_including('method' => 'tools/call'))
+                  .to_return(status: 200, body: "retry: 100\nid: evt-42\ndata:\n\n",
+                             headers: { 'Content-Type' => 'text/event-stream' })
+
+      stub_connect!
+      # The replayed response arrives on a GET carrying the cursor (registered
+      # after the general GET stub so it takes precedence for cursor requests)
+      resumed = { jsonrpc: '2.0', id: 2, result: { 'content' => [] } }
+      stub_request(:get, "#{base_url}#{endpoint}")
+        .with(headers: { 'Last-Event-ID' => 'evt-42' })
+        .to_return(status: 200, body: "id: evt-43\nevent: message\ndata: #{resumed.to_json}\n\n",
+                   headers: { 'Content-Type' => 'text/event-stream' })
+      server.connect
+
+      result = server.rpc_request('tools/call', { 'name' => 'x' })
+
+      expect(result).to eq({ 'content' => [] })
+      expect(post_stub).to have_been_requested.once
+    end
+
+    it 'raises a non-retryable error when resumption fails, without re-POSTing' do
+      post_stub = stub_request(:post, "#{base_url}#{endpoint}")
+                  .with(body: hash_including('method' => 'tools/call'))
+                  .to_return(status: 200, body: "retry: 100\nid: evt-42\ndata:\n\n",
+                             headers: { 'Content-Type' => 'text/event-stream' })
+      stub_connect!
+      server.connect
+
+      expect { server.rpc_request('tools/call', { 'name' => 'x' }) }.to raise_error(
+        MCPClient::Errors::ServerError, /resum/i
+      )
+      expect(post_stub).to have_been_requested.once
+    end
+  end
+end

--- a/spec/lib/mcp_client/streamable_resumability_spec.rb
+++ b/spec/lib/mcp_client/streamable_resumability_spec.rb
@@ -105,13 +105,75 @@ RSpec.describe 'Streamable HTTP resumability (SEP-1699)' do
     it 'resumes with the closed stream own cursor, not the shared one' do
       server.instance_variable_set(:@last_event_id, 'other-stream-cursor')
       allow(server).to receive(:resume_response_via_get)
-        .with(3, 'evt-42').and_return({ 'jsonrpc' => '2.0', 'id' => 3, 'result' => {} })
+        .with(3, 'evt-42', nil).and_return({ 'jsonrpc' => '2.0', 'id' => 3, 'result' => {} })
 
       body = "id: evt-42\ndata:\n\n"
       result = server.send(:parse_sse_response, body, 3)
 
       expect(result['id']).to eq(3)
-      expect(server).to have_received(:resume_response_via_get).with(3, 'evt-42')
+      expect(server).to have_received(:resume_response_via_get).with(3, 'evt-42', nil)
+    end
+  end
+
+  describe 'resumption retry delay isolation' do
+    it 'passes the POST stream own retry directive to resumption, not the shared ivar' do
+      # A concurrent GET/POST stream moved the shared directive; this POST
+      # stream carries its own retry directive which must be the one used.
+      server.instance_variable_set(:@sse_retry_ms, 10_000)
+      allow(server).to receive(:resume_response_via_get)
+        .and_return({ 'jsonrpc' => '2.0', 'id' => 3, 'result' => {} })
+
+      body = "retry: 50\nid: evt-42\ndata:\n\n"
+      server.send(:parse_sse_response, body, 3)
+
+      expect(server).to have_received(:resume_response_via_get).with(3, 'evt-42', 50)
+    end
+
+    it 'passes no delay when the POST stream carried no retry directive' do
+      server.instance_variable_set(:@sse_retry_ms, 10_000)
+      allow(server).to receive(:resume_response_via_get)
+        .and_return({ 'jsonrpc' => '2.0', 'id' => 3, 'result' => {} })
+
+      server.send(:parse_sse_response, "id: evt-42\ndata:\n\n", 3)
+
+      expect(server).to have_received(:resume_response_via_get).with(3, 'evt-42', nil)
+    end
+  end
+
+  describe 'resumption GET stream parsing' do
+    it 'dispatches a CRLF-delimited resumed response' do
+      response = { jsonrpc: '2.0', id: 8, result: { 'ok' => true } }
+      stub_request(:get, "#{base_url}#{endpoint}")
+        .with(headers: { 'Last-Event-ID' => 'evt-1' })
+        .to_return(status: 200,
+                   body: "id: evt-2\r\nevent: message\r\ndata: #{response.to_json}\r\n\r\n",
+                   headers: { 'Content-Type' => 'text/event-stream' })
+
+      result = server.send(:resume_response_via_get, 8, 'evt-1', 0)
+
+      expect(result).to include('id' => 8, 'result' => { 'ok' => true })
+    end
+
+    it 'reconnects with the updated cursor when the resumed stream closes without the response' do
+      # First resumed GET (cursor evt-1) delivers only a priming event with a
+      # new cursor and retry directive, then closes — the SEP-1699 polling
+      # pattern applied to the resumed stream itself.
+      first_get = stub_request(:get, "#{base_url}#{endpoint}")
+                  .with(headers: { 'Last-Event-ID' => 'evt-1' })
+                  .to_return(status: 200, body: "id: evt-2\nretry: 50\ndata:\n\n",
+                             headers: { 'Content-Type' => 'text/event-stream' })
+      response = { jsonrpc: '2.0', id: 7, result: { 'ok' => true } }
+      second_get = stub_request(:get, "#{base_url}#{endpoint}")
+                   .with(headers: { 'Last-Event-ID' => 'evt-2' })
+                   .to_return(status: 200,
+                              body: "id: evt-3\nevent: message\ndata: #{response.to_json}\n\n",
+                              headers: { 'Content-Type' => 'text/event-stream' })
+
+      result = server.send(:resume_response_via_get, 7, 'evt-1', 50)
+
+      expect(result).to include('id' => 7, 'result' => { 'ok' => true })
+      expect(first_get).to have_been_requested
+      expect(second_get).to have_been_requested
     end
   end
 

--- a/spec/lib/mcp_client/streamable_resumability_spec.rb
+++ b/spec/lib/mcp_client/streamable_resumability_spec.rb
@@ -94,6 +94,25 @@ RSpec.describe 'Streamable HTTP resumability (SEP-1699)' do
     it 'falls back to the caller delay without a directive' do
       expect(server.send(:events_reconnect_delay, 4)).to eq(4)
     end
+
+    it 'accepts retry: 0 as a valid immediate-reconnect directive' do
+      server.send(:parse_and_handle_event, "retry: 0\ndata: \n")
+
+      expect(server.instance_variable_get(:@sse_retry_ms)).to eq(0)
+      expect(server.send(:events_reconnect_delay, 4)).to eq(0)
+    end
+
+    it 'resumes with the closed stream own cursor, not the shared one' do
+      server.instance_variable_set(:@last_event_id, 'other-stream-cursor')
+      allow(server).to receive(:resume_response_via_get)
+        .with(3, 'evt-42').and_return({ 'jsonrpc' => '2.0', 'id' => 3, 'result' => {} })
+
+      body = "id: evt-42\ndata:\n\n"
+      result = server.send(:parse_sse_response, body, 3)
+
+      expect(result['id']).to eq(3)
+      expect(server).to have_received(:resume_response_via_get).with(3, 'evt-42')
+    end
   end
 
   describe 'polling pattern: stream closed before the response' do


### PR DESCRIPTION
## What

Reworks Streamable HTTP reconnection per [MCP 2025-11-25 basic/transports — Resumability and Redelivery](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery) (SEP-1699 + its clarifications):

### 1. The SSE `retry` directive is honored (MUST)

> "The client **MUST** respect the `retry` field, waiting the given number of milliseconds before attempting to reconnect."

It was parsed, logged, and ignored — the events loop slept its own exponential backoff (1s→30s) regardless. A server directing `retry: 60000` was reconnected to up to 60× too often; `retry: 250` fast polling waited 4–120× too long. Both the GET stream parser and the POST SSE parser now record it, and every reconnect sleep consults it.

### 2. Cursor placement fixed (SHOULD)

> "If the client wishes to resume after a disconnection ... it **SHOULD** issue an HTTP GET to the MCP endpoint, and include the `Last-Event-ID` header." — "Resumption is always via HTTP GET with `Last-Event-ID`," regardless of how the original stream was initiated.

The implementation had it inverted: `Last-Event-ID` was attached to **every subsequent JSON-RPC POST** (meaningless there, potentially confusing servers) and **never** to GET reconnects — so replay of missed messages could never happen. Now the cursor rides only on the GET events request.

### 3. The polling pattern works without duplicate execution

Per SEP-1699 a server **MAY** close a stream at any time (priming event, then close, response later). Previously that raised a `TransportError`, and `with_retry` re-POSTed the identical JSON-RPC request — re-executing a non-idempotent `tools/call`. Now, when a POST stream ends with a cursor but no response, the client resumes via the GET events stream (which carries the cursor), waits — bounded by `read_timeout` — for the replayed response routed back to the caller, and returns it. If resumption fails, it raises a **non-retryable** `ServerError`, because the request may already be executing server-side.

**Honest scope note:** interleaved messages on a still-open POST stream are dispatched when the stream completes (Faraday buffers POST bodies); the SEP-1699-sanctioned server behavior — closing the stream — is now fully handled via GET resumption, which *is* incremental. Fully incremental POST-body parsing remains a possible future refinement.

## Tests

New `spec/lib/mcp_client/streamable_resumability_spec.rb` (8 examples: no cursor on POSTs, cursor on GET, retry recorded from both stream types, retry-driven reconnect delay, wire-level resume-via-GET returning the replayed response with exactly one POST, and non-retryable failure without re-POST). All 8 failed before the fix. Existing tests asserting the old cursor-on-POST behavior updated to assert the SEP-1699 placement. Full suite: 1337 examples, 0 failures; RuboCop clean.

> Stacked on #158 (`fix/streamable-http-post-sse-stream`) — builds on its SSE parser rework. Merge #158 first.

Part of an MCP 2025-11-25 compliance audit of this gem against the official spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)