### PR TITLE
Bound server-initiated response POST threads

### DIFF
--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -33,6 +33,14 @@ module MCPClient
     SSE_MAX_RECONNECT_DELAY = 30   # Maximum reconnect delay in seconds
     THREAD_JOIN_TIMEOUT = 5 # Timeout for thread cleanup
 
+    # Ceiling on concurrent threads POSTing server-initiated responses
+    # (pongs, roots/sampling/elicitation replies, error responses). Each
+    # server request on the events stream costs one blocking HTTP POST in
+    # its own thread; without a bound, a peer flooding requests could
+    # accumulate threads and connections until the host is exhausted.
+    # Responses beyond the budget are dropped with a warning.
+    MAX_CONCURRENT_RESPONSE_POSTS = 8
+
     # @!attribute [r] base_url
     #   @return [String] The base URL of the MCP server
     # @!attribute [r] endpoint
@@ -113,6 +121,7 @@ module MCPClient
       @last_event_id = nil
       @sse_retry_ms = nil
       @pending_stream_responses = {}
+      @response_post_count = 0
       @oauth_provider = opts[:oauth_provider]
 
       # SSE events connection state
@@ -985,26 +994,9 @@ module MCPClient
         result: {}
       }
 
-      # Send pong response in a separate thread to avoid blocking event processing
-      Thread.new do
-        conn = http_connection
-        response = conn.post(@endpoint) do |req|
-          @headers.each { |k, v| req.headers[k] = v }
-          req.headers['Mcp-Session-Id'] = @session_id if @session_id
-          req.headers['Mcp-Protocol-Version'] = @protocol_version if @protocol_version
-          # MCP: authorization MUST be included in every HTTP request
-          @oauth_provider&.apply_authorization(req)
-          req.body = pong_response.to_json
-        end
-
-        if response.success?
-          @logger.debug("Sent pong response for ping ID: #{ping_id}") if @logger.level <= Logger::DEBUG
-        else
-          @logger.warn("Failed to send pong response: HTTP #{response.status}")
-        end
-      rescue StandardError => e
-        @logger.error("Failed to send pong response: #{e.message}")
-      end
+      # Pongs go through the same bounded response path as every other
+      # server-initiated reply, so a ping flood cannot fan out threads.
+      post_jsonrpc_response(pong_response)
     end
 
     # Handle incoming JSON-RPC request from server (MCP 2025-06-18)
@@ -1184,7 +1176,17 @@ module MCPClient
     # @return [void]
     # @private
     def post_jsonrpc_response(response)
-      # Send response in a separate thread to avoid blocking event processing
+      # Send the response in a separate thread to avoid blocking event
+      # processing, but never beyond the concurrency budget: server requests
+      # arrive at the peer's rate, and each unanswered POST would otherwise
+      # pin one thread and one connection.
+      unless acquire_response_post_slot
+        response_id = response[:id] || response['id']
+        @logger.warn("Dropping server-initiated response #{response_id.inspect}: " \
+                     "#{MAX_CONCURRENT_RESPONSE_POSTS} response POSTs already in flight")
+        return
+      end
+
       Thread.new do
         conn = http_connection
         json_body = JSON.generate(response)
@@ -1205,7 +1207,26 @@ module MCPClient
         end
       rescue StandardError => e
         @logger.error("Failed to send JSON-RPC response: #{e.message}")
+      ensure
+        release_response_post_slot
       end
+    end
+
+    # Reserve one slot of the response-POST concurrency budget.
+    # @return [Boolean] whether a slot was available
+    def acquire_response_post_slot
+      @mutex.synchronize do
+        return false if @response_post_count >= MAX_CONCURRENT_RESPONSE_POSTS
+
+        @response_post_count += 1
+        true
+      end
+    end
+
+    # Release a slot reserved by acquire_response_post_slot.
+    # @return [void]
+    def release_response_post_slot
+      @mutex.synchronize { @response_post_count -= 1 }
     end
   end
 end

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -38,8 +38,12 @@ module MCPClient
     # server request on the events stream costs one blocking HTTP POST in
     # its own thread; without a bound, a peer flooding requests could
     # accumulate threads and connections until the host is exhausted.
-    # Responses beyond the budget are dropped with a warning.
+    # Responses beyond the budget are dropped, with saturation logged at most
+    # once per SATURATION_LOG_INTERVAL seconds.
     MAX_CONCURRENT_RESPONSE_POSTS = 8
