### PR TITLE
Bound server-supplied schema pattern matching with a timeout

### DIFF
--- a/lib/mcp_client/elicitation_validator.rb
+++ b/lib/mcp_client/elicitation_validator.rb
@@ -18,6 +18,11 @@ module MCPClient
     # Allowed string formats per MCP spec
     STRING_FORMATS = %w[email uri date date-time].freeze
 
+    # Wall-clock budget for matching one server-supplied `pattern`. The
+    # requestedSchema comes from the remote server, so an expensive
+    # expression must not be able to monopolize the calling thread.
+    PATTERN_MATCH_TIMEOUT = 1.0
+
     # Validate that a requestedSchema conforms to MCP elicitation constraints.
     # Returns an array of error messages (empty if valid).
     # @param schema [Hash] the requestedSchema
@@ -183,15 +188,7 @@ module MCPClient
         errors << "Field '#{field}' must be one of: #{allowed.join(', ')}" unless allowed.include?(value)
       end
 
-      if prop['pattern']
-        begin
-          unless value.match?(Regexp.new(prop['pattern']))
-            errors << "Field '#{field}' must match pattern '#{prop['pattern']}'"
-          end
-        rescue RegexpError
-          # Skip pattern validation if the pattern is invalid
-        end
-      end
+      errors.concat(validate_string_pattern(field, value, prop['pattern'])) if prop['pattern']
 
       if prop['minLength'] && value.length < prop['minLength']
         errors << "Field '#{field}' must be at least #{prop['minLength']} characters"
@@ -204,6 +201,27 @@ module MCPClient
       errors.concat(validate_string_format(field, value, prop['format']))
 
       errors
+    end
+
+    # Validate a string value against the schema's regular-expression pattern.
+    # An invalid pattern is not enforced (unchanged behavior), but matching
+    # runs under PATTERN_MATCH_TIMEOUT because the pattern comes from the
+    # remote server. A match that exceeds the budget is reported as a
+    # validation error rather than silently accepted — the value was never
+    # shown to satisfy the constraint.
+    # @param field [String] field name
+    # @param value [String] the value
+    # @param pattern [String] the declared pattern
+    # @return [Array<String>] validation errors
+    def self.validate_string_pattern(field, value, pattern)
+      return [] if value.match?(Regexp.new(pattern, timeout: PATTERN_MATCH_TIMEOUT))
+
+      ["Field '#{field}' must match pattern '#{pattern}'"]
+    rescue Regexp::TimeoutError
+      ["Field '#{field}' pattern '#{pattern}' timed out after #{PATTERN_MATCH_TIMEOUT}s"]
+    rescue RegexpError
+      # Skip pattern validation if the pattern is invalid
+      []
     end
 
     # Validate a string value against the schema's format constraint.

--- a/lib/mcp_client/elicitation_validator.rb
+++ b/lib/mcp_client/elicitation_validator.rb
@@ -18,10 +18,17 @@ module MCPClient
     # Allowed string formats per MCP spec
     STRING_FORMATS = %w[email uri date date-time].freeze
 
-    # Wall-clock budget for matching one server-supplied `pattern`. The
-    # requestedSchema comes from the remote server, so an expensive
+    # Wall-clock budget for ALL pattern matching in a single validate_content
+    # call. The requestedSchema comes from the remote server, so an expensive
     # expression must not be able to monopolize the calling thread.
+    #
+    # The budget covers the whole operation, not each match: a per-match limit
+    # multiplies, since the server also controls how many fields it declares.
     PATTERN_MATCH_TIMEOUT = 1.0
+
+    # Floor for an individual match, so a nearly-exhausted budget still makes
+    # progress rather than failing every remaining field.
+    MIN_PATTERN_MATCH_TIMEOUT = 0.01
 
     # Validate that a requestedSchema conforms to MCP elicitation constraints.
     # Returns an array of error messages (empty if valid).
@@ -123,6 +130,9 @@ module MCPClient
       errors = []
       return errors unless content.is_a?(Hash) && schema.is_a?(Hash)
 
+      # One deadline covers every field's pattern in this call.
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + PATTERN_MATCH_TIMEOUT
+
       properties = schema['properties'] || {}
       required = Array(schema['required'])
 
@@ -137,7 +147,7 @@ module MCPClient
         prop = properties[field.to_s]
         next unless prop.is_a?(Hash)
 
