### PR TITLE
Ask the model for "./" rather than "the sandbox directory"

### DIFF
--- a/examples/gemini_ai_mcp.rb
+++ b/examples/gemini_ai_mcp.rb
@@ -201,7 +201,7 @@ second_input = {
     function_declarations: google_tools
   },
   contents: [
-    { role: 'user', parts: { text: 'List all files in the sandbox directory' } },
+    { role: 'user', parts: { text: 'List all files in the directory path "./"' } },
     candidate['content'], # the assistant message containing the functionCall
     { role: 'function', parts: [function_response_part] }
   ],

--- a/examples/openai_ruby_mcp.rb
+++ b/examples/openai_ruby_mcp.rb
@@ -40,7 +40,7 @@ tools = mcp_client.to_openai_tools
 # Build initial chat messages
 messages = [
   { role: 'system', content: 'You can call filesystem tools.' },
-  { role: 'user', content: 'List all files in the sandbox directory' }
+  { role: 'user', content: 'List all files in the directory path "./"' }
 ]
 
 # 1) Send chat with function definitions

--- a/examples/ruby_anthropic_mcp.rb
+++ b/examples/ruby_anthropic_mcp.rb
@@ -49,7 +49,7 @@ claude_tools = mcp_client.to_anthropic_tools
 
 # Build initial chat messages
 messages = [
-  { role: 'user', content: 'List all files in the sandbox directory' }
+  { role: 'user', content: 'List all files in the directory path "./"' }
 ]
 
 # Faraday raises on HTTP errors with only the status in the message; surface


### PR DESCRIPTION
## Summary

Found while running the full examples suite against merged `main`.

When #201 moved the filesystem examples onto a disposable sandbox root, I also reworded their prompts to "List all files in the sandbox directory". That is ambiguous: the MCP filesystem server is *already rooted at* the sandbox, so there is no directory called `sandbox` inside it.

GPT took it literally, looked for that subdirectory, found nothing, and replied:

> There is no sandbox directory available. Please let me know if there is any other directory you would like to check.

…**without calling any tool at all**. The example still scored `✔ PASS`, because the runner's criteria for it are lenient — so the demo quietly stopped demonstrating the thing it exists to demonstrate.

Gemini was unaffected: its first turn kept an explicit `"./"`. That contrast is what made the cause obvious.

## Fix

All three filesystem examples now ask for `"./"` consistently, including Gemini's follow-up turn (which had inherited the reworded text).

## Testing

Re-ran `openai_ruby_mcp.rb` against the live API:

```
The directory "./" contains the following files and folders:
- README.txt (file)
- notes.md (file)
- subdir (directory)
```

i.e. it calls `list_directory` and returns the sandbox contents, matching Gemini's behaviour. RuboCop clean.

`ruby_anthropic_mcp.rb` has the same one-line change but could not be run here — no `ANTHROPIC_API_KEY` in this environment, so the suite skips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)