### PR TITLE
Implement MCP 2025-11-25 tasks in the streamable echo server; run the tasks example locally

### DIFF
--- a/examples/echo_server_streamable.py
+++ b/examples/echo_server_streamable.py
@@ -30,7 +30,7 @@ import time
 import threading
 import uuid
 import base64
-from datetime import datetime
+from datetime import datetime, timezone
 from flask import Flask, request, Response, jsonify
 from queue import Queue
 import logging
@@ -61,6 +61,97 @@ class Session:
         self.log_level = 'info'  # Default log level
         self.sampling_requests = {}  # Track pending sampling requests
         self.sampling_responses = {}  # Store sampling responses
+
+# ---------------------------------------------------------------------------
+# Tasks (MCP 2025-11-25): task-augmented tools/call with get/result/list/cancel
+# ---------------------------------------------------------------------------
+
+tasks_store = {}     # taskId -> task dict
+tasks_lock = threading.Lock()
+
+
+def _now_iso():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def create_task_record(task_id, tool_name, arguments, ttl=None):
+    """Create a task record in the MCP 2025-11-25 shape."""
+    now = _now_iso()
+    task = {
+        "taskId": task_id,
+        "status": "working",
+        "statusMessage": "Task created",
+        "createdAt": now,
+        "lastUpdatedAt": now,
+        "ttl": ttl,
+        "pollInterval": 300,
+        # Internal bookkeeping (not sent to the client)
+        "_tool_name": tool_name,
+        "_arguments": arguments,
+        "_result": None,
+    }
+    with tasks_lock:
+        tasks_store[task_id] = task
+    return task
+
+
+def task_to_response(task):
+    """Return the flat, spec-shaped Task fields (GetTaskResult / CancelTaskResult)."""
+    response = {
+        "taskId": task["taskId"],
+        "status": task["status"],
+        "createdAt": task["createdAt"],
+        "lastUpdatedAt": task["lastUpdatedAt"],
+        "ttl": task.get("ttl"),
+    }
+    if task.get("statusMessage"):
+        response["statusMessage"] = task["statusMessage"]
+    if task.get("pollInterval") is not None:
+        response["pollInterval"] = task["pollInterval"]
+    return response
+
+
+def push_task_status(session_id, task):
+    """Deliver notifications/tasks/status on the session's GET events stream."""
+    session = sessions.get(session_id)
+    if not session or not session.active:
+        return
+    notification = {
+        "jsonrpc": "2.0",
+        "method": "notifications/tasks/status",
+        "params": task_to_response(task),
+    }
+    session.event_queue.put(format_sse_event("message", notification))
+
+
+def run_task_in_background(task_id, session_id):
+    """Simulate long-running work for a task, then store its CallToolResult."""
+    for _ in range(4):
+        time.sleep(0.3)
+        with tasks_lock:
+            task = tasks_store.get(task_id)
+            if not task or task["status"] == "cancelled":
+                return
+            task["lastUpdatedAt"] = _now_iso()
+
+    with tasks_lock:
+        task = tasks_store.get(task_id)
+        if not task or task["status"] == "cancelled":
+            return
+        task["status"] = "completed"
+        task["statusMessage"] = "All steps done"
+        task["lastUpdatedAt"] = _now_iso()
+        # tasks/result returns exactly what tools/call would have returned
+        task["_result"] = {
+            "content": [
+                {"type": "text", "text": "Background task finished successfully"},
+            ],
+            "isError": False,
+        }
+        completed = dict(task)
+
+    push_task_status(session_id, completed)
+
 
 def generate_session_id():
     """Generate a cryptographically secure session ID"""
@@ -178,6 +269,11 @@ def handle_rpc():
                         "logging": {},
                         "sampling": {},
                         "completions": {},
+                        "tasks": {
+                            "list": {},
+                            "cancel": {},
+                            "requests": {"tools": {"call": {}}}
+                        },
                         "roots": {
                             "listChanged": True
                         },
@@ -235,6 +331,17 @@ def handle_rpc():
                                 },
                                 "required": ["message"]
                             }
