### PR TITLE
Never auto-retry non-idempotent tools/call requests

### DIFF
--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -33,7 +33,7 @@ module MCPClient
     def rpc_request(method, params = {}, timeout: nil)
       ensure_connected
 
-      with_retry do
+      with_retry(method) do
         request_id = @mutex.synchronize { @request_id += 1 }
         request = build_jsonrpc_request(method, params, request_id)
         begin

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -3,6 +3,14 @@
 module MCPClient
   # Shared retry/backoff logic for JSON-RPC transports
   module JsonRpcCommon
+    # JSON-RPC methods with arbitrary side effects that MUST NOT be re-sent
+    # automatically. Even a "transient" failure (5xx, dropped connection,
+    # malformed response) can arrive AFTER the server received the request,
+    # so a retry could execute the operation twice — and JSON-RPC has no
+    # idempotency key to make the duplicate safe. Callers who want to retry
+    # such an operation must decide that explicitly.
+    NON_IDEMPOTENT_METHODS = %w[tools/call].freeze
+
     # Execute the block with retry/backoff for transient errors only.
     #
     # Retries genuinely transient failures where the request most likely did not
@@ -14,10 +22,15 @@ module MCPClient
     # server received and processed (or deterministically rejected) the request.
     # Re-sending those would silently re-execute a non-idempotent operation
     # (e.g. a tools/call), which JSON-RPC provides no way to make safe.
+    #
+    # It also never retries a NON_IDEMPOTENT_METHODS request (pass the
+    # JSON-RPC method being sent): an ambiguous failure may follow server-side
+    # receipt, so those fail fast instead of risking a duplicate execution.
+    # @param method [String, nil] the JSON-RPC method the block sends
     # @yield block to execute
     # @return [Object] result of block
     # @raise original exception if max retries exceeded or the error is not retryable
-    def with_retry
+    def with_retry(method = nil)
       attempts = 0
       begin
         yield
@@ -26,6 +39,11 @@ module MCPClient
         # A timed-out request may still be executing server-side; re-sending
         # it could run a non-idempotent operation twice. Never retry those.
         raise if e.is_a?(MCPClient::Errors::RequestTimeoutError)
+
+        if NON_IDEMPOTENT_METHODS.include?(method)
+          @logger.debug("Not retrying non-idempotent #{method} after error: #{e.message}")
+          raise
+        end
 
         attempts += 1
         if attempts <= @max_retries

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -19,7 +19,7 @@ module MCPClient
       def rpc_request(method, params = {}, timeout: nil)
         ensure_initialized
 
-        with_retry do
+        with_retry(method) do
           request_id = @mutex.synchronize { @request_id += 1 }
           request = build_jsonrpc_request(method, params, request_id)
           begin

--- a/lib/mcp_client/server_stdio/json_rpc_transport.rb
+++ b/lib/mcp_client/server_stdio/json_rpc_transport.rb
@@ -118,7 +118,7 @@ module MCPClient
       # @raise [MCPClient::Errors::ToolCallError] on tool call errors
       def rpc_request(method, params = {}, timeout: nil)
         ensure_initialized
-        with_retry do
+        with_retry(method) do
           req_id = next_id
           req = build_jsonrpc_request(method, params, req_id)
           send_request(req)

--- a/spec/lib/mcp_client/http_transport_base_spec.rb
+++ b/spec/lib/mcp_client/http_transport_base_spec.rb
@@ -423,7 +423,7 @@ RSpec.describe MCPClient::HttpTransportBase do
         expect(calls).to eq(1)
       end
 
-      it 'retries a TransientServerError (HTTP 5xx) and can then succeed' do
+      it 'retries a TransientServerError (HTTP 5xx) on an idempotent method and can then succeed' do
         calls = 0
         allow(transport).to receive(:send_jsonrpc_request) do
           calls += 1
@@ -432,11 +432,11 @@ RSpec.describe MCPClient::HttpTransportBase do
           'ok'
         end
 
-        expect(transport.rpc_request('tools/call', {})).to eq('ok')
+        expect(transport.rpc_request('tools/list', {})).to eq('ok')
         expect(calls).to eq(3)
       end
 
-      it 'retries a transient transport (network) error and can then succeed' do
+      it 'retries a transient transport (network) error on an idempotent method and can then succeed' do
         calls = 0
         allow(transport).to receive(:send_jsonrpc_request) do
           calls += 1
@@ -445,8 +445,22 @@ RSpec.describe MCPClient::HttpTransportBase do
           'ok'
         end
 
-        expect(transport.rpc_request('tools/call', {})).to eq('ok')
+        expect(transport.rpc_request('tools/list', {})).to eq('ok')
         expect(calls).to eq(2)
+      end
+
+      it 'does not re-send a non-idempotent tools/call even for transient failures' do
+        # A 5xx or dropped connection can arrive AFTER the server received
+        # the request; re-POSTing tools/call could execute it twice.
+        calls = 0
+        allow(transport).to receive(:send_jsonrpc_request) do
+          calls += 1
+          raise MCPClient::Errors::TransientServerError, 'Server error: HTTP 503'
+        end
+
+        expect { transport.rpc_request('tools/call', {}) }
+          .to raise_error(MCPClient::Errors::TransientServerError)
+        expect(calls).to eq(1)
       end
     end
   end

