### PR TITLE
Parse and expose 2025-11-25 metadata fields (icons, title, _meta) on model classes

### DIFF
--- a/lib/mcp_client/prompt.rb
+++ b/lib/mcp_client/prompt.rb
@@ -5,23 +5,35 @@ module MCPClient
   class Prompt
     # @!attribute [r] name
     #   @return [String] the name of the prompt
+    # @!attribute [r] title
+    #   @return [String, nil] optional human-readable name of the prompt for display purposes
     # @!attribute [r] description
     #   @return [String] the description of the prompt
     # @!attribute [r] arguments
     #   @return [Hash] the JSON arguments for the prompt
+    # @!attribute [r] icons
+    #   @return [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25, SEP-973)
+    # @!attribute [r] meta
+    #   @return [Hash, nil] optional `_meta` metadata attached to the prompt (MCP 2025-11-25)
     # @!attribute [r] server
     #   @return [MCPClient::ServerBase, nil] the server this prompt belongs to
-    attr_reader :name, :description, :arguments, :server
+    attr_reader :name, :title, :description, :arguments, :icons, :meta, :server
 
     # Initialize a new prompt
     # @param name [String] the name of the prompt
     # @param description [String] the description of the prompt
     # @param arguments [Hash] the JSON arguments for the prompt
+    # @param title [String, nil] optional human-readable name of the prompt for display purposes
+    # @param icons [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25)
+    # @param meta [Hash, nil] optional `_meta` metadata attached to the prompt (MCP 2025-11-25)
     # @param server [MCPClient::ServerBase, nil] the server this prompt belongs to
-    def initialize(name:, description:, arguments: {}, server: nil)
+    def initialize(name:, description:, arguments: {}, title: nil, icons: nil, meta: nil, server: nil)
       @name = name
+      @title = title
       @description = description
       @arguments = arguments
+      @icons = icons
+      @meta = meta
       @server = server
     end
 
@@ -32,8 +44,11 @@ module MCPClient
     def self.from_json(data, server: nil)
       new(
         name: data['name'],
+        title: data['title'],
         description: data['description'],
         arguments: data['arguments'] || {},
+        icons: data['icons'],
+        meta: data['_meta'],
         server: server
       )
     end

--- a/lib/mcp_client/resource.rb
+++ b/lib/mcp_client/resource.rb
@@ -17,9 +17,13 @@ module MCPClient
     #   @return [Integer, nil] optional size in bytes
     # @!attribute [r] annotations
     #   @return [Hash, nil] optional annotations that provide hints to clients
+    # @!attribute [r] icons
+    #   @return [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25, SEP-973)
+    # @!attribute [r] meta
+    #   @return [Hash, nil] optional `_meta` metadata attached to the resource (MCP 2025-11-25)
     # @!attribute [r] server
     #   @return [MCPClient::ServerBase, nil] the server this resource belongs to
-    attr_reader :uri, :name, :title, :description, :mime_type, :size, :annotations, :server
+    attr_reader :uri, :name, :title, :description, :mime_type, :size, :annotations, :icons, :meta, :server
 
     # Initialize a new resource
     # @param uri [String] unique identifier for the resource
@@ -29,8 +33,12 @@ module MCPClient
     # @param mime_type [String, nil] optional MIME type
     # @param size [Integer, nil] optional size in bytes
     # @param annotations [Hash, nil] optional annotations that provide hints to clients
+    # @param icons [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25)
+    # @param meta [Hash, nil] optional `_meta` metadata attached to the resource (MCP 2025-11-25)
     # @param server [MCPClient::ServerBase, nil] the server this resource belongs to
-    def initialize(uri:, name:, title: nil, description: nil, mime_type: nil, size: nil, annotations: nil, server: nil)
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(uri:, name:, title: nil, description: nil, mime_type: nil, size: nil, annotations: nil,
+                   icons: nil, meta: nil, server: nil)
       @uri = uri
       @name = name
       @title = title
@@ -38,8 +46,11 @@ module MCPClient
       @mime_type = mime_type
       @size = size
       @annotations = annotations
+      @icons = icons
+      @meta = meta
       @server = server
     end
