### PR TITLE
Stop JSON parser errors from echoing peer payload

### DIFF
--- a/lib/mcp_client/auth/oauth_provider.rb
+++ b/lib/mcp_client/auth/oauth_provider.rb
@@ -1143,7 +1143,7 @@ module MCPClient
         storage.set_token(server_url, new_token)
         new_token
       rescue JSON::ParserError => e
-        logger.warn("Invalid token refresh response: #{e.message}")
+        logger.warn("Invalid token refresh response: #{describe_parse_error(e)}")
         nil
       rescue Faraday::Error => e
         logger.warn("Network error during token refresh: #{e.message}")

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -212,7 +212,7 @@ module MCPClient
       rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError, MCPClient::Errors::ServerError
         raise
       rescue JSON::ParserError => e
-        raise MCPClient::Errors::TransportError, "Invalid JSON response from server: #{e.message}"
+        raise MCPClient::Errors::TransportError, "Invalid JSON response from server: #{describe_parse_error(e)}"
       rescue Errno::ECONNREFUSED => e
         raise MCPClient::Errors::ConnectionError, "Server connection lost: #{e.message}"
       rescue StandardError => e

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -80,6 +80,24 @@ module MCPClient
       parts.join(' ')
     end
 
+    # A log-safe description of a JSON parse failure.
+    #
+    # JSON::ParserError#message quotes the offending token — e.g.
+    # "expected object key, got 'SECRET-123' at line 1 column 2" — so
+    # interpolating it puts peer-controlled bytes straight into logs and
+    # exception messages. Keep the position, which is what actually helps
+    # diagnose a broken server, and drop the quoted content.
+    # @param error [JSON::ParserError] the parse failure
+    # @param payload [String, nil] the payload that failed to parse
+    # @return [String] position and size, never payload content
+    def describe_parse_error(error, payload = nil)
+      location = error.message[/at line \d+ column \d+/]
+      parts = ['malformed JSON']
+      parts << location if location
+      parts << describe_body_size(payload) if payload
+      parts.join(', ')
+    end
+
     # A log-safe description of a payload body: its size, never its content.
     # @param body [String, nil] the response/request body
     # @return [String]

--- a/lib/mcp_client/server_http/json_rpc_transport.rb
+++ b/lib/mcp_client/server_http/json_rpc_transport.rb
@@ -21,7 +21,7 @@ module MCPClient
         data = JSON.parse(body)
         process_jsonrpc_response(data)
       rescue JSON::ParserError => e
-        raise MCPClient::Errors::TransportError, "Invalid JSON response from server: #{e.message}"
+        raise MCPClient::Errors::TransportError, "Invalid JSON response from server: #{describe_parse_error(e)}"
       end
     end
   end

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -140,7 +140,7 @@ module MCPClient
         rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError, MCPClient::Errors::ServerError
           raise
         rescue JSON::ParserError => e
-          raise MCPClient::Errors::TransportError, "Invalid JSON response from server: #{e.message}"
+          raise MCPClient::Errors::TransportError, "Invalid JSON response from server: #{describe_parse_error(e)}"
         rescue Errno::ECONNREFUSED => e
           raise MCPClient::Errors::ConnectionError, "Server connection lost: #{e.message}"
         rescue StandardError => e
@@ -334,7 +334,7 @@ module MCPClient
         data = JSON.parse(response.body)
         process_jsonrpc_response(data)
       rescue JSON::ParserError => e
-        raise MCPClient::Errors::TransportError, "Invalid JSON response from server: #{e.message}"
+        raise MCPClient::Errors::TransportError, "Invalid JSON response from server: #{describe_parse_error(e)}"
       end
     end
   end

--- a/lib/mcp_client/server_sse/sse_parser.rb
+++ b/lib/mcp_client/server_sse/sse_parser.rb
@@ -42,7 +42,7 @@ module MCPClient
         rescue MCPClient::Errors::ConnectionError
           raise
         rescue JSON::ParserError => e
-          @logger.warn("Failed to parse JSON from event data: #{e.message}")
+          @logger.warn("Failed to parse JSON from event data: #{describe_parse_error(e, event[:data])}")
         rescue StandardError => e
           @logger.error("Error processing SSE event: #{e.message}")
         end

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -1101,7 +1101,7 @@ module MCPClient
       rescue JSON::ParserError => e
         # The parser message names the failure position, not the payload; the
         # payload itself stays out of the log.
-        @logger.error("Invalid JSON in server message: #{e.message} (#{describe_body_size(data)})")
+        @logger.error("Invalid JSON in server message: #{describe_parse_error(e, data)}")
       end
     end
 

--- a/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
+++ b/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
@@ -78,7 +78,7 @@ module MCPClient
 
         process_jsonrpc_response(data)
       rescue JSON::ParserError => e
-        raise MCPClient::Errors::TransportError, "Invalid JSON response from server: #{e.message}"
+        raise MCPClient::Errors::TransportError, "Invalid JSON response from server: #{describe_parse_error(e)}"
       end
 
       # Incrementally decompress a gzip response body, aborting once the
