### PR TITLE
Cap the legacy SSE parse buffer to prevent memory exhaustion

### DIFF
--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -99,7 +99,9 @@ module MCPClient
       @request_id = 0
       @sse_results = {}
       @mutex = Monitor.new
-      @buffer = ''
+      @buffer = +''
+      # How much of @buffer has already been searched for an event terminator
+      @buffer_scanned = 0
       @sse_connected = false
       @connection_established = false
       @connection_cv = @mutex.new_cond
@@ -430,7 +432,8 @@ module MCPClient
 
         # Reset the SSE parse buffer so a reconnect never inherits a leftover
         # partial event from the previous connection.
-        @buffer = ''
+        @buffer = +''
+        @buffer_scanned = 0
 
         # Log cleanup for debugging
         @logger.debug('Cleaning up SSE connection')
@@ -904,30 +907,59 @@ module MCPClient
     # @return [Array<String>, nil] array of complete events or nil if none
     # @private
     def extract_complete_events(chunk)
-      event_buffers = nil
+      event_buffers = []
       @mutex.synchronize do
-        @buffer += chunk
+        # Append in place. `@buffer += chunk` allocates and copies the whole
+        # buffer on every callback, so an unterminated event delivered in N
+        # chunks costs O(N^2) copying — memory stays capped but a peer can
+        # still burn CPU and thrash the allocator on the way there.
+        @buffer << chunk
 
-        # Extract all complete events from the buffer
-        # Handle both Unix (\n\n) and Windows (\r\n\r\n) line endings
-        event_buffers = []
-        while (event_end = @buffer.index("\n\n") || @buffer.index("\r\n\r\n"))
-          event_data = extract_single_event(event_end)
-          event_buffers << event_data
+        # Rescan only the newly arrived bytes, backing up by the longest
+        # delimiter minus one so one split across two chunks is still found.
+        scan_from = [@buffer_scanned - 3, 0].max
+        while (event_end = next_event_end(scan_from))
+          event_buffers << extract_single_event(event_end)
+          # The buffer shifted; what remains is short (one event at most).
+          scan_from = 0
+          @buffer_scanned = 0
         end
+        @buffer_scanned = @buffer.length
 
-        # Everything left is a partial event awaiting its terminator. The
-        # stream is peer-controlled, so cap how much may accumulate: drop the
-        # oversized data and fail the connection rather than growing without
-        # bound (the normal reconnect path takes over from there).
-        if @buffer.bytesize > MAX_SSE_BUFFER_BYTES
-          @buffer = ''
-          raise MCPClient::Errors::ConnectionError,
-                "SSE event exceeded the maximum buffered size (#{MAX_SSE_BUFFER_BYTES} bytes) " \
-                'without a terminator'
-        end
+        # Whatever is left is a partial event still awaiting its terminator.
+        # The cap is applied here rather than before appending so a single
+        # oversized chunk that DOES contain complete events is still parsed.
+        fail_oversized_sse_buffer! if @buffer.bytesize > MAX_SSE_BUFFER_BYTES
       end
       event_buffers
+    end
+
+    # Index of the earliest event terminator at or after an offset.
+    # @param offset [Integer] character offset to start searching from
+    # @return [Integer, nil] index of the terminator, or nil if none yet
+    def next_event_end(offset)
+      lf = @buffer.index("\n\n", offset)
+      crlf = @buffer.index("\r\n\r\n", offset)
+      [lf, crlf].compact.min
+    end
+
+    # Drop an oversized partial event and fail the connection.
+    #
+    # Recording the cause matters: this runs inside Faraday's on_data callback
+    # on the SSE worker thread, whose generic rescue would otherwise leave
+    # callers with a bare "connection lost" and no reason. Mirrors the
+    # endpoint-URI failure path so wait_for_connection surfaces it promptly.
+    # @raise [MCPClient::Errors::ConnectionError] always
+    def fail_oversized_sse_buffer!
+      message = "SSE event exceeded the maximum buffered size (#{MAX_SSE_BUFFER_BYTES} bytes) " \
+                'without a terminator'
+      @buffer = +''
+      @buffer_scanned = 0
+      @connection_error = message
+      @connection_established = false
+      @connection_cv.broadcast
+      @logger.error(message)
+      raise MCPClient::Errors::ConnectionError, message
     end
 
     # Extract a single event from the buffer

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -40,6 +40,13 @@ module MCPClient
     MAX_RECONNECT_DELAY = 30
     JITTER_FACTOR = 0.25
 
+    # Maximum bytes the SSE parse buffer may hold while waiting for an event
+    # terminator. The stream is peer-controlled: without a cap, a hostile
+    # server could withhold the blank-line delimiter forever and grow the
+    # buffer until the host runs out of memory. Generous enough for any
+    # legitimate JSON-RPC response event.
+    MAX_SSE_BUFFER_BYTES = 32 * 1024 * 1024
+
     # @!attribute [r] base_url
     #   @return [String] The base URL of the MCP server
     # @!attribute [r] tools
@@ -907,6 +914,17 @@ module MCPClient
         while (event_end = @buffer.index("\n\n") || @buffer.index("\r\n\r\n"))
           event_data = extract_single_event(event_end)
           event_buffers << event_data
