### PR TITLE
Place request _meta at the params level on all transports; add progress tracking

### DIFF
--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'logger'
+require 'securerandom'
 
 module MCPClient
   # MCP Client for integrating with the Model Context Protocol
@@ -44,6 +45,9 @@ module MCPClient
         MCPClient::ServerFactory.create(config, logger: @logger)
       end
       @tool_cache = {}
+      # Active progressToken -> callback registrations (MCP progress utility)
+      @progress_callbacks = {}
+      @progress_mutex = Mutex.new
       @prompt_cache = {}
       @resource_cache = {}
       # JSON-RPC notification listeners
@@ -259,34 +263,8 @@ module MCPClient
     # @param parameters [Hash] the parameters to pass to the tool
     # @param server [String, Symbol, Integer, MCPClient::ServerBase, nil] optional server to use
     # @return [Object] the result of the tool invocation
-    def call_tool(tool_name, parameters, server: nil)
-      tools = list_tools
-
-      if server
-        # Use the specified server
-        srv = select_server(server)
-        # Find the tool on this specific server
-        tool = tools.find { |t| t.name == tool_name && t.server == srv }
-        unless tool
-          raise MCPClient::Errors::ToolNotFound,
-                "Tool '#{tool_name}' not found on server '#{srv.name || srv.class.name}'"
-        end
-      else
-        # Find the tool across all servers
-        matching_tools = tools.select { |t| t.name == tool_name }
-
-        if matching_tools.empty?
-          raise MCPClient::Errors::ToolNotFound, "Tool '#{tool_name}' not found"
-        elsif matching_tools.size > 1
-          # If multiple matches, disambiguate with server names
-          server_names = matching_tools.map { |t| t.server&.name || 'unnamed' }
-          raise MCPClient::Errors::AmbiguousToolName,
-                "Multiple tools named '#{tool_name}' found across servers (#{server_names.join(', ')}). " \
-                "Please specify a server using the 'server' parameter."
-        end
-
-        tool = matching_tools.first
-      end
+    def call_tool(tool_name, parameters, server: nil, progress: nil)
+      tool = resolve_tool(tool_name, server: server)
 
       # Validate parameters against tool schema
       validate_params!(tool, parameters)
@@ -296,12 +274,21 @@ module MCPClient
       server = tool.server
       raise MCPClient::Errors::ServerNotFound, "No server found for tool '#{tool_name}'" unless server
 
+      # MCP progress utility: attach an auto-generated progressToken to the
+      # request _meta and route matching notifications/progress to the
+      # caller's callback while the request is active.
+      parameters, token = setup_progress_tracking(parameters, progress)
+
       begin
         server.call_tool(tool_name, parameters)
       rescue MCPClient::Errors::ConnectionError => e
         # Add server identity information to the error for better context
         server_id = server.name ? "#{server.class}[#{server.name}]" : server.class.name
         raise MCPClient::Errors::ToolCallError, "Error calling tool '#{tool_name}': #{e.message} (Server: #{server_id})"
+      ensure
+        # Tokens are only valid for the lifetime of the request: dropping the
+        # registration filters out stale post-completion notifications.
+        unregister_progress_callback(token) if token
       end
     end
 
@@ -406,33 +393,7 @@ module MCPClient
     # @param server [String, Symbol, Integer, MCPClient::ServerBase, nil] optional server to use
     # @return [Enumerator] streaming enumerator or single-value enumerator
     def call_tool_streaming(tool_name, parameters, server: nil)
-      tools = list_tools
-
-      if server
-        # Use the specified server
-        srv = select_server(server)
-        # Find the tool on this specific server
-        tool = tools.find { |t| t.name == tool_name && t.server == srv }
-        unless tool
-          raise MCPClient::Errors::ToolNotFound,
-                "Tool '#{tool_name}' not found on server '#{srv.name || srv.class.name}'"
-        end
-      else
-        # Find the tool across all servers
-        matching_tools = tools.select { |t| t.name == tool_name }
-
-        if matching_tools.empty?
-          raise MCPClient::Errors::ToolNotFound, "Tool '#{tool_name}' not found"
-        elsif matching_tools.size > 1
-          # If multiple matches, disambiguate with server names
-          server_names = matching_tools.map { |t| t.server&.name || 'unnamed' }
-          raise MCPClient::Errors::AmbiguousToolName,
-                "Multiple tools named '#{tool_name}' found across servers (#{server_names.join(', ')}). " \
-                "Please specify a server using the 'server' parameter."
-        end
-
-        tool = matching_tools.first
-      end
+      tool = resolve_tool(tool_name, server: server)
 
       # Validate parameters against tool schema
       validate_params!(tool, parameters)
