### PR TITLE
Enforce UTF-8 on stdio pipes and implement the spec shutdown sequence

### DIFF
--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -21,6 +21,12 @@ module MCPClient
     # Timeout in seconds for responses
     READ_TIMEOUT = 15
 
+    # Grace period in seconds allowed at each stage of the shutdown sequence
+    # (after closing stdin, then after SIGTERM) before escalating further, per
+    # MCP 2025-11-25 basic/lifecycle.mdx (Shutdown / stdio): close stdin, wait
+    # for the server to exit, send SIGTERM, then SIGKILL if it still runs.
+    SHUTDOWN_GRACE_PERIOD = 2
+
     # Chunk size (bytes) used when draining the subprocess stderr pipe
     STDERR_READ_CHUNK_SIZE = 8192
 
@@ -87,9 +93,23 @@ module MCPClient
       else
         @stdin, @stdout, @stderr, @wait_thread = Open3.popen3(@command)
       end
+      pin_pipe_encodings
       true
     rescue StandardError => e
       raise MCPClient::Errors::ConnectionError, "Failed to connect to MCP server: #{e.message}"
+    end
+
+    # Pin the subprocess pipe encodings to UTF-8 instead of inheriting the
+    # process locale (Encoding.default_external). JSON-RPC messages MUST be
+    # UTF-8 encoded (MCP 2025-11-25 basic/transports.mdx); under a non-UTF-8
+    # locale (e.g. LANG=C) a valid UTF-8 message would otherwise fail to
+    # decode and kill the reader thread. The server MAY also write UTF-8 to
+    # stderr, so that pipe is pinned as well.
+    # @return [void]
+    def pin_pipe_encodings
+      [@stdin, @stdout, @stderr].each do |io|
+        io&.set_encoding(Encoding::UTF_8)
+      end
     end
 
     # Spawn a reader thread to collect JSON-RPC responses
@@ -142,6 +162,13 @@ module MCPClient
       msg = JSON.parse(line)
       @logger.debug("Received line: #{line.chomp}")
 
+      # A JSON-parseable line that is not an object cannot be a JSON-RPC
+      # message; skip it rather than raising inside the reader thread
+      unless msg.is_a?(Hash)
+        @logger.debug("Skipping non-object JSON-RPC line: #{line.chomp}")
+        return
+      end
+
       # Dispatch JSON-RPC requests from server (has id AND method) - MCP 2025-06-18
       if msg['method'] && msg.key?('id')
         handle_server_request(msg)
@@ -169,8 +196,9 @@ module MCPClient
           @logger.debug("Discarding response for unknown or expired request id=#{id}")
         end
       end
-    rescue JSON::ParserError
-      # Skip non-JSONRPC lines in the output stream
+    rescue JSON::ParserError, EncodingError
+      # Skip non-JSONRPC or undecodable lines in the output stream so a single
+      # bad line cannot kill the reader thread
     end
 
     # List all prompts available from the MCP server
@@ -673,17 +701,17 @@ module MCPClient
 
     # Clean up the server connection
     # Closes all stdio handles and terminates any running processes and threads
+    # following the MCP 2025-11-25 stdio shutdown sequence (basic/lifecycle.mdx):
+    # close stdin, wait for the server to exit, send SIGTERM if it does not exit
+    # within a reasonable time, then SIGKILL if it still does not exit.
     # @return [void]
     def cleanup
       return unless @stdin
 
       @stdin.close unless @stdin.closed?
+      terminate_server_process
       @stdout.close unless @stdout.closed?
       @stderr.close unless @stderr.closed?
-      if @wait_thread&.alive?
-        Process.kill('TERM', @wait_thread.pid)
-        @wait_thread.join(1)
-      end
       @reader_thread&.kill
       @stderr_thread&.kill
     rescue StandardError
@@ -695,6 +723,32 @@ module MCPClient
         @awaiting.clear
       end
       @stdin = @stdout = @stderr = @wait_thread = @reader_thread = @stderr_thread = nil
