### PR TITLE
Send anthropic-workspace-id header in the code-review job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,10 @@ jobs:
       with:
         fetch-depth: 0
     - uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1.0.211
+      env:
+        # The repo's ANTHROPIC_API_KEY is an identity-linked key; the API requires
+        # the anthropic-workspace-id header on every request for such keys.
+        ANTHROPIC_CUSTOM_HEADERS: "anthropic-workspace-id: wrkspc_01LSrT7tFuppN7RCBZqHox3v"
       with:
         prompt: |
           REPO: ${{ github.repository }}


### PR DESCRIPTION
Root cause of the `code-review` job's instant failures (~300 ms, 1 turn, $0, `is_error:true`, no error text): the repo's `ANTHROPIC_API_KEY` is an **identity-linked** key, and the API rejects it with:

> 400 `anthropic-workspace-id is required when authenticating with an identity-linked API key`

The action sanitizes the error text (anthropics/claude-code-action#880), which is why the logs showed nothing.

Fix: pass the workspace id via `ANTHROPIC_CUSTOM_HEADERS` step env. Verified locally against a header-dumping server that the Claude CLI forwards this env var onto its API requests as the `anthropic-workspace-id` header (and that `ANTHROPIC_WORKSPACE_ID` alone is ignored for API-key auth — it's only read by the workload-identity-federation path).

The claude action self-skips on this PR (workflow-validation guard); real verification happens on PR #221 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)