+    # rubocop:enable Metrics/ParameterLists
 
     # Return the lastModified annotation value (ISO 8601 timestamp string)
     # @return [String, nil] the lastModified timestamp, or nil if not set
@@ -62,6 +73,8 @@ module MCPClient
         mime_type: data['mimeType'],
         size: data['size'],
         annotations: data['annotations'],
+        icons: data['icons'],
+        meta: data['_meta'],
         server: server
       )
     end

--- a/lib/mcp_client/resource_content.rb
+++ b/lib/mcp_client/resource_content.rb
@@ -18,7 +18,9 @@ module MCPClient
     #   @return [String, nil] base64-encoded binary content (mutually exclusive with text)
     # @!attribute [r] annotations
     #   @return [Hash, nil] optional annotations that provide hints to clients
-    attr_reader :uri, :name, :title, :mime_type, :text, :blob, :annotations
+    # @!attribute [r] meta
+    #   @return [Hash, nil] optional `_meta` metadata attached to the resource contents (MCP 2025-11-25)
+    attr_reader :uri, :name, :title, :mime_type, :text, :blob, :annotations, :meta
 
     # Initialize resource content
     # @param uri [String] unique identifier for the resource
@@ -28,7 +30,8 @@ module MCPClient
     # @param text [String, nil] text content (mutually exclusive with blob)
     # @param blob [String, nil] base64-encoded binary content (mutually exclusive with text)
     # @param annotations [Hash, nil] optional annotations that provide hints to clients
-    def initialize(uri:, name:, title: nil, mime_type: nil, text: nil, blob: nil, annotations: nil)
+    # @param meta [Hash, nil] optional `_meta` metadata attached to the resource contents (MCP 2025-11-25)
+    def initialize(uri:, name:, title: nil, mime_type: nil, text: nil, blob: nil, annotations: nil, meta: nil)
       raise ArgumentError, 'ResourceContent cannot have both text and blob' if text && blob
       raise ArgumentError, 'ResourceContent must have either text or blob' if !text && !blob
 
@@ -39,6 +42,7 @@ module MCPClient
       @text = text
       @blob = blob
       @annotations = annotations
+      @meta = meta
     end
 
     # Create a ResourceContent instance from JSON data
@@ -52,7 +56,8 @@ module MCPClient
         mime_type: data['mimeType'],
         text: data['text'],
         blob: data['blob'],
-        annotations: data['annotations']
+        annotations: data['annotations'],
+        meta: data['_meta']
       )
     end
 

--- a/lib/mcp_client/resource_link.rb
+++ b/lib/mcp_client/resource_link.rb
@@ -19,7 +19,11 @@ module MCPClient
     #   @return [String, nil] optional display title for the resource
     # @!attribute [r] size
     #   @return [Integer, nil] optional size of the resource in bytes
-    attr_reader :uri, :name, :description, :mime_type, :annotations, :title, :size
+    # @!attribute [r] icons
+    #   @return [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25, SEP-973)
+    # @!attribute [r] meta
+    #   @return [Hash, nil] optional `_meta` metadata attached to the resource link (MCP 2025-11-25)
+    attr_reader :uri, :name, :description, :mime_type, :annotations, :title, :size, :icons, :meta
 
     # Initialize a resource link
     # @param uri [String] URI of the linked resource
@@ -29,7 +33,11 @@ module MCPClient
     # @param annotations [Hash, nil] optional annotations that provide hints to clients
     # @param title [String, nil] optional display title for the resource
     # @param size [Integer, nil] optional size of the resource in bytes
-    def initialize(uri:, name:, description: nil, mime_type: nil, annotations: nil, title: nil, size: nil)
+    # @param icons [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25)
+    # @param meta [Hash, nil] optional `_meta` metadata attached to the resource link (MCP 2025-11-25)
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(uri:, name:, description: nil, mime_type: nil, annotations: nil, title: nil, size: nil,
+                   icons: nil, meta: nil)
       @uri = uri
       @name = name
       @description = description
@@ -37,7 +45,10 @@ module MCPClient
       @annotations = annotations
       @title = title
       @size = size
