### PR TITLE
Reject cross-origin SSE endpoint events

### DIFF
--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -2,10 +2,13 @@
 
 require_relative '../json_rpc_common'
 
+require_relative 'origin_policy'
+
 module MCPClient
   class ServerSSE
     # JSON-RPC request/notification plumbing for SSE transport
     module JsonRpcTransport
+      include OriginPolicy
       include JsonRpcCommon
 
       # Generic JSON-RPC request: send method with params and return result
@@ -178,7 +181,7 @@ module MCPClient
       def create_json_rpc_connection(base_url)
         Faraday.new(url: base_url) do |f|
           f.request :retry, max: @max_retries, interval: @retry_backoff, backoff_factor: 2
-          f.response :follow_redirects, limit: 3
+          f.response :follow_redirects, limit: 3, callback: method(:reject_cross_origin_redirect!)
           f.options.open_timeout = @read_timeout
           f.options.timeout = @read_timeout
           f.adapter Faraday.default_adapter

--- a/lib/mcp_client/server_sse/origin_policy.rb
+++ b/lib/mcp_client/server_sse/origin_policy.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+module MCPClient
+  class ServerSSE
+    # Origin pinning for the legacy HTTP+SSE transport.
+    #
+    # Everything this transport sends carries the caller's configured headers
+    # (Authorization, API keys, cookies), and callback responses carry
+    # roots/sampling/elicitation data, so no request may leave the origin the
+    # caller connected to — neither by a server-chosen endpoint URI nor by a
+    # redirect.
+    module OriginPolicy
+      # @param base [URI::Generic] the SSE connection URL
+      # @param other [URI::Generic] the URL to compare
+      # @return [Boolean] whether both share scheme, host and port
+      def same_origin?(base, other)
+        base.scheme == other.scheme &&
+          base.host&.downcase == other.host&.downcase &&
+          base.port == other.port
+      end
+
+      # @param uri [URI::Generic]
+      # @return [String] scheme://host:port of the URI
+      def origin_of(uri)
+        "#{uri.scheme}://#{uri.host}:#{uri.port}"
+      end
+
+      # Refuse to follow a redirect that leaves the SSE connection's origin.
+      #
+      # Pinning the endpoint event's origin is not sufficient on its own: a
+      # same-origin endpoint can answer a POST with a 307/308 to another
+      # origin, and faraday-follow_redirects replays the request there. It
+      # strips only the literal Authorization header, so configured API-key
+      # and other custom headers — plus the JSON-RPC body — would still reach
+      # the foreign origin.
+      #
+      # Raises ConnectionError rather than TransportError because the server
+      # has already received the original request; with_retry must not re-send
+      # it.
+      # @param _old_env [Faraday::Env] the redirecting response environment
+      # @param new_env [Faraday::Env] environment of the request about to be replayed
+      # @return [void]
+      # @raise [MCPClient::Errors::ConnectionError] if the redirect changes origin
+      def reject_cross_origin_redirect!(_old_env, new_env)
+        base = URI.parse(@base_url)
+        target = new_env.url
+        return if same_origin?(base, target)
+
+        message = "Refusing cross-origin redirect from #{origin_of(base)} to #{origin_of(target)}"
+        @logger.error(message)
+        raise MCPClient::Errors::ConnectionError, message
+      end
+    end
+  end
+end

--- a/lib/mcp_client/server_sse/reconnect_monitor.rb
+++ b/lib/mcp_client/server_sse/reconnect_monitor.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require_relative 'origin_policy'
+
 module MCPClient
   class ServerSSE
     # Extracted module for back-off, ping, and reconnection logic
     module ReconnectMonitor
+      include OriginPolicy
+
       # Start an activity monitor thread to maintain the connection
       # @return [void]
       def start_activity_monitor
@@ -202,7 +206,9 @@ module MCPClient
           f.options.open_timeout = 10
           f.options.timeout = nil
           f.request :retry, max: @max_retries, interval: @retry_backoff, backoff_factor: 2
-          f.response :follow_redirects, limit: 3
+          # Same origin pinning as the RPC connection: the SSE stream carries
+          # the configured credential headers too.
+          f.response :follow_redirects, limit: 3, callback: method(:reject_cross_origin_redirect!)
           f.adapter Faraday.default_adapter
         end
 

--- a/lib/mcp_client/server_sse/sse_parser.rb
+++ b/lib/mcp_client/server_sse/sse_parser.rb
@@ -156,20 +156,54 @@ module MCPClient
         end
       end
 
-      # Resolve an endpoint URI reference against the SSE connection URL
+      # Resolve an endpoint URI reference against the SSE connection URL.
+      # The resolved endpoint MUST stay on the SSE connection's origin: the
+      # event payload is server-controlled input, and honoring a cross-origin
+      # target would redirect every JSON-RPC POST — including the configured
+      # Authorization/API-key headers and callback response bodies — to a
+      # server the caller never chose.
       # @param data [String] the endpoint event payload (absolute or relative URI)
       # @return [String] the absolute endpoint URL
       def resolve_endpoint_uri(data)