@@ -679,6 +640,8 @@ module MCPClient
       when 'notifications/tasks/status'
         # MCP 2025-11-25: task status update (params are a flat Task)
         handle_task_status_notification(server_id, params)
+      when 'notifications/progress'
+        handle_progress_notification(server_id, params)
       else
         # Log unknown notification types for debugging purposes
         logger.debug("[#{server_id}] Received unknown notification: #{method} - #{params}")
@@ -689,6 +652,66 @@ module MCPClient
     # @param server_id [String] server identifier for log prefix
     # @param params [Hash] log message params (level, logger, data)
     # @return [void]
+    # Route a notifications/progress message to the callback registered for
+    # its progressToken; unknown or stale tokens are debug-logged and dropped
+    # (MCP: "Senders and receivers SHOULD track active progress tokens").
+    # @param server_id [String] identity of the emitting server (for logs)
+    # @param params [Hash, nil] notification params
+    # @return [void]
+    def handle_progress_notification(server_id, params)
+      token = params && params['progressToken']
+      callback = @progress_mutex.synchronize { @progress_callbacks[token] }
+      unless callback
+        logger.debug("[#{server_id}] Progress for unknown or completed token #{token.inspect}")
+        return
+      end
+
+      callback.call(params['progress'], params['total'], params['message'])
+    rescue StandardError => e
+      logger.warn("[#{server_id}] Progress callback error: #{e.message}")
+    end
+
+    # Attach progress tracking to an outgoing request when requested.
+    # @param parameters [Hash] user arguments
+    # @param progress [#call, nil] optional progress callback
+    # @return [Array(Hash, String|nil)] possibly-augmented parameters and token
+    def setup_progress_tracking(parameters, progress)
+      return [parameters, nil] unless progress
+
+      token = generate_progress_token
+      register_progress_callback(token, progress)
+      [attach_progress_token(parameters, token), token]
+    end
+
+    # @return [String] a unique progress token for an outgoing request
+    def generate_progress_token
+      "rb-mcp-#{SecureRandom.hex(8)}"
+    end
+
+    # @param parameters [Hash] user arguments (not mutated)
+    # @param token [String] progress token
+    # @return [Hash] parameters with _meta.progressToken merged in
+    def attach_progress_token(parameters, token)
+      params = parameters.dup
+      meta = (params['_meta'] || params[:_meta] || {}).merge('progressToken' => token)
+      params.delete(:_meta)
+      params['_meta'] = meta
+      params
+    end
+
+    # @param token [String] progress token
+    # @param callback [#call] receives (progress, total, message)
+    # @return [void]
+    def register_progress_callback(token, callback)
+      @progress_mutex.synchronize { @progress_callbacks[token] = callback }
+    end
+
+    # @param token [String] progress token
+    # @return [void]
+    def unregister_progress_callback(token)
+      @progress_mutex.synchronize { @progress_callbacks.delete(token) }
+    end
+
     def handle_log_message(server_id, params)
       level = params['level'] || 'info'
       logger_name = params['logger']

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -43,6 +43,33 @@ module MCPClient
       rpc_request('ping')
     end
 