+      @icons = icons
+      @meta = meta
     end
+    # rubocop:enable Metrics/ParameterLists
 
     # Create a ResourceLink instance from JSON data
     # @param data [Hash] JSON data from MCP server (content item with type 'resource_link')
@@ -50,7 +61,9 @@ module MCPClient
         mime_type: data['mimeType'],
         annotations: data['annotations'],
         title: data['title'],
-        size: data['size']
+        size: data['size'],
+        icons: data['icons'],
+        meta: data['_meta']
       )
     end
 

--- a/lib/mcp_client/resource_template.rb
+++ b/lib/mcp_client/resource_template.rb
@@ -16,9 +16,13 @@ module MCPClient
     #   @return [String, nil] optional MIME type for resources created from this template
     # @!attribute [r] annotations
     #   @return [Hash, nil] optional annotations that provide hints to clients
+    # @!attribute [r] icons
+    #   @return [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25, SEP-973)
+    # @!attribute [r] meta
+    #   @return [Hash, nil] optional `_meta` metadata attached to the resource template (MCP 2025-11-25)
     # @!attribute [r] server
     #   @return [MCPClient::ServerBase, nil] the server this resource template belongs to
-    attr_reader :uri_template, :name, :title, :description, :mime_type, :annotations, :server
+    attr_reader :uri_template, :name, :title, :description, :mime_type, :annotations, :icons, :meta, :server
 
     # Initialize a new resource template
     # @param uri_template [String] URI template following RFC 6570
@@ -27,16 +31,23 @@ module MCPClient
     # @param description [String, nil] optional description
     # @param mime_type [String, nil] optional MIME type
     # @param annotations [Hash, nil] optional annotations that provide hints to clients
+    # @param icons [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25)
+    # @param meta [Hash, nil] optional `_meta` metadata attached to the resource template (MCP 2025-11-25)
     # @param server [MCPClient::ServerBase, nil] the server this resource template belongs to
-    def initialize(uri_template:, name:, title: nil, description: nil, mime_type: nil, annotations: nil, server: nil)
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(uri_template:, name:, title: nil, description: nil, mime_type: nil, annotations: nil,
+                   icons: nil, meta: nil, server: nil)
       @uri_template = uri_template
       @name = name
       @title = title
       @description = description
       @mime_type = mime_type
       @annotations = annotations
+      @icons = icons
+      @meta = meta
       @server = server
     end
+    # rubocop:enable Metrics/ParameterLists
 
     # Create a ResourceTemplate instance from JSON data
     # @param data [Hash] JSON data from MCP server
@@ -50,6 +61,8 @@ module MCPClient
         description: data['description'],
         mime_type: data['mimeType'],
         annotations: data['annotations'],
+        icons: data['icons'],
+        meta: data['_meta'],
         server: server
       )
     end

--- a/lib/mcp_client/tool.rb
+++ b/lib/mcp_client/tool.rb
@@ -20,7 +20,12 @@ module MCPClient
     # @!attribute [r] task_support
     #   @return [String, nil] tool-level task negotiation (MCP 2025-11-25):
     #     'forbidden' (default), 'optional', or 'required'; nil when not advertised
-    attr_reader :name, :title, :description, :schema, :output_schema, :annotations, :server, :task_support
+    # @!attribute [r] icons
+    #   @return [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25, SEP-973)
+    # @!attribute [r] meta
+    #   @return [Hash, nil] optional `_meta` metadata attached to the tool (MCP 2025-11-25)
+    attr_reader :name, :title, :description, :schema, :output_schema, :annotations, :server, :task_support,
+                :icons, :meta
 
     # Initialize a new Tool
     # @param name [String] the name of the tool
@@ -31,8 +36,11 @@ module MCPClient
     # @param annotations [Hash, nil] optional annotations describing tool behavior
     # @param server [MCPClient::ServerBase, nil] the server this tool belongs to
     # @param task_support [String, nil] execution.taskSupport value (MCP 2025-11-25)
