### PR TITLE
Harden examples: sandbox roots, pinned npm servers, no auto tool calls

### DIFF
--- a/examples/gemini_ai_mcp.rb
+++ b/examples/gemini_ai_mcp.rb
@@ -4,7 +4,7 @@
 # MCPClient integration example using the `gemini-ai` Ruby gem
 #
 # Prerequisites
-#  - A running MCP server (for instance: `npx @modelcontextprotocol/server-filesystem .`)
+#  - A running MCP server (for instance: `npx @modelcontextprotocol/server-filesystem@2026.7.10 .`)
 #  - A Vertex AI service-account JSON file (downloaded from Google Cloud) named
 #    `google-credentials.json` in the project root, or set its location in
 #      export VERTEX_CREDENTIALS_FILE=/path/to/file.json
@@ -20,6 +20,7 @@
 
 require 'bundler/setup'
 require_relative '../lib/mcp_client'
+require_relative 'support/example_sandbox'
 
 # The gem itself
 require 'gemini-ai'
@@ -52,9 +53,13 @@ end
 logger = Logger.new($stdout)
 logger.level = Logger::WARN
 
-# Connect using stdio - passing an array of command arguments auto-detects stdio transport
+# Connect using stdio - passing an array of command arguments auto-detects stdio transport.
+# The server is pinned to a known version and rooted at a disposable sandbox, not
+# the checkout: this process can read the Vertex credentials file, and the model
+# below picks the tool calls that run unattended.
+ExampleSandbox.announce_auto_execution("filesystem tools under #{ExampleSandbox.filesystem_root}")
 mcp_client = MCPClient.connect(
-  %W[npx -y @modelcontextprotocol/server-filesystem #{Dir.pwd}],
+  ExampleSandbox.filesystem_server_command,
   logger: logger
 )
 
@@ -195,7 +200,7 @@ second_input = {
     function_declarations: google_tools
   },
   contents: [
-    { role: 'user', parts: { text: 'List all files in current directory' } },
+    { role: 'user', parts: { text: 'List all files in the sandbox directory' } },
     candidate['content'], # the assistant message containing the functionCall
     { role: 'function', parts: [function_response_part] }
   ],

--- a/examples/gemini_ai_mcp.rb
+++ b/examples/gemini_ai_mcp.rb
@@ -60,6 +60,7 @@ logger.level = Logger::WARN
 ExampleSandbox.announce_auto_execution("filesystem tools under #{ExampleSandbox.filesystem_root}")
 mcp_client = MCPClient.connect(
   ExampleSandbox.filesystem_server_command,
+  env: ExampleSandbox.secret_free_env,
   logger: logger
 )
 

--- a/examples/json_input_mcp_servers_example.rb
+++ b/examples/json_input_mcp_servers_example.rb
@@ -6,7 +6,7 @@
 # - Filesystem MCP server via STDIO
 #
 # Usage:
-#  1. Start Playwright MCP server: npx @playwright/mcp@latest --port 8931
+#  1. Start Playwright MCP server: npx @playwright/mcp@0.0.78 --port 8931
 #  2. Run this example: ruby json_input_mcp_servers_example.rb
 #
 require 'bundler/setup'

--- a/examples/oauth_example.rb
+++ b/examples/oauth_example.rb
@@ -152,8 +152,18 @@ class FileTokenStorage
     {}
   end
 
+  # Access tokens, refresh tokens and client secrets end up in this file, so
+  # create it owner-readable only. File.write would leave the mode to the
+  # process umask (commonly 0644 — world-readable) on first creation.
+  #
+  # This is the minimum for a local demo. Production storage should keep
+  # credentials in an OS keychain or a secrets manager, or encrypt them at
+  # rest, rather than in a plaintext file.
   def save_data
-    File.write(@filename, JSON.pretty_generate(@data))
+    File.open(@filename, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |f|
+      f.write(JSON.pretty_generate(@data))
+    end
+    File.chmod(0o600, @filename)
   end
 end
 

--- a/examples/oauth_example.rb
+++ b/examples/oauth_example.rb
@@ -7,6 +7,8 @@
 require 'bundler/setup'
 require_relative '../lib/mcp_client'
 require 'logger'
+require 'fileutils'
+require 'json'
 
 # Create an MCPClient client (stdio stub for demo)
 logger = Logger.new($stdout)
@@ -153,17 +155,33 @@ class FileTokenStorage
   end
 
   # Access tokens, refresh tokens and client secrets end up in this file, so
-  # create it owner-readable only. File.write would leave the mode to the
-  # process umask (commonly 0644 — world-readable) on first creation.
+  # it must never be readable by other local users.
+  #
+  # Written as a fresh 0600 temp file in the same directory and renamed over
+  # the destination. Writing in place would be wrong on the upgrade path that
+  # matters most: a file an earlier version created as 0644 keeps that mode
+  # through open/truncate/write, so refreshed credentials would sit
+  # world-readable until the chmod lands — and stay that way if the process
+  # dies in between. rename(2) is atomic within a directory, so readers see
+  # either the old file or the new one, always at 0600.
   #
   # This is the minimum for a local demo. Production storage should keep
   # credentials in an OS keychain or a secrets manager, or encrypt them at
   # rest, rather than in a plaintext file.
   def save_data
-    File.open(@filename, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |f|
-      f.write(JSON.pretty_generate(@data))
+    dir = File.dirname(File.expand_path(@filename))
+    temp = File.join(dir, ".#{File.basename(@filename)}.#{Process.pid}.tmp")
+    begin
+      File.open(temp, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |f|
+        f.write(JSON.pretty_generate(@data))
+        f.flush
+        f.fsync
+      end
+      File.rename(temp, @filename)
+    rescue StandardError
+      FileUtils.rm_f(temp)
+      raise
     end
-    File.chmod(0o600, @filename)
   end
 end
 

--- a/examples/openai_ruby_mcp.rb
+++ b/examples/openai_ruby_mcp.rb
@@ -4,6 +4,7 @@
 # MCPClient integration example using the openai/openai-ruby gem
 require 'bundler/setup'
 require_relative '../lib/mcp_client'
+require_relative 'support/example_sandbox'
 # Both the official 'openai' gem and 'ruby-openai' are bundled and both expose
 # lib/openai.rb + OpenAI::Client; load the official gem's lib first so
 # require resolves deterministically to the gem this example targets.
@@ -20,9 +21,12 @@ abort 'Please set OPENAI_API_KEY' unless api_key
 logger = Logger.new($stdout)
 logger.level = Logger::WARN
 
-# Connect using stdio - passing an array of command arguments auto-detects stdio transport
+# Connect using stdio - passing an array of command arguments auto-detects stdio transport.
+# The server is pinned to a known version and rooted at a disposable sandbox, not
+# the checkout: the model below picks the tool calls and they run unattended.
+ExampleSandbox.announce_auto_execution("filesystem tools under #{ExampleSandbox.filesystem_root}")
 mcp_client = MCPClient.connect(
-  %W[npx -y @modelcontextprotocol/server-filesystem #{Dir.pwd}],
+  ExampleSandbox.filesystem_server_command,
   logger: logger
 )
 
@@ -35,7 +39,7 @@ tools = mcp_client.to_openai_tools
 # Build initial chat messages
 messages = [
   { role: 'system', content: 'You can call filesystem tools.' },
-  { role: 'user', content: 'List all files in current directory' }
+  { role: 'user', content: 'List all files in the sandbox directory' }
 ]
 
 # 1) Send chat with function definitions

--- a/examples/openai_ruby_mcp.rb
+++ b/examples/openai_ruby_mcp.rb
@@ -27,6 +27,7 @@ logger.level = Logger::WARN
 ExampleSandbox.announce_auto_execution("filesystem tools under #{ExampleSandbox.filesystem_root}")
 mcp_client = MCPClient.connect(
   ExampleSandbox.filesystem_server_command,
+  env: ExampleSandbox.secret_free_env,
   logger: logger
 )
 

--- a/examples/ruby_anthropic_mcp.rb
+++ b/examples/ruby_anthropic_mcp.rb
@@ -24,7 +24,7 @@ logger.level = Logger::WARN
 ExampleSandbox.announce_auto_execution("filesystem tools under #{ExampleSandbox.filesystem_root}")
 mcp_client = MCPClient.connect(
   ExampleSandbox.filesystem_server_command,
-  env: { 'EXAMPLE_ENV_VAR' => 'example_value' },
+  env: ExampleSandbox.secret_free_env('EXAMPLE_ENV_VAR' => 'example_value'),
   logger: logger
 )
 

--- a/examples/ruby_anthropic_mcp.rb
+++ b/examples/ruby_anthropic_mcp.rb
@@ -4,6 +4,7 @@
 # MCPClient integration example using the alexrudall/ruby-anthropic gem
 require 'bundler/setup'
 require_relative '../lib/mcp_client'
+require_relative 'support/example_sandbox'
 require 'anthropic'
 require 'json'
 require 'logger'
@@ -17,9 +18,12 @@ abort 'Please set ANTHROPIC_API_KEY' if api_key.nil? || api_key.strip.empty?
 logger = Logger.new($stdout)
 logger.level = Logger::WARN
 
-# Connect using stdio - passing an array of command arguments auto-detects stdio transport
+# Connect using stdio - passing an array of command arguments auto-detects stdio transport.
+# The server is pinned to a known version and rooted at a disposable sandbox, not
+# the checkout: the model below picks the tool calls and they run unattended.
+ExampleSandbox.announce_auto_execution("filesystem tools under #{ExampleSandbox.filesystem_root}")
 mcp_client = MCPClient.connect(
-  %W[npx -y @modelcontextprotocol/server-filesystem #{Dir.pwd}],
+  ExampleSandbox.filesystem_server_command,
   env: { 'EXAMPLE_ENV_VAR' => 'example_value' },
   logger: logger
 )
@@ -45,7 +49,7 @@ claude_tools = mcp_client.to_anthropic_tools
 
 # Build initial chat messages
 messages = [
-  { role: 'user', content: 'List all files in current directory' }
+  { role: 'user', content: 'List all files in the sandbox directory' }
 ]
 
 # Faraday raises on HTTP errors with only the status in the message; surface

--- a/examples/ruby_llm_mcp.rb
+++ b/examples/ruby_llm_mcp.rb
@@ -2,10 +2,16 @@
 # frozen_string_literal: true
 
 # MCPClient integration example using the RubyLLM gem (OpenAI provider)
-# MCP server command:
-#  npx @playwright/mcp@latest --port 8931
+# MCP server command (pin the version rather than tracking @latest):
+#  npx @playwright/mcp@0.0.78 --port 8931
+#
+# The model drives the browser unattended: every tool it selects is executed
+# with no approval step, and page content it reads can influence the next
+# call it makes. Point it at a disposable browser profile, never one holding
+# authenticated sessions.
 require 'bundler/setup'
 require_relative '../lib/mcp_client'
+require_relative 'support/example_sandbox'
 require 'ruby_llm'
 require 'json'
 require 'logger'
@@ -17,6 +23,8 @@ abort 'Please set OPENAI_API_KEY' unless api_key
 # Create an MCPClient client using the simplified connect API
 logger = Logger.new($stdout)
 logger.level = Logger::WARN
+
+ExampleSandbox.announce_auto_execution('every browser tool the Playwright MCP server exposes')
 
 # Connect using Streamable HTTP - the /mcp suffix auto-detects the transport
 mcp_client = MCPClient.connect('http://localhost:8931/mcp',

--- a/examples/ruby_openai_mcp.rb
+++ b/examples/ruby_openai_mcp.rb
@@ -2,10 +2,16 @@
 # frozen_string_literal: true
 
 # MCPClient integration example using the alexrudall/ruby-openai gem
-# MCP server command:
-#  npx @playwright/mcp@latest --port 8931
+# MCP server command (pin the version rather than tracking @latest):
+#  npx @playwright/mcp@0.0.78 --port 8931
+#
+# The model drives the browser unattended: every tool it selects is executed
+# with no approval step, and page content it reads can influence the next call
+# it makes. Point it at a disposable browser profile, never one holding
+# authenticated sessions.
 require 'bundler/setup'
 require_relative '../lib/mcp_client'
+require_relative 'support/example_sandbox'
 # Both 'ruby-openai' and the official 'openai' gem are bundled and both expose
 # lib/openai.rb + OpenAI::Client; load ruby-openai's lib first so require
 # resolves deterministically to the gem this example targets.
@@ -22,6 +28,8 @@ abort 'Please set OPENAI_API_KEY' unless api_key
 # Create an MCPClient client using the simplified connect API
 logger = Logger.new($stdout)
 logger.level = Logger::WARN # DEBUG
+
+ExampleSandbox.announce_auto_execution('every browser tool the Playwright MCP server exposes')
 
 # Connect using Streamable HTTP - the /mcp suffix auto-detects the transport
 mcp_client = MCPClient.connect('http://localhost:8931/mcp',

--- a/examples/run_all_examples.sh
+++ b/examples/run_all_examples.sh
@@ -45,6 +45,19 @@ RUN_NPX="${RUN_NPX:-1}"
 # Override to try a newer release, e.g. PLAYWRIGHT_MCP_VERSION=0.0.79 ./run_all_examples.sh
 PLAYWRIGHT_MCP_VERSION="${PLAYWRIGHT_MCP_VERSION:-0.0.78}"
 PLAYWRIGHT_MCP_PKG="@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}"
+# npx resolves the pinned package's transitive dependencies on version ranges,
+# so the child can still run code this repo never pinned. This script sources
+# secrets.env into its own environment, so strip every credential-looking
+# variable before launching an npm server: it needs none of them.
+strip_secrets() {
+  local args=() key
+  while IFS='=' read -r key _; do
+    case "$key" in
+      *_KEY|*_TOKEN|*_SECRET|*CREDENTIAL*|*PASSWORD*|*AUTH*) args+=(-u "$key") ;;
+    esac
+  done < <(env)
+  env "${args[@]}" "$@"
+}
 TIMEOUT="${TIMEOUT:-120}"
 LOG_DIR="${LOG_DIR:-$(mktemp -d -t mcp-examples-XXXXXX)}"
 mkdir -p "$LOG_DIR"
@@ -311,7 +324,7 @@ else
   # json_input uses BOTH a filesystem stdio server (self-launched) and a Playwright
   # MCP server on :8931 (external). Start Playwright, then run.
   start_server "playwright-mcp" 8931 "$LOG_DIR/_server_playwright.log" \
-    npx -y "$PLAYWRIGHT_MCP_PKG" --port 8931
+    strip_secrets npx -y "$PLAYWRIGHT_MCP_PKG" --port 8931
   if wait_ready 60; then
     RUN_TIMEOUT=300 run_example "json_input_mcp_servers_example.rb" "Connected to MCP servers|tools" - -- \
       bundle exec ruby examples/json_input_mcp_servers_example.rb
@@ -356,7 +369,7 @@ else
   # F2 — need an external Playwright MCP server on :8931.
   if [ -n "${OPENAI_API_KEY:-}" ] && command -v npx >/dev/null 2>&1; then
     start_server "playwright-mcp" 8931 "$LOG_DIR/_server_playwright2.log" \
-      npx -y "$PLAYWRIGHT_MCP_PKG" --port 8931
+      strip_secrets npx -y "$PLAYWRIGHT_MCP_PKG" --port 8931
     if wait_ready 60; then
       RUN_TIMEOUT=240 run_example "ruby_openai_mcp.rb" - - -- \
         bundle exec ruby examples/ruby_openai_mcp.rb

--- a/examples/run_all_examples.sh
+++ b/examples/run_all_examples.sh
@@ -39,6 +39,12 @@ cd "$REPO_ROOT"
 PYTHON="${PYTHON:-python3}"
 RUN_AI="${RUN_AI:-1}"
 RUN_NPX="${RUN_NPX:-1}"
+# npm packages are pinned rather than tracking @latest: this script exports the
+# local secrets file into the environment of every example it launches, so a
+# changed or compromised release would run with live API credentials in reach.
+# Override to try a newer release, e.g. PLAYWRIGHT_MCP_VERSION=0.0.79 ./run_all_examples.sh
+PLAYWRIGHT_MCP_VERSION="${PLAYWRIGHT_MCP_VERSION:-0.0.78}"
+PLAYWRIGHT_MCP_PKG="@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}"
 TIMEOUT="${TIMEOUT:-120}"
 LOG_DIR="${LOG_DIR:-$(mktemp -d -t mcp-examples-XXXXXX)}"
 mkdir -p "$LOG_DIR"
@@ -305,7 +311,7 @@ else
   # json_input uses BOTH a filesystem stdio server (self-launched) and a Playwright
   # MCP server on :8931 (external). Start Playwright, then run.
   start_server "playwright-mcp" 8931 "$LOG_DIR/_server_playwright.log" \
-    npx -y @playwright/mcp@latest --port 8931
+    npx -y "$PLAYWRIGHT_MCP_PKG" --port 8931
   if wait_ready 60; then
     RUN_TIMEOUT=300 run_example "json_input_mcp_servers_example.rb" "Connected to MCP servers|tools" - -- \
       bundle exec ruby examples/json_input_mcp_servers_example.rb
@@ -350,7 +356,7 @@ else
   # F2 — need an external Playwright MCP server on :8931.
   if [ -n "${OPENAI_API_KEY:-}" ] && command -v npx >/dev/null 2>&1; then
     start_server "playwright-mcp" 8931 "$LOG_DIR/_server_playwright2.log" \
-      npx -y @playwright/mcp@latest --port 8931
+      npx -y "$PLAYWRIGHT_MCP_PKG" --port 8931
     if wait_ready 60; then
       RUN_TIMEOUT=240 run_example "ruby_openai_mcp.rb" - - -- \
         bundle exec ruby examples/ruby_openai_mcp.rb

--- a/examples/sample_server_definition.json
+++ b/examples/sample_server_definition.json
@@ -8,9 +8,10 @@
       "command": "/opt/homebrew/bin/npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-filesystem",
+        "@modelcontextprotocol/server-filesystem@2026.7.10",
         "."
-      ]
+      ],
+      "comment": "Version-pinned so a changed release cannot silently run in this process. The root ('.') is the checkout; scope it to a disposable directory for anything beyond a read-only demo."
     }
   }
 }

--- a/examples/streamable_http_example.rb
+++ b/examples/streamable_http_example.rb
@@ -51,27 +51,33 @@ begin
     puts "  - #{tool.name}: #{tool.description&.split("\n")&.first || 'No description'}"
   end
 
-  # Example tool call. Prefer a tool that needs no required arguments so the demo
-  # succeeds regardless of which tools the server exposes (e.g. an arbitrary set of
-  # connected Zapier actions); fall back to describing how to call one explicitly.
-  if tools.any?
-    callable = tools.find do |tool|
-      required = (tool.schema && (tool.schema['required'] || tool.schema[:required])) || []
-      required.empty?
-    end
+  # Example tool call. The server picks which tools exist (for Zapier, an
+  # arbitrary set of connected actions that may send mail, move money, or
+  # change records), so this demo never invokes one on its own initiative:
+  # name the tool you want with MCP_EXAMPLE_TOOL. A zero-argument tool is only
+  # suggested, not called.
+  requested_tool = ENV.fetch('MCP_EXAMPLE_TOOL', nil)
 
-    if callable
-      puts "\n🔧 Calling tool: #{callable.name}"
-      result = client.call_tool(callable.name, {})
+  if tools.empty?
+    puts "\n⚠️  No tools available to call"
+  elsif requested_tool
+    tool = tools.find { |t| t.name == requested_tool }
+    if tool
+      puts "\n🔧 Calling tool requested via MCP_EXAMPLE_TOOL: #{tool.name}"
+      result = client.call_tool(tool.name, {})
       puts 'Tool result:'
       puts result.inspect
     else
-      puts "\nℹ️  Every advertised tool requires arguments, so no zero-arg demo call is possible."
-      puts '   Call one explicitly with its parameters, e.g.:'
-      puts "   client.call_tool('#{tools.first.name}', { ... })"
+      puts "\n⚠️  MCP_EXAMPLE_TOOL=#{requested_tool} is not advertised by this server"
     end
   else
-    puts "\n⚠️  No tools available to call"
+    suggestion = tools.find do |tool|
+      required = (tool.schema && (tool.schema['required'] || tool.schema[:required])) || []
+      required.empty?
+    end
+    puts "\nℹ️  No tool was called: this example does not invoke server-advertised tools on its own."
+    puts "   Pick one explicitly, e.g. MCP_EXAMPLE_TOOL='#{(suggestion || tools.first).name}'"
+    puts "   or in code: client.call_tool('#{(suggestion || tools.first).name}', { ... })"
   end
 
   # Test server connectivity

--- a/examples/streamable_http_example.rb
+++ b/examples/streamable_http_example.rb
@@ -30,6 +30,10 @@ abort 'Please set MCP_SERVER_URL (and optionally MCP_BEARER_TOKEN for authentica
 headers = {}
 headers['Authorization'] = "Bearer #{bearer_token}" if bearer_token
 
+# Tracks whether anything failed, so the process exit status reflects it —
+# printing an error while exiting 0 hides failures from CI and scripts.
+example_failed = false
+
 begin
   # Create client using the simplified connect API
   client = MCPClient.connect(server_url,
@@ -62,14 +66,21 @@ begin
     puts "\n⚠️  No tools available to call"
   elsif requested_tool
     tool = tools.find { |t| t.name == requested_tool }
-    if tool
-      puts "\n🔧 Calling tool requested via MCP_EXAMPLE_TOOL: #{tool.name}"
-      result = client.call_tool(tool.name, {})
-      puts 'Tool result:'
-      puts result.inspect
-    else
-      puts "\n⚠️  MCP_EXAMPLE_TOOL=#{requested_tool} is not advertised by this server"
+    # An explicit request must not end in a success marker when it did not
+    # run: a typo or a stale tool name has to be visible to a human and to
+    # exit-code-driven automation.
+    raise "MCP_EXAMPLE_TOOL=#{requested_tool} is not advertised by this server" unless tool
+
+    required = (tool.schema && (tool.schema['required'] || tool.schema[:required])) || []
+    unless required.empty?
+      raise "MCP_EXAMPLE_TOOL=#{requested_tool} requires arguments #{required.inspect}; " \
+            'this example only performs zero-argument calls'
     end
+
+    puts "\n🔧 Calling tool requested via MCP_EXAMPLE_TOOL: #{tool.name}"
+    result = client.call_tool(tool.name, {})
+    puts 'Tool result:'
+    puts result.inspect
   else
     suggestion = tools.find do |tool|
       required = (tool.schema && (tool.schema['required'] || tool.schema[:required])) || []
@@ -87,14 +98,18 @@ begin
 
   puts "\n✅ Example completed successfully!"
 rescue MCPClient::Errors::ConnectionError => e
+  example_failed = true
   puts "\n❌ Connection Error: #{e.message}"
   puts 'Make sure your server URL and credentials are correct'
 rescue MCPClient::Errors::TransportError => e
+  example_failed = true
   puts "\n❌ Transport Error: #{e.message}"
   puts 'The server may not be returning valid SSE format'
 rescue MCPClient::Errors::ServerError => e
+  example_failed = true
   puts "\n❌ Server Error: #{e.message}"
 rescue StandardError => e
+  example_failed = true
   puts "\n❌ Unexpected Error: #{e.class}: #{e.message}"
 ensure
   # Clean up connections
@@ -110,3 +125,5 @@ puts '   data: {"jsonrpc":"2.0","id":1,"result":{...}}'
 puts '3. Client parses SSE format and extracts JSON data'
 puts '4. Standard JSON-RPC processing continues normally'
 puts "\nThis allows HTTP semantics with streaming response format!"
+
+exit(1) if example_failed

--- a/examples/support/example_sandbox.rb
+++ b/examples/support/example_sandbox.rb
@@ -43,6 +43,23 @@ module ExampleSandbox
     %W[npx -y @modelcontextprotocol/server-filesystem@#{FILESYSTEM_SERVER_VERSION} #{filesystem_root}]
   end
 
+  # Environment overrides that strip credentials from a child process.
+  #
+  # Pinning the top-level npm package still leaves its transitive dependencies
+  # on version ranges, so `npx` can execute code this repo never pinned. The
+  # child also inherits the parent environment by default — which for these
+  # examples holds live API keys, and under examples/run_all_examples.sh the
+  # whole of secrets.env. Passing a key with a nil value makes Open3 unset it
+  # in the child, so a compromised package has nothing to exfiltrate.
+  #
+  # @param extra [Hash] additional variables the child does need
+  # @return [Hash] env hash for MCPClient.connect(env:)
+  def secret_free_env(extra = {})
+    stripped = ENV.keys.grep(/(_KEY|_TOKEN|_SECRET|CREDENTIAL|PASSWORD|AUTH)/i)
+                  .to_h { |key| [key, nil] }
+    stripped.merge(extra)
+  end
+
   # Print the standing caveat for examples that execute model-selected tools.
   # @param scope [String] what the model can reach in this example
   # @return [void]

--- a/examples/support/example_sandbox.rb
+++ b/examples/support/example_sandbox.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'tmpdir'
+
+# Shared safety helpers for the runnable examples.
+#
+# The LLM examples hand a model a set of MCP tools and execute whatever the
+# model picks, with no human in the loop. That is fine for a demo, but only if
+# the blast radius is a throwaway directory rather than the checkout — which
+# holds the git history, and (when the runner is configured)
+# examples/secrets.env with live API tokens.
+module ExampleSandbox
+  # npm packages the examples launch are pinned rather than floating on
+  # @latest, so a compromised or simply changed release cannot silently gain
+  # code execution in a process that holds live API credentials. Override to
+  # try a newer release, e.g.:
+  #   MCP_FS_SERVER_VERSION=2026.8.1 ruby examples/openai_ruby_mcp.rb
+  FILESYSTEM_SERVER_VERSION = ENV.fetch('MCP_FS_SERVER_VERSION', '2026.7.10')
+  PLAYWRIGHT_MCP_VERSION = ENV.fetch('PLAYWRIGHT_MCP_VERSION', '0.0.78')
+
+  module_function
+
+  # A disposable directory with a few sample files, used as the filesystem
+  # server's only root. Deleted when the example exits.
+  # @return [String] absolute path to the sandbox root
+  def filesystem_root
+    @filesystem_root ||= begin
+      root = Dir.mktmpdir('mcp-example-sandbox-')
+      File.write(File.join(root, 'README.txt'), "Sample file for the MCP filesystem demo.\n")
+      File.write(File.join(root, 'notes.md'), "# Notes\n\nAnother sample file.\n")
+      FileUtils.mkdir_p(File.join(root, 'subdir'))
+      File.write(File.join(root, 'subdir', 'nested.txt'), "A nested sample file.\n")
+      at_exit { FileUtils.remove_entry(root) if File.directory?(root) }
+      root
+    end
+  end
+
+  # Command that launches the pinned filesystem MCP server scoped to the
+  # sandbox, suitable for MCPClient.connect.
+  # @return [Array<String>]
+  def filesystem_server_command
+    %W[npx -y @modelcontextprotocol/server-filesystem@#{FILESYSTEM_SERVER_VERSION} #{filesystem_root}]
+  end
+
+  # Print the standing caveat for examples that execute model-selected tools.
+  # @param scope [String] what the model can reach in this example
+  # @return [void]
+  def announce_auto_execution(scope)
+    warn <<~WARNING
+      NOTE: this example executes whatever tool the model selects, without asking.
+      Reachable in this run: #{scope}
+      Production hosts should gate side-effecting tools behind user approval and
+      an explicit allowlist.
+    WARNING
+  end
+end


### PR DESCRIPTION
## Summary

Batched security fix for **twelve** low-severity findings from the codex-security scan, all in `examples/`. They share one root cause: the examples hand a model a set of MCP tools and execute whatever it selects, unattended, in a process holding live API credentials.

### Confused deputy — blast radius (6 findings)

`csf_a53a8d0f` (Anthropic), `csf_6e7bee6c` (OpenAI), `csf_cc319de1` (Gemini), `csf_6f0ec6a0` (Streamable HTTP), `csf_d4db8113` (RubyLLM), `csf_a2004a0e` (ruby-openai).

- The three filesystem examples rooted the server at `Dir.pwd` — the whole checkout, including `.git` and `examples/secrets.env` (live tokens, when the runner is configured). They now use a **disposable sandbox** (`examples/support/example_sandbox.rb`): a tmp directory seeded with sample files, removed at exit, and the run prints what it can reach. The Gemini case was the sharpest — that process can also read the Vertex service-account file.
- `streamable_http_example.rb` searched the server's advertised tools for any zero-argument one and **called it**. Against Zapier that is an arbitrary connected action (send mail, move money, change records) chosen by the server, not the user. It now *names* a candidate and calls nothing unless you set `MCP_EXAMPLE_TOOL`.
- The two browser examples document that they execute every model-selected Playwright action without confirmation, and that page content read by one tool can influence the next call — so they need a disposable browser profile, not an authenticated one.

### Supply chain (5 findings)

`csf_36298d0e`, `csf_834092af`, `csf_bd31f1ff` (unversioned `server-filesystem`), `csf_3f21ac26`, `csf_750fc629` (`@playwright/mcp@latest`).

`npx -y` resolves and executes a mutable release with no integrity check, in processes that hold `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / Vertex credentials — and `run_all_examples.sh` sources `secrets.env` into the environment of everything it launches. Both packages are now pinned (`@modelcontextprotocol/server-filesystem@2026.7.10`, `@playwright/mcp@0.0.78` — both verified to resolve on the registry), overridable via `MCP_FS_SERVER_VERSION` / `PLAYWRIGHT_MCP_VERSION`, across the examples, the runner script, and `sample_server_definition.json`.

### Plaintext credential storage (1 finding)

`csf_1ec706e6`: the `FileTokenStorage` demo wrote access tokens, refresh tokens and client secrets via `File.write`, leaving the mode to the process umask (commonly `0644`, world-readable). It now creates the file `0600` and says plainly that production storage belongs in an OS keychain or secrets manager.

## Testing

- Every modified file syntax-checked (`ruby -c`, `bash -n`, JSON parse); RuboCop clean across `examples/`.
- Sandbox helper smoke-tested: creates the tmp root with sample files and emits the pinned, sandbox-scoped command.
- Pinned versions confirmed present on the npm registry (HTTP 200).
- Library suite unaffected: 1613 examples, 0 failures.

Note: the LLM examples themselves make paid API calls and were not executed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)