+    # Split request-level _meta (RequestParams._meta, e.g. progressToken or
+    # related-task metadata) out of user-supplied tool/prompt arguments.
+    # Accepts both :_meta and '_meta' key spellings; per MCP, _meta belongs at
+    # the request params level, not inside the tool's arguments.
+    # @param arguments [Hash, nil] user-supplied arguments
+    # @return [Array(Hash, Hash|nil)] [arguments without _meta, _meta or nil]
+    def split_request_meta(arguments)
+      return [arguments, nil] unless arguments.is_a?(Hash)
+
+      meta = arguments[:_meta] || arguments['_meta']
+      return [arguments, nil] unless meta
+
+      [arguments.except(:_meta, '_meta'), meta]
+    end
+
+    # Build tools/call- or prompts/get-style params with request-level _meta
+    # hoisted out of the arguments (string keys, matching the JSON wire form).
+    # @param name [String] tool or prompt name
+    # @param arguments [Hash] user-supplied arguments (possibly carrying _meta)
+    # @return [Hash] params hash for the JSON-RPC request
+    def build_named_request_params(name, arguments)
+      args, meta = split_request_meta(arguments)
+      params = { 'name' => name, 'arguments' => args }
+      params['_meta'] = meta if meta
+      params
+    end
+
     # Build a JSON-RPC request object
     # @param method [String] JSON-RPC method name
     # @param params [Hash] parameters for the request

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -183,10 +183,7 @@ module MCPClient
     # @raise [MCPClient::Errors::ToolCallError] for other errors during tool execution
     # @raise [MCPClient::Errors::ConnectionError] if server is disconnected
     def call_tool(tool_name, parameters)
-      rpc_request('tools/call', {
-                    name: tool_name,
-                    arguments: parameters
-                  })
+      rpc_request('tools/call', build_named_request_params(tool_name, parameters))
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       # Re-raise connection/transport errors directly to match test expectations
       raise
@@ -271,10 +268,7 @@ module MCPClient
     # @raise [MCPClient::Errors::TransportError] if response isn't valid JSON
     # @raise [MCPClient::Errors::PromptGetError] for other errors during prompt interpolation
     def get_prompt(prompt_name, parameters)
-      rpc_request('prompts/get', {
-                    name: prompt_name,
-                    arguments: parameters
-                  })
+      rpc_request('prompts/get', build_named_request_params(prompt_name, parameters))
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       raise
     rescue StandardError => e

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -157,10 +157,7 @@ module MCPClient
     # @raise [MCPClient::Errors::PromptGetError] for other errors during prompt interpolation
     # @raise [MCPClient::Errors::ConnectionError] if server is disconnected
     def get_prompt(prompt_name, parameters)
-      rpc_request('prompts/get', {
-                    name: prompt_name,
-                    arguments: parameters
-                  })
+      rpc_request('prompts/get', build_named_request_params(prompt_name, parameters))
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       # Re-raise connection/transport errors directly to match test expectations
       raise
@@ -315,10 +312,7 @@ module MCPClient
     # @raise [MCPClient::Errors::ToolCallError] for other errors during tool execution
     # @raise [MCPClient::Errors::ConnectionError] if server is disconnected
     def call_tool(tool_name, parameters)
-      rpc_request('tools/call', {
-                    name: tool_name,
-                    arguments: parameters
-                  })
+      rpc_request('tools/call', build_named_request_params(tool_name, parameters))
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       # Re-raise connection/transport errors directly to match test expectations
       raise

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -212,7 +212,7 @@ module MCPClient
         'jsonrpc' => '2.0',
         'id' => req_id,
         'method' => 'prompts/get',
-        'params' => { 'name' => prompt_name, 'arguments' => parameters }
+        'params' => build_named_request_params(prompt_name, parameters)
       }
       send_request(req)
       res = wait_response(req_id)
@@ -391,7 +391,7 @@ module MCPClient
         'jsonrpc' => '2.0',
         'id' => req_id,
         'method' => 'tools/call',
-        'params' => { 'name' => tool_name, 'arguments' => parameters }
+        'params' => build_named_request_params(tool_name, parameters)
       }
       send_request(req)
       res = wait_response(req_id)

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -196,11 +196,7 @@ module MCPClient
     # @raise [MCPClient::Errors::ToolCallError] for other errors during tool execution
     # @raise [MCPClient::Errors::ConnectionError] if server is disconnected
     def call_tool(tool_name, parameters)
-      rpc_request('tools/call', {
-                    name: tool_name,
-                    arguments: parameters.except(:_meta),
-                    **parameters.slice(:_meta)
-                  })
+      rpc_request('tools/call', build_named_request_params(tool_name, parameters))
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       # Re-raise connection/transport errors directly to match test expectations
       raise
@@ -282,11 +278,7 @@ module MCPClient
     # @return [Object] the result of the prompt (with string keys for backward compatibility)
     # @raise [MCPClient::Errors::PromptGetError] if prompt retrieval fails
     def get_prompt(prompt_name, parameters)
