### PR TITLE
Keep secrets and payloads out of logs; stop reflecting host errors to peers

### DIFF
--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -29,6 +29,20 @@ module MCPClient
     # :warn logs a warning on mismatch, :strict raises a ValidationError.
     STRUCTURED_CONTENT_MODES = %i[warn strict].freeze
 
+    # Server-config keys whose values carry credentials (HTTP headers, the
+    # subprocess environment, inline tokens). Their values are replaced before
+    # a config is written to the log.
+    SENSITIVE_CONFIG_KEYS = %i[headers env token access_token api_key auth authorization
+                               password secret client_secret oauth_provider].freeze
+
+    # Placeholder written in place of a redacted value.
+    REDACTED = '[REDACTED]'
+
+    # Maximum characters of a peer-supplied log message written to the host
+    # log. The remote server controls this content, so an unbounded message
+    # would let it inflate log storage at will.
+    MAX_PEER_LOG_MESSAGE_LENGTH = 4096
+
     # Initialize a new MCPClient::Client
     # @param mcp_server_configs [Array<Hash>] configurations for MCP servers
     # @param logger [Logger, nil] optional logger, defaults to STDOUT
@@ -65,7 +79,7 @@ module MCPClient
         @logger.formatter = proc { |severity, _datetime, progname, msg| "#{severity} [#{progname}] #{msg}\n" }
       end
       @servers = mcp_server_configs.map do |config|
-        @logger.debug("Creating server with config: #{config.inspect}")
+        @logger.debug("Creating server with config: #{redact_config(config).inspect}")
         MCPClient::ServerFactory.create(config, logger: @logger)
       end
       @tool_cache = {}
@@ -823,9 +837,10 @@ module MCPClient
       logger_name = params['logger']
       data = params['data']
 
-      # Format the message
-      prefix = logger_name ? "[#{server_id}:#{logger_name}]" : "[#{server_id}]"
-      message = data.is_a?(String) ? data : data.inspect
+      # Format the message. Both the logger name and the payload come from the
+      # remote server, so both are sanitized before they reach the host log.
+      prefix = logger_name ? "[#{server_id}:#{sanitize_peer_log_text(logger_name.to_s)}]" : "[#{server_id}]"
+      message = sanitize_peer_log_text(data.is_a?(String) ? data : data.inspect)
 
       # Map MCP log levels to Ruby Logger levels
       case level.to_s.downcase
@@ -839,6 +854,34 @@ module MCPClient
         logger.error("#{prefix} #{message}")
       else
         logger.info("#{prefix} [#{level}] #{message}")
+      end
+    end
+
+    # Make peer-supplied log text safe to write to the host log: control
+    # characters (notably newlines, which would let a server forge additional
+    # log entries) are escaped, and the result is capped.
+    # @param text [String] the peer-supplied text
+    # @return [String] sanitized, length-bounded text
+    def sanitize_peer_log_text(text)
+      escaped = text.gsub(/[ -]/) { |c| format('\\x%02X', c.ord) }
+      return escaped if escaped.length <= MAX_PEER_LOG_MESSAGE_LENGTH
+
+      "#{escaped[0, MAX_PEER_LOG_MESSAGE_LENGTH]}... (truncated from #{escaped.length} chars)"
+    end
+
+    # Copy of a server config with credential-bearing values replaced, for
+    # safe logging. Nested hashes (headers, env) have every value redacted;
+    # sensitive scalars are replaced outright.
+    # @param config [Hash, Object] a server configuration
+    # @return [Hash, Object] a redacted copy (non-Hash input is returned as-is)
+    def redact_config(config)
+      return config unless config.is_a?(Hash)
+
+      config.to_h do |key, value|
+        next [key, value] unless SENSITIVE_CONFIG_KEYS.include?(key.to_s.downcase.to_sym)
+
+        redacted = value.is_a?(Hash) ? value.transform_values { REDACTED } : REDACTED
+        [key, redacted]
       end
     end
 
@@ -1387,8 +1430,10 @@ module MCPClient
         @logger.debug(e.backtrace.join("\n"))
         # A handler exception is an internal client failure (-32603), not a
         # user rejection: sampling.mdx § Error Handling reserves -1 for
-        # "User rejected sampling request".
-        jsonrpc_error_result(-32_603, "Sampling error: #{e.message}")
+        # "User rejected sampling request". The exception message itself is
+        # host-internal (file paths, connection strings, library internals)
+        # and stays in the local log rather than crossing to the server.
+        jsonrpc_error_result(-32_603, 'Sampling error')
       end
     end
 

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -853,7 +853,10 @@ module MCPClient
       when 'error', 'critical', 'alert', 'emergency'
         logger.error("#{prefix} #{message}")
       else
