### PR TITLE
Route task operations to the task's own server

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,15 +327,24 @@ task = client.call_tool_as_task('long_job', { input: 'data' }, ttl: 60_000)
 # honoring the server's suggested poll interval
 until task.terminal? || task.input_required?
   sleep((task.poll_interval || 1000) / 1000.0)
-  task = client.get_task(task.task_id)   # tasks/get
+  task = client.get_task(task)          # tasks/get, routed to the task's own server
 end
 
 # Retrieve the underlying result (e.g. a CallToolResult) via tasks/result
-result = client.get_task_result(task.task_id)
+result = client.get_task_result(task)
 
 # List and cancel tasks
 page = client.list_tasks               # { tasks: [...], next_cursor: ... }
-client.cancel_task(task.task_id)       # tasks/cancel
+client.cancel_task(task)               # tasks/cancel
+```
+
+Task IDs are only unique within the server that issued them, so pass the `Task`
+returned by `call_tool_as_task` — it carries its own server. A bare task ID also
+works when the client has a single server; with several servers configured it
+raises `ArgumentError` rather than guessing, so name the server explicitly:
+
+```ruby
+client.get_task('task-123', server: 'my-server')
 
 # React to server-pushed status updates
 client.on_notification do |server, method, params|

--- a/examples/tasks_example.rb
+++ b/examples/tasks_example.rb
@@ -59,12 +59,12 @@ def run_task_flow(client, tool_name)
   # suggested poll interval (milliseconds).
   until task.terminal? || task.input_required?
     sleep((task.poll_interval || 1000) / 1000.0)
-    task = client.get_task(task.task_id)
+    task = client.get_task(task)
     puts "  status: #{task.status}"
   end
 
   if task.terminal? && task.status == 'completed'
-    result = client.get_task_result(task.task_id)
+    result = client.get_task_result(task)
     puts "Result: #{result.inspect}"
   else
     puts "Task ended in status: #{task.status}"

--- a/examples/test_mcp_2025_11_25.rb
+++ b/examples/test_mcp_2025_11_25.rb
@@ -301,14 +301,14 @@ begin
     break if final.terminal?
 
     sleep((final.poll_interval || 500) / 1000.0)
-    final = client.get_task(task.task_id)
+    final = client.get_task(task)
   end
   runner.assert('get_task returns a Task', final.is_a?(MCPClient::Task))
   runner.assert('task is completed after waiting', final.status == 'completed', "status: #{final.status}")
 
   # Retrieve the underlying result via tasks/result
   if final.status == 'completed'
-    result = client.get_task_result(task.task_id)
+    result = client.get_task_result(task)
     runner.assert('get_task_result returns the underlying content', result['content'].is_a?(Array))
   end
 
@@ -318,7 +318,7 @@ begin
 
   # Create another task and cancel it quickly
   cancel_target = client.call_tool_as_task('background_work', {})
-  cancelled = client.cancel_task(cancel_target.task_id)
+  cancelled = client.cancel_task(cancel_target)
   runner.assert('cancel_task returns a cancelled Task', cancelled.status == 'cancelled')
 
   # Task error handling: get non-existent task

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -562,14 +562,17 @@ module MCPClient
     end
 
     # Get the current state of a task (tasks/get, MCP 2025-11-25)
-    # @param task_id [String] the ID of the task to query
+    # @param task_id [String, MCPClient::Task] the task to query; passing the
+    #   Task handle returned by #call_tool_as_task routes to its own server
     # @param server [Integer, String, Symbol, MCPClient::ServerBase, nil] server selector
     # @return [MCPClient::Task] the task with current status
+    # @raise [ArgumentError] if the server is ambiguous in a multi-server client
     # @raise [MCPClient::Errors::ServerNotFound] if no server is available
     # @raise [MCPClient::Errors::TaskNotFound] if the task does not exist
     # @raise [MCPClient::Errors::TaskError] if retrieving the task fails
     def get_task(task_id, server: nil)