+    end
+
+    # Terminate the spawned server process per the MCP 2025-11-25 stdio
+    # shutdown sequence (basic/lifecycle.mdx): stdin has already been closed,
+    # so wait for the process to exit on its own; if it does not exit within
+    # the grace period send SIGTERM, wait again, and finally send SIGKILL.
+    # @return [void]
+    def terminate_server_process
+      return unless @wait_thread
+      return if @wait_thread.join(SHUTDOWN_GRACE_PERIOD)
+
+      signal_server_process('TERM')
+      return if @wait_thread.join(SHUTDOWN_GRACE_PERIOD)
+
+      signal_server_process('KILL')
+      @wait_thread.join(SHUTDOWN_GRACE_PERIOD)
+    end
+
+    # Send a signal to the server process, tolerating a process that has
+    # already exited or cannot be signalled.
+    # @param signal [String] signal name, e.g. 'TERM' or 'KILL'
+    # @return [void]
+    def signal_server_process(signal)
+      Process.kill(signal, @wait_thread.pid)
+    rescue Errno::ESRCH, Errno::EPERM => e
+      @logger.debug("Could not send SIG#{signal} to server process: #{e.class}")
     end
   end
 end

--- a/spec/lib/mcp_client/server_stdio_compliance_spec.rb
+++ b/spec/lib/mcp_client/server_stdio_compliance_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Compliance specs for the MCP 2025-11-25 stdio transport.
+#
+# - basic/transports.mdx: "JSON-RPC messages MUST be UTF-8 encoded."
+# - basic/lifecycle.mdx (Shutdown / stdio): the client SHOULD initiate shutdown
+#   by (1) closing the input stream to the child process, (2) waiting for the
+#   server to exit, or sending SIGTERM if it does not exit within a reasonable
+#   time, and (3) sending SIGKILL if it still does not exit after SIGTERM.
+RSpec.describe MCPClient::ServerStdio do
+  describe 'UTF-8 enforcement on subprocess pipes' do
+    # Simulate a non-UTF-8 locale (e.g. LANG=C in containers/CI): pipes created
+    # while Encoding.default_external is US-ASCII inherit that encoding unless
+    # the transport pins UTF-8 explicitly.
+    around do |example|
+      original_encoding = Encoding.default_external
+      original_verbose = $VERBOSE
+      $VERBOSE = nil
+      Encoding.default_external = Encoding::US_ASCII
+      example.run
+    ensure
+      Encoding.default_external = original_encoding
+      $VERBOSE = original_verbose
+    end
+
+    it 'pins the subprocess pipes to UTF-8 regardless of the process locale' do
+      server = described_class.new(command: ['ruby', '-e', '$stdin.read'])
+      server.connect
+      expect(server.instance_variable_get(:@stdout).external_encoding).to eq(Encoding::UTF_8)
+      expect(server.instance_variable_get(:@stderr).external_encoding).to eq(Encoding::UTF_8)
+      expect(server.instance_variable_get(:@stdin).external_encoding).to eq(Encoding::UTF_8)
+    ensure
+      server.cleanup
+    end
+
+    it 'delivers a valid UTF-8 response under a non-UTF-8 locale instead of killing the reader thread' do
+      script = '$stdout.puts(%({"jsonrpc":"2.0","id":1,"result":{"text":"żółć"}})); $stdout.flush; $stdin.read'
+      server = described_class.new(command: ['ruby', '-e', script], read_timeout: 3)
+      server.connect
+      server.instance_variable_set(:@awaiting, { 1 => true })
+      server.start_reader
+
+      response = server.send(:wait_response, 1)
+      expect(response['result']).to eq({ 'text' => 'żółć' })
+    ensure
+      server.cleanup
+    end
+  end
+
+  describe 'shutdown sequence' do
+    context 'with a real subprocess' do
+      it 'does not signal a well-behaved server that exits when stdin is closed' do
+        server = described_class.new(command: ['ruby', '-e', '$stdin.read'])
+        server.connect
+        expect(Process).not_to receive(:kill)
+        server.cleanup
+      end
+
+      it 'escalates to SIGKILL when the server ignores SIGTERM' do
+        stub_const('MCPClient::ServerStdio::SHUTDOWN_GRACE_PERIOD', 0.2)
+        script = 'Signal.trap("TERM") {}; $stdout.puts("ready"); $stdout.flush; $stdin.read; sleep 60'
+        server = described_class.new(command: ['ruby', '-e', script])
+        server.connect
+        # Wait until the TERM handler is installed before shutting down
+        expect(server.instance_variable_get(:@stdout).gets).to eq("ready\n")
+        pid = server.instance_variable_get(:@wait_thread).pid
+
+        server.cleanup
+        expect { Process.kill(0, pid) }.to raise_error(Errno::ESRCH)
+      ensure
+        begin
+          Process.kill('KILL', pid) if pid
+        rescue Errno::ESRCH
+          # already gone — expected
+        end
+      end
+    end
+
+    context 'with a mocked subprocess' do
+      let(:server) { described_class.new(command: 'echo test') }
+
+      before do
+        @stdin = double('stdin', close: nil, closed?: false)
+        @stdout = double('stdout', close: nil, closed?: false)
+        @stderr = double('stderr', close: nil, closed?: false)
+        @wait_thread = double('wait_thread', pid: 12_345, alive?: true, join: nil)
+        @reader_thread = double('reader_thread', kill: nil)
+        @stderr_thread = double('stderr_thread', kill: nil)
+
+        allow(Process).to receive(:kill)
+
+        server.instance_variable_set(:@stdin, @stdin)
+        server.instance_variable_set(:@stdout, @stdout)
+        server.instance_variable_set(:@stderr, @stderr)
+        server.instance_variable_set(:@wait_thread, @wait_thread)
+        server.instance_variable_set(:@reader_thread, @reader_thread)
+        server.instance_variable_set(:@stderr_thread, @stderr_thread)
+      end
+
+      it 'follows the close-stdin -> wait -> SIGTERM -> wait -> SIGKILL sequence' do
+        events = []
+        allow(@stdin).to receive(:close) { events << :close_stdin }
+        allow(@wait_thread).to receive(:join) do |timeout|
+          events << [:join, timeout]
+          nil
+        end
+        allow(Process).to receive(:kill) { |sig, _pid| events << [:kill, sig] }
+
+        server.cleanup
+
+        grace = described_class::SHUTDOWN_GRACE_PERIOD
+        expect(events).to eq(
+          [
+            :close_stdin,
+            [:join, grace],
+            [:kill, 'TERM'],
+            [:join, grace],
+            [:kill, 'KILL'],
+            [:join, grace]
+          ]
+        )
+      end
+
+      it 'sends no signal when the process exits within the grace period after stdin closes' do
+        allow(@wait_thread).to receive(:join).and_return(@wait_thread)
+        expect(Process).not_to receive(:kill)
+        server.cleanup
+      end
+
+      it 'continues cleanup when the process is already dead (Errno::ESRCH)' do
+        allow(Process).to receive(:kill).and_raise(Errno::ESRCH)
+        expect(@reader_thread).to receive(:kill)
+        expect(@stderr_thread).to receive(:kill)
+        expect { server.cleanup }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#handle_line robustness' do
+    let(:server) { described_class.new(command: 'echo test') }
+
+    it 'skips JSON-parseable lines that are not objects instead of raising' do
+      expect { server.send(:handle_line, "[]\n") }.not_to raise_error
+      expect { server.send(:handle_line, "123\n") }.not_to raise_error
+      expect { server.send(:handle_line, "\"text\"\n") }.not_to raise_error
+      expect { server.send(:handle_line, "null\n") }.not_to raise_error
+    end
+
+    it 'keeps handling subsequent valid messages after a non-object line' do
+      server.instance_variable_set(:@awaiting, { 7 => true })
+      server.send(:handle_line, "[]\n")
+      server.send(:handle_line, { 'jsonrpc' => '2.0', 'id' => 7, 'result' => 'ok' }.to_json)
+      expect(server.instance_variable_get(:@pending)[7]).to include('result' => 'ok')
+    end
+
+    it 'does not raise on a line that cannot be decoded (EncodingError)' do
+      line = (+%({"jsonrpc":"2.0","id":1,"result":"ż"})).force_encoding(Encoding::US_ASCII)
+      expect { server.send(:handle_line, line) }.not_to raise_error
+    end
+  end
+end