-        logger.info("#{prefix} [#{level}] #{message}")
+        # An out-of-enum level is peer-controlled text like any other: it must
+        # be sanitized and capped, or it becomes the log-forging vector the
+        # sanitizing of `data` was added to close.
+        logger.info("#{prefix} [#{sanitize_peer_log_text(level.to_s)}] #{message}")
       end
     end
 
@@ -1204,9 +1207,13 @@ module MCPClient
 
         format_elicitation_response(result, params)
       rescue StandardError => e
+        # Same reasoning as the sampling path: the handler's exception text is
+        # host-internal and must not cross to the server. Because this rescue
+        # runs inside the client, the transports' constant-message rescues
+        # never see it — so it has to be constant here.
         @logger.error("Elicitation handler error: #{e.message}")
         @logger.debug(e.backtrace.join("\n"))
-        jsonrpc_error_result(-32_603, "Elicitation handler error: #{e.message}")
+        jsonrpc_error_result(-32_603, 'Elicitation handler error')
       end
     end
 

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -181,7 +181,7 @@ module MCPClient
     # @raise [MCPClient::Errors::TransportError] if response isn't valid JSON
     # @raise [MCPClient::Errors::ToolCallError] for other errors during request execution
     def send_jsonrpc_request(request, timeout: nil)
-      @logger.debug("Sending JSON-RPC request: #{request.to_json}")
+      @logger.debug("Sending JSON-RPC request: #{describe_jsonrpc_message(request)}")
 
       begin
         response = send_http_request(request, timeout: timeout)
@@ -471,7 +471,7 @@ module MCPClient
     # Log HTTP response (to be overridden by specific transports)
     # @param response [Faraday::Response] the HTTP response
     def log_response(response)
-      @logger.debug("Received HTTP response: #{response.status} #{response.body}")
+      @logger.debug("Received HTTP response: #{response.status} (#{describe_body_size(response.body)})")
     end
 
     # Parse HTTP response (to be implemented by specific transports)

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -38,6 +38,35 @@ module MCPClient
       end
     end
 
+    # A log-safe description of a JSON-RPC message: its method and id only.
+    #
+    # Params and results are deliberately omitted. tools/call arguments and
+    # tool results routinely carry credentials, personal data or customer
+    # content, and logs are frequently shipped to lower-trust destinations
+    # (aggregators, CI artifacts, support bundles) — so enabling DEBUG must
+    # not silently start recording payloads.
+    # @param message [Hash] a JSON-RPC request, notification or response
+    # @return [String] method/id summary, never payload content
+    def describe_jsonrpc_message(message)
+      return '(non-object message)' unless message.is_a?(Hash)
+
+      parts = []
+      parts << (message['method'] || message[:method] || '(response)').to_s
+      id = message['id'] || message[:id]
+      parts << "id=#{id}" if id
+      parts << 'error' if message['error'] || message[:error]
+      parts.join(' ')
+    end
+
+    # A log-safe description of a payload body: its size, never its content.
+    # @param body [String, nil] the response/request body
+    # @return [String]
+    def describe_body_size(body)
+      return 'empty body' if body.nil? || body.empty?
+
+      "#{body.bytesize} bytes"
+    end
+
     # Ping the server to keep the connection alive
     # @return [Hash] the result of the ping request
     # @raise [MCPClient::Errors::ToolCallError] if ping times out or fails

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -519,8 +519,11 @@ module MCPClient
         send_error_response(request_id, -32_601, "Method not found: #{method}")
       end
     rescue StandardError => e
+      # The exception message is host-internal (file paths, connection
+      # strings, library internals): log it locally, but answer the peer with
+      # a constant message so failures cannot be used to probe the host.
       @logger.error("Error handling server request: #{e.message}")
-      send_error_response(request_id, -32_603, "Internal error: #{e.message}")
+      send_error_response(request_id, -32_603, 'Internal error')
     end
 
     # Handle a server-initiated ping request (MCP ping utility)
@@ -717,7 +720,7 @@ module MCPClient
         req.body = json_body
       end
 