-        errors.concat(validate_value(field.to_s, value, prop))
+        errors.concat(validate_value(field.to_s, value, prop, deadline))
       end
 
       errors
@@ -148,13 +158,13 @@ module MCPClient
     # @param value [Object] the value to validate
     # @param prop [Hash] property schema
     # @return [Array<String>] validation errors
-    def self.validate_value(field, value, prop)
+    def self.validate_value(field, value, prop, deadline = nil)
       errors = []
       type = prop['type']
 
       case type
       when 'string'
-        errors.concat(validate_string_value(field, value, prop))
+        errors.concat(validate_string_value(field, value, prop, deadline))
       when 'number', 'integer'
         errors.concat(validate_number_value(field, value, prop))
       when 'boolean'
@@ -171,7 +181,7 @@ module MCPClient
     # @param value [Object] the value
     # @param prop [Hash] property schema
     # @return [Array<String>] validation errors
-    def self.validate_string_value(field, value, prop)
+    def self.validate_string_value(field, value, prop, deadline = nil)
       errors = []
 
       unless value.is_a?(String)
@@ -188,7 +198,7 @@ module MCPClient
         errors << "Field '#{field}' must be one of: #{allowed.join(', ')}" unless allowed.include?(value)
       end
 
-      errors.concat(validate_string_pattern(field, value, prop['pattern'])) if prop['pattern']
+      errors.concat(validate_string_pattern(field, value, prop['pattern'], deadline)) if prop['pattern']
 
       if prop['minLength'] && value.length < prop['minLength']
         errors << "Field '#{field}' must be at least #{prop['minLength']} characters"
@@ -213,15 +223,30 @@ module MCPClient
     # @param value [String] the value
     # @param pattern [String] the declared pattern
     # @return [Array<String>] validation errors
-    def self.validate_string_pattern(field, value, pattern)
-      return [] if value.match?(Regexp.new(pattern, timeout: PATTERN_MATCH_TIMEOUT))
+    def self.validate_string_pattern(field, value, pattern, deadline = nil)
+      remaining = pattern_budget_remaining(deadline)
+      return ["Field '#{field}' pattern matching budget exhausted"] if remaining.zero?
+
+      return [] if value.match?(Regexp.new(pattern, timeout: remaining))
 
       ["Field '#{field}' must match pattern '#{pattern}'"]
     rescue Regexp::TimeoutError
-      ["Field '#{field}' pattern '#{pattern}' timed out after #{PATTERN_MATCH_TIMEOUT}s"]
+      ["Field '#{field}' pattern '#{pattern}' exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"]
     rescue RegexpError
       # Skip pattern validation if the pattern is invalid
       []
+    end
+
+    # Time left in the validation-wide pattern budget.
+    # @param deadline [Float, nil] monotonic deadline, or nil for a lone match
+    # @return [Float] seconds available for the next match; 0.0 when exhausted
+    def self.pattern_budget_remaining(deadline)
+      return PATTERN_MATCH_TIMEOUT unless deadline
+
+      remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      return 0.0 if remaining <= 0
+
+      [remaining, MIN_PATTERN_MATCH_TIMEOUT].max
     end
 
     # Validate a string value against the schema's format constraint.

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -35,6 +35,11 @@ module MCPClient
       unevaluatedProperties unevaluatedItems
     ].freeze
 
+    # Wall-clock budget for matching one server-supplied `pattern`. Schemas
+    # come from the remote server, so an expensive expression must not be able
+    # to monopolize the calling thread.
+    PATTERN_MATCH_TIMEOUT = 1.0
+
     # Keywords whose value is a single subschema to walk.
     SUBSCHEMA_KEYWORDS = %w[
       items contains additionalProperties propertyNames not if then else
@@ -247,15 +252,23 @@ module MCPClient
 
     # Validate a string against a regular-expression pattern.
     # Invalid patterns are not enforced.
+    #
+    # The pattern comes from the tool's outputSchema, i.e. from the remote
+    # server, so matching runs under PATTERN_MATCH_TIMEOUT: an expensive
+    # expression cannot pin the calling thread indefinitely. A match that
+    # exceeds the budget is reported as a validation error rather than
+    # silently accepted — the value was never shown to satisfy the schema.
     # @param data [String] the string
     # @param pattern [Object] the pattern keyword value
     # @param path [String] location for error messages
     # @return [Array<String>] validation errors
     def self.validate_pattern(data, pattern, path)
       return [] unless pattern.is_a?(String)
-      return [] if data.match?(Regexp.new(pattern))
+      return [] if data.match?(Regexp.new(pattern, timeout: PATTERN_MATCH_TIMEOUT))
 
       ["#{path}: string does not match pattern #{pattern.inspect}"]
+    rescue Regexp::TimeoutError
+      ["#{path}: pattern #{pattern.inspect} timed out after #{PATTERN_MATCH_TIMEOUT}s"]
     rescue RegexpError
       []
     end

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -35,10 +35,18 @@ module MCPClient
       unevaluatedProperties unevaluatedItems
     ].freeze
 