@@ -263,7 +263,7 @@ module MCPClient
         @logger.warn("Skipping non-object JSON-RPC message in SSE event (#{message.class})")
         nil
       rescue JSON::ParserError => e
-        @logger.warn("Skipping invalid JSON in SSE event: #{e.message}")
+        @logger.warn("Skipping invalid JSON in SSE event: #{describe_parse_error(e, json_data)}")
         :invalid
       end
 

--- a/spec/lib/mcp_client/sensitive_logging_spec.rb
+++ b/spec/lib/mcp_client/sensitive_logging_spec.rb
@@ -102,6 +102,51 @@ RSpec.describe 'Sensitive data in logs' do
       streamable.cleanup
     end
 
+    it 'omits payload from parser errors on every SSE receive path' do
+      # JSON::ParserError#message quotes the OFFENDING TOKEN, so the sentinel
+      # is placed first here: an earlier test passed only because its secret
+      # sat after the first invalid token.
+      streamable = MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/rpc',
+                                                       logger: logger)
+      legacy = MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', logger: logger)
+
+      streamable.send(:handle_server_message, '{LEAK-GET-111 : 1}')
+      streamable.send(:parse_sse_event_data, '{LEAK-POST-222 : 1}')
+      legacy.send(:handle_message_event, { data: '{LEAK-SSE-333 : 1}' })
+
+      %w[LEAK-GET-111 LEAK-POST-222 LEAK-SSE-333].each do |sentinel|
+        expect(log_output.string).not_to include(sentinel)
+      end
+      expect(log_output.string).to include('malformed JSON')
+      streamable.cleanup
+      legacy.cleanup
+    end
+
+    it 'omits payload from the exception raised for a malformed response body' do
+      server = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/rpc', logger: logger)
+      response = instance_double(Faraday::Response, status: 200, body: '{LEAK-HTTP-444 : 1}')
+
+      expect { server.send(:parse_response, response) }
+        .to raise_error(MCPClient::Errors::TransportError) { |e|
+              expect(e.message).not_to include('LEAK-HTTP-444')
+              expect(e.message).to include('Invalid JSON response from server')
+            }
+    end
+
+    it 'keeps the position, which is what makes a parse failure diagnosable' do
+      error = begin
+        JSON.parse('{LEAK-555 : 1}')
+      rescue JSON::ParserError => e
+        e
+      end
+      described = MCPClient::ServerHTTP.new(base_url: 'https://example.com', logger: logger)
+                                       .send(:describe_parse_error, error, '{LEAK-555 : 1}')
+
+      expect(described).not_to include('LEAK-555')
+      expect(described).to match(/line 1 column 2/)
+      expect(described).to include('bytes')
+    end
+
     it 'omits response bodies, logging only the status and size' do
       response = instance_double(Faraday::Response, status: 200, body: '{"result":{"ssn":"123-45-6789"}}')
 


### PR DESCRIPTION
## Summary

Found by Codex in a follow-up review of the 2.1.0 release PR (#208), verified before fixing.

`JSON::ParserError#message` **quotes the offending token**:

```
JSON.parse('{LEAKME-123-45-6789 bad}')
# => expected object key, got 'LEAKME-123-45-6789' at line 1 column 2
```

#210 replaced the log lines that printed payloads directly, but kept `e.message` — on my assumption that it carried only a position. It doesn't, so peer-controlled bytes still reached logs.

The leak was reachable on **every** JSON receive path:

| Path | Channel |
|---|---|
| GET events stream (`server_streamable_http.rb`) | `logger.error` |
| POST SSE response parser (`server_streamable_http/json_rpc_transport.rb`) | `logger.warn` — **default-visible** |
| Legacy SSE parser (`server_sse/sse_parser.rb`) | `logger.warn` — **default-visible** |
| OAuth token-refresh (`auth/oauth_provider.rb`) | `logger.warn` — and the payload there is a *token response* |
| All four transports' `Invalid JSON response from server` | `TransportError` message, which hosts routinely log |

## The test that gave false assurance

Codex also spotted that the regression test I added in #210 **passed by accident**: its sentinel appeared *after* the first invalid token, so the parser never quoted it. That is the more useful half of the finding — the fix looked verified when it wasn't.

The new tests place the sentinel as the **first** invalid token on each path, which is the case that actually exercises the quoting.

## Fix

`describe_parse_error` (in `JsonRpcCommon`, shared by every transport) keeps what makes a parse failure diagnosable — the `line N column M` position and the payload byte size — and drops the quoted content:

```
Invalid JSON in server message: malformed JSON, at line 1 column 2, 18 bytes
```

I kept the position deliberately rather than logging only a class name: debugging a server that emits subtly broken JSON is painful without it, and the position is not peer content.

The `Invalid JSON response from server:` prefix is unchanged, so existing rescues and the nine specs matching on it are unaffected.

## Testing

New specs assert no sentinel reaches the log on the GET, POST-SSE and legacy-SSE paths, none reaches the raised `TransportError` for a malformed HTTP body, and that the position and size survive. Full suite 1699 examples / 0 failures, RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)