-      @logger.debug("Sent response via HTTP POST: #{json_body}")
+      @logger.debug("Sent response via HTTP POST: #{describe_jsonrpc_message(response)}")
     rescue StandardError => e
       @logger.error("Failed to send response via HTTP POST: #{e.message}")
     end

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -842,7 +842,9 @@ module MCPClient
     # Process an SSE chunk from the server
     # @param chunk [String] the chunk to process
     def process_sse_chunk(chunk)
-      @logger.debug("Processing SSE chunk: #{chunk.inspect}")
+      # Size only: the chunk is raw wire data carrying sampling prompts,
+      # elicitation content and tool results.
+      @logger.debug("Processing SSE chunk (#{describe_body_size(chunk)})")
 
       # Only record activity for real events
       record_activity if chunk.include?('event:')

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -119,7 +119,7 @@ module MCPClient
       # @raise [MCPClient::Errors::TransportError] if response isn't valid JSON
       # @raise [MCPClient::Errors::ToolCallError] for other errors during request execution
       def send_jsonrpc_request(request, timeout: nil)
-        @logger.debug("Sending JSON-RPC request: #{request.to_json}")
+        @logger.debug("Sending JSON-RPC request: #{describe_jsonrpc_message(request)}")
         record_activity
 
         begin

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -207,7 +207,7 @@ module MCPClient
         end
 
         msg = "Received JSON-RPC response: #{response.status}"
-        msg += " #{response.body}" if response.respond_to?(:body)
+        msg += " (#{describe_body_size(response.body)})" if response.respond_to?(:body)
         @logger.debug(msg)
         response
       end

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -542,8 +542,11 @@ module MCPClient
         send_error_response(request_id, -32_601, "Method not found: #{method}")
       end
     rescue StandardError => e
+      # The exception message is host-internal (file paths, connection
+      # strings, library internals): log it locally, answer the peer with a
+      # constant message, matching the SSE and Streamable HTTP transports.
       @logger.error("Error handling server request: #{e.message}")
-      send_error_response(request_id, -32_603, "Internal error: #{e.message}")
+      send_error_response(request_id, -32_603, 'Internal error')
     end
 
     # Handle a server-initiated ping request (MCP ping utility)

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -160,7 +160,7 @@ module MCPClient
     # @return [void]
     def handle_line(line)
       msg = JSON.parse(line)
-      @logger.debug("Received line: #{line.chomp}")
+      @logger.debug("Received line: #{describe_jsonrpc_message(msg)}")
 
       # A JSON-parseable line that is not an object cannot be a JSON-RPC
       # message; skip it rather than raising inside the reader thread
@@ -694,7 +694,7 @@ module MCPClient
       json = JSON.generate(message)
       @stdin.puts(json)
       @stdin.flush
-      @logger.debug("Sent message: #{json}")
+      @logger.debug("Sent message: #{describe_jsonrpc_message(message)}")
     rescue StandardError => e
       @logger.error("Error sending message: #{e.message}")
     end

--- a/lib/mcp_client/server_stdio/json_rpc_transport.rb
+++ b/lib/mcp_client/server_stdio/json_rpc_transport.rb
@@ -66,7 +66,7 @@ module MCPClient
       # @return [void]
       # @raise [MCPClient::Errors::TransportError] on write errors
       def send_request(req)
-        @logger.debug("Sending JSONRPC request: #{req.to_json}")
+        @logger.debug("Sending JSONRPC request: #{describe_jsonrpc_message(req)}")
         @stdin.puts(req.to_json)
       rescue StandardError => e
         # A request that failed to send will never receive a response, so drop

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -875,7 +875,9 @@ module MCPClient
     # Buffers partial chunks and processes complete SSE events
     # @param chunk [String] the chunk to process
     def process_event_chunk(chunk)
-      @logger.debug("Processing event chunk: #{chunk.inspect}") if @logger.level <= Logger::DEBUG
+      # Size only: the chunk is raw wire data carrying sampling prompts,
+      # elicitation content and tool results.
+      @logger.debug("Processing event chunk (#{describe_body_size(chunk)})") if @logger.level <= Logger::DEBUG
 
       @mutex.synchronize do
         @buffer += chunk

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -1029,8 +1029,11 @@ module MCPClient
         send_error_response(request_id, -32_601, "Method not found: #{method}")
       end
     rescue StandardError => e
+      # The exception message is host-internal (file paths, connection
+      # strings, library internals): log it locally, but answer the peer with
+      # a constant message so failures cannot be used to probe the host.
       @logger.error("Error handling server request: #{e.message}")
-      send_error_response(request_id, -32_603, "Internal error: #{e.message}")
+      send_error_response(request_id, -32_603, 'Internal error')
     end
 
     # Handle elicitation/create request from server (MCP 2025-11-25)