--- a/spec/lib/mcp_client/server_sse_spec.rb
+++ b/spec/lib/mcp_client/server_sse_spec.rb
@@ -967,6 +967,24 @@ RSpec.describe MCPClient::ServerSSE do
       expect(call_count).to eq(2) # Verify it was called twice (one fail, one success)
     end
 
+    it 'does not retry a non-idempotent tools/call after an ambiguous failure' do
+      server.instance_variable_set(:@max_retries, 2)
+      server.instance_variable_set(:@retry_backoff, 0.01)
+
+      # The failure may have arrived after the server received the request;
+      # re-sending tools/call could execute the operation twice.
+      call_count = 0
+      allow(server).to receive(:send_jsonrpc_request) do
+        call_count += 1
+        raise MCPClient::Errors::TransportError, 'Network timeout'
+      end
+
+      expect { server.rpc_request('tools/call', { name: 't' }) }.to raise_error(
+        MCPClient::Errors::TransportError, /Network timeout/
+      )
+      expect(call_count).to eq(1)
+    end
+
     it 'gives up after max retries' do
       server.instance_variable_set(:@max_retries, 1)
       server.instance_variable_set(:@retry_backoff, 0.01) # Speed up tests

--- a/spec/lib/mcp_client/server_stdio_spec.rb
+++ b/spec/lib/mcp_client/server_stdio_spec.rb
@@ -384,6 +384,38 @@ RSpec.describe MCPClient::ServerStdio do
     end
   end
 
+  describe 'retry idempotency' do
+    let(:server) { described_class.new(command: command, retries: 2, retry_backoff: 0.01) }
+
+    before { allow(server).to receive(:ensure_initialized) }
+
+    it 'retries an idempotent request after a transient failure' do
+      call_count = 0
+      allow(server).to receive(:send_request) do
+        call_count += 1
+        raise MCPClient::Errors::TransportError, 'stdio pipe broke'
+      end
+
+      expect { server.rpc_request('tools/list') }.to raise_error(MCPClient::Errors::TransportError)
+      expect(call_count).to eq(3)
+    end
+
+    it 'does not retry a non-idempotent tools/call after an ambiguous failure' do
+      # The child process may have consumed the request before the pipe broke;
+      # re-sending tools/call could execute the operation twice.
+      call_count = 0
+      allow(server).to receive(:send_request) do
+        call_count += 1
+        raise MCPClient::Errors::TransportError, 'stdio pipe broke'
+      end
+
+      expect { server.rpc_request('tools/call', { 'name' => 't' }) }.to raise_error(
+        MCPClient::Errors::TransportError
+      )
+      expect(call_count).to eq(1)
+    end
+  end
+
   describe 'private methods' do
     describe '#next_id' do
       it 'generates sequential IDs' do

--- a/spec/lib/mcp_client/server_streamable_http/json_rpc_transport_spec.rb
+++ b/spec/lib/mcp_client/server_streamable_http/json_rpc_transport_spec.rb
@@ -269,6 +269,20 @@ RSpec.describe MCPClient::ServerStreamableHTTP::JsonRpcTransport do
         expect(result).to eq(response_data[:result])
         expect(@attempt_count).to eq(3)
       end
+
+      it 'does not retry a non-idempotent tools/call after an ambiguous failure' do
+        # A TransportError may arrive after the server received the request;
+        # re-POSTing tools/call could execute the operation twice.
+        allow(transport).to receive(:send_http_request) do
+          @attempt_count += 1
+          raise MCPClient::Errors::TransportError, 'Temporary failure'
+        end
+
+        expect { transport.rpc_request('tools/call', params) }.to raise_error(
+          MCPClient::Errors::TransportError, /Temporary failure/
+        )
+        expect(@attempt_count).to eq(1)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Batched security fix for four low-severity findings from the codex-security scan (`csf_11def2fd` SSE, `csf_a4cbaa88` Streamable HTTP, `csf_9f56a0b6` plain HTTP, `csf_a1df8a81` stdio — `request-replay.non-idempotent-retry`).

`with_retry` re-sent any request after failures classified as transient (HTTP 5xx → `TransientServerError`, `TransportError`, `IOError`, connection resets). But an "ambiguous" failure can arrive **after** the server received and started executing the request — so an automatic retry of `tools/call` could run a non-idempotent operation twice. JSON-RPC provides no idempotency key to make the duplicate safe, and `ServerHTTP` enables retries by default (`retries: 3`).

## Fix

- `with_retry` now takes the JSON-RPC method being sent; `rpc_request` passes it on all four transports.
- Methods in `NON_IDEMPOTENT_METHODS` (currently `tools/call`) fail fast on any error instead of being replayed. Everything else (`tools/list`, `resources/read`, `ping`, custom methods, …) retries exactly as before.
- This extends the existing posture (plain `ServerError` and `RequestTimeoutError` were already never retried, for the same reason) to cover the ambiguous-failure classes.

**Behavior change**: a `tools/call` that hits a 5xx or dropped connection now surfaces the error to the caller instead of silently re-POSTing. Two specs that asserted the old replay behavior are updated to use an idempotent method; new specs on each transport pin the fail-fast behavior.

## Testing

- New specs per transport (HTTP-base shared path, SSE, stdio): `tools/call` is attempted exactly once on transient failure; idempotent methods still retry to success.
- Full suite: 1611 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)