### PR TITLE
Fix examples for the compliance-audited client; document new public APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,81 @@ client = MCPClient.connect('http://server/mcp',
 )
 ```
 
+Sampling tool calling (SEP-1577) is opt-in: pass `sampling_supports_tools: true`
+to declare the `sampling.tools` capability. The handler then receives the full
+request params (including `tools`/`toolChoice`) as an optional fifth argument;
+without the opt-in, tool-enabled sampling requests are rejected with `-32602`
+as the spec requires:
+
+```ruby
+client = MCPClient::Client.new(
+  mcp_server_configs: [...],
+  sampling_supports_tools: true,
+  sampling_handler: ->(messages, prefs, system_prompt, max_tokens, params = nil) {
+    tools = params && params['tools'] # ToolUseContent may be returned in content
+    # ...
+  }
+)
+```
+
+### Progress Tracking
+
+Attach a per-call progress callback — the client generates a unique
+`progressToken`, places it in the request `_meta`, and routes matching
+`notifications/progress` to your block while the request is active (stale
+tokens after completion are dropped):
+
+```ruby
+client.call_tool('long_running', args, progress: ->(progress, total, message) {
+  puts "#{message}: #{progress}/#{total}"
+})
+```
+
+A request-level `_meta` (e.g. a hand-picked `progressToken`) can also be passed
+inside the arguments under the `'_meta'` key on every transport — it is hoisted
+to the JSON-RPC params level on the wire, never sent as a tool argument.
+
+### Timeouts and Cancellation
+
+Timeouts are configurable per request in addition to the per-server
+`read_timeout`. A timed-out request raises
+`MCPClient::Errors::RequestTimeoutError` (a `TransportError` subclass), is
+**never** silently re-sent by the retry layer, and a best-effort
+`notifications/cancelled` is sent for the abandoned request (never for
+`initialize`, and task-augmented calls use `tasks/cancel` instead):
+
+```ruby
+client.send_rpc('tools/call', params: { name: 'slow', arguments: {} }, timeout: 300)
+server.rpc_request('tools/list', {}, timeout: 5)
+```
+
+### Client Identity and Server Instructions
+
+Hosts can present their own `Implementation` info (sent as `clientInfo` during
+initialize; `name` and `version` required — `title`, `description`,
+`websiteUrl`, `icons` optional), and read the server's `instructions` hint
+after connecting:
+
+```ruby
+client = MCPClient::Client.new(
+  mcp_server_configs: [...],
+  client_info: { 'name' => 'my-ide', 'version' => '2.0.0', 'description' => 'An MCP-powered IDE' }
+)
+client.servers.first.connect
+puts client.servers.first.instructions # e.g. "Use the search tool before answering."
+```
+
+### Capability Gating
+
+Optional server features (`logging/setLevel`, `resources/subscribe`,
+`completion/complete`, `tasks/list`, `tasks/cancel`) are only sent to servers
+that negotiated the corresponding capability; otherwise
+`MCPClient::Errors::CapabilityError` is raised (the lifecycle forbids using
+capabilities that were not negotiated). `Client#log_level=` skips
+non-logging servers instead of failing. Declared *client* capabilities are
+derived from what the host actually registered (handlers, roots), never
+hardcoded.
+
 ### Completion (Autocomplete)
 
 ```ruby
@@ -488,6 +563,20 @@ client = MCPClient::Client.new(
 Features: PKCE, server discovery (`.well-known`), dynamic registration, token refresh.
 
 See [OAUTH.md](OAUTH.md) for full documentation.
+
+### OAuth Extras (2025-11-25)
+
+- **Client ID Metadata Documents (SEP-991)** — pass
+  `client_id_metadata_url: 'https://myapp.example/oauth-client.json'` (an HTTPS
+  URL with a path, which doubles as the `client_id`); when the authorization
+  server advertises `client_id_metadata_document_supported`, dynamic client
+  registration is skipped entirely.
+- **Scope challenges (SEP-835)** — an HTTP 403 `insufficient_scope` challenge
+  raises `MCPClient::Errors::InsufficientScopeError` (a `ConnectionError`
+  subclass) exposing `#scope` and `#error_description`; the challenged scopes
+  are treated as authoritative for the next authorization flow.
+- **PKCE** — authorization refuses to proceed when the authorization server
+  does not advertise `code_challenge_methods_supported` including `S256`.
 
 ## Server Notifications
 

--- a/examples/elicitation/elicitation_streamable_server.py
+++ b/examples/elicitation/elicitation_streamable_server.py
@@ -355,6 +355,21 @@ def handle_rpc():
         params = request_data.get('params', {})
         request_id = request_data.get('id')
 
