### PR TITLE
Scope example servers to their session and fix fixture path containment

### DIFF
--- a/examples/echo_server_streamable.py
+++ b/examples/echo_server_streamable.py
@@ -74,7 +74,7 @@ def _now_iso():
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-def create_task_record(task_id, tool_name, arguments, ttl=None):
+def create_task_record(task_id, tool_name, arguments, ttl=None, owner_session_id=None):
     """Create a task record in the MCP 2025-11-25 shape."""
     now = _now_iso()
     task = {
@@ -86,6 +86,7 @@ def create_task_record(task_id, tool_name, arguments, ttl=None):
         "ttl": ttl,
         "pollInterval": 300,
         # Internal bookkeeping (not sent to the client)
+        "_owner_session_id": owner_session_id,
         "_tool_name": tool_name,
         "_arguments": arguments,
         "_result": None,
@@ -93,6 +94,18 @@ def create_task_record(task_id, tool_name, arguments, ttl=None):
     with tasks_lock:
         tasks_store[task_id] = task
     return task
+
+
+def task_owned_by(task, session_id):
+    """Whether a task belongs to the requesting MCP session.
+
+    Task IDs are handed to one session, so every task operation must be scoped
+    to its owner: otherwise any connected client could poll, read the result
+    of, or cancel another session's task by guessing or observing its ID.
+    Tasks created before ownership was recorded have no owner and stay
+    reachable only by a session-less caller.
+    """
+    return task.get("_owner_session_id") == session_id
 
 
 def task_to_response(task):
@@ -883,7 +896,9 @@ End of sample data.""".format(datetime.now().isoformat())
                 if task_aug is not None:
                     task_id = str(uuid.uuid4())
                     ttl = task_aug.get('ttl') if isinstance(task_aug, dict) else None
-                    task = create_task_record(task_id, tool_name, tool_args, ttl=ttl)
+                    task = create_task_record(
+                        task_id, tool_name, tool_args, ttl=ttl, owner_session_id=session_id
+                    )
                     threading.Thread(
                         target=run_task_in_background, args=(task_id, session_id), daemon=True
                     ).start()
@@ -1260,6 +1275,10 @@ End of sample data.""".format(datetime.now().isoformat())
             task_id = params.get('taskId', '')
             with tasks_lock:
                 task = tasks_store.get(task_id)
+                # A task belonging to another session is reported exactly like
+                # a missing one, so IDs cannot be probed for existence.
+                if task and not task_owned_by(task, session_id):
+                    task = None
             if task:
                 response_data = {"jsonrpc": "2.0", "id": request_id, "result": task_to_response(task)}
             else:
@@ -1277,6 +1296,8 @@ End of sample data.""".format(datetime.now().isoformat())
             task_id = params.get('taskId', '')
             with tasks_lock:
                 task = tasks_store.get(task_id)
+                if task and not task_owned_by(task, session_id):
+                    task = None
                 if not task:
                     response_data = {
                         "jsonrpc": "2.0", "id": request_id,
@@ -1303,7 +1324,10 @@ End of sample data.""".format(datetime.now().isoformat())
 
         elif method == 'tasks/list':
             with tasks_lock:
-                task_list = [task_to_response(t) for t in tasks_store.values()]
+                task_list = [
+                    task_to_response(t) for t in tasks_store.values()
+                    if task_owned_by(t, session_id)
+                ]
             response_data = {"jsonrpc": "2.0", "id": request_id, "result": {"tasks": task_list}}
             return Response(
                 format_sse_event("message", response_data),
@@ -1315,6 +1339,8 @@ End of sample data.""".format(datetime.now().isoformat())
             task_id = params.get('taskId', '')
             with tasks_lock:
                 task = tasks_store.get(task_id)
+                if task and not task_owned_by(task, session_id):
+                    task = None
                 if not task:
                     response_data = {
                         "jsonrpc": "2.0", "id": request_id,

--- a/examples/echo_server_streamable.py
+++ b/examples/echo_server_streamable.py
@@ -96,15 +96,29 @@ def create_task_record(task_id, tool_name, arguments, ttl=None, owner_session_id
     return task
 
 
+def active_session(session_id):
+    """Return the live Session for an id, or None.
+
+    Task operations must fail closed rather than fall back to an anonymous
+    owner: with a None owner every header-less caller matches every other
+    header-less caller's tasks, which is not isolation at all.
+    """
+    if not session_id:
+        return None
+    return sessions.get(session_id)
+
+
 def task_owned_by(task, session_id):
     """Whether a task belongs to the requesting MCP session.
 
     Task IDs are handed to one session, so every task operation must be scoped
     to its owner: otherwise any connected client could poll, read the result
     of, or cancel another session's task by guessing or observing its ID.
-    Tasks created before ownership was recorded have no owner and stay
-    reachable only by a session-less caller.
+    An unidentified caller owns nothing: comparing None to None would make
+    every anonymous caller the owner of every anonymous task.
     """
+    if not session_id or not task.get("_owner_session_id"):
+        return False
     return task.get("_owner_session_id") == session_id
 
 
@@ -260,6 +274,20 @@ def handle_rpc():
         params = request_data.get('params', {})
         request_id = request_data.get('id')
         
+        # Task operations are per-session: reject anything without a live
+        # session before touching tasks_store, so a caller with no (or a
+        # stale) session id cannot reach another caller's tasks.
+        if isinstance(method, str) and method.startswith('tasks/') and not active_session(session_id):
+            response_data = {
+                "jsonrpc": "2.0", "id": request_id,
+                "error": {"code": -32600, "message": "Missing or unknown Mcp-Session-Id for task operation"}
+            }
+            return Response(
+                format_sse_event("message", response_data),
+                content_type='text/event-stream',
+                headers={'Cache-Control': 'no-cache'}
+            )
+
         # Handle different methods
         if method == 'initialize':
             # Create new session
@@ -893,6 +921,17 @@ End of sample data.""".format(datetime.now().isoformat())
                 # Task-augmented request: create a task and return a
                 # CreateTaskResult now; the result comes later via tasks/result.
                 task_aug = params.get('task')
+                if task_aug is not None and not active_session(session_id):
+                    response_data = {
+                        "jsonrpc": "2.0", "id": request_id,
+                        "error": {"code": -32600,
+                                  "message": "Missing or unknown Mcp-Session-Id for task-augmented call"}
+                    }
+                    return Response(
+                        format_sse_event("message", response_data),
+                        content_type='text/event-stream',
+                        headers={'Cache-Control': 'no-cache'}
+                    )
                 if task_aug is not None:
                     task_id = str(uuid.uuid4())
                     ttl = task_aug.get('ttl') if isinstance(task_aug, dict) else None

--- a/examples/elicitation/elicitation_streamable_server.py
+++ b/examples/elicitation/elicitation_streamable_server.py
@@ -679,8 +679,11 @@ def handle_sse_stream():
 
     def generate_sse_events():
         try:
-            # Send endpoint as first event (just the path string)
-            yield "event: endpoint\ndata: /sse\n\n"
+            # Send endpoint as first event. The session id travels in the
+            # endpoint URI so every POST identifies its own session; without
+            # it the POST handler would have to guess which stream a request
+            # belongs to. Same-origin relative URI, per MCP 2024-11-05.
+            yield f"event: endpoint\ndata: /sse?sessionId={session_id}\n\n"
 
             # Stream events from the queue (client will send initialize via
             # POST)
@@ -720,29 +723,38 @@ def handle_sse_rpc():
     try:
         data = request.get_json()
 
-        # Get session ID from header (sent by SSE client after opening stream)
-        session_id = request.headers.get('Mcp-Session-Id')
+        # Identify the session explicitly: the Mcp-Session-Id header, or the
+        # sessionId carried by the endpoint URI we advertised on the stream.
+        #
+        # There is deliberately NO "use the first active session" fallback.
+        # With several clients connected that silently bound one client's
+        # POSTs — including elicitation responses holding whatever the user
+        # typed — to another client's session, and queued the replies onto
+        # that other client's SSE stream.
+        session_id = request.headers.get('Mcp-Session-Id') or request.args.get('sessionId')
 
-        if session_id and session_id in sessions:
-            session = sessions[session_id]
-            logger.debug(f"Using existing session: {session_id}")
-        else:
-            # Fallback: find first active session or create new one
-            session = None
-            if sessions:
-                for sid, sess in sessions.items():
-                    if sess.active:
-                        session = sess
-                        session_id = sid
-                        logger.debug(f"Found active session: {session_id}")
-                        break
+        if not session_id:
+            logger.warning("Rejecting SSE POST with no session id")
+            return jsonify({
+                'jsonrpc': '2.0',
+                'id': (request.get_json(silent=True) or {}).get('id'),
+                'error': {
+                    'code': -32600,
+                    'message': 'Missing session id: POST to the endpoint URI advertised '
+                               'on the SSE stream, or send the Mcp-Session-Id header'
+                }
+            }), 400
 
-            if not session:
-                # Create new session if none exists
-                session_id = str(uuid.uuid4())
-                session = Session(session_id)
-                sessions[session_id] = session
-                logger.info(f"Created new session for SSE RPC: {session_id}")
+        session = sessions.get(session_id)
+        if not session or not session.active:
+            logger.warning(f"Rejecting SSE POST for unknown session: {session_id}")
+            return jsonify({
+                'jsonrpc': '2.0',
+                'id': (request.get_json(silent=True) or {}).get('id'),
+                'error': {'code': -32600, 'message': f'Unknown session: {session_id}'}
+            }), 404
+
+        logger.debug(f"Using session: {session_id}")
 
         # Handle the JSON-RPC request or notification
         method = data.get('method')

--- a/spec/support/fake_filesystem_mcp_server.rb
+++ b/spec/support/fake_filesystem_mcp_server.rb
@@ -251,12 +251,42 @@ def send_error(id, message)
   $stdout.puts({ jsonrpc: '2.0', id: id, error: { code: -32_601, message: message } }.to_json)
 end
 
+# Whether a requested path stays inside ROOT_DIR.
+#
+# Both halves matter. Comparing strings with start_with? accepts a sibling
+# whose name merely begins with the root ("/srv/root-backup" vs "/srv/root"),
+# so containment is checked per path component. And an unresolved path follows
+# a symlink straight out of the root, so both sides are resolved with realpath
+# first (falling back to the lexical path when the target does not exist).
+# @param target [Pathname] the requested path
+# @return [Boolean]
+def within_root?(target)
+  resolved = resolve_path(target)
+  root = resolve_path(ROOT_DIR)
+  return true if resolved == root
+
+  resolved.to_s.start_with?("#{root}#{File::SEPARATOR}")
+end
+
+# @param path [Pathname]
+# @return [Pathname] the symlink-resolved path, or the lexical one if absent
+def resolve_path(path)
+  Pathname.new(File.realpath(path.to_s))
+rescue Errno::ENOENT
+  # A path that does not exist yet cannot be a symlink; resolve the deepest
+  # existing ancestor so a link in the middle of the path is still followed.
+  parent = path.parent
+  return path.expand_path if parent == path
+
+  resolve_path(parent).join(path.basename)
+end
+
 # Process list_directory tool call
 def process_list_directory(id, args)
   path = args['path'] || '.'
   target = ROOT_DIR.join(path).expand_path
 
-  unless target.to_s.start_with?(ROOT_DIR.to_s)
+  unless within_root?(target)
     send_error(id, 'Access denied')
     return
   end

--- a/spec/support/fake_filesystem_mcp_server_spec.rb
+++ b/spec/support/fake_filesystem_mcp_server_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'json'
+require 'open3'
+
+# The fixture server is a stand-in for a real filesystem MCP server, so its
+# root containment must behave like one: a lexical string prefix accepts a
+# sibling directory whose name merely starts with the root, and an unresolved
+# path follows a symlink straight out of the root.
+RSpec.describe 'fake_filesystem_mcp_server root containment' do
+  let(:server_path) { File.expand_path('fake_filesystem_mcp_server.rb', __dir__) }
+
+  around do |example|
+    Dir.mktmpdir('fs-fixture-') do |base|
+      @base = base
+      @root = File.join(base, 'root')
+      FileUtils.mkdir_p(@root)
+      File.write(File.join(@root, 'inside.txt'), "inside\n")
+      example.run
+    end
+  end
+
+  # Drive the stub over stdio the way the client does and return the parsed
+  # response to the single request.
+  def call_tool(name, args)
+    request = { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: name, arguments: args } }
+    out, = Open3.capture2(RbConfig.ruby, server_path, @root, stdin_data: "#{JSON.generate(request)}\n")
+    messages = out.lines.filter_map do |l|
+      JSON.parse(l)
+    rescue JSON::ParserError
+      nil
+    end
+    messages.find { |m| m['id'] == 1 } || {}
+  end
+
+  it 'lists a directory inside the root' do
+    response = call_tool('list_directory', { 'path' => '.' })
+
+    expect(response['error']).to be_nil
+    expect(response.dig('result', 'content', 0, 'text')).to include('inside.txt')
+  end
+
+  it 'denies a sibling directory whose name merely starts with the root path' do
+    sibling = "#{@root}-sibling"
+    FileUtils.mkdir_p(sibling)
+    File.write(File.join(sibling, 'secret.txt'), "outside\n")
+
+    response = call_tool('list_directory', { 'path' => '../root-sibling' })
+
+    expect(response.dig('error', 'message')).to eq('Access denied')
+  end
+
+  it 'denies a path that escapes the root through a symlink' do
+    outside = File.join(@base, 'outside')
+    FileUtils.mkdir_p(outside)
+    File.write(File.join(outside, 'secret.txt'), "outside\n")
+    File.symlink(outside, File.join(@root, 'link'))
+
+    response = call_tool('list_directory', { 'path' => 'link' })
+
+    expect(response.dig('error', 'message')).to eq('Access denied')
+  end
+
+  it 'denies a parent-directory traversal' do
+    response = call_tool('list_directory', { 'path' => '..' })
+
+    expect(response.dig('error', 'message')).to eq('Access denied')
+  end
+end


### PR DESCRIPTION
## Summary

Batched security fix for **seven** low-severity findings from the codex-security scan, all in the demo/fixture servers. Each one is a missing authorization or containment check that a real server must not copy from an example.

### Task ownership — `examples/echo_server_streamable.py` (4 findings)

`csf_1051a2ae` (cancel), `csf_f1baa2cb` (get), `csf_d2eb058f` (list), `csf_cefeb09c` (result).

`tasks_store` was process-global and every handler looked a task up by ID alone. Any connected session could therefore poll another session's task state, retrieve its completed result, cancel its in-progress work, or enumerate the entire process-wide inventory via `tasks/list`.

Tasks now record `_owner_session_id` at creation. `tasks/get`, `tasks/result` and `tasks/cancel` treat another session's task exactly like a missing one — so IDs can't be probed for existence — and `tasks/list` returns only the caller's own tasks.

### Session binding — `examples/elicitation/elicitation_streamable_server.py` (1 finding)

`csf_bd31ed78`. A POST whose `Mcp-Session-Id` header was missing or unknown fell through to "find the first active session". With more than one client connected, that silently bound one client's requests to another client's session — including elicitation *responses* carrying whatever the user typed — and queued the replies onto that other client's SSE stream.

The `endpoint` event now advertises `/sse?sessionId=<id>` (a same-origin relative URI, per MCP 2024-11-05), so every POST identifies its own session. A POST with no session id gets `400`; an unknown/inactive one gets `404`. No guessing.

### Path containment — `spec/support/fake_filesystem_mcp_server.rb` (2 findings)

`csf_6f8d9c0c` (lexical prefix), `csf_62a6556f` (symlink). Containment was `target.to_s.start_with?(ROOT_DIR.to_s)` on an unresolved path, which accepts a sibling directory whose name merely begins with the root (`/srv/root-backup` vs `/srv/root`) and follows a symlink straight out of the root. Now both sides are `realpath`-resolved (falling back to the deepest existing ancestor for paths that don't exist yet) and compared per path component.

## Testing

Verified by running the servers, not just by reading them:

- **New spec** `spec/support/fake_filesystem_mcp_server_spec.rb` drives the fixture over stdio: both escapes reproduced as failures before the fix and pass after; in-root listing and `..` traversal still behave.
- **Cross-session probe** against the running echo server: session A creates a task, session B gets `TaskNotFound` for get and cancel and an empty `tasks/list`, while A still sees `working` and lists its own. `examples/tasks_example.rb` completes its full lifecycle unchanged.
- **Elicitation SSE round trip** (`test_elicitation_sse_simple.rb`) completes against the modified server; a POST with no session id returns 400 and one with an unknown id returns 404.
- Full suite: 1610 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)