### PR TITLE
Cap Streamable HTTP SSE buffers to prevent memory exhaustion

### DIFF
--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -33,6 +33,13 @@ module MCPClient
     SSE_MAX_RECONNECT_DELAY = 30   # Maximum reconnect delay in seconds
     THREAD_JOIN_TIMEOUT = 5 # Timeout for thread cleanup
 
+    # Maximum bytes an SSE parse buffer (events stream or resumption GET) may
+    # hold while waiting for an event terminator. The stream is
+    # peer-controlled: without a cap, a hostile server could withhold the
+    # blank-line delimiter forever and grow the buffer until the host runs
+    # out of memory. Generous enough for any legitimate JSON-RPC event.
+    MAX_SSE_BUFFER_BYTES = 32 * 1024 * 1024
+
     # @!attribute [r] base_url
     #   @return [String] The base URL of the MCP server
     # @!attribute [r] endpoint
@@ -803,6 +810,10 @@ module MCPClient
         req.options.on_data = proc do |chunk, _bytes|
           buffer << chunk
           process_resumption_buffer(buffer, state)
+          # A peer replaying delimiter-free data must not grow this buffer
+          # without bound: abort the GET (rescued below); the deadline-bounded
+          # resumption loop decides whether to retry with a fresh buffer.
+          enforce_sse_buffer_cap!(buffer)
         end
       end
     rescue StandardError => e
@@ -885,10 +896,33 @@ module MCPClient
           event_data = extract_event(event_end)
           parse_and_handle_event(event_data)
         end
+
+        # Everything left is a partial event awaiting its terminator; cap how
+        # much a peer may accumulate. The raise propagates (unlike processing
+        # errors below) so the events loop drops this connection and its
+        # backoff takes over — memory stays bounded either way.
+        begin
+          enforce_sse_buffer_cap!(@buffer)
+        rescue MCPClient::Errors::ConnectionError
+          @buffer = ''
+          raise
+        end
       end
+    rescue MCPClient::Errors::ConnectionError
+      raise
     rescue StandardError => e
       @logger.error("Error processing event chunk: #{e.message}")
       @logger.debug(e.backtrace.join("\n")) if @logger.level <= Logger::DEBUG
+    end
+
+    # @param buffer [String] a partial-event SSE buffer
+    # @raise [MCPClient::Errors::ConnectionError] when the buffer exceeds MAX_SSE_BUFFER_BYTES
+    def enforce_sse_buffer_cap!(buffer)
+      return if buffer.bytesize <= MAX_SSE_BUFFER_BYTES
+
+      raise MCPClient::Errors::ConnectionError,
+            "SSE event exceeded the maximum buffered size (#{MAX_SSE_BUFFER_BYTES} bytes) " \
+            'without a terminator'
     end
 
     # Extract a single event from the buffer

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -125,7 +125,9 @@ module MCPClient
       # SSE events connection state
       @events_connection = nil
       @events_thread = nil
-      @buffer = '' # Buffer for partial SSE event data
+      @buffer = +'' # Buffer for partial SSE event data
+      # How much of @buffer has already been searched for an event terminator
+      @buffer_scanned = 0
       @elicitation_request_callback = nil # MCP 2025-06-18
       @roots_list_request_callback = nil # MCP 2025-06-18
       @sampling_request_callback = nil # MCP 2025-11-25
@@ -499,7 +501,8 @@ module MCPClient
         @prompts_data = nil
         @resources = nil
         @resources_data = nil
-        @buffer = ''
+        @buffer = +''
+        @buffer_scanned = 0
 
         @logger.info('Cleanup completed')
       end
@@ -826,10 +829,16 @@ module MCPClient
     # @param state [Hash] mutable resumption state (:cursor, :retry_ms)
     # @return [void]
     def process_resumption_buffer(buffer, state)
-      while (separator = buffer.match(/\r\n\r\n|\n\n/))
+      # Same incremental scan as the events stream: without a cursor every
+      # chunk re-matched the whole accumulated buffer from byte zero.
+      scan_from = [state[:scanned].to_i - 3, 0].max
+      while (separator = buffer.match(/\r\n\r\n|\n\n/, scan_from))
         event_text = buffer.slice!(0, separator.end(0))
         handle_resumption_event(event_text, state)
+        scan_from = 0
+        state[:scanned] = 0
       end
+      state[:scanned] = buffer.length
     end
 
     # Parse one SSE event received on a resumption stream: track `id:` lines