-      srv = select_server(server)
+      srv = select_task_server(task_id, server, 'get_task')
+      task_id = task_identifier(task_id)
 
       begin
         result = srv.rpc_request('tasks/get', { taskId: task_id })
@@ -591,13 +594,16 @@ module MCPClient
     # identify which tool (and therefore which outputSchema) produced the
     # result, and the client keeps no task-to-tool registry. Callers who need
     # validation here can run MCPClient::SchemaValidator.validate themselves.
-    # @param task_id [String] the ID of the task
+    # @param task_id [String, MCPClient::Task] the task; passing the Task
+    #   handle returned by #call_tool_as_task routes to its own server
     # @param server [Integer, String, Symbol, MCPClient::ServerBase, nil] server selector
     # @return [Object] the underlying task result
+    # @raise [ArgumentError] if the server is ambiguous in a multi-server client
     # @raise [MCPClient::Errors::TaskNotFound] if the task does not exist
     # @raise [MCPClient::Errors::TaskError] if retrieval fails
     def get_task_result(task_id, server: nil)
-      srv = select_server(server)
+      srv = select_task_server(task_id, server, 'get_task_result')
+      task_id = task_identifier(task_id)
 
       begin
         srv.rpc_request('tasks/result', { taskId: task_id })
@@ -629,14 +635,17 @@ module MCPClient
     end
 
     # Cancel a task (tasks/cancel, MCP 2025-11-25)
-    # @param task_id [String] the ID of the task to cancel
+    # @param task_id [String, MCPClient::Task] the task to cancel; passing the
+    #   Task handle returned by #call_tool_as_task routes to its own server
     # @param server [Integer, String, Symbol, MCPClient::ServerBase, nil] server selector
     # @return [MCPClient::Task] the task with updated (cancelled) status
+    # @raise [ArgumentError] if the server is ambiguous in a multi-server client
     # @raise [MCPClient::Errors::ServerNotFound] if no server is available
     # @raise [MCPClient::Errors::TaskNotFound] if the task does not exist
     # @raise [MCPClient::Errors::TaskError] if cancellation fails (including cancelling a terminal task)
     def cancel_task(task_id, server: nil)
-      srv = select_server(server)
+      srv = select_task_server(task_id, server, 'cancel_task')
+      task_id = task_identifier(task_id)
       ensure_task_capability!(srv, 'cancel')
 
       begin
@@ -840,6 +849,37 @@ module MCPClient
       else
         logger.info("#{prefix} [#{level}] #{message}")
       end
+    end
+
+    # Resolve which server a task operation targets.
+    #
+    # Task IDs are only unique within the server that issued them, so silently
+    # defaulting to the first configured server can poll, read or cancel an
+    # unrelated task on the wrong server. Resolution order:
+    #   1. an explicit server: argument wins;
+    #   2. a Task handle carries the server that issued it;
+    #   3. a bare ID with exactly one configured server is unambiguous;
+    #   4. anything else is ambiguous and fails closed.
+    # @param task [String, MCPClient::Task] the task or its ID
+    # @param server_arg [Integer, String, Symbol, MCPClient::ServerBase, nil] explicit selector
+    # @param operation [String] calling method name, for the error message
+    # @return [MCPClient::ServerBase]
+    # @raise [ArgumentError] when the target server cannot be determined
+    def select_task_server(task, server_arg, operation)
+      return select_server(server_arg) if server_arg
+      return task.server if task.is_a?(MCPClient::Task) && task.server
+      return select_server(nil) if @servers.size <= 1
+
+      raise ArgumentError,
+            "#{operation} is ambiguous with multiple servers configured: task IDs are only unique per server. " \
+            'Pass the Task returned by call_tool_as_task, or name the server explicitly ' \
+            "(e.g. #{operation}(id, server: 'name'))."
+    end
+
+    # @param task [String, MCPClient::Task] a task or its ID
+    # @return [String] the task ID
+    def task_identifier(task)
+      task.is_a?(MCPClient::Task) ? task.task_id : task
     end
 
     # Select a server based on index, name, type, or instance

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -866,7 +866,10 @@ module MCPClient
     # @return [MCPClient::ServerBase]
     # @raise [ArgumentError] when the target server cannot be determined
     def select_task_server(task, server_arg, operation)