--- a/spec/lib/mcp_client/server_stdio_spec.rb
+++ b/spec/lib/mcp_client/server_stdio_spec.rb
@@ -18,15 +18,20 @@ RSpec.describe MCPClient::ServerStdio do
   end
 
   describe '#connect' do
+    # Pipe doubles must accept set_encoding: connect pins the subprocess pipes
+    # to UTF-8 because JSON-RPC messages MUST be UTF-8 encoded
+    # (MCP 2025-11-25 basic/transports.mdx)
+    let(:pipe_doubles) { Array.new(3) { double('pipe', set_encoding: nil) } }
+
     it 'starts the command process with Open3' do
-      expect(Open3).to receive(:popen3).with(command).and_return([double, double, double, double])
+      expect(Open3).to receive(:popen3).with(command).and_return([*pipe_doubles, double])
       expect(server.connect).to be true
     end
 
     it 'passes environment variables when env is provided' do
       env = { 'FOO' => 'bar' }
       server_env = described_class.new(command: command, env: env)
-      expect(Open3).to receive(:popen3).with(env, command).and_return([double, double, double, double])
+      expect(Open3).to receive(:popen3).with(env, command).and_return([*pipe_doubles, double])
       expect(server_env.connect).to be true
     end
 
@@ -276,9 +281,14 @@ RSpec.describe MCPClient::ServerStdio do
       server.cleanup
     end
 