-    # Wall-clock budget for matching one server-supplied `pattern`. Schemas
-    # come from the remote server, so an expensive expression must not be able
-    # to monopolize the calling thread.
+    # Wall-clock budget for ALL pattern matching in a single validate call.
+    # Schemas come from the remote server, so an expensive expression must not
+    # be able to monopolize the calling thread.
+    #
+    # The budget is for the whole operation, not per match: a per-match limit
+    # multiplies, since the server also controls how many strings it sends
+    # (N array items under one pathological items.pattern costs N x limit).
     PATTERN_MATCH_TIMEOUT = 1.0
+
+    # Floor for an individual match's timeout, so a nearly-exhausted budget
+    # still makes progress rather than failing every remaining pattern.
+    MIN_PATTERN_MATCH_TIMEOUT = 0.01
 
     # Keywords whose value is a single subschema to walk.
     SUBSCHEMA_KEYWORDS = %w[
@@ -90,17 +98,20 @@ module MCPClient
     # @param schema [Hash] the JSON schema
     # @param path [String] JSON-pointer-style location used in error messages
     # @return [Array<String>] human-readable validation errors (empty if valid)
-    def self.validate(data, schema, path: '#')
+    def self.validate(data, schema, path: '#', deadline: nil)
       return [] unless schema.is_a?(Hash)
+
+      # One deadline covers the entire (recursive) validation.
+      deadline ||= Process.clock_gettime(Process::CLOCK_MONOTONIC) + PATTERN_MATCH_TIMEOUT
 
       schema = schema.transform_keys(&:to_s)
       errors = []
       errors.concat(validate_type(data, schema['type'], path)) if schema.key?('type')
       errors.concat(validate_enum(data, schema, path))
       case data
-      when Hash then errors.concat(validate_object(data, schema, path))
-      when Array then errors.concat(validate_array(data, schema, path))
-      when String then errors.concat(validate_string(data, schema, path))
+      when Hash then errors.concat(validate_object(data, schema, path, deadline))
+      when Array then errors.concat(validate_array(data, schema, path, deadline))
+      when String then errors.concat(validate_string(data, schema, path, deadline))
       when Numeric then errors.concat(validate_number(data, schema, path))
       end
       errors
@@ -184,7 +195,7 @@ module MCPClient
     # @param schema [Hash] string-keyed schema
     # @param path [String] location for error messages
     # @return [Array<String>] validation errors
-    def self.validate_object(data, schema, path)
+    def self.validate_object(data, schema, path, deadline = nil)
       errors = []
       Array(schema['required']).each do |raw_name|
         name = raw_name.to_s
@@ -204,7 +215,7 @@ module MCPClient
               end
         next if key.nil?
 
-        errors.concat(validate(data[key], prop_schema, path: "#{path}/#{name}"))
+        errors.concat(validate(data[key], prop_schema, path: "#{path}/#{name}", deadline: deadline))
       end
       errors
     end
@@ -214,7 +225,7 @@ module MCPClient
     # @param schema [Hash] string-keyed schema
     # @param path [String] location for error messages
     # @return [Array<String>] validation errors
-    def self.validate_array(data, schema, path)
+    def self.validate_array(data, schema, path, deadline = nil)
       errors = []
       min_items = schema['minItems']
       max_items = schema['maxItems']
@@ -226,7 +237,9 @@ module MCPClient
       end
       items = schema['items']
       if items.is_a?(Hash)
-        data.each_with_index { |item, idx| errors.concat(validate(item, items, path: "#{path}/#{idx}")) }
+        data.each_with_index do |item, idx|
+          errors.concat(validate(item, items, path: "#{path}/#{idx}", deadline: deadline))
+        end
       end
       errors
     end
@@ -236,7 +249,7 @@ module MCPClient
     # @param schema [Hash] string-keyed schema
     # @param path [String] location for error messages
     # @return [Array<String>] validation errors
-    def self.validate_string(data, schema, path)
+    def self.validate_string(data, schema, path, deadline = nil)
       errors = []
       min_length = schema['minLength']
       max_length = schema['maxLength']
@@ -246,7 +259,7 @@ module MCPClient
       if max_length.is_a?(Numeric) && data.length > max_length
         errors << "#{path}: string is longer than maxLength #{max_length}"
       end
-      errors.concat(validate_pattern(data, schema['pattern'], path))
+      errors.concat(validate_pattern(data, schema['pattern'], path, deadline))
       errors
     end
 
@@ -254,23 +267,41 @@ module MCPClient
     # Invalid patterns are not enforced.
     #
     # The pattern comes from the tool's outputSchema, i.e. from the remote
-    # server, so matching runs under PATTERN_MATCH_TIMEOUT: an expensive
-    # expression cannot pin the calling thread indefinitely. A match that
-    # exceeds the budget is reported as a validation error rather than
-    # silently accepted — the value was never shown to satisfy the schema.
+    # server, so matching runs against the validation-wide deadline: neither a
+    # single expensive expression nor many cheap-looking ones can pin the
+    # calling thread. A match that exceeds the budget is reported as a
+    # validation error rather than silently accepted — the value was never
+    # shown to satisfy the schema.
     # @param data [String] the string
     # @param pattern [Object] the pattern keyword value
     # @param path [String] location for error messages
+    # @param deadline [Float, nil] monotonic deadline for the whole validation
     # @return [Array<String>] validation errors
-    def self.validate_pattern(data, pattern, path)
+    def self.validate_pattern(data, pattern, path, deadline = nil)
       return [] unless pattern.is_a?(String)
-      return [] if data.match?(Regexp.new(pattern, timeout: PATTERN_MATCH_TIMEOUT))
+
+      remaining = pattern_budget_remaining(deadline)
+      return ["#{path}: pattern matching budget exhausted before #{pattern.inspect}"] if remaining.zero?
+
+      return [] if data.match?(Regexp.new(pattern, timeout: remaining))
 
       ["#{path}: string does not match pattern #{pattern.inspect}"]
     rescue Regexp::TimeoutError
-      ["#{path}: pattern #{pattern.inspect} timed out after #{PATTERN_MATCH_TIMEOUT}s"]
+      ["#{path}: pattern #{pattern.inspect} exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"]
     rescue RegexpError
       []
+    end
+
+    # Time left in the validation-wide pattern budget.
+    # @param deadline [Float, nil] monotonic deadline, or nil for a lone match
+    # @return [Float] seconds available for the next match; 0.0 when exhausted
+    def self.pattern_budget_remaining(deadline)
+      return PATTERN_MATCH_TIMEOUT unless deadline
+
+      remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      return 0.0 if remaining <= 0
+
+      [remaining, MIN_PATTERN_MATCH_TIMEOUT].max
     end
 
     # Validate a number against inclusive/exclusive bounds.

--- a/spec/lib/mcp_client/elicitation_validator_spec.rb
+++ b/spec/lib/mcp_client/elicitation_validator_spec.rb
@@ -367,6 +367,33 @@ RSpec.describe MCPClient::ElicitationValidator do
         errors = described_class.validate_content({ 'version' => 'invalid' }, schema)
         expect(errors).to include(match(/must match pattern/))
       end
+
+      it 'compiles server-supplied patterns with a match timeout' do
+        # The elicitation schema comes from the remote server: an expensive
+        # expression must not be able to pin the CPU indefinitely.
+        compiled = nil
+        allow(Regexp).to receive(:new).and_wrap_original do |orig, *args, **kwargs|
+          compiled = orig.call(*args, **kwargs)
+        end
+
+        described_class.validate_content({ 'version' => 'v1.2.3' }, schema)
+
+        expect(compiled.timeout).to eq(MCPClient::ElicitationValidator::PATTERN_MATCH_TIMEOUT)
+      end
+
+      it 'reports an error instead of accepting the value when pattern matching times out' do
+        # Real timeout, no stubbing: an ambiguous alternation over a long
+        # input exceeds a tight budget, and the value must NOT be accepted
+        # just because the constraint could not be evaluated.
+        stub_const('MCPClient::ElicitationValidator::PATTERN_MATCH_TIMEOUT', 0.001)
+        slow_schema = {
+          'type' => 'object',
+          'properties' => { 'version' => { 'type' => 'string', 'pattern' => '\\A(a|b|ab)*\\z' } }
+        }
+
+        errors = described_class.validate_content({ 'version' => "#{'ab' * 20_000}c" }, slow_schema)
+        expect(errors).to include(match(/pattern.*timed out/i))
+      end
     end
 
     context 'number validation' do

--- a/spec/lib/mcp_client/elicitation_validator_spec.rb
+++ b/spec/lib/mcp_client/elicitation_validator_spec.rb
@@ -378,7 +378,8 @@ RSpec.describe MCPClient::ElicitationValidator do
 
         described_class.validate_content({ 'version' => 'v1.2.3' }, schema)
 
-        expect(compiled.timeout).to eq(MCPClient::ElicitationValidator::PATTERN_MATCH_TIMEOUT)
+        expect(compiled.timeout).to be > 0
+        expect(compiled.timeout).to be <= MCPClient::ElicitationValidator::PATTERN_MATCH_TIMEOUT
       end
 
       it 'reports an error instead of accepting the value when pattern matching times out' do
@@ -386,13 +387,27 @@ RSpec.describe MCPClient::ElicitationValidator do
         # input exceeds a tight budget, and the value must NOT be accepted
         # just because the constraint could not be evaluated.
         stub_const('MCPClient::ElicitationValidator::PATTERN_MATCH_TIMEOUT', 0.001)
+        stub_const('MCPClient::ElicitationValidator::MIN_PATTERN_MATCH_TIMEOUT', 0.0005)
         slow_schema = {
           'type' => 'object',
           'properties' => { 'version' => { 'type' => 'string', 'pattern' => '\\A(a|b|ab)*\\z' } }
         }
 
         errors = described_class.validate_content({ 'version' => "#{'ab' * 20_000}c" }, slow_schema)
-        expect(errors).to include(match(/pattern.*timed out/i))
+        expect(errors).to include(match(/pattern.*budget/i))
+      end
+
+      it 'bounds TOTAL pattern time across many fields, not per field' do
+        stub_const('MCPClient::ElicitationValidator::PATTERN_MATCH_TIMEOUT', 0.3)
+        props = (1..8).to_h { |i| ["f#{i}", { 'type' => 'string', 'pattern' => '\\A(a|b|ab)*\\z' }] }
+        content = (1..8).to_h { |i| ["f#{i}", "#{'ab' * 20_000}c"] }
+
+        started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        errors = described_class.validate_content(content, { 'type' => 'object', 'properties' => props })
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+        expect(elapsed).to be < 1.5
+        expect(errors).not_to be_empty
       end
     end
 

--- a/spec/lib/mcp_client/structured_content_validation_spec.rb
+++ b/spec/lib/mcp_client/structured_content_validation_spec.rb
@@ -59,6 +59,31 @@ RSpec.describe MCPClient::SchemaValidator do
       expect(described_class.validate('abcde', schema)).to contain_exactly(a_string_matching(/maxLength/))
     end
 
+    it 'compiles server-supplied patterns with a match timeout' do
+      # The pattern comes from the tool's outputSchema, i.e. from the remote
+      # server: an expensive expression must not be able to pin the CPU
+      # indefinitely.
+      compiled = nil
+      allow(Regexp).to receive(:new).and_wrap_original do |orig, *args, **kwargs|
+        compiled = orig.call(*args, **kwargs)
+      end
+
+      described_class.validate('abc', { 'type' => 'string', 'pattern' => '\\A[a-z]+\\z' })
+
+      expect(compiled.timeout).to eq(MCPClient::SchemaValidator::PATTERN_MATCH_TIMEOUT)
+    end
+
+    it 'reports an error instead of accepting the value when pattern matching times out' do
+      # Real timeout, no stubbing: an ambiguous alternation over a long input
+      # exceeds a tight budget, and the value must NOT be accepted just
+      # because the constraint could not be evaluated.
+      stub_const('MCPClient::SchemaValidator::PATTERN_MATCH_TIMEOUT', 0.001)
+      schema = { 'type' => 'string', 'pattern' => '\\A(a|b|ab)*\\z' }
+
+      expect(described_class.validate("#{'ab' * 20_000}c", schema))
+        .to contain_exactly(a_string_matching(/pattern.*timed out/i))
+    end
+
     it 'enforces string patterns' do
       schema = { 'type' => 'string', 'pattern' => '\\A[a-z]+\\z' }
       expect(described_class.validate('abc', schema)).to be_empty

--- a/spec/lib/mcp_client/structured_content_validation_spec.rb
+++ b/spec/lib/mcp_client/structured_content_validation_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe MCPClient::SchemaValidator do
 
       described_class.validate('abc', { 'type' => 'string', 'pattern' => '\\A[a-z]+\\z' })
 
-      expect(compiled.timeout).to eq(MCPClient::SchemaValidator::PATTERN_MATCH_TIMEOUT)
+      expect(compiled.timeout).to be > 0
+      expect(compiled.timeout).to be <= MCPClient::SchemaValidator::PATTERN_MATCH_TIMEOUT
     end
 
     it 'reports an error instead of accepting the value when pattern matching times out' do
@@ -78,10 +79,27 @@ RSpec.describe MCPClient::SchemaValidator do
       # exceeds a tight budget, and the value must NOT be accepted just
       # because the constraint could not be evaluated.
       stub_const('MCPClient::SchemaValidator::PATTERN_MATCH_TIMEOUT', 0.001)
+      stub_const('MCPClient::SchemaValidator::MIN_PATTERN_MATCH_TIMEOUT', 0.0005)
       schema = { 'type' => 'string', 'pattern' => '\\A(a|b|ab)*\\z' }
 
       expect(described_class.validate("#{'ab' * 20_000}c", schema))
-        .to contain_exactly(a_string_matching(/pattern.*timed out/i))
+        .to contain_exactly(a_string_matching(/pattern.*budget/i))
+    end
+
+    it 'bounds TOTAL pattern time across many items, not per match' do
+      # The server controls how many strings it sends as well as the pattern,
+      # so a per-match limit would multiply: N items x limit.
+      stub_const('MCPClient::SchemaValidator::PATTERN_MATCH_TIMEOUT', 0.3)
+      schema = { 'type' => 'array', 'items' => { 'type' => 'string', 'pattern' => '\\A(a|b|ab)*\\z' } }
+      data = Array.new(8) { "#{'ab' * 20_000}c" }
+
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      errors = described_class.validate(data, schema)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      # Without an aggregate budget this would take ~8 x 0.3s.
+      expect(elapsed).to be < 1.5
+      expect(errors).not_to be_empty
     end
 
     it 'enforces string patterns' do


### PR DESCRIPTION
## Summary

Batched security fix for two low-severity findings from the codex-security scan (`csf_4b941e97`, `csf_6b2310a1`, `redos.schema-pattern-validation`).

Both validators compiled and evaluated a `pattern` keyword taken directly from remote input with no time bound:

- `SchemaValidator.validate_pattern` — pattern comes from the tool's `outputSchema`, applied to every structured tool result.
- `ElicitationValidator.validate_string_value` — pattern comes from the server's elicitation `requestedSchema`.

A pathological expression could therefore monopolize the calling thread.

## Fix

- New `PATTERN_MATCH_TIMEOUT` (1.0s) on both validators; patterns are compiled with `Regexp.new(pattern, timeout:)`.
- A timeout now produces a **validation error**, not a skip. This matters: `Regexp::TimeoutError` descends from `RegexpError`, so the pre-existing "an invalid pattern is not enforced" rescue would have swallowed a timeout and *accepted* a value whose constraint was never evaluated. Genuinely invalid patterns keep the old unenforced behavior.
- The elicitation pattern check moved into its own `validate_string_pattern` helper so both call sites read the same way.

## Scoping note (updated after Codex review)

My original note here hedged that Ruby >= 3.2 memoizes regex backtracking and that I could not construct a payload that hangs on 3.3. That was too weak: memoization is bypassed by **backreferences**, and Codex found a pattern of the shape `\A((a|aa)*)\1+\z` that stayed stuck well beyond 2 seconds on main. The vulnerability is real in the strong sense, not merely defence-in-depth.

Codex also showed that a *per-match* timeout is not an overall bound, since the peer chooses how many strings are matched. The fix now applies a single deadline to the whole validation. See the review comment on this PR for the reproductions.

## Testing

- New specs on both validators: the compiled Regexp carries the timeout, and a real timeout (ambiguous alternation over a 40 KB input with a 1 ms stubbed budget — no mocking of the match itself) produces an error instead of silently accepting the value.
- Full suite: 1610 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
