### PR TITLE
Validate root URIs (file:// MUST) and expose Root _meta

### DIFF
--- a/lib/mcp_client/root.rb
+++ b/lib/mcp_client/root.rb
@@ -17,6 +17,9 @@ module MCPClient
     # @raise [ArgumentError] if uri is not a valid file:// URI or contains '..' path segments
     def initialize(uri:, name: nil, meta: nil)
       validate_uri!(uri)
+      # Root._meta is an object of arbitrary keys per the schema
+      raise ArgumentError, "Root _meta must be a Hash, got #{meta.class}" if meta && !meta.is_a?(Hash)
+
       @uri = uri
       @name = name
       @meta = meta
@@ -84,13 +87,19 @@ module MCPClient
       raise ArgumentError, 'Root uri must be a String, got nil' if uri.nil?
       raise ArgumentError, "Root uri must be a String, got #{uri.class}" unless uri.is_a?(String)
 
-      parsed = parse_uri(uri)
-      unless parsed.scheme&.casecmp('file')&.zero?
+      # The schema requires the literal file:// form ("must start with
+      # file://"), not merely a file scheme — file:relative and file:/path
+      # forms are rejected.
+      unless uri.downcase.start_with?('file://')
         raise ArgumentError,
               "Root uri must be a file:// URI (MCP spec: 'This MUST be a file:// URI'), got: #{uri.inspect}"
       end
 
-      return unless parsed.path.to_s.split('/').include?('..')
+      parsed = parse_uri(uri)
+      # Decode before the traversal check so percent-encoded segments
+      # (%2e%2e) cannot smuggle a '..' past validation.
+      decoded_path = URI::DEFAULT_PARSER.unescape(parsed.path.to_s)
+      return unless decoded_path.split('/').include?('..')
 
       raise ArgumentError, "Root uri must not contain '..' path traversal segments, got: #{uri.inspect}"
     end

--- a/lib/mcp_client/root.rb
+++ b/lib/mcp_client/root.rb
@@ -1,26 +1,36 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 module MCPClient
   # Represents an MCP Root - a URI that defines a boundary where servers can operate
   # Roots are declared by clients to inform servers about relevant resources and their locations
   class Root
-    attr_reader :uri, :name
+    attr_reader :uri, :name, :meta
 
     # Create a new Root
-    # @param uri [String] The URI for the root (typically file:// URI)
+    # @param uri [String] The URI for the root. Per the MCP specification this
+    #   MUST be a file:// URI ("This **MUST** be a `file://` URI in the current
+    #   specification" - client/roots.mdx, 2025-11-25)
     # @param name [String, nil] Optional human-readable name for display purposes
-    def initialize(uri:, name: nil)
+    # @param meta [Hash, nil] Optional _meta field attached to the root (schema.ts Root._meta)
+    # @raise [ArgumentError] if uri is not a valid file:// URI or contains '..' path segments
+    def initialize(uri:, name: nil, meta: nil)
+      validate_uri!(uri)
       @uri = uri
       @name = name
+      @meta = meta
     end
 
     # Create a Root from a JSON hash
-    # @param json [Hash] The JSON hash with 'uri' and optional 'name' keys
+    # @param json [Hash] The JSON hash with 'uri' and optional 'name' and '_meta' keys
     # @return [Root]
+    # @raise [ArgumentError] if the uri is missing or not a valid file:// URI
     def self.from_json(json)
       new(
         uri: json['uri'] || json[:uri],
-        name: json['name'] || json[:name]
+        name: json['name'] || json[:name],
+        meta: json['_meta'] || json[:_meta]
       )
     end
 
@@ -29,6 +39,7 @@ module MCPClient
     def to_h
       result = { 'uri' => @uri }
       result['name'] = @name if @name
+      result['_meta'] = @meta if @meta
       result
     end
 
@@ -42,13 +53,13 @@ module MCPClient
     def ==(other)
       return false unless other.is_a?(Root)
 
-      uri == other.uri && name == other.name
+      uri == other.uri && name == other.name && meta == other.meta
     end
 
     alias eql? ==
 
     def hash
-      [uri, name].hash
+      [uri, name, meta].hash
     end
 
     # String representation
@@ -58,6 +69,40 @@ module MCPClient
 
     def inspect
       "#<MCPClient::Root uri=#{uri.inspect} name=#{name.inspect}>"
+    end
+
+    private
+
+    # Validate that the uri is a well-formed file:// URI without path traversal.
+    # Spec (client/roots.mdx, 2025-11-25): the root uri "MUST be a `file://` URI
+    # in the current specification", and clients "MUST ... Validate all root
+    # URIs to prevent path traversal".
+    # @param uri [Object] the uri to validate
+    # @return [void]
+    # @raise [ArgumentError] if the uri is invalid
+    def validate_uri!(uri)
+      raise ArgumentError, 'Root uri must be a String, got nil' if uri.nil?
+      raise ArgumentError, "Root uri must be a String, got #{uri.class}" unless uri.is_a?(String)
+
+      parsed = parse_uri(uri)
+      unless parsed.scheme&.casecmp('file')&.zero?
+        raise ArgumentError,
+              "Root uri must be a file:// URI (MCP spec: 'This MUST be a file:// URI'), got: #{uri.inspect}"
+      end
+
+      return unless parsed.path.to_s.split('/').include?('..')
+
+      raise ArgumentError, "Root uri must not contain '..' path traversal segments, got: #{uri.inspect}"
+    end
+
+    # Parse a URI string, converting parse errors to ArgumentError
+    # @param uri [String] the uri string to parse
+    # @return [URI::Generic]
+    # @raise [ArgumentError] if the uri cannot be parsed
+    def parse_uri(uri)
+      URI.parse(uri)
+    rescue URI::InvalidURIError => e
+      raise ArgumentError, "Root uri is not a valid URI: #{uri.inspect} (#{e.message})"
     end
   end
 end

--- a/spec/lib/mcp_client/roots_validation_spec.rb
+++ b/spec/lib/mcp_client/roots_validation_spec.rb
@@ -156,4 +156,23 @@ RSpec.describe 'Root URI validation and _meta support' do
       expect(response).to eq({ 'roots' => [{ 'uri' => 'file:///path', '_meta' => { 'k' => 'v' } }] })
     end
   end
+
+  describe 'review hardening (Codex findings)' do
+    let(:described_root) { MCPClient::Root }
+
+    it 'rejects percent-encoded traversal segments' do
+      expect { described_root.new(uri: 'file:///safe/%2e%2e/etc') }
+        .to raise_error(ArgumentError, /traversal/)
+    end
+
+    it 'rejects file: forms that do not start with file://' do
+      expect { described_root.new(uri: 'file:relative/path') }.to raise_error(ArgumentError, /file:/)
+      expect { described_root.new(uri: 'file:/absolute/path') }.to raise_error(ArgumentError, /file:/)
+    end
+
+    it 'rejects non-Hash _meta' do
+      expect { described_root.new(uri: 'file:///ws', meta: 'not-an-object') }
+        .to raise_error(ArgumentError, /_meta/)
+    end
+  end
 end

--- a/spec/lib/mcp_client/roots_validation_spec.rb
+++ b/spec/lib/mcp_client/roots_validation_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2025-11-25 roots spec (client/roots.mdx, Data Types - Root):
+#   "uri: Unique identifier for the root. This MUST be a file:// URI in the
+#    current specification."
+# Security Considerations: "Clients MUST: ... Validate all root URIs to
+# prevent path traversal".
+# schema.ts Root also declares an optional `_meta?: { [key: string]: unknown }`.
+RSpec.describe 'Root URI validation and _meta support' do
+  describe MCPClient::Root do
+    describe 'URI validation' do
+      it 'accepts a file:// URI' do
+        root = described_class.new(uri: 'file:///home/user/project')
+        expect(root.uri).to eq('file:///home/user/project')
+      end
+
+      it 'accepts a file:// URI with a name' do
+        root = described_class.new(uri: 'file:///home/user/project', name: 'My Project')
+        expect(root.name).to eq('My Project')
+      end
+
+      it 'accepts an uppercase FILE scheme (schemes are case-insensitive)' do
+        root = described_class.new(uri: 'FILE:///home/user/project')
+        expect(root.uri).to eq('FILE:///home/user/project')
+      end
+
+      it 'rejects an http:// URI' do
+        expect do
+          described_class.new(uri: 'http://example.com/project')
+        end.to raise_error(ArgumentError, %r{file://})
+      end
+
+      it 'rejects an https:// URI' do
+        expect do
+          described_class.new(uri: 'https://example.com/project')
+        end.to raise_error(ArgumentError, %r{file://})
+      end
+
+      it 'rejects a relative path with no scheme' do
+        expect do
+          described_class.new(uri: 'relative/path')
+        end.to raise_error(ArgumentError, %r{file://})
+      end
+
+      it 'rejects an absolute filesystem path with no scheme' do
+        expect do
+          described_class.new(uri: '/home/user/project')
+        end.to raise_error(ArgumentError, %r{file://})
+      end
+
+      it 'rejects a nil uri' do
+        expect do
+          described_class.new(uri: nil)
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'rejects a non-string uri' do
+        expect do
+          described_class.new(uri: 123)
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'rejects an unparseable uri' do
+        expect do
+          described_class.new(uri: 'file://<not a uri>')
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'rejects a file:// URI containing ".." path traversal segments' do
+        expect do
+          described_class.new(uri: 'file:///home/user/../../etc/passwd')
+        end.to raise_error(ArgumentError, /traversal|\.\./)
+      end
+
+      it 'rejects invalid URIs in from_json too' do
+        expect do
+          described_class.from_json({ 'uri' => 'https://example.com' })
+        end.to raise_error(ArgumentError, %r{file://})
+      end
+
+      it 'rejects from_json input with a missing uri' do
+        expect do
+          described_class.from_json({ 'name' => 'No URI' })
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    describe '_meta support' do
+      it 'accepts an optional meta kwarg and exposes it' do
+        root = described_class.new(uri: 'file:///path', meta: { 'key' => 'value' })
+        expect(root.meta).to eq({ 'key' => 'value' })
+      end
+
+      it 'defaults meta to nil' do
+        root = described_class.new(uri: 'file:///path')
+        expect(root.meta).to be_nil
+      end
+
+      it 'parses _meta in from_json (string keys)' do
+        root = described_class.from_json({ 'uri' => 'file:///path', '_meta' => { 'a' => 1 } })
+        expect(root.meta).to eq({ 'a' => 1 })
+      end
+
+      it 'parses _meta in from_json (symbol keys)' do
+        root = described_class.from_json({ uri: 'file:///path', _meta: { 'a' => 1 } })
+        expect(root.meta).to eq({ 'a' => 1 })
+      end
+
+      it 'includes _meta in to_h when present' do
+        root = described_class.new(uri: 'file:///path', name: 'Test', meta: { 'a' => 1 })
+        expect(root.to_h).to eq({ 'uri' => 'file:///path', 'name' => 'Test', '_meta' => { 'a' => 1 } })
+      end
+
+      it 'omits _meta from to_h when absent' do
+        root = described_class.new(uri: 'file:///path')
+        expect(root.to_h).to eq({ 'uri' => 'file:///path' })
+      end
+
+      it 'round-trips _meta through from_json and to_h' do
+        json = { 'uri' => 'file:///path', 'name' => 'Test', '_meta' => { 'trace' => 'abc' } }
+        expect(described_class.from_json(json).to_h).to eq(json)
+      end
+
+      it 'considers _meta in equality' do
+        root1 = described_class.new(uri: 'file:///path', meta: { 'a' => 1 })
+        root2 = described_class.new(uri: 'file:///path', meta: { 'a' => 2 })
+        root3 = described_class.new(uri: 'file:///path', meta: { 'a' => 1 })
+
+        expect(root1).not_to eq(root2)
+        expect(root1).to eq(root3)
+        expect(root1.hash).to eq(root3.hash)
+      end
+    end
+  end
+
+  describe MCPClient::Client do
+    it 'raises ArgumentError when constructed with a non-file:// root' do
+      expect do
+        MCPClient::Client.new(roots: [{ uri: 'https://example.com/project' }])
+      end.to raise_error(ArgumentError, %r{file://})
+    end
+
+    it 'raises ArgumentError when roots= is given a non-file:// root' do
+      client = MCPClient::Client.new
+      expect do
+        client.roots = [MCPClient::Root.new(uri: 'file:///ok'), { 'uri' => '/no/scheme' }]
+      end.to raise_error(ArgumentError, %r{file://})
+    end
+
+    it 'serializes _meta in the roots/list response' do
+      client = MCPClient::Client.new(roots: [{ 'uri' => 'file:///path', '_meta' => { 'k' => 'v' } }])
+      response = client.send(:handle_roots_list_request, 1, {})
+
+      expect(response).to eq({ 'roots' => [{ 'uri' => 'file:///path', '_meta' => { 'k' => 'v' } }] })
+    end
+  end
+end


### PR DESCRIPTION
## What

The MCP 2025-11-25 roots spec (`client/roots.mdx`, Data Types — Root) states:

> `uri`: Unique identifier for the root. This **MUST** be a `file://` URI in the current specification.

and, under Security Considerations:

> Clients **MUST**: ... Validate all root URIs to prevent path traversal

Previously `MCPClient::Root` accepted any uri value (including `nil`, `https://` URIs, or bare paths) and the client emitted it verbatim in `roots/list` responses, producing spec-invalid Roots on the wire.

- `Root#initialize` now raises `ArgumentError` unless the uri is a parseable `file://` URI (scheme compared case-insensitively) whose path contains no `..` traversal segments. Since `Client#initialize` and `Client#roots=` both funnel through `normalize_roots` → `Root.new`/`Root.from_json`, both entry points are covered with no client changes.
- `Root` also gains the optional `_meta` field declared in `schema.ts` (`_meta?: { [key: string]: unknown }`): a `meta:` kwarg, parsed from `_meta` in `from_json` (string or symbol keys), emitted in `to_h` only when present, and included in `==`/`hash`. It was previously silently dropped, so hosts could never attach metadata to roots.

## Tests

- New `spec/lib/mcp_client/roots_validation_spec.rb` (24 examples): rejects `http://`/`https://`, relative and schemeless paths, `nil`/non-string/unparseable uris, and `..` traversal; accepts `file:///path` (including uppercase scheme); `_meta` round-trips through `from_json`/`to_h` and appears in the `roots/list` response; `Client.new(roots: [...])` and `Client#roots=` raise on invalid roots.
- Full suite: 1344 examples, 0 failures. RuboCop: 111 files inspected, no offenses.

Part of an MCP 2025-11-25 compliance audit of this gem against the official spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)