@@ -1199,7 +1202,7 @@ module MCPClient
         end
 
         if resp.success?
-          @logger.debug("Sent JSON-RPC response: #{json_body}")
+          @logger.debug("Sent JSON-RPC response: #{describe_jsonrpc_message(response)}")
         else
           @logger.warn("Failed to send JSON-RPC response: HTTP #{resp.status}")
         end

--- a/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
+++ b/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
@@ -17,7 +17,7 @@ module MCPClient
       # Log HTTP response for Streamable HTTP
       # @param response [Faraday::Response] the HTTP response
       def log_response(response)
-        @logger.debug("Received Streamable HTTP response: #{response.status} #{response.body}")
+        @logger.debug("Received Streamable HTTP response: #{response.status} (#{describe_body_size(response.body)})")
       end
 
       # Parse a Streamable HTTP JSON-RPC response (JSON or SSE format)

--- a/spec/lib/mcp_client/logging_spec.rb
+++ b/spec/lib/mcp_client/logging_spec.rb
@@ -109,6 +109,18 @@ RSpec.describe 'Logging (MCP 2025-06-18)' do
         end
       end
 
+      it 'sanitizes an out-of-enum level, which takes the fallback branch' do
+        # The level is peer-controlled too; the fallback interpolated it raw,
+        # so it bypassed both the newline escaping and the length cap.
+        client.send(:handle_log_message, 'server1',
+                    { 'level' => "bogus\nERROR [server1] forged", 'data' => 'x' })
+
+        expect(test_logger).to have_received(:info) do |line|
+          expect(line).not_to include("\n")
+          expect(line).to include('forged')
+        end
+      end
+
       it 'truncates an oversized peer log message' do
         # The peer controls both content and volume; an unbounded message
         # lets it inflate host log storage at will.

--- a/spec/lib/mcp_client/logging_spec.rb
+++ b/spec/lib/mcp_client/logging_spec.rb
@@ -96,6 +96,30 @@ RSpec.describe 'Logging (MCP 2025-06-18)' do
         expect(test_logger).to have_received(:error).with('[server1] Critical message')
       end
 
+      it 'neutralizes newlines and control characters in peer-supplied messages' do
+        # A peer that can inject raw newlines can forge additional log lines
+        # in the host's log.
+        client.send(:handle_log_message, 'server1',
+                    { 'level' => 'info', 'data' => "ok\nERROR [server1] forged entry\r\n" })
+
+        expect(test_logger).to have_received(:info) do |line|
+          expect(line).not_to include("\n")
+          expect(line).not_to include("\r")
+          expect(line).to include('forged entry')
+        end
+      end
+
+      it 'truncates an oversized peer log message' do
+        # The peer controls both content and volume; an unbounded message
+        # lets it inflate host log storage at will.
+        client.send(:handle_log_message, 'server1', { 'level' => 'info', 'data' => 'a' * 20_000 })
+
+        expect(test_logger).to have_received(:info) do |line|
+          expect(line.length).to be <= MCPClient::Client::MAX_PEER_LOG_MESSAGE_LENGTH + 100
+          expect(line).to include('truncated')
+        end
+      end
+
       it 'includes logger name in prefix when provided' do
         client.send(:handle_log_message, 'server1', {
                       'level' => 'info',

--- a/spec/lib/mcp_client/sampling_tool_use_spec.rb
+++ b/spec/lib/mcp_client/sampling_tool_use_spec.rb
@@ -335,7 +335,10 @@ RSpec.describe 'Sampling tool use (MCP 2025-11-25, SEP-1577)' do
                            })
 
       expect(result['error']['code']).to eq(-32_603)
-      expect(result['error']['message']).to include('boom')
+      # The handler's exception message is host-internal and must not be
+      # reflected to the untrusted server; it stays in the local log.
+      expect(result['error']['message']).not_to include('boom')
+      expect(result['error']['message']).to eq('Sampling error')
     end
 
     it 'reports the no-handler fallback as -32601 (method not found), not -1' do

--- a/spec/lib/mcp_client/sensitive_logging_spec.rb
+++ b/spec/lib/mcp_client/sensitive_logging_spec.rb
@@ -70,6 +70,23 @@ RSpec.describe 'Sensitive data in logs' do
       expect(log_output.string).to include('id=7')
     end
 