-        URI.join(@base_url, data).to_s
+        endpoint = URI.join(@base_url, data)
+        base = URI.parse(@base_url)
+        unless same_origin?(base, endpoint)
+          fail_endpoint_handshake!(
+            "Cross-origin endpoint in SSE endpoint event: #{data.inspect} " \
+            "does not match the connection origin #{origin_of(base)}"
+          )
+        end
+        endpoint.to_s
       rescue URI::Error => e
         # The endpoint event is the handshake's core payload; an unresolvable
         # URI must fail the handshake rather than deferring a broken POST
         # target to the first request.
         @logger.error("Failed to resolve endpoint URI #{data.inspect} against #{@base_url}: #{e.message}")
-        message = "Invalid endpoint URI in SSE endpoint event: #{data.inspect} (#{e.message})"
-        # The SSE worker thread swallows this exception with a generic rescue,
-        # so also record the failure cause (mirroring @auth_error) for the
-        # connect caller blocked in wait_for_connection to surface promptly.
+        fail_endpoint_handshake!("Invalid endpoint URI in SSE endpoint event: #{data.inspect} (#{e.message})")
+      end
+
+      # @param base [URI::Generic] the SSE connection URL
+      # @param endpoint [URI::Generic] the resolved endpoint URL
+      # @return [Boolean] whether both share scheme, host and port
+      def same_origin?(base, endpoint)
+        base.scheme == endpoint.scheme &&
+          base.host&.downcase == endpoint.host&.downcase &&
+          base.port == endpoint.port
+      end
+
+      # @param uri [URI::Generic]
+      # @return [String] scheme://host:port of the URI
+      def origin_of(uri)
+        "#{uri.scheme}://#{uri.host}:#{uri.port}"
+      end
+
+      # Record the handshake failure cause and raise. The SSE worker thread
+      # swallows this exception with a generic rescue, so also record the
+      # failure (mirroring @auth_error) for the connect caller blocked in
+      # wait_for_connection to surface promptly.
+      # @param message [String] the failure description
+      # @raise [MCPClient::Errors::TransportError] always
+      def fail_endpoint_handshake!(message)
         @mutex.synchronize do
           @connection_error = message
           @connection_established = false

--- a/lib/mcp_client/server_sse/sse_parser.rb
+++ b/lib/mcp_client/server_sse/sse_parser.rb
@@ -2,11 +2,14 @@
 
 require 'json'
 require 'uri'
+require_relative 'origin_policy'
 
 module MCPClient
   class ServerSSE
     # === Wire-level SSE parsing & dispatch ===
     module SseParser
+      include OriginPolicy
+
       # Parse and handle a raw SSE event payload.
       # @param event_data [String] the raw event chunk
       def parse_and_handle_sse_event(event_data)
@@ -180,21 +183,6 @@ module MCPClient
         # target to the first request.
         @logger.error("Failed to resolve endpoint URI #{data.inspect} against #{@base_url}: #{e.message}")
         fail_endpoint_handshake!("Invalid endpoint URI in SSE endpoint event: #{data.inspect} (#{e.message})")
-      end
-
-      # @param base [URI::Generic] the SSE connection URL
-      # @param endpoint [URI::Generic] the resolved endpoint URL
-      # @return [Boolean] whether both share scheme, host and port
-      def same_origin?(base, endpoint)
-        base.scheme == endpoint.scheme &&
-          base.host&.downcase == endpoint.host&.downcase &&
-          base.port == endpoint.port
-      end
-
-      # @param uri [URI::Generic]
-      # @return [String] scheme://host:port of the URI
-      def origin_of(uri)
-        "#{uri.scheme}://#{uri.host}:#{uri.port}"
       end
 
       # Record the handshake failure cause and raise. The SSE worker thread

--- a/spec/lib/mcp_client/server_sse/sse_parser_spec.rb
+++ b/spec/lib/mcp_client/server_sse/sse_parser_spec.rb
@@ -64,6 +64,42 @@ RSpec.describe MCPClient::ServerSSE::SseParser do
       expect(parser.connection_established).to be true
     end
 