-    it 'kills the process' do
-      expect(Process).to receive(:kill).with('TERM', @wait_thread.pid)
-      expect(@wait_thread).to receive(:join).with(1)
+    # MCP 2025-11-25 basic/lifecycle.mdx (Shutdown / stdio): after closing
+    # stdin the client waits for exit, sends SIGTERM if the server has not
+    # exited within a reasonable time, then SIGKILL. The double's join always
+    # returns nil (timeout), so the full escalation runs.
+    it 'terminates a process that never exits with SIGTERM then SIGKILL' do
+      expect(@wait_thread).to receive(:join).with(described_class::SHUTDOWN_GRACE_PERIOD).exactly(3).times
+      expect(Process).to receive(:kill).with('TERM', @wait_thread.pid).ordered
+      expect(Process).to receive(:kill).with('KILL', @wait_thread.pid).ordered
       server.cleanup
     end
 


### PR DESCRIPTION
## What

Fixes two verified findings against the MCP 2025-11-25 spec in the stdio transport, plus one reader-thread robustness fix.

**1. UTF-8 is now enforced on the subprocess pipes** (`basic/transports.mdx`):

> MCP uses JSON-RPC to encode messages. JSON-RPC messages **MUST** be UTF-8 encoded.

`connect` now pins `@stdin`/`@stdout`/`@stderr` to UTF-8 (`set_encoding(Encoding::UTF_8)`) right after `Open3.popen3`. Previously the pipes inherited `Encoding.default_external`, so under a non-UTF-8 locale (e.g. `LANG=C` in containers, systemd units, CI) a fully spec-compliant response containing any non-ASCII byte raised `Encoding::InvalidByteSequenceError` inside the reader thread, silently killing it and causing every subsequent request to time out. `@stderr` is pinned too, since the server "**MAY** write UTF-8 strings to its standard error".

**2. `cleanup` now follows the spec shutdown sequence** (`basic/lifecycle.mdx` § Shutdown / stdio):

> the client **SHOULD** initiate shutdown by:
> 1. First, closing the input stream to the child process (the server)
> 2. Waiting for the server to exit, or sending `SIGTERM` if the server does not exit within a reasonable time
> 3. Sending `SIGKILL` if the server does not exit within a reasonable time after `SIGTERM`

Previously `cleanup` sent `SIGTERM` immediately after closing stdin (a well-behaved server never got the chance to exit on EOF) and never escalated, so a server that ignores `SIGTERM` leaked as a running orphan. It now closes stdin, waits `SHUTDOWN_GRACE_PERIOD` (2s), sends `SIGTERM` if still alive, waits again, then sends `SIGKILL` and reaps. Signalling tolerates already-dead processes (`Errno::ESRCH`/`Errno::EPERM`).

**3. Reader-thread robustness:** `handle_line` rescued only `JSON::ParserError`, so a JSON-parseable line that is not an object (e.g. `[]` or `123`) raised `TypeError` and permanently killed the reader thread. Non-object values are now logged and skipped, and the rescue also covers `EncodingError` so a stray undecodable line drops one line instead of the whole transport.

## Tests

New `spec/lib/mcp_client/server_stdio_compliance_spec.rb` (10 examples, written red-first against the old behavior):

- pipes are pinned to UTF-8 under a simulated non-UTF-8 locale (`Encoding.default_external = US-ASCII`), and a real `ruby -e` subprocess response containing `żółć` is delivered instead of deadening the transport
- a real subprocess that exits on stdin EOF is never signalled; a real subprocess that traps `SIGTERM` is escalated to `SIGKILL` and verified dead via `Process.kill(0, pid)`
- mocked-process ordering test for close-stdin → wait → `SIGTERM` → wait → `SIGKILL`, no-signal-on-graceful-exit, and `Errno::ESRCH` tolerance
- `handle_line` skips non-object JSON lines, keeps processing subsequent messages, and survives `EncodingError`

Two existing specs that encoded the old behavior (`#connect` pipe doubles, `#cleanup` immediate-`SIGTERM` expectation) were updated with spec citations.

Full suite: 1330 examples, 0 failures. RuboCop: 111 files inspected, no offenses.

Part of an MCP 2025-11-25 compliance audit of this gem against the official spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)