@@ -889,13 +898,20 @@ module MCPClient
       @logger.debug("Processing event chunk: #{chunk.inspect}") if @logger.level <= Logger::DEBUG
 
       @mutex.synchronize do
-        @buffer += chunk
+        # Append in place and scan only the newly arrived bytes. `+= chunk`
+        # reallocated and copied the whole buffer per callback, and each
+        # search restarted at index 0, so an unterminated event delivered in
+        # N chunks cost O(N^2) work: capped memory, uncapped CPU.
+        @buffer << chunk
 
-        # Extract complete events (SSE format: events end with double newline)
-        while (event_end = @buffer.index("\n\n") || @buffer.index("\r\n\r\n"))
+        scan_from = [@buffer_scanned - 3, 0].max
+        while (event_end = next_buffer_event_end(scan_from))
           event_data = extract_event(event_end)
           parse_and_handle_event(event_data)
+          scan_from = 0
+          @buffer_scanned = 0
         end
+        @buffer_scanned = @buffer.length
 
         # Everything left is a partial event awaiting its terminator; cap how
         # much a peer may accumulate. The raise propagates (unlike processing
@@ -904,7 +920,8 @@ module MCPClient
         begin
           enforce_sse_buffer_cap!(@buffer)
         rescue MCPClient::Errors::ConnectionError
-          @buffer = ''
+          @buffer = +''
+          @buffer_scanned = 0
           raise
         end
       end
@@ -913,6 +930,15 @@ module MCPClient
     rescue StandardError => e
       @logger.error("Error processing event chunk: #{e.message}")
       @logger.debug(e.backtrace.join("\n")) if @logger.level <= Logger::DEBUG
+    end
+
+    # Index of the earliest event terminator at or after an offset.
+    # @param offset [Integer] character offset to start searching from
+    # @return [Integer, nil] index of the terminator, or nil if none yet
+    def next_buffer_event_end(offset)
+      lf = @buffer.index("\n\n", offset)
+      crlf = @buffer.index("\r\n\r\n", offset)
+      [lf, crlf].compact.min
     end
 
     # @param buffer [String] a partial-event SSE buffer

--- a/spec/lib/mcp_client/server_streamable_http_spec.rb
+++ b/spec/lib/mcp_client/server_streamable_http_spec.rb
@@ -1323,6 +1323,32 @@ RSpec.describe MCPClient::ServerStreamableHTTP do
     end
   end
 
+  describe '#process_event_chunk buffer cap' do
+    it 'raises and drops the buffer when an unterminated event exceeds the cap' do
+      stub_const('MCPClient::ServerStreamableHTTP::MAX_SSE_BUFFER_BYTES', 1024)
+
+      # A peer that withholds the blank-line terminator must not be able to
+      # grow the events-stream buffer without bound.
+      expect do
+        server.send(:process_event_chunk, "event: message\ndata: #{'a' * 2048}")
+      end.to raise_error(MCPClient::Errors::ConnectionError, /buffer/i)
+
+      expect(server.instance_variable_get(:@buffer)).to eq('')
+    end
+
+    it 'accepts complete events even when a single chunk exceeds the cap' do
+      stub_const('MCPClient::ServerStreamableHTTP::MAX_SSE_BUFFER_BYTES', 1024)
+
+      # The cap bounds UNPROCESSED bytes, not chunk size: terminated events
+      # inside an oversized chunk are extracted before the check.
+      chunk = "event: message\ndata: #{'a' * 2048}\n\n"
+      expect(server).to receive(:parse_and_handle_event).once
+
+      expect { server.send(:process_event_chunk, chunk) }.not_to raise_error
+      expect(server.instance_variable_get(:@buffer)).to eq('')
+    end
+  end
+
   describe 'security validation' do
     # Session ID and URL validation tests are shared with HTTP transport
     # through the HttpTransportBase module, so we just verify they work here

--- a/spec/lib/mcp_client/server_streamable_http_spec.rb
+++ b/spec/lib/mcp_client/server_streamable_http_spec.rb
@@ -1349,6 +1349,39 @@ RSpec.describe MCPClient::ServerStreamableHTTP do
     end
   end
 