+
+    # Minimum gap between "response budget saturated" warnings
+    SATURATION_LOG_INTERVAL = 5
 
     # @!attribute [r] base_url
     #   @return [String] The base URL of the MCP server
@@ -122,6 +126,9 @@ module MCPClient
       @sse_retry_ms = nil
       @pending_stream_responses = {}
       @response_post_count = 0
+      # Saturation bookkeeping for the response-POST budget
+      @dropped_response_posts = 0
+      @last_saturation_log_at = nil
       @oauth_provider = opts[:oauth_provider]
 
       # SSE events connection state
@@ -1181,12 +1188,26 @@ module MCPClient
       # arrive at the peer's rate, and each unanswered POST would otherwise
       # pin one thread and one connection.
       unless acquire_response_post_slot
-        response_id = response[:id] || response['id']
-        @logger.warn("Dropping server-initiated response #{response_id.inspect}: " \
-                     "#{MAX_CONCURRENT_RESPONSE_POSTS} response POSTs already in flight")
+        log_response_post_saturation
         return
       end
 
+      begin
+        start_response_post_thread(response)
+      rescue ThreadError => e
+        # Thread.new failed, so the ensure inside the block never runs and the
+        # reservation would leak. Eight such failures would silently mute this
+        # instance's replies for the rest of its life, including after
+        # reconnect (cleanup does not reset the counter).
+        release_response_post_slot
+        @logger.error("Failed to start response POST thread: #{e.message}")
+      end
+    end
+
+    # Spawn the worker that POSTs one server-initiated response.
+    # @param response [Hash] the JSON-RPC response
+    # @return [Thread]
+    def start_response_post_thread(response)
       Thread.new do
         conn = http_connection
         json_body = JSON.generate(response)
@@ -1210,6 +1231,29 @@ module MCPClient
       ensure
         release_response_post_slot
       end
+    end
+
+    # Warn that the response-POST budget is saturated, at most once per
+    # SATURATION_LOG_INTERVAL.
+    #
+    # The peer controls how often this path is reached, so logging every
+    # rejection (at WARN, which the default logger emits) would just trade a
+    # thread-exhaustion vector for a log-volume one. The peer-supplied request
+    # id is deliberately omitted for the same reason.
+    # @return [void]
+    def log_response_post_saturation
+      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      dropped = @mutex.synchronize do
+        @dropped_response_posts += 1
+        next nil if @last_saturation_log_at && now - @last_saturation_log_at < SATURATION_LOG_INTERVAL
+
+        @last_saturation_log_at = now
+        @dropped_response_posts
+      end
+      return unless dropped
+
+      @logger.warn("Dropping server-initiated responses: #{MAX_CONCURRENT_RESPONSE_POSTS} " \
+                   "response POSTs already in flight (#{dropped} dropped so far)")
     end
 
     # Reserve one slot of the response-POST concurrency budget.

--- a/spec/lib/mcp_client/server_streamable_http_spec.rb
+++ b/spec/lib/mcp_client/server_streamable_http_spec.rb
@@ -1326,6 +1326,35 @@ RSpec.describe MCPClient::ServerStreamableHTTP do
   describe 'server-initiated response POST bounding' do
     let(:budget) { MCPClient::ServerStreamableHTTP::MAX_CONCURRENT_RESPONSE_POSTS }
 
+    it 'releases the slot when the worker thread cannot be created' do
+      # The release lives in the thread's ensure block, so a Thread.new failure
+      # would leak the reservation; eight of those would mute this instance
+      # permanently, surviving reconnects.
+      allow(server).to receive(:start_response_post_thread).and_raise(ThreadError, 'cannot create thread')
+
+      server.send(:post_jsonrpc_response, { 'jsonrpc' => '2.0', 'id' => 1, 'result' => {} })
+
+      expect(server.instance_variable_get(:@response_post_count)).to eq(0)
+    end
+
+    it 'rate-limits saturation warnings and omits the peer-supplied id' do
+      # The peer chooses how often this path is hit, so logging every drop
+      # would swap a thread-exhaustion vector for a log-volume one.
+      server.instance_variable_set(:@response_post_count, budget)
+      logger = server.instance_variable_get(:@logger)
+      warnings = []
+      allow(logger).to receive(:warn) { |msg| warnings << msg }
+
+      20.times { |i| server.send(:post_jsonrpc_response, { 'jsonrpc' => '2.0', 'id' => "peer-#{i}", 'result' => {} }) }
+
+      # 20 drops produce a single warning; the cumulative counter is what
+      # makes the suppressed ones visible in a later one.
+      expect(warnings.size).to eq(1)
+      expect(warnings.first).not_to include('peer-')
+      expect(warnings.first).to match(/dropped so far/)
+      expect(server.instance_variable_get(:@dropped_response_posts)).to eq(20)
+    end
+
     it 'drops a JSON-RPC response instead of spawning a thread when the budget is exhausted' do
       # Each server-initiated request costs one blocking HTTP POST in its own
       # thread; without a bound a peer flooding requests on the events stream