+    it 'omits raw SSE chunk contents on both SSE transports' do
+      # Raw wire chunks carry sampling prompts, elicitation answers and tool
+      # results — the same payloads the JSON-RPC summaries exist to keep out.
+      sse = MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', logger: logger)
+      streamable = MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/rpc',
+                                                       logger: logger)
+      secret_chunk = "event: message\ndata: {\"ssn\":\"123-45-6789\"}\n\n"
+
+      sse.send(:process_sse_chunk, secret_chunk.dup)
+      streamable.send(:process_event_chunk, secret_chunk.dup)
+
+      expect(log_output.string).not_to include('123-45-6789')
+      expect(log_output.string).to match(/bytes/)
+      sse.cleanup
+      streamable.cleanup
+    end
+
     it 'omits response bodies, logging only the status and size' do
       response = instance_double(Faraday::Response, status: 200, body: '{"result":{"ssn":"123-45-6789"}}')
 

--- a/spec/lib/mcp_client/sensitive_logging_spec.rb
+++ b/spec/lib/mcp_client/sensitive_logging_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Logs are routinely shipped to lower-trust destinations (aggregators, CI
+# artifacts, support bundles), so neither credentials nor request/response
+# payloads may be written verbatim just because DEBUG is enabled.
+RSpec.describe 'Sensitive data in logs' do
+  let(:log_output) { StringIO.new }
+  let(:logger) do
+    Logger.new(log_output).tap { |l| l.level = Logger::DEBUG }
+  end
+
+  describe 'server configuration logging' do
+    it 'redacts headers and environment values when logging a server config' do
+      MCPClient::Client.new(
+        mcp_server_configs: [
+          {
+            type: 'streamable_http',
+            base_url: 'https://example.com',
+            endpoint: '/rpc',
+            headers: { 'Authorization' => 'Bearer super-secret-token' }
+          }
+        ],
+        logger: logger
+      )
+
+      expect(log_output.string).not_to include('super-secret-token')
+      expect(log_output.string).to include('[REDACTED]')
+    end
+
+    it 'redacts stdio subprocess environment secrets' do
+      MCPClient::Client.new(
+        mcp_server_configs: [
+          { type: 'stdio', command: 'echo', env: { 'OPENAI_API_KEY' => 'sk-live-secret' } }
+        ],
+        logger: logger
+      )
+
+      expect(log_output.string).not_to include('sk-live-secret')
+      expect(log_output.string).to include('[REDACTED]')
+    end
+
+    it 'still logs non-sensitive configuration fields' do
+      MCPClient::Client.new(
+        mcp_server_configs: [{ type: 'stdio', command: 'echo' }],
+        logger: logger
+      )
+
+      expect(log_output.string).to include('stdio')
+    end
+  end
+
+  describe 'JSON-RPC payload logging' do
+    let(:server) do
+      MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/rpc', logger: logger)
+    end
+
+    it 'omits outbound request params, logging only the method and id' do
+      request = {
+        'jsonrpc' => '2.0', 'id' => 7, 'method' => 'tools/call',
+        'params' => { 'name' => 'send_email', 'arguments' => { 'body' => 'patient record 12345' } }
+      }
+      allow(server).to receive(:send_http_request).and_raise(MCPClient::Errors::TransportError, 'stop here')
+
+      expect { server.send(:send_jsonrpc_request, request) }.to raise_error(MCPClient::Errors::TransportError)
+
+      expect(log_output.string).not_to include('patient record 12345')
+      expect(log_output.string).to include('tools/call')
+      expect(log_output.string).to include('id=7')
+    end
+
+    it 'omits response bodies, logging only the status and size' do
+      response = instance_double(Faraday::Response, status: 200, body: '{"result":{"ssn":"123-45-6789"}}')
+
+      server.send(:log_response, response)
+
+      expect(log_output.string).not_to include('123-45-6789')
+      expect(log_output.string).to include('200')
+      expect(log_output.string).to include('32 bytes')
+    end
+  end
+end

--- a/spec/lib/mcp_client/server_sse_elicitation_spec.rb
+++ b/spec/lib/mcp_client/server_sse_elicitation_spec.rb
@@ -92,8 +92,12 @@ RSpec.describe MCPClient::ServerSSE, 'Elicitation (MCP 2025-06-18)' do
       end
 
       it 'sends error response for internal error' do
+        # The exception message is host-internal (paths, connection strings,
+        # library internals) and must not cross the peer boundary; details
+        # stay in the local log.
         allow(server).to receive(:handle_elicitation_create).and_raise(StandardError, 'Test error')
-        expect(server).to receive(:send_error_response).with(request_id, -32_603, 'Internal error: Test error')
+        expect(server).to receive(:send_error_response).with(request_id, -32_603, 'Internal error')
+        expect(server.instance_variable_get(:@logger)).to receive(:error).with(/Test error/)
         server.handle_server_request(message)
       end
     end

--- a/spec/lib/mcp_client/server_stdio_elicitation_spec.rb
+++ b/spec/lib/mcp_client/server_stdio_elicitation_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe MCPClient::ServerStdio, 'Elicitation (MCP 2025-06-18)' do
 
       it 'sends error response for internal error' do
         allow(server).to receive(:handle_elicitation_create).and_raise(StandardError, 'Test error')
-        expect(server).to receive(:send_error_response).with(request_id, -32_603, 'Internal error: Test error')
+        expect(server).to receive(:send_error_response).with(request_id, -32_603, 'Internal error')
         server.handle_server_request(message)
       end
     end

--- a/spec/lib/mcp_client/server_streamable_http_elicitation_spec.rb
+++ b/spec/lib/mcp_client/server_streamable_http_elicitation_spec.rb
@@ -90,8 +90,12 @@ RSpec.describe MCPClient::ServerStreamableHTTP, 'Elicitation (MCP 2025-06-18)' d
       end
 
       it 'sends error response for internal error' do
+        # The exception message is host-internal (paths, connection strings,
+        # library internals) and must not cross the peer boundary; details
+        # stay in the local log.
         allow(server).to receive(:handle_elicitation_create).and_raise(StandardError, 'Test error')
-        expect(server).to receive(:send_error_response).with(request_id, -32_603, 'Internal error: Test error')
+        expect(server).to receive(:send_error_response).with(request_id, -32_603, 'Internal error')
+        expect(server.instance_variable_get(:@logger)).to receive(:error).with(/Test error/)
         server.send(:handle_server_request, message)
       end
     end


### PR DESCRIPTION
## Summary

Batched security fix for **seven** low-severity findings from the codex-security scan, grouped because they all concern data crossing a trust boundary it shouldn't (host → log, or host → remote peer).

### Logging hygiene (4 findings)

| Finding | Problem |
|---|---|
| `csf_8af6f441` | `Client#initialize` logged each server config with `#inspect` — including `Authorization`/API-key headers and the stdio subprocess `env`. |
| `csf_d48a863c` | Every outbound JSON-RPC request was logged in full, so DEBUG recorded `tools/call` arguments verbatim. |
| `csf_e87cee75` | Every HTTP response body was logged in full, recording tool results and resource contents. |
| `csf_1ad7603f` | `notifications/message` content from the server was written verbatim at a peer-chosen severity. |

Fixes:

- **Config redaction** — `SENSITIVE_CONFIG_KEYS` (headers, env, token, api_key, …) are replaced with `[REDACTED]` before logging; nested hashes have every value redacted. Non-sensitive fields still log normally.
- **Payload omission** — new shared `describe_jsonrpc_message` / `describe_body_size` helpers in `JsonRpcCommon`; all four transports now log `tools/call id=7` and `200 (1432 bytes)` rather than the payload. Enabling DEBUG no longer starts recording sensitive content.
- **Peer log sanitizing** — control characters (notably newlines, which let a server forge additional log lines) are escaped, and messages are capped at `MAX_PEER_LOG_MESSAGE_LENGTH` (4096) with a truncation marker. Peer-chosen *severity* is intentionally still honored — that is the MCP logging utility working as designed, and the client asked for those levels via `logging/setLevel`.

### Callback error reflection (3 findings)

`csf_b2316fd0` (sampling), `csf_1aa20fb2` (SSE), `csf_2723f046` (Streamable HTTP): a host callback exception was echoed to the remote server inside the JSON-RPC error response (`"Internal error: #{e.message}"`), leaking file paths, connection strings and library internals to an untrusted peer — and giving it a probe for host internals.

Peers now receive a constant `'Internal error'` / `'Sampling error'`; the full message and backtrace stay in the local log. Error *codes* are unchanged (`-32603`, `-32601`), so spec-conformant error semantics are preserved.

## Testing

- New `spec/lib/mcp_client/sensitive_logging_spec.rb`: credentials never reach the log while non-sensitive fields do; request params and response bodies are absent while method/id/size are present.
- New logging specs: forged-newline content is escaped, oversized messages truncate.
- Three existing specs updated to assert peers get the constant message while the detail is logged locally.
- Full suite: 1613 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)