+    # @param icons [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25)
+    # @param meta [Hash, nil] optional `_meta` metadata attached to the tool (MCP 2025-11-25)
+    # rubocop:disable Metrics/ParameterLists
     def initialize(name:, description:, schema:, title: nil, output_schema: nil, annotations: nil, server: nil,
-                   task_support: nil)
+                   task_support: nil, icons: nil, meta: nil)
       @name = name
       @title = title
       @description = description
@@ -41,7 +49,10 @@ module MCPClient
       @annotations = annotations
       @server = server
       @task_support = task_support
+      @icons = icons
+      @meta = meta
     end
+    # rubocop:enable Metrics/ParameterLists
 
     # Create a Tool instance from JSON data
     # @param data [Hash] JSON data from MCP server
@@ -56,6 +67,8 @@ module MCPClient
       title = data['title'] || data[:title]
       execution = data['execution'] || data[:execution]
       task_support = execution && (execution['taskSupport'] || execution[:taskSupport])
+      icons = data['icons'] || data[:icons]
+      meta = data['_meta'] || data[:_meta]
       new(
         name: data['name'] || data[:name],
         description: data['description'] || data[:description],
@@ -64,7 +77,9 @@ module MCPClient
         output_schema: output_schema,
         annotations: annotations,
         server: server,
-        task_support: task_support
+        task_support: task_support,
+        icons: icons,
+        meta: meta
       )
     end
 

--- a/spec/lib/mcp_client/model_metadata_fidelity_spec.rb
+++ b/spec/lib/mcp_client/model_metadata_fidelity_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2025-11-25 metadata fidelity (SEP-973 icons, BaseMetadata title, _meta).
+# Each model class must round-trip the optional wire fields `icons`, `title`,
+# and `_meta` from a fully-populated wire hash instead of silently dropping them.
+RSpec.describe 'MCP 2025-11-25 model metadata fidelity' do
+  let(:icons) do
+    [
+      { 'src' => 'https://example.com/icon-48.png', 'mimeType' => 'image/png', 'sizes' => ['48x48'] },
+      { 'src' => 'https://example.com/icon.svg', 'mimeType' => 'image/svg+xml', 'sizes' => ['any'],
+        'theme' => 'dark' }
+    ]
+  end
+  let(:meta) { { 'vendor.example/trace-id' => 'abc-123', 'io.modelcontextprotocol/example' => { 'k' => 'v' } } }
+
+  describe MCPClient::Tool do
+    it 'round-trips icons and _meta from a fully-populated tools/list wire hash' do
+      data = {
+        'name' => 'search',
+        'title' => 'Search',
+        'description' => 'Searches things',
+        'inputSchema' => { 'type' => 'object', 'properties' => { 'q' => { 'type' => 'string' } } },
+        'outputSchema' => { 'type' => 'object' },
+        'annotations' => { 'readOnlyHint' => true },
+        'execution' => { 'taskSupport' => 'optional' },
+        'icons' => icons,
+        '_meta' => meta
+      }
+
+      tool = described_class.from_json(data)
+
+      expect(tool.title).to eq('Search')
+      expect(tool.icons).to eq(icons)
+      expect(tool.meta).to eq(meta)
+    end
+  end
+
+  describe MCPClient::Prompt do
+    it 'round-trips title, icons, and _meta from a fully-populated prompts/list wire hash' do
+      data = {
+        'name' => 'code_review',
+        'title' => 'Request Code Review',
+        'description' => 'Asks the LLM to review code',
+        'arguments' => [{ 'name' => 'code', 'required' => true }],
+        'icons' => icons,
+        '_meta' => meta
+      }
+
+      prompt = described_class.from_json(data)
+
+      expect(prompt.title).to eq('Request Code Review')
+      expect(prompt.icons).to eq(icons)
+      expect(prompt.meta).to eq(meta)
+    end
+  end
+
+  describe MCPClient::Resource do
+    it 'round-trips icons and _meta from a fully-populated resources/list wire hash' do
+      data = {
+        'uri' => 'file:///project/src/main.rs',
+        'name' => 'main.rs',
+        'title' => 'Rust Software Application Main File',
+        'description' => 'Primary application entry point',
+        'mimeType' => 'text/x-rust',
+        'size' => 1024,
+        'annotations' => { 'audience' => ['user'], 'priority' => 0.5 },
+        'icons' => icons,
+        '_meta' => meta
+      }
+
+      resource = described_class.from_json(data)
+
+      expect(resource.title).to eq('Rust Software Application Main File')
+      expect(resource.icons).to eq(icons)
+      expect(resource.meta).to eq(meta)
+    end
+  end
+
+  describe MCPClient::ResourceTemplate do
+    it 'round-trips icons and _meta from a fully-populated resources/templates/list wire hash' do
+      data = {
+        'uriTemplate' => 'file:///{path}',
+        'name' => 'project_files',
+        'title' => 'Project Files',
+        'description' => 'Access files in the project directory',
+        'mimeType' => 'application/octet-stream',
+        'annotations' => { 'audience' => ['assistant'] },
+        'icons' => icons,
+        '_meta' => meta
+      }
+
+      template = described_class.from_json(data)
+
+      expect(template.title).to eq('Project Files')
+      expect(template.icons).to eq(icons)
+      expect(template.meta).to eq(meta)
+    end
+  end
+
+  describe MCPClient::ResourceLink do
+    it 'round-trips icons and _meta from a fully-populated resource_link content wire hash' do
+      data = {
+        'type' => 'resource_link',
+        'uri' => 'file:///project/README.md',
+        'name' => 'README.md',
+        'title' => 'Project README',
+        'description' => 'Project documentation',
+        'mimeType' => 'text/markdown',
+        'size' => 2048,
+        'annotations' => { 'audience' => ['user'] },
+        'icons' => icons,
+        '_meta' => meta
+      }
+
+      link = described_class.from_json(data)
+
+      expect(link.title).to eq('Project README')
+      expect(link.icons).to eq(icons)
+      expect(link.meta).to eq(meta)
+    end
+  end
+
+  describe MCPClient::ResourceContent do
+    it 'round-trips _meta from a fully-populated resources/read contents wire hash' do
+      data = {
+        'uri' => 'file:///project/README.md',
+        'name' => 'README.md',
+        'title' => 'Project README',
+        'mimeType' => 'text/markdown',
+        'text' => '# Project',
+        'annotations' => { 'audience' => ['user'] },
+        '_meta' => meta
+      }
+
+      content = described_class.from_json(data)
+
+      expect(content.title).to eq('Project README')
+      expect(content.meta).to eq(meta)
+    end
+  end
+end