--- a/spec/lib/mcp_client/server_streamable_http_spec.rb
+++ b/spec/lib/mcp_client/server_streamable_http_spec.rb
@@ -1323,6 +1323,41 @@ RSpec.describe MCPClient::ServerStreamableHTTP do
     end
   end
 
+  describe 'server-initiated response POST bounding' do
+    let(:budget) { MCPClient::ServerStreamableHTTP::MAX_CONCURRENT_RESPONSE_POSTS }
+
+    it 'drops a JSON-RPC response instead of spawning a thread when the budget is exhausted' do
+      # Each server-initiated request costs one blocking HTTP POST in its own
+      # thread; without a bound a peer flooding requests on the events stream
+      # could exhaust host threads.
+      server.instance_variable_set(:@response_post_count, budget)
+
+      expect(Thread).not_to receive(:new)
+      expect(server.instance_variable_get(:@logger)).to receive(:warn).with(/[Dd]ropping/)
+
+      server.send(:post_jsonrpc_response, { 'jsonrpc' => '2.0', 'id' => 9, 'result' => {} })
+    end
+
+    it 'drops a pong instead of spawning a thread when the budget is exhausted' do
+      server.instance_variable_set(:@response_post_count, budget)
+
+      expect(Thread).not_to receive(:new)
+      expect(server.instance_variable_get(:@logger)).to receive(:warn).with(/[Dd]ropping/)
+
+      server.send(:handle_ping_request, 'ping-1')
+    end
+
+    it 'releases the slot once the response POST completes' do
+      stub_request(:post, "#{base_url}#{endpoint}").to_return(status: 200, body: '')
+
+      server.send(:post_jsonrpc_response, { 'jsonrpc' => '2.0', 'id' => 3, 'result' => {} })
+
+      deadline = Time.now + 2
+      sleep 0.05 while server.instance_variable_get(:@response_post_count).positive? && Time.now < deadline
+      expect(server.instance_variable_get(:@response_post_count)).to eq(0)
+    end
+  end
+
   describe 'security validation' do
     # Session ID and URL validation tests are shared with HTTP transport
     # through the HttpTransportBase module, so we just verify they work here


### PR DESCRIPTION
## Summary

Security fix for two medium-severity findings from a codex-security scan (`csf_2c81df29`, `csf_19a3c0f2`, `resource-exhaustion.unbounded-thread-fanout`).

In `ServerStreamableHTTP`, every server-initiated message needing a reply spawned an untracked `Thread.new` performing a blocking HTTP POST:

- `handle_ping_request` created one thread per remotely supplied ping, and
- `post_jsonrpc_response` created one thread per roots/sampling/elicitation reply and per error response (including `-32601` replies to *unknown* methods — so arbitrary garbage requests also fanned out threads).

No pool, semaphore, or queue bounded the fan-out, so a peer flooding requests on the events stream (or holding reply POSTs open) could accumulate Ruby threads and connections until the host was exhausted.

## Fix

- Pongs now go through `post_jsonrpc_response`, removing the duplicated POST code and second spawn site; wire behavior (headers, body, endpoint) is unchanged.
- That single path is gated by a concurrency budget: `MAX_CONCURRENT_RESPONSE_POSTS` (8). A slot is acquired before spawning and released when the POST finishes; when the budget is exhausted the response is dropped with a warning — backpressure against a flooding peer, ample headroom for legitimate traffic.

## Testing

- New specs: at budget, neither a response nor a pong spawns a thread (and a drop warning is logged); the slot count returns to zero after a POST completes. The existing POST-SSE-stream ping spec still verifies pong wire format end-to-end.
- Full suite: 1609 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)