### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
 
+# Third-party actions are pinned to a full commit SHA rather than a mutable
+# tag. A tag can be repointed at new code by the action's owner (or anyone who
+# compromises that account), and here it would inherit ANTHROPIC_API_KEY,
+# pull-requests: write, and OIDC-minting rights. The trailing comment records
+# the human-readable version the SHA corresponds to; bump both together.
 on:
   push:
     branches: [ main ]
@@ -14,10 +19,10 @@ jobs:
         ruby-version: ['3.2', '3.3']
 
     steps:
-    - uses: actions/checkout@v4
-    
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
@@ -36,10 +41,10 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0
-    - uses: anthropics/claude-code-action@v1
+    - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
       with:
         prompt: |
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Security fix for a low-severity finding from the codex-security scan (`csf_07420c4b`, `supply-chain.mutable-github-action`).

`.github/workflows/ci.yml` referenced third-party actions by mutable tag (`@v1`, `@v4`). A tag is a movable pointer: the action's owner — or anyone who compromises that account — can repoint it at new code, and every subsequent workflow run picks it up silently. The `code-review` job is the sharp end, since it grants the referenced action `secrets.ANTHROPIC_API_KEY`, `pull-requests: write`, and `id-token: write` (OIDC minting).

## Fix

All three actions are pinned to the full commit SHA their tag currently resolves to, with the version in a trailing comment:

| Action | Pinned SHA | Was |
|---|---|---|
| `actions/checkout` | `11d5960a326750d5838078e36cf38b85af677262` | `@v4` |
| `ruby/setup-ruby` | `95ef2b042f9d7a56d8268cba8559e2842e2ad01b` | `@v1` |
| `anthropics/claude-code-action` | `be7b93b1907a4abad570368f3c74b6fe3807510b` | `@v1` |

Each SHA was resolved from the tag through the GitHub API and verified to exist in the upstream repository. This is GitHub's own [recommended hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), and Dependabot understands the `SHA # version` form, so update PRs still arrive — they just become reviewable diffs instead of invisible tag moves.

## Note on the code-review check

The `code-review` job fails on most PRs in this repo (~370 ms, `is_error:true`, `$0` cost), including before this change and on re-runs. It happened to succeed on this PR's first run, but a same-day re-run of an unpinned branch failed again with the identical signature — so this is flaky/expiring upstream configuration (likely the `ANTHROPIC_API_KEY` secret or the pinned `claude-opus-4-6` model), **not** something pinning fixed or broke. The `test` jobs are the reliable signal. Worth a separate look.

Note also that `v1` here is an *annotated* tag: its ref object dereferences to commit `be7b93b…`, which is what this PR pins. Pinning the commit (not the tag object) is the correct form.

## Testing

Workflow YAML parses and every `uses:` resolves to the intended pinned reference. No library code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