### PR DESCRIPTION
## What

MCP 2025-11-25 added `icons` (SEP-973) to Tool, Prompt, Resource, ResourceTemplate, and ResourceLink, and reserves `_meta` on schema objects so servers can attach metadata for clients to pass through. The typed model classes silently dropped these wire fields — and `Prompt` additionally dropped `title` — which is interop-affecting: because `from_json` is the mandatory parse path for `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`, `resources/read`, and `resource_link` content blocks, hosts using this library could never display a tool/prompt/resource icon or a prompt title, and could never read server-attached `_meta`.

This PR parses and exposes the dropped fields, mirroring the exact field names in `schema/2025-11-25/schema.ts`:

- `Tool`: `icons`, `_meta` (exposed as `#icons` / `#meta`; both string and symbol keys, matching the rest of `Tool.from_json`)
- `Prompt`: `title`, `icons`, `_meta`
- `Resource`, `ResourceTemplate`, `ResourceLink`: `icons`, `_meta`
- `ResourceContent`: `_meta` (ResourceContents does not carry `icons` in the schema, so only `_meta` is added)

All new constructor keyword arguments default to `nil`, so existing callers are unaffected. No fields beyond those in the official schema were introduced.

## Tests

- New `spec/lib/mcp_client/model_metadata_fidelity_spec.rb` (written first, red before the fix): one example per class asserting a fully-populated wire hash round-trips `icons`/`title`/`_meta` through `from_json`.
- Full suite: `bundle exec rspec` — 1326 examples, 0 failures.
- `bundle exec rubocop` — 111 files inspected, no offenses detected.

Part of an MCP 2025-11-25 compliance audit of this gem against the official spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)