-      return select_server(server_arg) if server_arg
+      # nil, not falsiness: `server: false` is an invalid selector that
+      # select_server rejects with ArgumentError, and treating it as "omitted"
+      # would silently route a read or a cancel somewhere instead of failing.
+      return select_server(server_arg) unless server_arg.nil?
       return task.server if task.is_a?(MCPClient::Task) && task.server
       return select_server(nil) if @servers.size <= 1
 

--- a/spec/lib/mcp_client/task_server_routing_spec.rb
+++ b/spec/lib/mcp_client/task_server_routing_spec.rb
@@ -92,6 +92,17 @@ RSpec.describe 'Task operations server routing' do
         .to raise_error(ArgumentError, /multiple servers/i)
     end
 
+    it 'rejects an invalid falsy selector instead of routing anyway' do
+      # server: false is not "no selector" — select_server rejects it, and a
+      # dynamically-built false must not turn into a real cancel.
+      handle = MCPClient::Task.new(task_id: 'task-1', server: server_b)
+      expect(server_a).not_to receive(:rpc_request)
+      expect(server_b).not_to receive(:rpc_request)
+
+      expect { multi_client.cancel_task(handle, server: false) }.to raise_error(ArgumentError)
+      expect { single_client.get_task('task-1', server: false) }.to raise_error(ArgumentError)
+    end
+
     it 'accepts a bare task id when the server is named explicitly' do
       expect(server_b).to receive(:rpc_request)
         .with('tasks/get', { taskId: 'task-1' })