+        # MCP 2025-11-25: the client answers elicitation/create with a standard
+        # JSON-RPC *response* (no method; the id echoes our request id). Accept
+        # that shape in addition to the legacy 'elicitation/response' request.
+        if method is None and request_id is not None and session_id and session_id in sessions:
+            session = sessions[session_id]
+            if request_id in session.elicitation_events:
+                result = request_data.get('result') or {}
+                session.elicitation_responses[request_id] = {
+                    'action': result.get('action'),
+                    'content': result.get('content', {})
+                }
+                session.elicitation_events[request_id].set()
+                logger.info(f"Received JSON-RPC elicitation result for {request_id}: {result.get('action')}")
+                return Response('', status=202)
+
         # Handle different methods
         if method == 'initialize':
             # Create new session
@@ -736,6 +751,18 @@ def handle_sse_rpc():
 
         logger.info(f"SSE RPC {'notification' if rpc_id is None else 'request'}: {
                     method} (id: {rpc_id})")
+
+        # MCP 2025-11-25: accept a standard JSON-RPC elicitation *response*
+        # (no method; id echoes our elicitation request id).
+        if method is None and rpc_id is not None and rpc_id in session.elicitation_events:
+            result = data.get('result') or {}
+            session.elicitation_responses[rpc_id] = {
+                'action': result.get('action'),
+                'content': result.get('content', {})
+            }
+            session.elicitation_events[rpc_id].set()
+            logger.info(f"Received JSON-RPC elicitation result for {rpc_id}: {result.get('action')}")
+            return Response('', status=202)
 
         # Handle notifications (no response needed)
         if method and rpc_id is None:

--- a/examples/openai_ruby_mcp.rb
+++ b/examples/openai_ruby_mcp.rb
@@ -4,6 +4,10 @@
 # MCPClient integration example using the openai/openai-ruby gem
 require 'bundler/setup'
 require_relative '../lib/mcp_client'
+# Both the official 'openai' gem and 'ruby-openai' are bundled and both expose
+# lib/openai.rb + OpenAI::Client; load the official gem's lib first so
+# require resolves deterministically to the gem this example targets.
+$LOAD_PATH.unshift(*Gem::Specification.find_by_name('openai').full_require_paths)
 require 'openai'
 require 'json'
 require 'logger'

--- a/examples/ruby_openai_mcp.rb
+++ b/examples/ruby_openai_mcp.rb
@@ -6,6 +6,10 @@
 #  npx @playwright/mcp@latest --port 8931
 require 'bundler/setup'
 require_relative '../lib/mcp_client'
+# Both 'ruby-openai' and the official 'openai' gem are bundled and both expose
+# lib/openai.rb + OpenAI::Client; load ruby-openai's lib first so require
+# resolves deterministically to the gem this example targets.
+$LOAD_PATH.unshift(*Gem::Specification.find_by_name('ruby-openai').full_require_paths)
 require 'openai'
 require 'json'
 require 'logger'


### PR DESCRIPTION
## What

Post-merge examples-suite fixes and documentation for the MCP 2025-11-25 compliance audit (#158–#181):

### 1. Elicitation streamable demo server spoke the old invented protocol

The demo server only understood the `elicitation/response` *request* the pre-audit client used to send. Since #159 the client replies with a standard JSON-RPC *response* (id echoing the elicitation request, `result` carrying the `ElicitResult`) — which the server's method-keyed dispatch silently dropped, blocking the tool call until the read timeout (the intermittent `run_all_examples.sh` failure). Both dispatch sites now also accept the standard shape; the legacy branch remains. The full four-round elicitation flow now completes end to end.

### 2. OpenAI gem collision in the examples

`openai` (official) and `ruby-openai` are both bundled and both expose `lib/openai.rb` + `OpenAI::Client`; load-path order decided which example broke (a 401 from mismatched constructor kwargs). Each example now pins its intended gem's `full_require_paths` before `require 'openai'`.

### 3. README

Documents the audit's new public APIs: sampling tool calling opt-in (`sampling_supports_tools:`), per-call progress tracking (`progress:`), request-level `_meta` placement, per-request `timeout:` + `RequestTimeoutError`/cancellation semantics, `client_info:`/`instructions`, capability gating (`CapabilityError`), and OAuth additions (CIMD `client_id_metadata_url:`, `InsufficientScopeError`, strict PKCE).

## Verification

Full `examples/run_all_examples.sh` (including the paid-LLM group): **17 PASS / 0 FAIL / 3 environment-dependent SKIPs** (no Anthropic key, no remote task-capable server, interactive browser OAuth) — same skip set as at v1.1.0. RSpec 1606 examples green, RuboCop clean. No gem code changed in this PR, so no new gem specs; every audit PR carried its own regression specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)