### PR TITLE
Keep peer payloads out of the SSE error-logging paths

### DIFF
--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -1089,10 +1089,19 @@ module MCPClient
       return if data.empty?
 
       begin
-        dispatch_server_message(JSON.parse(data))
+        message = JSON.parse(data)
+        unless message.is_a?(Hash)
+          # A JSON-parseable scalar/array is not a JSON-RPC message; dispatch
+          # would raise on it. Log the type, never the value.
+          @logger.warn("Skipping non-object JSON-RPC message on the events stream (#{message.class})")
+          return
+        end
+
+        dispatch_server_message(message)
       rescue JSON::ParserError => e
-        @logger.error("Invalid JSON in server message: #{e.message}")
-        @logger.debug("Raw data: #{data.inspect}") if @logger.level <= Logger::DEBUG
+        # The parser message names the failure position, not the payload; the
+        # payload itself stays out of the log.
+        @logger.error("Invalid JSON in server message: #{e.message} (#{describe_body_size(data)})")
       end
     end
 

--- a/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
+++ b/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
@@ -258,7 +258,9 @@ module MCPClient
         message = JSON.parse(json_data)
         return message if message.is_a?(Hash)
 
-        @logger.warn("Skipping non-object JSON-RPC message in SSE event: #{message.inspect}")
+        # Type only: the value is peer-controlled payload and may carry tool
+        # arguments, results or elicitation content.
+        @logger.warn("Skipping non-object JSON-RPC message in SSE event (#{message.class})")
         nil
       rescue JSON::ParserError => e
         @logger.warn("Skipping invalid JSON in SSE event: #{e.message}")

--- a/spec/lib/mcp_client/sensitive_logging_spec.rb
+++ b/spec/lib/mcp_client/sensitive_logging_spec.rb
@@ -87,6 +87,21 @@ RSpec.describe 'Sensitive data in logs' do
       streamable.cleanup
     end
 
+    it 'omits peer payload from non-object and malformed SSE messages' do
+      # Both paths previously logged the value: a non-object JSON payload at
+      # WARN (on by default) and malformed data at DEBUG.
+      streamable = MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/rpc',
+                                                       logger: logger)
+
+      streamable.send(:handle_server_message, '"ssn-123-45-6789"')
+      streamable.send(:handle_server_message, '{not json ssn-987-65-4321}')
+
+      expect(log_output.string).not_to include('123-45-6789')
+      expect(log_output.string).not_to include('987-65-4321')
+      expect(log_output.string).to match(/non-object JSON-RPC message/)
+      streamable.cleanup
+    end
+
     it 'omits response bodies, logging only the status and size' do
       response = instance_double(Faraday::Response, status: 200, body: '{"result":{"ssn":"123-45-6789"}}')
 


### PR DESCRIPTION
## Summary

Found by Codex during the adversarial review of the 2.1.0 release PR (#208), reproduced before fixing.

#198 replaced payload logging with method/id summaries — but only on the paths that log a *successfully parsed* message. The paths that log **because something was unexpected** still wrote the value verbatim:

| Site | Level | What leaked |
|---|---|---|
| `parse_sse_event_data` (`server_streamable_http/json_rpc_transport.rb`) | **WARN** | a valid but non-object JSON payload, via `#inspect` |
| `handle_server_message` (`server_streamable_http.rb`) | DEBUG | malformed event data, verbatim |

The WARN one is the worse of the two: the default logger emits WARN, so that path leaked **without anyone enabling DEBUG**. A peer that sends `"patient-record-456"` as SSE data got it written straight into the host's log.

## Fix

Both now log type and size only:

```ruby
@logger.warn("Skipping non-object JSON-RPC message in SSE event (#{message.class})")
@logger.error("Invalid JSON in server message: #{e.message} (#{describe_body_size(data)})")
```

The `JSON::ParserError` message names the failure position, not the payload, so it is safe to keep.

## A related robustness bug the reproduction exposed

A JSON-parseable **scalar or array** on the GET events stream reached `dispatch_server_message`, which calls `#key?` on it and raised `NoMethodError`. It was caught upstream by `process_event_chunk`'s generic rescue — so it never surfaced, but only by luck, and it aborted processing of that chunk. Non-object messages are now skipped with a typed warning, matching what the POST response path already did.

## Testing

New spec asserts sentinel values from both a non-object payload and a malformed one never appear in the log, while the typed warning does. Full suite 1694 examples / 0 failures, RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)