### PR TITLE
Release 2.1.0 — Hostile-Server Hardening

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,11 @@ Metrics/PerceivedComplexity:
 
 Metrics/ParameterLists:
   Max: 8
+  # The *_config builders are keyword-only option factories: every keyword is a
+  # documented, defaulted transport setting. Counting those against a limit
+  # meant for positional arguments would push new options into an opaque
+  # options hash, which is worse for callers.
+  CountKeywordArgs: false
 
 Metrics/ModuleLength:
   Max: 500

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 A security pass over every transport, driven by an external scan of the 2.0.0
 codebase (50 findings: 12 medium, 38 low) and a second, adversarial review of
-each fix (PRs #188–#210). Every finding was reproduced before it was fixed and
-re-verified afterwards — including two bugs found by reviewing the release
-notes themselves against the code (#209, #210).
+each fix (PRs #188–#211). Every finding was reproduced before it was fixed and
+re-verified afterwards — including three bugs found by reviewing the release
+notes themselves against the code (#209, #210, #211).
 
 The theme: **a remote MCP server is untrusted input.** 2.0.0 was correct against
 a cooperative server but assumed good faith in places where a hostile — or merely
@@ -45,15 +45,18 @@ retries, logs and reflects back.
   server. Peers receive `'Internal error'` / `'Sampling error'` /
   `'Elicitation handler error'`; the detail stays in the local log. Error
   **codes** are unchanged.
-- **Logs no longer contain payloads** (#198, #210). Request params, response
-  bodies and raw SSE chunks are replaced by a method/id summary and a byte count,
-  so enabling DEBUG no longer records `tools/call` arguments, tool results or
-  elicitation content. The SSE *error* paths are covered too: a non-object JSON
-  payload used to be logged with `#inspect` at **WARN**, which the default
-  logger emits, so that one leaked without DEBUG being enabled at all. Server
-  configs are logged with credential-bearing keys redacted, and peer-supplied
-  log messages are control-character escaped and capped (a server could
-  otherwise forge log lines).
+- **Logs no longer contain payloads** (#198, #210, #211). Request params,
+  response bodies and raw SSE chunks are replaced by a method/id summary and a
+  byte count, so enabling DEBUG no longer records `tools/call` arguments, tool
+  results or elicitation content. The *error* paths are covered too, and they
+  were the leakier ones: a non-object JSON payload used to be logged with
+  `#inspect` at **WARN** (which the default logger emits, so it leaked with
+  DEBUG off), and `JSON::ParserError#message` quotes the offending token, so
+  malformed peer JSON echoed into logs and into the `Invalid JSON response from
+  server` exception on every transport. Parse failures now report position and
+  size only. Server configs are logged with credential-bearing keys redacted,
+  and peer-supplied log messages are control-character escaped and capped (a
+  server could otherwise forge log lines).
 - **Cross-origin traffic is refused on the legacy SSE transport** (#189). An
   `endpoint` control event that changes scheme/host/port fails the handshake, and
   redirects that leave the connection origin are refused — `faraday-follow_redirects`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,150 @@
 # Changelog
 
+## 2.1.0 — Hostile-Server Hardening (2026-08-04)
+
+A security pass over every transport, driven by an external scan of the 2.0.0
+codebase (50 findings: 12 medium, 38 low) and a second, adversarial review of
+each fix (PRs #188–#210). Every finding was reproduced before it was fixed and
+re-verified afterwards — including two bugs found by reviewing the release
+notes themselves against the code (#209, #210).
+
+The theme: **a remote MCP server is untrusted input.** 2.0.0 was correct against
+a cooperative server but assumed good faith in places where a hostile — or merely
+compromised — peer controls the data. Nothing here changes the wire protocol, and
+the ordinary client API is unchanged; what changes is what the client accepts,
+retries, logs and reflects back.
+
+### Breaking Changes
+
+- **`tools/call` is never retried automatically** (#196). A "transient" failure
+  (HTTP 5xx, dropped connection) can arrive *after* the server executed the
+  request, so replaying it risks a duplicate side effect, and JSON-RPC has no
+  idempotency key to make that safe. `NON_IDEMPOTENT_METHODS` is excluded from
+  `with_retry` on all four transports. Idempotent methods (`tools/list`,
+  `resources/read`, `ping`, …) retry exactly as before. Hosts that relied on
+  tool calls being retried must now retry explicitly and decide for themselves
+  whether re-execution is acceptable.
+
+  This also covers **session-expiry recovery** on the HTTP transports (#209).
+  A 404 carrying an expired `Mcp-Session-Id` still starts a fresh session, but
+  the original request is only re-sent when it is idempotent; a `tools/call`
+  instead raises `ConnectionError` saying the request was not resent because it
+  may already have executed. Without this, session recovery was a second,
+  independent path around the guarantee — and it applied even with
+  `retries: 0`.
+- **Task operations refuse to guess a server** (#199). Task IDs are unique only
+  within the server that issued them, so `get_task`/`get_task_result`/
+  `cancel_task` no longer default to the first configured server. Pass the
+  `MCPClient::Task` returned by `call_tool_as_task` (it carries its own server),
+  or name the server explicitly. A bare ID still works with a single configured
+  server; with several it raises `ArgumentError` rather than acting on the wrong
+  one.
+- **Peer-facing error messages are constant** (#198). Host callback exceptions
+  are no longer interpolated into JSON-RPC error responses on any transport —
+  a handler raising with a file path or connection string used to send it to the
+  server. Peers receive `'Internal error'` / `'Sampling error'` /
+  `'Elicitation handler error'`; the detail stays in the local log. Error
+  **codes** are unchanged.
+- **Logs no longer contain payloads** (#198, #210). Request params, response
+  bodies and raw SSE chunks are replaced by a method/id summary and a byte count,
+  so enabling DEBUG no longer records `tools/call` arguments, tool results or
+  elicitation content. The SSE *error* paths are covered too: a non-object JSON
+  payload used to be logged with `#inspect` at **WARN**, which the default
+  logger emits, so that one leaked without DEBUG being enabled at all. Server
+  configs are logged with credential-bearing keys redacted, and peer-supplied
+  log messages are control-character escaped and capped (a server could
+  otherwise forge log lines).
+- **Cross-origin traffic is refused on the legacy SSE transport** (#189). An
+  `endpoint` control event that changes scheme/host/port fails the handshake, and
+  redirects that leave the connection origin are refused — `faraday-follow_redirects`
+  strips only `Authorization`, so a custom API-key header and the request body
+  would otherwise reach the new origin.
+- **Peer-advertised OAuth discovery URLs must be HTTPS and non-local** (#190).
+  The `resource_metadata` URL from a 401 challenge and the `authorization_servers`
+  origin from Protected Resource Metadata are validated before any fetch. The
+  plain-HTTP loopback exception now applies only when the *configured* server is
+  itself local, so a remote server can no longer point discovery at a *literal*
+  loopback or private address. A refused challenge fails closed instead of
+  falling back to cached metadata. The check is textual: hostnames are not
+  resolved, so a public name whose DNS record points inside your network is not
+  caught — restrict egress at the network layer if that matters to you.
+- **Oversized and malformed peer data is rejected** rather than absorbed:
+  gzip bodies that expand past the limit (#188 — Streamable HTTP, the only
+  transport that requests gzip), SSE events that never terminate (#191, #192),
+  event IDs that are unbounded or illegal in an HTTP header (#200).
+
+### New Features
+
+- **`max_decompressed_body_bytes`** on the Streamable HTTP transport (#188).
+  Bounds how far a gzip response may expand (default 64 MiB) so a small
+  "gzip bomb" cannot exhaust memory. Configurable because the ceiling would
+  otherwise make a large legitimate response depend on whether the server chose
+  to compress it.
+- **`MCPClient::Errors::ResponseTooLargeError`** (#188), a `TransportError`
+  subclass that is deliberately excluded from retries: the server already ran the
+  request, so re-sending risks a duplicate side effect.
+- **Ruby 4.0.6 is the development default** (#204, #205), with a dedicated CI
+  suite. 3.2 and 3.3 remain tested and `required_ruby_version` is unchanged at
+  `>= 3.2.0`. A tracked `.ruby-version` replaces the gitignored `.tool-versions`,
+  and `BUNDLED WITH` moves to a bundler that supports Ruby 4.
+
+### Bug Fixes
+
+- Server-supplied schema `pattern` values are matched under a **whole-operation**
+  time budget (#197). A per-match limit was not a bound, because the peer also
+  chooses how many strings are matched; a timeout now fails validation rather than
+  silently accepting a value whose constraint was never evaluated.
+- Server-initiated replies (pongs, roots/sampling/elicitation, error responses)
+  no longer spawn unbounded threads (#194); the budget is released correctly when
+  thread creation fails, and saturation warnings are rate-limited so the fix does
+  not become its own log-flood vector.
+- Unsolicited SSE responses are discarded instead of accumulating in the pending
+  map, and `cleanup` no longer drops a result whose request is still pending —
+  which would have reported a timeout for a tool the server had already run (#195).
+- SSE buffers are appended and scanned incrementally (#191, #192). Capping the
+  size bounded memory but left an O(N²) copy/rescan path: an unterminated event
+  in 16 KiB chunks took 11.2s before, 0.018s now.
+- Server `retry:` directives are floored so `retry: 0` cannot drive a tight
+  reconnect loop (#193, #200), while the first resumption GET still goes out
+  immediately when no directive was given.
+- A JSON-parseable scalar or array arriving on the GET events stream no longer
+  raises inside message dispatch; it is skipped with a typed warning, matching
+  the POST response path (#210).
+
+### Examples & Tooling
+
+- Filesystem examples run against a disposable sandbox directory instead of the
+  checkout, npm servers are version-pinned, and credential-looking variables are
+  stripped from child processes (#201, #206). `streamable_http_example.rb` no
+  longer invokes an arbitrary server-advertised tool — name one with
+  `MCP_EXAMPLE_TOOL`. The OAuth storage demo writes its token file atomically
+  at `0600`.
+- The bundled example servers enforce session ownership for task operations and
+  reject session-less POSTs, and the filesystem test fixture resolves symlinks
+  and compares path components instead of string prefixes (#202).
+- GitHub Actions are pinned to commit SHAs (#203).
+
+### Migration notes
+
+- If you relied on `tools/call` being retried, retry explicitly. Treat the raised
+  error as "outcome unknown" — the server may already have executed the call.
+  This includes the session-expiry path: a tool call interrupted by an expired
+  session now raises instead of being transparently re-sent against the new one.
+- In multi-server clients, replace `client.get_task(id)` with
+  `client.get_task(task)` (the handle from `call_tool_as_task`) or add
+  `server:`. Single-server clients need no change.
+- If you parsed detail out of JSON-RPC error messages a peer sent you, or out of
+  this client's DEBUG logs, those strings are now constant/summarized. Codes and
+  local logs still carry the detail.
+- A server that advertises a cross-origin SSE `endpoint`, a plain-HTTP or loopback
+  OAuth discovery URL, or redirects RPC POSTs off-origin will now be rejected. If
+  you develop against a local stack, point the *configured* server URL at
+  localhost and the loopback exception still applies.
+- Set `max_decompressed_body_bytes:` if you legitimately exchange responses that
+  expand beyond 64 MiB.
+- Development now expects Ruby 4.0.6 (`.ruby-version`); the gem still supports
+  3.2+. Run `bundle install` after upgrading — `BUNDLED WITH` changed.
+
 ## 2.0.0 — MCP 2025-11-25 Conformance (2026-07-21)
 
 Full compliance pass against the **MCP 2025-11-25** specification: every transport,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    ruby-mcp-client (2.0.0)
+    ruby-mcp-client (2.1.0)
       base64 (~> 0.2)
       faraday (~> 2.0)
       faraday-follow_redirects (~> 0.3)
@@ -194,4 +194,4 @@ DEPENDENCIES
   yard (~> 0.9.34)
 
 BUNDLED WITH
-   4.0.17
+  4.0.17

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ with a revision it cannot speak (supported: `2025-11-25`, `2025-06-18`,
 - **Metadata**: `icons`, `title` and `_meta` parsed on tools, prompts and resources
 - **OAuth 2.1**: PKCE (S256 required), RFC 8414/9728 discovery, dynamic registration, Client ID Metadata Documents, scope step-up challenges
 
+Transports treat the server as untrusted input — see
+[Treating the Server as Untrusted](#treating-the-server-as-untrusted) for the
+limits applied to peer-controlled data.
+
 ## Quick Connect API (Recommended)
 
 The simplest way to connect to an MCP server:
@@ -401,11 +405,48 @@ The `retries:` option controls automatic retry with exponential backoff. Only
 failures where the request most likely did **not** complete at the server are
 retried: transport/network errors and HTTP **5xx** responses. Application-level
 failures — a JSON-RPC error response or an HTTP **4xx** — are **never** retried,
-because the server already processed or rejected the request and re-sending
-would risk re-executing a non-idempotent `tools/call`. Retryable server failures
-raise `MCPClient::Errors::TransientServerError`, a subclass of
+because the server already processed or rejected the request. Retryable server
+failures raise `MCPClient::Errors::TransientServerError`, a subclass of
 `MCPClient::Errors::ServerError`, so existing `rescue ServerError` handlers are
 unaffected.
+
+**`tools/call` is never retried automatically.** Even a "transient" failure can
+arrive *after* the server executed the request, and JSON-RPC has no idempotency
+key that would make a replay safe — so a retry could run a side effect twice.
+Retry a tool call explicitly if your application knows it is safe to repeat, and
+treat the raised error as *outcome unknown* rather than *not executed*:
+
+```ruby
+begin
+  client.call_tool('send_invoice', { customer: 'acme' })
+rescue MCPClient::Errors::TransportError => e
+  # The server may or may not have sent the invoice. Check before retrying.
+end
+```
+
+The same reasoning excludes `RequestTimeoutError` and `ResponseTooLargeError`
+from retries, and applies to session recovery: if a `tools/call` comes back with
+an expired-session 404, the client starts a fresh session but does **not** re-send
+the call — it raises so you can decide. Idempotent requests are re-sent against
+the new session as before.
+
+### Response Size Limits (Streamable HTTP)
+
+A gzip-encoded response is decompressed incrementally and abandoned once it
+expands past `max_decompressed_body_bytes` (default **64 MiB**), so a small
+highly-compressed body cannot exhaust memory. Exceeding it raises
+`MCPClient::Errors::ResponseTooLargeError`.
+
+Raise the limit if you legitimately exchange very large payloads — base64
+resource blobs or audio — so that whether a response is accepted does not depend
+on the server's choice to compress it:
+
+```ruby
+MCPClient.streamable_http_config(
+  base_url: 'https://api.example.com/mcp',
+  max_decompressed_body_bytes: 256 * 1024 * 1024
+)
+```
 
 ### Faraday Customization
 
@@ -646,10 +687,45 @@ tools = client.list_tools
 result = client.call_tool('echo', { message: 'Hello!' })
 ```
 
+## Treating the Server as Untrusted
+
+A connected MCP server controls everything it sends you, and the transports are
+written on that assumption. You do not need to configure any of this — it is the
+default behaviour — but it is worth knowing what the client will refuse:
+
+| Peer-controlled input | What the client does |
+|---|---|
+| Compressed response bodies (**Streamable HTTP only** — the only transport that requests gzip) | Decompressed incrementally, abandoned past `max_decompressed_body_bytes` (64 MiB default) |
+| SSE streams | Per-connection buffer cap; events scanned incrementally, so an unterminated event costs bounded memory *and* CPU |
+| `retry:` directives | Honored, but floored so `retry: 0` cannot drive a reconnect loop |
+| SSE event IDs | Bounded length, printable ASCII only (they are echoed in `Last-Event-ID`) |
+| Legacy SSE `endpoint` events | Must stay on the connection's origin; off-origin redirects are refused, so configured credential headers never reach another host |
+| OAuth discovery URLs from a peer | Must be HTTPS, and rejected when the host is a *literal* loopback/private/link-local address (unless the configured server is itself local); a refused challenge fails closed. Hostnames are not resolved, so a public name pointing at a private address is not caught — see the note below |
+| Unsolicited JSON-RPC responses | Discarded — only IDs with an outstanding request are accepted |
+| Server-initiated requests | Replies are bounded by a concurrency budget rather than spawning unbounded threads |
+| Schema `pattern` values | Matched under a whole-operation time budget; a timeout fails validation rather than silently passing |
+| Log messages (`notifications/message`) | Control characters escaped and length-capped, so a server cannot forge log lines |
+
+**Known limit:** the OAuth check is textual. A peer can still advertise a public
+hostname whose DNS record points inside your network; catching that needs
+resolution-time filtering in the HTTP layer, which this gem does not do. If you
+run in an environment where that matters, restrict egress at the network layer.
+
+Two related defaults worth calling out because they affect *your* data rather
+than the peer's:
+
+- **Payloads are never written to logs.** At DEBUG the client logs a method/id
+  summary and a byte count, not request params, response bodies or raw SSE
+  chunks. Server configurations are logged with credential-bearing keys redacted.
+- **Host exceptions are not reflected to the server.** A raising elicitation,
+  sampling or roots handler yields a constant JSON-RPC error message; the detail
+  stays in your local log.
+
 ## Requirements
 
 - Ruby >= 3.2.0
-- No runtime dependencies
+- Runtime dependencies: `faraday` (~> 2.0) with `faraday-follow_redirects` and
+  `faraday-retry`, plus `base64` — all pulled in automatically by the gem
 
 Development uses Ruby 4.0.6 (see `.ruby-version`). CI runs the suite on 4.0.6
 plus the supported floor, 3.2 and 3.3.

--- a/lib/mcp_client.rb
+++ b/lib/mcp_client.rb
@@ -453,11 +453,17 @@ module MCPClient
   # @param retry_backoff [Integer] Backoff delay in seconds (default: 1)
   # @param name [String, nil] Optional name for this server
   # @param logger [Logger, nil] Optional logger for server operations
+  # @param max_decompressed_body_bytes [Integer] ceiling on how far a gzip-encoded
+  #   response may expand before it is rejected, guarding against a small highly
+  #   compressed body exhausting memory (default: 64 MiB)
   # @yieldparam faraday [Faraday::Connection] the configured connection instance for additional customization
   #   (e.g., SSL settings, custom middleware). The block is called after default configuration is applied.
   # @return [Hash] server configuration
   def self.streamable_http_config(base_url:, endpoint: '/rpc', headers: {}, read_timeout: 30, retries: 3,
-                                  retry_backoff: 1, name: nil, logger: nil, &faraday_config)
+                                  retry_backoff: 1, name: nil, logger: nil,
+                                  max_decompressed_body_bytes:
+                                    MCPClient::ServerStreamableHTTP::JsonRpcTransport::MAX_DECOMPRESSED_BODY_BYTES,
+                                  &faraday_config)
     {
       type: 'streamable_http',
       base_url: base_url,
@@ -468,6 +474,7 @@ module MCPClient
       retry_backoff: retry_backoff,
       name: name,
       logger: logger,
+      max_decompressed_body_bytes: max_decompressed_body_bytes,
       faraday_config: faraday_config
     }
   end

--- a/lib/mcp_client/auth.rb
+++ b/lib/mcp_client/auth.rb
@@ -100,13 +100,11 @@ module MCPClient
       # @param tos_uri [String, nil] URL of the client terms of service
       # @param policy_uri [String, nil] URL of the client privacy policy
       # @param contacts [Array<String>, nil] List of contact emails for the client
-      # rubocop:disable Metrics/ParameterLists
       def initialize(redirect_uris:, token_endpoint_auth_method: 'none',
                      grant_types: %w[authorization_code refresh_token],
                      response_types: ['code'], scope: nil,
                      client_name: nil, client_uri: nil, logo_uri: nil,
                      tos_uri: nil, policy_uri: nil, contacts: nil)
-        # rubocop:enable Metrics/ParameterLists
         @redirect_uris = redirect_uris
         @token_endpoint_auth_method = token_endpoint_auth_method
         @grant_types = grant_types
@@ -238,11 +236,9 @@ module MCPClient
       # @param code_challenge_methods_supported [Array<String>, nil] Supported PKCE code challenge methods (RFC 8414)
       # @param client_id_metadata_document_supported [Boolean, nil] Whether the server accepts
       #   Client ID Metadata Document client IDs (MCP 2025-11-25 / SEP-991)
-      # rubocop:disable Metrics/ParameterLists
       def initialize(issuer:, authorization_endpoint:, token_endpoint:, registration_endpoint: nil,
                      scopes_supported: nil, response_types_supported: nil, grant_types_supported: nil,
                      code_challenge_methods_supported: nil, client_id_metadata_document_supported: nil)
-        # rubocop:enable Metrics/ParameterLists
         @issuer = issuer
         @authorization_endpoint = authorization_endpoint
         @token_endpoint = token_endpoint

--- a/lib/mcp_client/resource.rb
+++ b/lib/mcp_client/resource.rb
@@ -36,7 +36,6 @@ module MCPClient
     # @param icons [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25)
     # @param meta [Hash, nil] optional `_meta` metadata attached to the resource (MCP 2025-11-25)
     # @param server [MCPClient::ServerBase, nil] the server this resource belongs to
-    # rubocop:disable Metrics/ParameterLists
     def initialize(uri:, name:, title: nil, description: nil, mime_type: nil, size: nil, annotations: nil,
                    icons: nil, meta: nil, server: nil)
       @uri = uri
@@ -50,7 +49,6 @@ module MCPClient
       @meta = meta
       @server = server
     end
-    # rubocop:enable Metrics/ParameterLists
 
     # Return the lastModified annotation value (ISO 8601 timestamp string)
     # @return [String, nil] the lastModified timestamp, or nil if not set

--- a/lib/mcp_client/resource_link.rb
+++ b/lib/mcp_client/resource_link.rb
@@ -35,7 +35,6 @@ module MCPClient
     # @param size [Integer, nil] optional size of the resource in bytes
     # @param icons [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25)
     # @param meta [Hash, nil] optional `_meta` metadata attached to the resource link (MCP 2025-11-25)
-    # rubocop:disable Metrics/ParameterLists
     def initialize(uri:, name:, description: nil, mime_type: nil, annotations: nil, title: nil, size: nil,
                    icons: nil, meta: nil)
       @uri = uri
@@ -48,7 +47,6 @@ module MCPClient
       @icons = icons
       @meta = meta
     end
-    # rubocop:enable Metrics/ParameterLists
 
     # Create a ResourceLink instance from JSON data
     # @param data [Hash] JSON data from MCP server (content item with type 'resource_link')

--- a/lib/mcp_client/resource_template.rb
+++ b/lib/mcp_client/resource_template.rb
@@ -34,7 +34,6 @@ module MCPClient
     # @param icons [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25)
     # @param meta [Hash, nil] optional `_meta` metadata attached to the resource template (MCP 2025-11-25)
     # @param server [MCPClient::ServerBase, nil] the server this resource template belongs to
-    # rubocop:disable Metrics/ParameterLists
     def initialize(uri_template:, name:, title: nil, description: nil, mime_type: nil, annotations: nil,
                    icons: nil, meta: nil, server: nil)
       @uri_template = uri_template
@@ -47,7 +46,6 @@ module MCPClient
       @meta = meta
       @server = server
     end
-    # rubocop:enable Metrics/ParameterLists
 
     # Create a ResourceTemplate instance from JSON data
     # @param data [Hash] JSON data from MCP server

--- a/lib/mcp_client/server_factory.rb
+++ b/lib/mcp_client/server_factory.rb
@@ -99,7 +99,10 @@ module MCPClient
         name: config[:name],
         logger: logger,
         oauth_provider: config[:oauth_provider],
-        faraday_config: config[:faraday_config]
+        faraday_config: config[:faraday_config],
+        max_decompressed_body_bytes:
+          config[:max_decompressed_body_bytes] ||
+            MCPClient::ServerStreamableHTTP::JsonRpcTransport::MAX_DECOMPRESSED_BODY_BYTES
       )
     end
 

--- a/lib/mcp_client/tool.rb
+++ b/lib/mcp_client/tool.rb
@@ -38,7 +38,6 @@ module MCPClient
     # @param task_support [String, nil] execution.taskSupport value (MCP 2025-11-25)
     # @param icons [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25)
     # @param meta [Hash, nil] optional `_meta` metadata attached to the tool (MCP 2025-11-25)
-    # rubocop:disable Metrics/ParameterLists
     def initialize(name:, description:, schema:, title: nil, output_schema: nil, annotations: nil, server: nil,
                    task_support: nil, icons: nil, meta: nil)
       @name = name
@@ -52,7 +51,6 @@ module MCPClient
       @icons = icons
       @meta = meta
     end
-    # rubocop:enable Metrics/ParameterLists
 
     # Create a Tool instance from JSON data
     # @param data [Hash] JSON data from MCP server

--- a/lib/mcp_client/version.rb
+++ b/lib/mcp_client/version.rb
@@ -2,7 +2,7 @@
 
 module MCPClient
   # Current version of the MCP client gem
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 
   # MCP protocol version (date-based) - unified across all transports
   PROTOCOL_VERSION = '2025-11-25'

--- a/spec/lib/mcp_client/server_streamable_http/json_rpc_transport_spec.rb
+++ b/spec/lib/mcp_client/server_streamable_http/json_rpc_transport_spec.rb
@@ -613,6 +613,26 @@ RSpec.describe MCPClient::ServerStreamableHTTP::JsonRpcTransport do
       roomy.cleanup
     end
 
+    it 'is reachable through streamable_http_config and the server factory' do
+      # The knob is useless if the documented configuration path cannot set it.
+      config = MCPClient.streamable_http_config(
+        base_url: 'https://example.com/mcp', max_decompressed_body_bytes: 256 * 1024 * 1024
+      )
+      built = MCPClient::ServerFactory.create(config, logger: Logger.new(StringIO.new))
+
+      expect(built.instance_variable_get(:@max_decompressed_body_bytes)).to eq(256 * 1024 * 1024)
+      built.cleanup
+    end
+
+    it 'defaults to MAX_DECOMPRESSED_BODY_BYTES when the config omits it' do
+      config = MCPClient.streamable_http_config(base_url: 'https://example.com/mcp')
+      built = MCPClient::ServerFactory.create(config, logger: Logger.new(StringIO.new))
+
+      expect(built.instance_variable_get(:@max_decompressed_body_bytes))
+        .to eq(MCPClient::ServerStreamableHTTP::JsonRpcTransport::MAX_DECOMPRESSED_BODY_BYTES)
+      built.cleanup
+    end
+
     it 'rejects a non-positive configured limit' do
       expect do
         MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', max_decompressed_body_bytes: 0)


### PR DESCRIPTION
## Summary

Releases **2.1.0**, covering the PRs merged since 2.0.0 (#188–#210): a security pass over every transport, plus Ruby 4.0.6 support.

> **Rebased.** Codex's review of this PR found two real code bugs. Rather than smuggle them into a release commit, they shipped separately as **#209** (`tools/call` replayed by session recovery) and **#210** (peer payloads reaching the SSE error logs), both merged. This branch was rebuilt on top of them, so its diff is now version + docs + the two doc-driven fixes below — no security code changes. The review comment below has the reproductions.

The theme is one sentence: **a remote MCP server is untrusted input.** 2.0.0 was correct against a cooperative server but assumed good faith in places where a hostile — or merely compromised — peer controls the data. The wire protocol is unchanged and the ordinary client API is unchanged; what changed is what the client accepts, retries, logs and reflects back.

## What's in the release

| | |
|---|---|
| Version | `lib/mcp_client/version.rb`, `Gemfile.lock` self-reference → **2.1.0** (gemspec reads the constant) |
| CHANGELOG | New 2.1.0 entry in the established format, with **Breaking Changes** and **Migration notes** |
| README | New "Treating the Server as Untrusted" section; `tools/call` retry semantics; `max_decompressed_body_bytes` |

### Behaviour changes hosts must act on

These are spelled out in the CHANGELOG's Migration notes:

- **`tools/call` is never retried automatically** — including through session-expiry recovery (#209). A "transient" failure can arrive after the server executed the request, and JSON-RPC has no idempotency key to make a replay safe. Retry explicitly if your application knows it is safe, and treat the error as *outcome unknown*.
- **Task operations refuse to guess a server.** Pass the `Task` handle from `call_tool_as_task`, or name the server. A bare ID still works with one configured server; with several it raises `ArgumentError` rather than acting on the wrong one.
- **Peer-facing error messages are constant** and **DEBUG logs no longer contain payloads** — if you parsed either for detail, the detail now lives only in local logs. Error codes are unchanged.
- **Cross-origin SSE endpoints/redirects and non-HTTPS or loopback OAuth discovery URLs from a peer are refused.** Local development still works when the *configured* server is itself local.

## Two defects found while writing the docs

Writing the documentation turned out to be a review in its own right:

1. **`max_decompressed_body_bytes` could not be set through the documented path.** `streamable_http_config` did not accept it and `ServerFactory` did not forward it, so the option introduced in #188 only worked when constructing `ServerStreamableHTTP` directly — i.e. the knob was effectively unreachable for anyone using the normal config API. Wired through both, with specs asserting the config path, the default, and the positive-integer validation.
2. **The README claimed "No runtime dependencies"** while the gemspec declares `faraday`, `faraday-follow_redirects`, `faraday-retry` and `base64`. Pre-existing, corrected here.

## RuboCop config

`Metrics/ParameterLists` now sets `CountKeywordArgs: false`. The `*_config` builders are keyword-only option factories where each keyword is a documented, defaulted setting; counting them against a positional-argument limit would push new options into an opaque hash. The codebase already carried **six hand-written `rubocop:disable Metrics/ParameterLists`** comments for exactly this reason — those are now removed, which is what the 58 autocorrections in the diff are.

## Verification

| Check | Result |
|---|---|
| RSpec, Ruby 4.0.6 (default) | **1698 examples, 0 failures** |
| RSpec, Ruby 3.3.5 | **1698 examples, 0 failures** |
| RuboCop | 136 files, no offenses |
| `gem build` | builds `ruby-mcp-client-2.1.0.gem`; ships lib + LICENSE + README only (no specs/examples/secrets) |
| `Gem::Specification#validate` | passes |
| Version consistency | `version.rb`, `Gemfile.lock`, gemspec all report 2.1.0 |
| Examples suite (pre-release, on merged main) | 18 PASS · 0 FAIL · 2 SKIP |

The two example skips are environmental: no `ANTHROPIC_API_KEY` in this environment, and the interactive browser-OAuth example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