-      rpc_request('prompts/get', {
-                    name: prompt_name,
-                    arguments: parameters.except(:_meta),
-                    **parameters.slice(:_meta)
-                  })
+      rpc_request('prompts/get', build_named_request_params(prompt_name, parameters))
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       # Re-raise connection/transport errors directly
       raise

--- a/spec/lib/mcp_client/progress_meta_spec.rb
+++ b/spec/lib/mcp_client/progress_meta_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2025-11-25 basic/utilities/progress + RequestParams._meta:
+# "When a party wants to receive progress updates for a request, it includes
+# a progressToken in the request metadata" — request-level _meta, not a tool
+# argument. "Senders and receivers SHOULD track active progress tokens."
+RSpec.describe 'Progress tokens and request _meta (MCP 2025-11-25)' do
+  let(:meta) { { 'progressToken' => 'tok-1' } }
+  let(:args_with_meta) { { 'x' => 1, '_meta' => meta } }
+
+  describe 'request-level _meta hoisting' do
+    it 'stdio call_tool sends _meta at params level, not inside arguments' do
+      server = MCPClient::ServerStdio.new(command: 'echo test')
+      server.instance_variable_set(:@initialized, true)
+      captured = nil
+      allow(server).to receive(:send_request) { |req| captured = req }
+      allow(server).to receive(:next_id).and_return(5)
+      allow(server).to receive(:wait_response).and_return({ 'result' => {} })
+
+      server.call_tool('t', args_with_meta)
+
+      expect(captured['params']['_meta']).to eq(meta)
+      expect(captured['params']['arguments']).to eq({ 'x' => 1 })
+    end
+
+    it 'stdio get_prompt sends _meta at params level' do
+      server = MCPClient::ServerStdio.new(command: 'echo test')
+      server.instance_variable_set(:@initialized, true)
+      captured = nil
+      allow(server).to receive(:send_request) { |req| captured = req }
+      allow(server).to receive(:next_id).and_return(6)
+      allow(server).to receive(:wait_response).and_return({ 'result' => { 'messages' => [] } })
+
+      server.get_prompt('p', args_with_meta)
+
+      expect(captured['params']['_meta']).to eq(meta)
+      expect(captured['params']['arguments']).to eq({ 'x' => 1 })
+    end
+
+    it 'SSE call_tool sends _meta at params level' do
+      server = MCPClient::ServerSSE.new(base_url: 'https://example.com/sse')
+      captured = nil
+      allow(server).to receive(:rpc_request) { |_m, params| captured = params and {} }
+
+      server.call_tool('t', args_with_meta)
+
+      expect(captured['_meta'] || captured[:_meta]).to eq(meta)
+      arguments = captured['arguments'] || captured[:arguments]
+      expect(arguments).to eq({ 'x' => 1 })
+    end
+
+    it 'plain HTTP call_tool sends _meta at params level' do
+      server = MCPClient::ServerHTTP.new(base_url: 'https://example.com')
+      captured = nil
+      allow(server).to receive(:rpc_request) { |_m, params| captured = params and {} }
+
+      server.call_tool('t', args_with_meta)
+
+      expect(captured['_meta'] || captured[:_meta]).to eq(meta)
+      expect(captured['arguments'] || captured[:arguments]).to eq({ 'x' => 1 })
+    end
+
+    it 'Streamable HTTP call_tool honors the string _meta key too' do
+      server = MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com')
+      captured = nil
+      allow(server).to receive(:rpc_request) { |_m, params| captured = params and {} }
+
+      server.call_tool('t', args_with_meta)
+
+      expect(captured['_meta'] || captured[:_meta]).to eq(meta)
+      expect(captured['arguments'] || captured[:arguments]).to eq({ 'x' => 1 })
+    end
+  end
+
+  describe 'Client#call_tool progress callback' do
+    let(:tool_json) do
+      { 'name' => 'slow', 'description' => 'd', 'inputSchema' => { 'type' => 'object', 'properties' => {} } }
+    end
+    let(:srv) { double('server', name: 's') }
+    let(:client) do
+      c = MCPClient::Client.new
+      c.instance_variable_set(:@servers, [srv])
+      c
+    end
+
+    before do
+      tool = MCPClient::Tool.from_json(tool_json, server: srv)
+      allow(srv).to receive(:list_tools).and_return([tool])
+      allow(srv).to receive(:capabilities).and_return({})
+      allow(srv).to receive(:on_notification)
+    end
+
+    it 'auto-generates a progressToken, routes matching notifications, and drops stale ones' do
+      sent_params = nil
+      allow(srv).to receive(:call_tool) do |_name, params|
+        sent_params = params
+        { 'content' => [] }
+      end
+
+      updates = []
+      client.call_tool('slow', { 'a' => 1 }, progress: lambda { |progress, total, message|
+        updates << [progress, total, message]
+      })
+
+      token = sent_params.dig('_meta', 'progressToken')
+      expect(token).not_to be_nil
+      expect(sent_params['a']).to eq(1)
+
+      # During the request the token is active; simulate a progress notification
+      # arriving mid-flight by re-registering, then completing.
+      client.send(:register_progress_callback, token, ->(p, t, m) { updates << [p, t, m] })
+      client.send(:process_notification, srv, 'notifications/progress',
+                  { 'progressToken' => token, 'progress' => 50, 'total' => 100, 'message' => 'half' })
+      expect(updates).to include([50, 100, 'half'])
+
+      client.send(:unregister_progress_callback, token)
+      client.send(:process_notification, srv, 'notifications/progress',
+                  { 'progressToken' => token, 'progress' => 100, 'total' => 100, 'message' => 'done' })
+      expect(updates).not_to include([100, 100, 'done'])
+    end
+
+    it 'invokes the progress callback while the request is in flight' do
+      updates = []
+      allow(srv).to receive(:call_tool) do |_name, params|
+        token = params.dig('_meta', 'progressToken')
+        client.send(:process_notification, srv, 'notifications/progress',
+                    { 'progressToken' => token, 'progress' => 10, 'total' => 100 })
+        { 'content' => [] }
+      end
+
+      client.call_tool('slow', {}, progress: ->(p, t, _m) { updates << [p, t] })
+
+      expect(updates).to eq([[10, 100]])
+    end
+
+    it 'ignores progress for unknown tokens without raising' do
+      expect do
+        client.send(:process_notification, srv, 'notifications/progress',
+                    { 'progressToken' => 'stale', 'progress' => 1 })
+      end.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## What