+                        },
+                        {
+                            "name": "background_work",
+                            "description": "A long-running job that can run as a task (MCP 2025-11-25 Tasks)",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "input": {"type": "string", "description": "Arbitrary input for the job"}
+                                }
+                            },
+                            "execution": {"taskSupport": "optional"}
                         },
                         {
                             "name": "long_task",
@@ -769,7 +876,35 @@ End of sample data.""".format(datetime.now().isoformat())
             tool_name = params.get('name')
             tool_args = params.get('arguments', {})
             
-            if tool_name == 'echo':
+            if tool_name == 'background_work':
+                # Task-augmented request: create a task and return a
+                # CreateTaskResult now; the result comes later via tasks/result.
+                task_aug = params.get('task')
+                if task_aug is not None:
+                    task_id = str(uuid.uuid4())
+                    ttl = task_aug.get('ttl') if isinstance(task_aug, dict) else None
+                    task = create_task_record(task_id, tool_name, tool_args, ttl=ttl)
+                    threading.Thread(
+                        target=run_task_in_background, args=(task_id, session_id), daemon=True
+                    ).start()
+                    response_data = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {"task": task_to_response(task)}
+                    }
+                else:
+                    # Synchronous fallback when not called as a task
+                    response_data = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {
+                            "content": [
+                                {"type": "text", "text": "Background task finished successfully"}
+                            ]
+                        }
+                    }
+
+            elif tool_name == 'echo':
                 message = tool_args.get('message', '')
                 response_data = {
                     "jsonrpc": "2.0",
@@ -1121,6 +1256,89 @@ End of sample data.""".format(datetime.now().isoformat())
                 sessions[session_id].last_activity = datetime.now()
             return Response("", status=200)
             
+        elif method == 'tasks/get':
+            task_id = params.get('taskId', '')
+            with tasks_lock:
+                task = tasks_store.get(task_id)
+            if task:
+                response_data = {"jsonrpc": "2.0", "id": request_id, "result": task_to_response(task)}
+            else:
+                response_data = {
+                    "jsonrpc": "2.0", "id": request_id,
+                    "error": {"code": -32602, "message": f"Task not found: {task_id}"}
+                }
+            return Response(
+                format_sse_event("message", response_data),
+                content_type='text/event-stream',
+                headers={'Cache-Control': 'no-cache'}
+            )
+
+        elif method == 'tasks/result':
+            task_id = params.get('taskId', '')
+            with tasks_lock:
+                task = tasks_store.get(task_id)
+                if not task:
+                    response_data = {
+                        "jsonrpc": "2.0", "id": request_id,
+                        "error": {"code": -32602, "message": f"Task not found: {task_id}"}
+                    }
+                elif task['status'] != 'completed':
+                    response_data = {
+                        "jsonrpc": "2.0", "id": request_id,
+                        "error": {
+                            "code": -32602,
+                            "message": f"Task '{task_id}' is not complete (status: {task['status']})"
+                        }
+                    }
+                else:
+                    result = dict(task['_result'] or {})
+                    # tasks/result MUST carry the related-task metadata
+                    result.setdefault('_meta', {})['io.modelcontextprotocol/related-task'] = {'taskId': task_id}
+                    response_data = {"jsonrpc": "2.0", "id": request_id, "result": result}
+            return Response(
+                format_sse_event("message", response_data),
+                content_type='text/event-stream',
+                headers={'Cache-Control': 'no-cache'}
+            )
+
+        elif method == 'tasks/list':
+            with tasks_lock:
+                task_list = [task_to_response(t) for t in tasks_store.values()]
+            response_data = {"jsonrpc": "2.0", "id": request_id, "result": {"tasks": task_list}}
+            return Response(
+                format_sse_event("message", response_data),
+                content_type='text/event-stream',
+                headers={'Cache-Control': 'no-cache'}
+            )
+
+        elif method == 'tasks/cancel':
+            task_id = params.get('taskId', '')
+            with tasks_lock:
+                task = tasks_store.get(task_id)
+                if not task:
+                    response_data = {
+                        "jsonrpc": "2.0", "id": request_id,
+                        "error": {"code": -32602, "message": f"Task not found: {task_id}"}
+                    }
+                elif task['status'] in ('completed', 'failed', 'cancelled'):
+                    response_data = {
+                        "jsonrpc": "2.0", "id": request_id,
+                        "error": {
+                            "code": -32602,
+                            "message": f"Cannot cancel task in terminal status '{task['status']}'"
+                        }
+                    }
+                else:
+                    task['status'] = 'cancelled'
+                    task['statusMessage'] = 'Cancelled by client'
+                    task['lastUpdatedAt'] = _now_iso()
+                    response_data = {"jsonrpc": "2.0", "id": request_id, "result": task_to_response(task)}
+            return Response(
+                format_sse_event("message", response_data),
+                content_type='text/event-stream',
+                headers={'Cache-Control': 'no-cache'}
+            )
+
         else:
             # Unknown method
             response_data = {

--- a/examples/run_all_examples.sh
+++ b/examples/run_all_examples.sh
@@ -257,6 +257,10 @@ if wait_ready 40; then
     bundle exec ruby examples/test_mcp_protocol_features.rb
   run_example "test_ping_pong.rb" "Test completed" - -- \
     bundle exec ruby examples/test_ping_pong.rb
+  # Full task lifecycle (MCP 2025-11-25) against the local tasks-capable server
+  run_example "tasks_example.rb" "Tasks example completed" - -- \
+    env MCP_SERVER_URL=http://localhost:8931/mcp \
+    bundle exec ruby examples/tasks_example.rb
   # NOTE: streamable_http_example.rb is intentionally NOT run against this local
   # server. It calls the *first advertised tool* with no arguments — which only
   # makes sense for the remote server it targets (Zapier). Against echo_server it
@@ -377,19 +381,6 @@ if [ -n "${ZAPIER_MCP_TOKEN:-}" ]; then
 else
   skip_example "streamable_http_example.rb" "set ZAPIER_MCP_TOKEN in examples/secrets.env to run against Zapier (Authorization: Bearer). Transport also verified locally by echo_server_streamable_client.rb + test_mcp_protocol_features.rb"
 fi
-# tasks_example.rb → Zapier MCP. Zapier does not (yet) implement the
-# experimental 2025-11-25 tasks capability, so against it the example
-# demonstrates the client's capability-aware degradation (TaskError /
-# CapabilityError) rather than a full task lifecycle.
-if [ -n "${ZAPIER_MCP_TOKEN:-}" ]; then
-  ZAPIER_URL="${ZAPIER_MCP_URL:-https://mcp.zapier.com/api/v1/connect}"
-  run_example "tasks_example.rb (→ Zapier)" "Tasks example completed" - -- \
-    env MCP_SERVER_URL="$ZAPIER_URL" MCP_BEARER_TOKEN="$ZAPIER_MCP_TOKEN" \
-    bundle exec ruby examples/tasks_example.rb
-else
-  skip_example "tasks_example.rb" "set ZAPIER_MCP_TOKEN in examples/secrets.env to run against Zapier; a full task lifecycle additionally needs a task-capable server (MCP_SERVER_URL)"
-fi
-
 # oauth_example.rb → walks the OAuth API; connects to Zapier for real when
 # ZAPIER_MCP_TOKEN is set (Authorization: Bearer), otherwise stays illustrative.
 if [ -n "${ZAPIER_MCP_TOKEN:-}" ]; then

--- a/examples/tasks_example.rb
+++ b/examples/tasks_example.rb
@@ -8,18 +8,20 @@
 # "required". Calling such a tool as a task returns immediately with a task
 # handle; the actual result is fetched later once the task is terminal.
 #
-# Tasks are an experimental 2025-11-25 feature that most servers (including
-# Zapier, the default target here) do not implement yet. Against such servers
-# this example demonstrates the client's capability-aware behavior instead:
-# tool.supports_task?, the TaskError from call_tool_as_task, and the
-# CapabilityError raised by list_tasks (MCP lifecycle: "Only use capabilities
-# that were successfully negotiated").
+# The local streamable echo server implements the full tasks feature
+# (capability, background_work tool, tasks/get|result|list|cancel, status
+# notifications), so the default target runs the complete task lifecycle:
 #
-# Run against Zapier (default):
+#   python3 examples/echo_server_streamable.py &   # port 8931
+#   ./examples/tasks_example.rb
+#
+# Against servers that have not negotiated the experimental tasks capability
+# the example demonstrates the client's capability-aware behavior instead
+# (tool.supports_task?, TaskError from call_tool_as_task, CapabilityError
+# from list_tasks), e.g.:
+#
+#   MCP_SERVER_URL='https://mcp.zapier.com/api/v1/connect' \
 #   MCP_BEARER_TOKEN='your_zapier_token' ./examples/tasks_example.rb
-# Or against any task-capable server:
-#   MCP_SERVER_URL='https://example.com/mcp' \
-#   MCP_BEARER_TOKEN='your_token' ./examples/tasks_example.rb long_job
 
 require 'bundler/setup'
 require_relative '../lib/mcp_client'
@@ -28,7 +30,7 @@ require 'logger'
 logger = Logger.new($stdout)
 logger.level = Logger::WARN
 
-server_url = ENV.fetch('MCP_SERVER_URL', 'https://mcp.zapier.com/api/v1/connect')
+server_url = ENV.fetch('MCP_SERVER_URL', 'http://localhost:8931/mcp')
 bearer_token = ENV.fetch('MCP_BEARER_TOKEN', nil)
 tool_name = ARGV[0]
 


### PR DESCRIPTION
## What

Makes the tasks example a fully local, deterministic demonstration of the MCP 2025-11-25 tasks feature by implementing the server side in `examples/echo_server_streamable.py`:

- **Capability**: declares `tasks: {list, cancel, requests: {tools: {call}}}` in the initialize result.
- **Tool**: new `background_work` tool with `execution: {taskSupport: "optional"}`.
- **Task-augmented `tools/call`**: returns a `CreateTaskResult` immediately and completes the work on a background thread (~1.2s, `pollInterval` 300ms).
- **`tasks/get` / `tasks/result` / `tasks/list` / `tasks/cancel`**: full set, with `tasks/result` echoing the required `io.modelcontextprotocol/related-task` `_meta` and cancel rejecting terminal tasks.
- **`notifications/tasks/status`** pushed on the session's GET events stream on completion.

`tasks_example.rb` defaults to `http://localhost:8931/mcp` and now exercises the complete lifecycle (create → poll → result → list). Pointed at a server without the tasks capability it still demonstrates the client's gating (`TaskError` / `CapabilityError`) as before. The runner executes it in Group C against the already-booted local server, replacing the Zapier-token gating.

## Verification

- Live run: capability negotiated, task created (`working`), polled to `completed`, result fetched with related-task `_meta`, `tasks/list` returns it, exit 0.
- Full `RUN_AI=0 RUN_NPX=0` runner pass: **13 PASS / 0 FAIL**, including the other Group C examples against the modified server (tool list grew by one).
- RuboCop clean; Python file parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)