### PR TITLE
Pin a bundler that supports the new default Ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,4 +194,4 @@ DEPENDENCIES
   yard (~> 0.9.34)
 
 BUNDLED WITH
-   2.5.16
+   4.0.17


### PR DESCRIPTION
## Summary

Follow-up to #204, found while verifying merged `main`.

Making Ruby 4.0.6 the default left `Gemfile.lock` pinning `BUNDLED WITH 2.5.16`, which predates Ruby 4. Locally that combination breaks:

- every child process spawned from `bundle exec` inherits `RUBYOPT=-rbundler/setup`, and bundler 2.5.16 floods stderr with `already initialized constant Gem::Platform::*` against Ruby 4's RubyGems while re-resolving;
- that delayed the two **real-subprocess** stdio compliance specs past their timeouts (`server_stdio_compliance_spec.rb:38` and `:54`), and made the whole suite ~4× slower (3m59s vs 56s).

I confirmed it is not related to the security merges: the same two specs fail with the **pre-merge** stdio code under 4.0.6, and pass on 4.0.6 as soon as a compatible bundler is used.

CI never caught this because `ruby/setup-ruby` installs its own bundler rather than the one in the lockfile — so it only affected anyone following `.ruby-version`, which is exactly what #204 told people to do.

## Fix

`BUNDLED WITH` → `4.0.17`. It declares `required_ruby_version >= 3.2.0`, the same floor as this gem, so it covers all three tested Rubies (4.0.6, 3.3, 3.2).

## Testing

| | before | after |
|---|---|---|
| `server_stdio_compliance_spec.rb` on 4.0.6 | 2 failures | 10 examples, 0 failures |
| full suite on 4.0.6 | 2 failures, 3m59s | **1693 examples, 0 failures, 56s** |

RuboCop clean (136 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)