### PR TITLE
Floor server retry directives on the events stream to prevent reconnect storms

### DIFF
--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -33,6 +33,14 @@ module MCPClient
     SSE_MAX_RECONNECT_DELAY = 30   # Maximum reconnect delay in seconds
     THREAD_JOIN_TIMEOUT = 5 # Timeout for thread cleanup
 
+    # Floor for server-supplied retry directives on the long-lived events
+    # stream. The directive is peer-controlled: honoring "retry: 0" literally
+    # would let a hostile server that closes every stream drive a tight
+    # reconnect loop (sustained CPU/TLS/connection churn). Waiting longer
+    # than the directive stays SEP-1699 compliant — the retry field is a
+    # lower bound on the reconnect delay, not an exact schedule.
+    MIN_EVENTS_RECONNECT_DELAY = 0.1
+
     # @!attribute [r] base_url
     #   @return [String] The base URL of the MCP server
     # @!attribute [r] endpoint
@@ -723,12 +731,17 @@ module MCPClient
     end
 
     # Reconnect delay for the events stream: the server's SSE retry directive
-    # (in ms) when present, otherwise the caller's backoff value.
+    # (in ms) when present, otherwise the caller's backoff value. The
+    # peer-controlled directive is floored at MIN_EVENTS_RECONNECT_DELAY so a
+    # zero/near-zero value cannot drive a tight reconnect loop; the
+    # deadline-bounded resumption loop intentionally keeps honoring zero.
     # @param fallback_seconds [Numeric] exponential-backoff fallback
     # @return [Numeric] delay in seconds
     def events_reconnect_delay(fallback_seconds)
       retry_ms = @sse_retry_ms
-      retry_ms ? retry_ms / 1000.0 : fallback_seconds
+      return fallback_seconds unless retry_ms
+
+      [retry_ms / 1000.0, MIN_EVENTS_RECONNECT_DELAY].max
     end
 
     # Wait for a response replayed after the POST stream was closed before

--- a/spec/lib/mcp_client/streamable_resumability_spec.rb
+++ b/spec/lib/mcp_client/streamable_resumability_spec.rb
@@ -95,11 +95,24 @@ RSpec.describe 'Streamable HTTP resumability (SEP-1699)' do
       expect(server.send(:events_reconnect_delay, 4)).to eq(4)
     end
 
-    it 'accepts retry: 0 as a valid immediate-reconnect directive' do
+    it 'parses retry: 0 but floors the events reconnect delay to the safety minimum' do
+      # retry: 0 is a valid SSE directive (and stays an immediate-poll signal
+      # for the deadline-bounded resumption loop), but the long-lived events
+      # loop must not honor it literally: a hostile server repeatedly closing
+      # the stream with retry: 0 would otherwise drive a tight reconnect loop.
+      # Waiting LONGER than the directive stays SEP-1699 compliant ("waiting
+      # the given number of milliseconds" is a lower bound).
       server.send(:parse_and_handle_event, "retry: 0\ndata: \n")
 
       expect(server.instance_variable_get(:@sse_retry_ms)).to eq(0)
-      expect(server.send(:events_reconnect_delay, 4)).to eq(0)
+      expect(server.send(:events_reconnect_delay, 4))
+        .to eq(MCPClient::ServerStreamableHTTP::MIN_EVENTS_RECONNECT_DELAY)
+    end
+
+    it 'floors sub-minimum retry directives to the safety minimum' do
+      server.instance_variable_set(:@sse_retry_ms, 10)
+      expect(server.send(:events_reconnect_delay, 4))
+        .to eq(MCPClient::ServerStreamableHTTP::MIN_EVENTS_RECONNECT_DELAY)
     end
 
     it 'resumes with the closed stream own cursor, not the shared one' do


### PR DESCRIPTION
## Summary

Security fix for a medium-severity finding from a codex-security scan (`csf_16ba60d1`, `resource-exhaustion.zero-delay-reconnect`).

`events_reconnect_delay` honored the server's SSE `retry:` directive literally and preferred it over the exponential-backoff fallback. A malicious server could return `retry: 0` and close each events stream immediately, driving a tight reconnect loop — sustained CPU, TLS-handshake, and connection churn with no backoff for as long as the client stayed connected.

## Fix

- New `MIN_EVENTS_RECONNECT_DELAY` (100 ms) floors peer-supplied retry directives on the long-lived GET events stream.
- Directives ≥ 100 ms are honored exactly as before; only zero/near-zero values are floored, bounding worst-case churn at 10 reconnects/second instead of a busy loop.
- Spec compliance: SEP-1699 says the client MUST wait "the given number of milliseconds before attempting to reconnect" — the retry field is a lower bound, so waiting longer remains compliant. The existing spec that asserted a literal `0` delay is updated accordingly (parsing `retry: 0` as *valid* is unchanged).
- The SEP-1699 resumption loop intentionally keeps honoring `retry: 0` for the documented immediate-poll pattern — it is already bounded by the request deadline.

## Testing

- Updated/new specs: `retry: 0` still parses but the events reconnect delay floors to the minimum; a 10 ms directive floors as well; a 250 ms directive is honored exactly (existing spec, unchanged).
- Full suite: 1607 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)