### PR TITLE
Do not resend a non-idempotent request after a session-expiry 404

### DIFF
--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -112,6 +112,29 @@ module MCPClient
       end
     end
 
+    # Resend a request against the freshly restarted session — unless doing so
+    # could execute a side effect twice.
+    #
+    # A 404 usually means the server rejected the request outright, but it does
+    # not prove that: a session can expire after the tool ran. Automatic
+    # session recovery is worth having for idempotent methods, and would
+    # otherwise be a hole straight through the no-replay guarantee that
+    # with_retry enforces for NON_IDEMPOTENT_METHODS.
+    #
+    # Raises ConnectionError (which with_retry never retries) so no other path
+    # can turn this into a second attempt.
+    # @param request [Hash] the JSON-RPC request that hit the expired session
+    # @return [Faraday::Response] the response to the resent request
+    # @raise [MCPClient::Errors::ConnectionError] for a non-idempotent method
+    def resend_after_session_restart(request)
+      method = request['method']
+      return send_http_request(request) unless NON_IDEMPOTENT_METHODS.include?(method)
+
+      raise MCPClient::Errors::ConnectionError,
+            "Session expired during #{method}; a new session was started but the request was NOT resent " \
+            'because it may already have executed. Retry it explicitly if that is safe.'
+    end
+
     # Validate session ID format
     # Per MCP 2025-11-25, the server-assigned session ID "MUST only contain
     # visible ASCII characters (ranging from 0x21 to 0x7E)" — e.g. a UUID, a
@@ -274,14 +297,14 @@ module MCPClient
         # Recheck now that the monitor is held: another caller may already
         # have restarted the session while this one waited. If so, skip the
         # extra initialize and just resend against the fresh session.
-        return send_http_request(request) if @session_id != expired_session_id
+        return resend_after_session_restart(request) if @session_id != expired_session_id
 
         @logger.warn("Session #{@session_id} no longer valid (HTTP 404); starting a new session")
         @restarting_session = true
         @session_id = nil
         @last_event_id = nil if instance_variable_defined?(:@last_event_id)
         perform_initialize
-        send_http_request(request)
+        resend_after_session_restart(request)
       ensure
         @restarting_session = false
       end

--- a/spec/lib/mcp_client/streamable_session_lifecycle_spec.rb
+++ b/spec/lib/mcp_client/streamable_session_lifecycle_spec.rb
@@ -149,6 +149,76 @@ RSpec.describe 'Streamable HTTP session lifecycle (MCP 2025-11-25)' do
       expect(list_requests.last.headers['Mcp-Session-Id']).to eq('sess-2')
     end
 
+    it 'restarts the session but does NOT resend a non-idempotent tools/call' do
+      # A 404 usually means the request was rejected, but it does not prove it:
+      # the session can expire after the tool ran. Resending here would be a
+      # hole straight through the no-replay guarantee.
+      init_count = 0
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including('method' => 'initialize'))
+        .to_return do |_request|
+          init_count += 1
+          { status: 200, body: init_body,
+            headers: { 'Content-Type' => 'text/event-stream', 'Mcp-Session-Id' => "sess-#{init_count}" } }
+        end
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including('method' => 'notifications/initialized'))
+        .to_return(status: 202, body: '')
+      stub_request(:get, "#{base_url}#{endpoint}").to_return(status: 200, body: '')
+
+      calls = []
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including('method' => 'tools/call'))
+        .to_return do |request|
+          calls << request
+          { status: 404, body: 'session gone' }
+        end
+
+      server.connect
+      request = { 'jsonrpc' => '2.0', 'id' => 7, 'method' => 'tools/call',
+                  'params' => { 'name' => 'send_money' } }
+
+      expect { server.send(:send_http_request, request) }
+        .to raise_error(MCPClient::Errors::ConnectionError, /NOT resent|may already have executed/)
+
+      expect(calls.size).to eq(1)          # attempted once, never replayed
+      expect(init_count).to eq(2)          # the session WAS restarted
+    end
+
+    it 'still resends an idempotent request after a session restart' do
+      init_count = 0
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including('method' => 'initialize'))
+        .to_return do |_request|
+          init_count += 1
+          { status: 200, body: init_body,
+            headers: { 'Content-Type' => 'text/event-stream', 'Mcp-Session-Id' => "sess-#{init_count}" } }
+        end
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including('method' => 'notifications/initialized'))
+        .to_return(status: 202, body: '')
+      stub_request(:get, "#{base_url}#{endpoint}").to_return(status: 200, body: '')
+
+      list_requests = []
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .with(body: hash_including('method' => 'tools/list'))
+        .to_return do |request|
+          list_requests << request
+          if request.headers['Mcp-Session-Id'] == 'sess-1'
+            { status: 404, body: 'session gone' }
+          else
+            { status: 200, body: tools_body, headers: { 'Content-Type' => 'text/event-stream' } }
+          end
+        end
+
+      server.connect
+      request = { 'jsonrpc' => '2.0', 'id' => 8, 'method' => 'tools/list', 'params' => {} }
+      server.send(:send_http_request, request)
+
+      expect(list_requests.size).to eq(2)  # recovery still works for reads
+      expect(list_requests.last.headers['Mcp-Session-Id']).to eq('sess-2')
+    end
+
     it 'skips re-initialization when another caller already restarted the session' do
       init_count = 0
       stub_request(:post, "#{base_url}#{endpoint}")


### PR DESCRIPTION
## Summary

Found by Codex during the adversarial review of the 2.1.0 release PR (#208), reproduced before fixing.

#196 stopped `tools/call` being replayed by `with_retry`, on the grounds that a "transient" failure can arrive *after* the server executed the request. **Session recovery was a second, independent path around that same guarantee.** Any session-bearing HTTP 404 calls `restart_session_and_resend`, which re-sent the original request without consulting `NON_IDEMPOTENT_METHODS`:

```
tools/call POSTs: 2
sequence: ["initialize", "notifications/initialized", "tools/call",
           "initialize", "notifications/initialized", "tools/call"]
```

A 404 usually *does* mean the request was rejected outright — but it does not prove it. A session can expire after the tool ran, which is precisely the ambiguity the no-replay rule exists for. This is also the sharper version of the problem, because unlike a retry it happens even with `retries: 0`.

## Fix

`resend_after_session_restart` gates the resend on the same `NON_IDEMPOTENT_METHODS` constant:

- The session is **still restarted**, so recovery keeps working for idempotent requests (`tools/list`, `resources/read`, …).
- A non-idempotent request is **not** re-sent. It raises `ConnectionError` — chosen deliberately because `with_retry` never rescues that class, so no other path can quietly turn this into a second attempt — with a message saying the request was not resent because it may already have executed.
- Both call sites route through the helper, including the one that skips re-initialization when another caller already restarted the session (that path resent too).

After:

```
tools/call POSTs: 1  → MCPClient::Errors::ConnectionError
```

## Testing

Two regression tests in `streamable_session_lifecycle_spec.rb`:

- a `tools/call` hitting an expired session is attempted **exactly once**, raises, and the session **is** restarted (asserting we didn't fix this by disabling recovery);
- an idempotent `tools/list` is still re-sent against the fresh session.

Full suite 1695 examples / 0 failures, RuboCop clean.

## Note

The behaviour change is user-visible: a tool call interrupted by an expired session now raises instead of transparently recovering. It is documented in the 2.1.0 CHANGELOG and README in #208, which will pick this up once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)