### PR TITLE
Move code-review to claude-opus-5 and bump the action to v1.0.211

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0
-    - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
+    - uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1.0.211
       with:
         prompt: |
           REPO: ${{ github.repository }}
@@ -72,4 +72,4 @@ jobs:
 
           Review the PR changes. Focus on code quality, potential bugs, performance and security issues.
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-        claude_args: "--model claude-opus-4-6"
+        claude_args: "--model claude-opus-5"


### PR DESCRIPTION
The `code-review` job has been failing instantly on every real execution since late August: `is_error:true`, 1 turn, ~220 ms, $0 billed, no error text (the action sanitizes API error messages — anthropics/claude-code-action#880). Same signature as the open upstream reports anthropics/claude-code-action#1759 / anthropics/claude-code-action#1720. Re-running does not help, and a credit top-up did not change the signature.

Two changes:
- Bump `anthropics/claude-code-action` from the July `v1` pin (`be7b93b`) to `v1.0.211` (`833fb0f`) in case the startup crash is fixed upstream.
- Switch the review model from `claude-opus-4-6` to `claude-opus-5`.

Note: on this PR itself the claude action self-skips ("workflow validation" guard — the workflow file differs from main), so the real verification happens on the next PR run after merge; PR #221 will be used to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)