### PR TITLE
Drop Ruby 3.2 support; the floor is now 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,10 @@ jobs:
     - name: Run RSpec tests
       run: bundle exec rspec
 
-  # Compatibility floor: the oldest Rubies the gemspec still supports (>= 3.2.0).
-  test:
+  # Compatibility floor: the oldest Ruby the gemspec still supports (>= 3.3.0).
+  test-ruby-3-3:
+    name: Test (Ruby 3.3, floor)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby-version: ['3.2', '3.3']
 
     steps:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -46,7 +44,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
       with:
-        ruby-version: ${{ matrix.ruby-version }}
+        ruby-version: '3.3'
         bundler-cache: true
 
     - name: Run RuboCop

--- a/README.md
+++ b/README.md
@@ -723,12 +723,12 @@ than the peer's:
 
 ## Requirements
 
-- Ruby >= 3.2.0
+- Ruby >= 3.3.0
 - Runtime dependencies: `faraday` (~> 2.0) with `faraday-follow_redirects` and
   `faraday-retry`, plus `base64` — all pulled in automatically by the gem
 
 Development uses Ruby 4.0.6 (see `.ruby-version`). CI runs the suite on 4.0.6
-plus the supported floor, 3.2 and 3.3.
+plus the supported floor, 3.3.
 
 ## License
 

--- a/ruby-mcp-client.gemspec
+++ b/ruby-mcp-client.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir.glob('lib/**/*.rb') + ['README.md', 'LICENSE']
-  spec.required_ruby_version = '>= 3.2.0'
+  spec.required_ruby_version = '>= 3.3.0'
   spec.require_paths = ['lib']
   # base64 is required by the OAuth/PKCE and content helpers. It became a
   # bundled (non-default) gem in Ruby 3.4, so it must be declared explicitly


### PR DESCRIPTION
Supersedes #214, which kept the 3.2 job alive by gating the OpenAI SDK dev dependency behind a Ruby-version check and disabling gem caching on that one job.

## Problem

`bundle install` fails on the Ruby 3.2 matrix job whenever Bundler has to resolve for real (i.e. whenever `setup-ruby`'s cache misses, as it does on any PR that touches a rubygems-sourced gem — #213 is the current example):

```
openai-0.77.0 requires ruby version >= 3.3.0, which is incompatible with the current version, 3.2.11
```

#207 and #212 moved the git-sourced `openai` dev dependency to revisions where upstream raised its `required_ruby_version` to `>= 3.3.0`, while the gemspec here still declared `>= 3.2.0` and CI still tested that floor.

## Fix

Drop 3.2 instead of working around it. Ruby 3.2 has been EOL since 2026-03-31, `.rubocop.yml` already sets `TargetRubyVersion: 3.3.5`, and a Gemfile/CI workaround for one dependency would have had to be maintained indefinitely.

- `ruby-mcp-client.gemspec`: `required_ruby_version` is now `>= 3.3.0`.
- `.github/workflows/ci.yml`: the two-entry matrix becomes a single `Test (Ruby 3.3, floor)` job, mirroring the shape of the 4.0.6 job. Gem caching stays on for both.
- `README.md`: the Requirements section states the new floor.

No library code changes. No `Gemfile.lock` changes.

## Breaking change

This is a breaking change for anyone installing the gem on Ruby 3.2 — RubyGems will refuse the next released version there. `CHANGELOG.md` is written at release time in this repo, so the next release's **Breaking Changes** section should carry an entry for this.

## Verification

- **Ruby 4.0.6:** `bundle install` leaves `Gemfile.lock` byte-identical; RuboCop clean; 1701 examples, 0 failures.
- **Ruby 3.3.5 (new floor), uncached resolve in a fresh worktree:** `Gemfile.lock` byte-identical after `bundle install`, so the CI job's cached lockfile replay and a real resolve agree; RuboCop clean; 1701 examples, 0 failures.
- No branch protection or rulesets reference the old `test (3.2)` / `test (3.3)` check names, so the rename is safe.

Once merged, `@dependabot rebase` on #213 should turn it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