Two related fixes against MCP 2025-11-25 ([`RequestParams._meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic#meta) and [basic/utilities/progress](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress)):

### 1. Request-level `_meta` reaches the wire correctly on every transport

> "When a party wants to *receive* progress updates for a request, it includes a `progressToken` in the request **metadata**."

Only `ServerStreamableHTTP` hoisted `_meta` out of the tool arguments into the request params — and only for the symbol `:_meta` key. On stdio, legacy SSE, and plain HTTP, any `_meta` passed through `Client#call_tool`/`get_prompt` was serialized as `params.arguments._meta`: the server saw it as a **tool input argument** (breaking tools with `additionalProperties: false`) and never as request metadata, so progress could not be requested through the documented API on 3 of 4 transports. All transports now share one hoisting helper (both `:_meta` and `'_meta'` accepted), matching what `call_tool_as_task` already did.

### 2. Progress token tracking and per-request routing (SHOULD)

> "Senders and receivers **SHOULD** track active progress tokens"

The library never generated, validated, or tracked tokens — `notifications/progress` fell into the unknown-notification debug branch, reaching only the global `on_notification` firehose with no request association and no cutoff after completion. Now:

```ruby
client.call_tool('longRunning', args, progress: ->(progress, total, message) { ... })
```

auto-generates a unique token, injects it into the request `_meta`, routes matching `notifications/progress` to the callback while the request is active, and unregisters the token on completion so stale notifications are dropped (debug-logged). Raw notifications still reach `on_notification` listeners unchanged.

## Tests

New `spec/lib/mcp_client/progress_meta_spec.rb` (8 examples: `_meta` hoisting on all four transports for tools and prompts including the string-key case, token auto-generation + in-flight routing + stale-token drop, unknown-token tolerance). 7 failed before the fix. Also deduplicates `call_tool`'s inline tool resolution through the existing `resolve_tool`. Full suite: 1328 examples, 0 failures; RuboCop clean.

Part of an MCP 2025-11-25 compliance audit of this gem against the official spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)