+  describe 'SSE buffering cost' do
+    it 'stays fast when an unterminated event arrives in many small chunks' do
+      # Capping retained bytes does not help if reaching the cap costs O(N^2)
+      # copying and rescanning.
+      chunk = 'a' * 16_384
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      512.times { server.send(:process_event_chunk, chunk.dup) }
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      expect(elapsed).to be < 1.0
+      expect(server.instance_variable_get(:@buffer).bytesize).to eq(512 * 16_384)
+    end
+
+    it 'finds a terminator split across two chunks' do
+      expect(server).to receive(:parse_and_handle_event).once
+      server.send(:process_event_chunk, "event: message\r\ndata: x\r")
+      server.send(:process_event_chunk, "\n\r\n")
+    end
+
+    it 'scans the resumption buffer incrementally too' do
+      state = { cursor: 'evt-1', retry_ms: nil }
+      buffer = +''
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      512.times do
+        buffer << ('a' * 16_384)
+        server.send(:process_resumption_buffer, buffer, state)
+      end
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      expect(elapsed).to be < 1.0
+    end
+  end
+
   describe 'security validation' do
     # Session ID and URL validation tests are shared with HTTP transport
     # through the HttpTransportBase module, so we just verify they work here

--- a/spec/lib/mcp_client/streamable_resumability_spec.rb
+++ b/spec/lib/mcp_client/streamable_resumability_spec.rb
@@ -177,6 +177,32 @@ RSpec.describe 'Streamable HTTP resumability (SEP-1699)' do
     end
   end
 
+  describe 'resumption GET buffer cap' do
+    it 'aborts the GET when delimiter-free data exceeds the cap' do
+      stub_const('MCPClient::ServerStreamableHTTP::MAX_SSE_BUFFER_BYTES', 1024)
+
+      # A peer replaying delimiter-free data must not grow the resumption
+      # worker's buffer without bound: the cap aborts this GET (the
+      # deadline-bounded resumption loop handles any retry).
+      stub_request(:get, "#{base_url}#{endpoint}")
+        .with(headers: { 'Last-Event-ID' => 'evt-1' })
+        .to_return(status: 200, body: 'a' * 4096,
+                   headers: { 'Content-Type' => 'text/event-stream' })
+
+      expect(server).to receive(:enforce_sse_buffer_cap!).at_least(:once).and_call_original
+
+      state = { cursor: 'evt-1', retry_ms: nil }
+      expect { server.send(:issue_resumption_get, state) }.not_to raise_error
+    end
+
+    it 'raises through enforce_sse_buffer_cap! when the buffer exceeds the cap' do
+      stub_const('MCPClient::ServerStreamableHTTP::MAX_SSE_BUFFER_BYTES', 1024)
+
+      expect { server.send(:enforce_sse_buffer_cap!, +'a' * 2048) }
+        .to raise_error(MCPClient::Errors::ConnectionError, /buffer/i)
+    end
+  end
+
   describe 'polling pattern: stream closed before the response' do
     it 'resumes via GET with Last-Event-ID instead of re-POSTing' do
       # POST answers with a priming event (id, no data) and a fast retry


### PR DESCRIPTION
## Summary

Security fix for two medium-severity findings from a codex-security scan (`csf_326917c0`, `csf_9c01b079`, `resource-exhaustion.unterminated-sse-buffer`).

Two SSE parse buffers in `ServerStreamableHTTP` grew without bound while waiting for a blank-line event terminator:

1. **GET events stream** — `process_event_chunk` appended every chunk to `@buffer`, removing bytes only after a complete event was found. A peer could continuously send delimiter-free chunks (each arriving before the socket inactivity timeout) and grow host memory until exhaustion.
2. **Resumption GET** — `issue_resumption_get` accumulated chunks in a local buffer with no size cap and no byte budget inside the blocking request, so a peer could keep the socket active with delimiter-free replay data and exhaust the resumption worker.

## Fix

- New `MAX_SSE_BUFFER_BYTES` (32 MiB) bounds *unprocessed partial-event* bytes in both paths, enforced by a shared `enforce_sse_buffer_cap!` helper. Complete events inside an oversized chunk are still extracted before the check, so legitimate large events are unaffected.
- Events stream: on overflow the buffer is dropped and `ConnectionError` propagates to the events loop, which treats it like any connection failure (reconnect with existing backoff).
- Resumption GET: on overflow the GET aborts (rescued by the existing `StandardError` handler); the deadline-bounded resumption loop decides whether to retry, with a fresh buffer per attempt.

## Testing

- New specs: unterminated events-stream data beyond the (stubbed) cap raises and empties the buffer; terminated oversized events still parse; delimiter-free resumption data trips the cap and aborts the GET without raising out of the worker.
- Full suite: 1610 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)