+    it 'accepts an absolute same-origin endpoint URI' do
+      raw = "event: endpoint\ndata: https://example.com/messages?sid=1\n\n"
+      parser.parse_and_handle_sse_event(raw)
+      expect(parser.rpc_endpoint).to eq('https://example.com/messages?sid=1')
+      expect(parser.connection_established).to be true
+    end
+
+    it 'rejects a cross-origin endpoint URI and fails the handshake' do
+      # The endpoint event is attacker-influenced input: honoring a foreign
+      # origin would redirect every JSON-RPC POST (with configured
+      # Authorization/API-key headers) to a server the caller never chose.
+      raw = "event: endpoint\ndata: https://evil.example.net/steal\n\n"
+      expect { parser.parse_and_handle_sse_event(raw) }.to raise_error(
+        MCPClient::Errors::TransportError, /origin/
+      )
+      expect(parser.rpc_endpoint).to be_nil
+      expect(parser.connection_established).to be false
+      expect(parser.instance_variable_get(:@connection_error)).to match(/origin/)
+    end
+
+    it 'rejects an endpoint URI that changes only the port' do
+      raw = "event: endpoint\ndata: https://example.com:8443/messages\n\n"
+      expect { parser.parse_and_handle_sse_event(raw) }.to raise_error(
+        MCPClient::Errors::TransportError, /origin/
+      )
+      expect(parser.rpc_endpoint).to be_nil
+    end
+
+    it 'rejects an endpoint URI that downgrades the scheme' do
+      raw = "event: endpoint\ndata: http://example.com/messages\n\n"
+      expect { parser.parse_and_handle_sse_event(raw) }.to raise_error(
+        MCPClient::Errors::TransportError, /origin/
+      )
+      expect(parser.rpc_endpoint).to be_nil
+    end
+
     it 'ignores ping events' do
       expect { parser.parse_and_handle_sse_event("event: ping\n\n") }.not_to raise_error
     end

--- a/spec/lib/mcp_client/server_sse/sse_parser_spec.rb
+++ b/spec/lib/mcp_client/server_sse/sse_parser_spec.rb
@@ -104,6 +104,50 @@ RSpec.describe MCPClient::ServerSSE::SseParser do
       expect { parser.parse_and_handle_sse_event("event: ping\n\n") }.not_to raise_error
     end
 
+    describe 'cross-origin redirects from a same-origin endpoint' do
+      # Pinning the endpoint origin is not enough on its own: a same-origin
+      # endpoint can answer the POST with a 307 to another origin, and the
+      # redirect middleware replays the body there, stripping only the
+      # literal Authorization header.
+      let(:server) do
+        MCPClient::ServerSSE.new(
+          base_url: 'https://example.com/sse',
+          headers: { 'X-API-Key' => 'secret-key-123', 'Authorization' => 'Bearer tok' }
+        )
+      end
+
+      before do
+        server.instance_variable_set(:@use_sse, false)
+        server.instance_variable_set(:@initialized, true)
+        server.instance_variable_set(:@connection_established, true)
+        server.instance_variable_set(:@sse_connected, true)
+        server.send(:parse_and_handle_sse_event, "event: endpoint\ndata: /messages\n\n")
+      end
+
+      after { server.cleanup }
+
+      it 'does not replay the request or its headers to a foreign origin' do
+        stub_request(:post, 'https://example.com/messages')
+          .to_return(status: 307, headers: { 'Location' => 'https://evil.example.net/steal' })
+        foreign = stub_request(:post, 'https://evil.example.net/steal')
+                  .to_return(status: 200, body: '{"result":{}}')
+
+        expect { server.rpc_request('tools/call', { 'name' => 'x' }) }
+          .to raise_error(MCPClient::Errors::ConnectionError, /[Cc]ross-origin redirect/)
+        expect(foreign).not_to have_been_requested
+      end
+
+      it 'still follows a same-origin redirect' do
+        stub_request(:post, 'https://example.com/messages')
+          .to_return(status: 307, headers: { 'Location' => 'https://example.com/messages2' })
+        stub_request(:post, 'https://example.com/messages2')
+          .to_return(status: 200, body: '{"result":{"ok":true}}',
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(server.rpc_request('tools/list', {})).to eq({ 'ok' => true })
+      end
+    end
+
     it 'calls notification callback for JSON-RPC notifications' do
       notification = { method: 'n', params: { 'a' => 1 } }
       raw = "event: message\ndata: #{notification.to_json}\n\n"


### PR DESCRIPTION
## Summary

Security fix for two medium-severity findings from a codex-security scan (`csf_34259fcd`, `csf_3654a414`, `sensitive-data-exposure.cross-origin-sse-endpoint`).

The legacy SSE transport accepted any absolute URI in the server's `endpoint` control event (`SseParser#resolve_endpoint_uri` did a plain `URI.join` with no origin check). A malicious or compromised peer could therefore point `@rpc_endpoint` at an arbitrary origin, after which:

- every client JSON-RPC POST (`send_http_request`) forwarded the caller's configured headers — `Authorization`, cookies, API keys — to the server-selected origin, and
- every roots/sampling/elicitation callback response (`post_jsonrpc_response`) sent both the configured headers and host-produced callback data there too,

including to private-network hosts reachable from the embedding process.

## Fix

- The endpoint reference is still resolved against the SSE connection URL per RFC 3986 (relative URIs keep working).
- If the resolved endpoint's scheme, host, or port differs from the connection origin, the handshake fails with `MCPClient::Errors::TransportError`, and the failure cause is recorded for the blocked `connect` caller (same pattern as the existing unresolvable-URI path).

This matches the origin pinning other MCP SDKs apply to the legacy HTTP+SSE endpoint event.

## Testing

- New specs: same-origin absolute URIs accepted; cross-origin host, port-only, and scheme-downgrade changes all rejected with the handshake failed.
- Full suite: 1610 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)