### PR TITLE
Document optional Parallel Search MCP connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,23 @@ result = client.call_tool('example_tool', { param: 'value' })
 client.cleanup
 ```
 
+### Optional Parallel Search MCP
+
+Users can explicitly opt in to Parallel Search MCP for web search and URL
+fetching. When its tools are used, user-provided search objectives, search
+queries, and requested URLs are sent to Parallel. The hosted endpoint requires
+no Parallel account or API key; existing gateway authentication remains
+unchanged for other MCP servers.
+
+```ruby
+client = MCPClient.connect('https://search.parallel.ai/mcp')
+client.call_tool('web_search', {
+  objective: 'Find official Ruby documentation',
+  search_queries: ['Ruby official documentation']
+})
+client.cleanup
+```
+
 **Transport Detection:**
 
 | URL Pattern | Transport |


### PR DESCRIPTION
## Why

Adds an optional, explicitly opt-in native client example for Ruby users who want web search through MCP. The hosted endpoint requires no Parallel account or API key, while existing gateway authentication remains unchanged.

## Changes

- Show `MCPClient.connect` with the canonical Parallel Search MCP endpoint and a `web_search` call containing both required arguments.
- State that, when users explicitly opt in and use its tools, user-provided search objectives, search queries, and requested URLs are sent to Parallel.
- Preserve all existing examples, providers, user settings, defaults, and authentication behavior.

## Validation

- `git diff --check`: passed.
- README scope and required-content check: passed.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.