+        end
+
+        # Everything left is a partial event awaiting its terminator. The
+        # stream is peer-controlled, so cap how much may accumulate: drop the
+        # oversized data and fail the connection rather than growing without
+        # bound (the normal reconnect path takes over from there).
+        if @buffer.bytesize > MAX_SSE_BUFFER_BYTES
+          @buffer = ''
+          raise MCPClient::Errors::ConnectionError,
+                "SSE event exceeded the maximum buffered size (#{MAX_SSE_BUFFER_BYTES} bytes) " \
+                'without a terminator'
         end
       end
       event_buffers

--- a/spec/lib/mcp_client/server_sse_spec.rb
+++ b/spec/lib/mcp_client/server_sse_spec.rb
@@ -1149,6 +1149,37 @@ RSpec.describe MCPClient::ServerSSE do
       expect(server.instance_variable_get(:@buffer)).to eq('')
     end
 
+    it 'stays fast when an unterminated event arrives in many small chunks' do
+      # The peer chooses the chunking. Appending with += and rescanning the
+      # whole buffer each time is O(N^2): memory stays capped but CPU and the
+      # allocator do not.
+      chunk = 'a' * 16_384
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      512.times { server.send(:extract_complete_events, chunk.dup) }
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      expect(elapsed).to be < 1.0
+      expect(server.instance_variable_get(:@buffer).bytesize).to eq(512 * 16_384)
+    end
+
+    it 'finds a terminator split across two chunks' do
+      # The incremental scan backs up by the longest delimiter minus one, so a
+      # boundary-straddling "\r\n\r\n" is not missed.
+      expect(server).to receive(:parse_and_handle_sse_event).once
+      server.send(:process_sse_chunk, "event: message\r\ndata: x\r")
+      server.send(:process_sse_chunk, "\n\r\n")
+    end
+
+    it 'records the overflow cause so waiters see why the connection failed' do
+      stub_const('MCPClient::ServerSSE::MAX_SSE_BUFFER_BYTES', 1024)
+
+      expect { server.send(:process_sse_chunk, "event: message\ndata: #{'a' * 2048}") }
+        .to raise_error(MCPClient::Errors::ConnectionError)
+
+      expect(server.instance_variable_get(:@connection_error)).to match(/maximum buffered size/)
+      expect(server.instance_variable_get(:@connection_established)).to be false
+    end
+
     it 'detects direct JSON-RPC error responses with authorization errors' do
       # Authorization error in JSON-RPC format that isn't an SSE event
       error_response = '{

--- a/spec/lib/mcp_client/server_sse_spec.rb
+++ b/spec/lib/mcp_client/server_sse_spec.rb
@@ -1125,6 +1125,30 @@ RSpec.describe MCPClient::ServerSSE do
       server.send(:process_sse_chunk, completion_chunk)
     end
 
+    it 'raises and drops the buffer when an unterminated event exceeds the cap' do
+      stub_const('MCPClient::ServerSSE::MAX_SSE_BUFFER_BYTES', 1024)
+
+      # A peer that withholds the blank-line terminator must not be able to
+      # grow the parse buffer without bound.
+      expect do
+        server.send(:process_sse_chunk, "event: message\ndata: #{'a' * 2048}")
+      end.to raise_error(MCPClient::Errors::ConnectionError, /buffer/i)
+
+      expect(server.instance_variable_get(:@buffer)).to eq('')
+    end
+
+    it 'accepts complete events even when a single chunk exceeds the cap' do
+      stub_const('MCPClient::ServerSSE::MAX_SSE_BUFFER_BYTES', 1024)
+
+      # The cap bounds UNPROCESSED bytes, not chunk size: terminated events
+      # inside an oversized chunk are extracted before the check.
+      chunk = "event: message\ndata: #{'a' * 2048}\n\n"
+      expect(server).to receive(:parse_and_handle_sse_event).once
+
+      expect { server.send(:process_sse_chunk, chunk) }.not_to raise_error
+      expect(server.instance_variable_get(:@buffer)).to eq('')
+    end
+
     it 'detects direct JSON-RPC error responses with authorization errors' do
       # Authorization error in JSON-RPC format that isn't an SSE event
       error_response = '{


### PR DESCRIPTION
## Summary

Security fix for a medium-severity finding from a codex-security scan (`csf_9b731a9e`, `resource-exhaustion.unterminated-sse-buffer`).

`ServerSSE#extract_complete_events` appended every received chunk to `@buffer` and only removed bytes after finding a blank-line SSE terminator. There was no maximum event size, so after the ordinary endpoint handshake a hostile peer could continuously send an unterminated event (refreshing activity with `event:` text) and retain attacker-controlled bytes until host memory was exhausted.

## Fix

- New `MAX_SSE_BUFFER_BYTES` (32 MiB) bounds the *unprocessed partial-event* bytes — complete events inside an oversized chunk are still extracted first, so legitimate large responses are unaffected.
- On overflow the buffer is dropped and the connection fails with `ConnectionError` (same propagation path as the existing embedded-auth-error raise in `process_sse_chunk`), handing control to the existing reconnect logic. Memory stays bounded even against a peer that reconnects and retries forever, since `cleanup` also resets the buffer.

## Testing

- New specs: an unterminated event beyond the (stubbed) cap raises and empties the buffer; a *terminated* event larger than the cap in a single chunk still parses fine.
- Full suite: 1608 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