--- a/spec/lib/mcp_client/task_server_routing_spec.rb
+++ b/spec/lib/mcp_client/task_server_routing_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Task IDs are only unique within the server that issued them, so a task
+# operation that silently defaults to "the first configured server" can hit
+# the wrong server in a multi-server client — polling an unrelated task,
+# reading another server's result, or cancelling work that was never targeted.
+RSpec.describe 'Task operations server routing' do
+  let(:server_a) { instance_double(MCPClient::ServerStdio, name: 'alpha') }
+  let(:server_b) { instance_double(MCPClient::ServerStdio, name: 'beta') }
+  let(:task_caps) { { 'tasks' => { 'requests' => { 'tools' => { 'call' => {} } }, 'list' => {}, 'cancel' => {} } } }
+
+  let(:multi_client) do
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(server_a, server_b)
+    MCPClient::Client.new(
+      mcp_server_configs: [
+        { type: 'stdio', command: 'a' },
+        { type: 'stdio', command: 'b' }
+      ]
+    )
+  end
+
+  let(:single_client) do
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(server_a)
+    MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'a' }])
+  end
+
+  before do
+    [server_a, server_b].each do |srv|
+      allow(srv).to receive(:capabilities).and_return(task_caps)
+      allow(srv).to receive(:on_notification)
+      allow(srv).to receive(:capability?).and_return(true)
+    end
+  end
+
+  describe 'routing by Task handle' do
+    it 'sends tasks/get to the server the task came from, not the first server' do
+      handle = MCPClient::Task.new(task_id: 'task-1', server: server_b)
+      expect(server_b).to receive(:rpc_request)
+        .with('tasks/get', { taskId: 'task-1' })
+        .and_return({ 'taskId' => 'task-1', 'status' => 'working' })
+      expect(server_a).not_to receive(:rpc_request)
+
+      expect(multi_client.get_task(handle).task_id).to eq('task-1')
+    end
+
+    it 'sends tasks/result to the task own server' do
+      handle = MCPClient::Task.new(task_id: 'task-2', server: server_b)
+      expect(server_b).to receive(:rpc_request).with('tasks/result', { taskId: 'task-2' }).and_return({ 'ok' => true })
+      expect(server_a).not_to receive(:rpc_request)
+
+      expect(multi_client.get_task_result(handle)).to eq({ 'ok' => true })
+    end
+
+    it 'sends tasks/cancel to the task own server' do
+      handle = MCPClient::Task.new(task_id: 'task-3', server: server_b)
+      expect(server_b).to receive(:rpc_request)
+        .with('tasks/cancel', { taskId: 'task-3' })
+        .and_return({ 'taskId' => 'task-3', 'status' => 'cancelled' })
+      expect(server_a).not_to receive(:rpc_request)
+
+      expect(multi_client.cancel_task(handle).status).to eq('cancelled')
+    end
+
+    it 'honors an explicit server: over the handle own server' do
+      handle = MCPClient::Task.new(task_id: 'task-4', server: server_b)
+      expect(server_a).to receive(:rpc_request)
+        .with('tasks/get', { taskId: 'task-4' })
+        .and_return({ 'taskId' => 'task-4', 'status' => 'working' })
+
+      multi_client.get_task(handle, server: server_a)
+    end
+  end
+
+  describe 'ambiguous routing in a multi-server client' do
+    it 'refuses a bare task id for tasks/get instead of guessing a server' do
+      expect(server_a).not_to receive(:rpc_request)
+      expect(server_b).not_to receive(:rpc_request)
+
+      expect { multi_client.get_task('task-1') }
+        .to raise_error(ArgumentError, /multiple servers/i)
+    end
+
+    it 'refuses a bare task id for tasks/result' do
+      expect { multi_client.get_task_result('task-1') }
+        .to raise_error(ArgumentError, /multiple servers/i)
+    end
+
+    it 'refuses a bare task id for tasks/cancel' do
+      expect { multi_client.cancel_task('task-1') }
+        .to raise_error(ArgumentError, /multiple servers/i)
+    end
+
+    it 'accepts a bare task id when the server is named explicitly' do
+      expect(server_b).to receive(:rpc_request)
+        .with('tasks/get', { taskId: 'task-1' })
+        .and_return({ 'taskId' => 'task-1', 'status' => 'working' })
+
+      multi_client.get_task('task-1', server: 'beta')
+    end
+  end
+
+  describe 'single-server clients are unaffected' do
+    it 'still accepts a bare task id' do
+      expect(server_a).to receive(:rpc_request)
+        .with('tasks/get', { taskId: 'task-1' })
+        .and_return({ 'taskId' => 'task-1', 'status' => 'working' })
+
+      expect(single_client.get_task('task-1').task_id).to eq('task-1')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Batched security fix for three low-severity findings from the codex-security scan (`csf_879782f9` `get_task`, `csf_c09a1eab` `get_task_result`, `csf_5b68e696` `cancel_task` — `routing-error.task-server-selection`).

All three task methods resolved their target server with `select_server(server)` where a `nil` selector returns `@servers.first`. Task IDs are only unique within the server that issued them, so in a multi-server client a call like `client.get_task('task-123')` silently went to server 0 regardless of which server was actually running that task — polling an unrelated task's state, retrieving another server's result, or cancelling work that was never targeted (whichever task happened to share the ID).

## Fix

Server resolution for task operations is now explicit and fails closed:

1. an explicit `server:` argument wins;
2. a `MCPClient::Task` handle carries the server that issued it — `Task#server` was already populated by `call_tool_as_task`, it just wasn't consulted;
3. a bare ID with exactly one configured server remains unambiguous and works as before;
4. anything else raises `ArgumentError` with a message pointing at both remedies, instead of guessing.

All three methods now accept either a `Task` or a `String` ID.

**Compatibility**: single-server clients — the common case and every README/example flow — are unaffected. A multi-server client that passed a bare ID was already routing arbitrarily; it now gets a clear error instead of silent misrouting.

README and the two task examples now pass the `Task` handle (`client.get_task(task)`), which is the idiom that makes routing correct by construction.

## Testing

- New `spec/lib/mcp_client/task_server_routing_spec.rb`: handle-based routing reaches the issuing server and never the first server (for get/result/cancel); explicit `server:` overrides the handle; bare IDs raise in multi-server clients but work in single-server ones and when the server is named.
- Full suite: 1615 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)