### PR TITLE
MCP 2026-07-28 (1/11): protocol foundations — versions, typed errors, resultType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ examples/__pycache__/
 # Local, real secrets for the example runner (Zapier MCP token, etc.).
 # Copy examples/secrets.env.example -> examples/secrets.env and fill it in.
 examples/secrets.env
+
+# Bundler install path (BUNDLE_PATH: vendor/bundle)
+/vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,19 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   for the multi round-trip handling that follows, and any unrecognized value
   raises `MCPClient::Errors::InvalidResultError` (a non-retried
   `ServerError`), as the spec requires.
-- **Resource not found.** A `resources/read` error with code `-32602`
-  (2026-07-28) or the legacy `-32002` now raises
+- **Typed errors from HTTP error bodies.** 2026-07-28 servers carry their
+  protocol errors in the body of an HTTP 400 (and an unknown method as a 404
+  with -32601). The HTTP, Streamable HTTP and SSE transports now parse a
+  JSON-RPC error out of a 4xx body and raise the typed error (with the HTTP
+  status prefixed to the message and the code preserved), so a dual-era
+  client can tell a modern rejection from a legacy one. 5xx responses stay
+  `TransientServerError`.
+- **Resource not found.** A `resources/read` error with the legacy `-32002`
+  code — or `-32602` from a modern (2026-07-28) server — now raises
   `MCPClient::Errors::ResourceNotFound` on every transport instead of a
-  generic `ResourceReadError`.
+  generic `ResourceReadError`. On a legacy session `-32602` stays the
+  generic Invalid params it always was. `protocol_version` / `modern?` are
+  now readable on every transport.
 
 ## 2.1.0 — Hostile-Server Hardening (2026-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   and `UnsupportedProtocolVersionError` (-32022, `#supported`, `#requested`).
   `MCPClient::Errors::Codes` holds the code constants and the allocation
   policy helpers. All four transports raise these typed errors.
+- **Only a well-formed error identifies a modern server.**
+  `#modern_protocol_error?` (which suppresses the legacy `initialize`
+  fallback, and lets the error propagate through the public wrappers) is true
+  only for an error carrying the wire shape its schema mandates: the JSON-RPC
+  `message` string, plus `requiredCapabilities` as an object for -32021 and
+  `supported: string[]` (non-empty) with `requested: string` for -32022. An
+  error object with no JSON-RPC `message` is malformed at the JSON-RPC level
+  and does not even earn a typed class — it stays a plain `ServerError` with
+  its `code` and `data` preserved. A legacy endpoint or intermediary emitting
+  a bare -3202x code therefore cannot suppress the fallback.
 - **`resultType`.** Every result is checked: an absent field is treated as
   `"complete"` (earlier-protocol servers), `"input_required"` passes through
   for the multi round-trip handling that follows, and any unrecognized value
@@ -30,9 +40,13 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   protocol errors in the body of an HTTP 400 (and an unknown method as a 404
   with -32601). The HTTP, Streamable HTTP and SSE transports now parse a
   JSON-RPC error out of a 4xx body and raise the typed error (with the HTTP
-  status prefixed to the message and the code preserved), so a dual-era
-  client can tell a modern rejection from a legacy one. 5xx responses stay
-  `TransientServerError`.
+  status prefixed to the message, and the code, data and HTTP status
+  preserved), so a dual-era client can tell a modern rejection from a legacy
+  one. 5xx responses stay `TransientServerError`. The body is read whether it
+  arrives raw or already decoded by host-configured response middleware
+  (`faraday_config` with `conn.response :json`, with or without
+  `conn.response :raise_error`); a raw body is size-bounded and incrementally
+  gunzipped before it is parsed.
 - **Resource not found.** A `resources/read` error with the legacy `-32002`
   code — or `-32602` from a modern (2026-07-28) server — now raises
   `MCPClient::Errors::ResourceNotFound` on every transport instead of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased — MCP 2026-07-28
+
+Groundwork for the 2026-07-28 protocol revision (stateless, per-request
+metadata). Each feature lands in its own PR; this section accumulates them.
+
+### Protocol foundations
+
+- **Version constants.** `MCPClient::LATEST_PROTOCOL_VERSION` (`2026-07-28`),
+  `MODERN_PROTOCOL_VERSIONS` (per-request metadata revisions) and
+  `LEGACY_PROTOCOL_VERSIONS` (initialize-handshake revisions).
+  `SUPPORTED_PROTOCOL_VERSIONS` is now their union; `PROTOCOL_VERSION` stays
+  `2025-11-25` because it is the version the legacy `initialize` request asks
+  for, and a server answering `initialize` with a modern version is rejected.
+- **Typed JSON-RPC errors.** `MCPClient::Errors::ServerError` now carries the
+  JSON-RPC `code` and `data` (`ServerError.new(msg, code:, data:)`, fully
+  backward compatible). `ServerError.from_jsonrpc(error)` builds the
+  2026-07-28 spec-defined errors: `HeaderMismatchError` (-32020),
+  `MissingRequiredClientCapabilityError` (-32021, `#required_capabilities`)
+  and `UnsupportedProtocolVersionError` (-32022, `#supported`, `#requested`).
+  `MCPClient::Errors::Codes` holds the code constants and the allocation
+  policy helpers. All four transports raise these typed errors.
+- **`resultType`.** Every result is checked: an absent field is treated as
+  `"complete"` (earlier-protocol servers), `"input_required"` passes through
+  for the multi round-trip handling that follows, and any unrecognized value
+  raises `MCPClient::Errors::InvalidResultError` (a non-retried
+  `ServerError`), as the spec requires.
+- **Resource not found.** A `resources/read` error with code `-32602`
+  (2026-07-28) or the legacy `-32002` now raises
+  `MCPClient::Errors::ResourceNotFound` on every transport instead of a
+  generic `ResourceReadError`.
+
 ## 2.1.0 — Hostile-Server Hardening (2026-08-04)
 
 A security pass over every transport, driven by an external scan of the 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,25 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   fallback, and lets the error propagate through the public wrappers) is true
   only for an error carrying the wire shape its schema mandates: the JSON-RPC
   `message` string, plus `requiredCapabilities` as an object for -32021 and
-  `supported: string[]` (non-empty) with `requested: string` for -32022. An
-  error object with no JSON-RPC `message` is malformed at the JSON-RPC level
-  and does not even earn a typed class — it stays a plain `ServerError` with
-  its `code` and `data` preserved. A legacy endpoint or intermediary emitting
-  a bare -3202x code therefore cannot suppress the fallback.
+  `supported: string[]` with `requested: string` for -32022. Those are the
+  schema's types and nothing more — an empty `supported` list still marks a
+  modern server that named no version this client can retry with, which is a
+  failed negotiation rather than evidence of a legacy peer. An error object
+  with no JSON-RPC `message` at all is malformed at the JSON-RPC level and
+  does not even earn a typed class — it stays a plain `ServerError` with its
+  `code` and `data` preserved. A legacy endpoint or intermediary emitting a
+  bare -3202x code therefore cannot suppress the fallback.
 - **`resultType`.** Every result is checked: an absent field is treated as
-  `"complete"` (earlier-protocol servers), `"input_required"` passes through
-  for the multi round-trip handling that follows, and any unrecognized value
-  raises `MCPClient::Errors::InvalidResultError` (a non-retried
-  `ServerError`), as the spec requires.
+  `"complete"` (earlier-protocol servers, and modern ones that omit it), and
+  any unrecognized value raises `MCPClient::Errors::InvalidResultError` (a
+  `ServerError`, so it is answered rather than re-sent), as the spec
+  requires. `"input_required"` passes through for the multi round-trip
+  handling that follows, but only on a modern session: the pattern exists
+  only in 2026-07-28, so a handshake-era server claiming an unfinished result
+  is malformed. Operations that project a field out of the result
+  (`read_resource`) never flatten an unfinished one into an empty success —
+  they raise, with the whole result on the error's `data` so a host can drive
+  the round trip itself.
 - **Typed errors from HTTP error bodies.** 2026-07-28 servers carry their
   protocol errors in the body of an HTTP 400 (and an unknown method as a 404
   with -32601). The HTTP, Streamable HTTP and SSE transports now parse a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,13 +37,24 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   check follows the schema all the way down: `requiredCapabilities` is typed
   as `ClientCapabilities`, so its members must be objects too — a body
   claiming `{"elicitation": []}` is malformed and does not identify a modern
-  server. `#modern_http_protocol_error?` is the Streamable-HTTP-specific
-  predicate: it additionally recognizes an unknown method answered with HTTP
-  404 and a JSON-RPC -32601 body, which that transport's backward
-  compatibility rules name as a modern-server signal. It is deliberately
-  separate from `#modern_protocol_error?`, because on stdio a bare -32601 is
-  exactly what a legacy peer answers a modern probe with and must keep the
-  `initialize` fallback alive.
+  server — and so is one whose nested members break the schema's types
+  (`elicitation`/`sampling` hold objects, `experimental`/`extensions` map
+  names to objects, `roots.listChanged` is a boolean); unknown capability
+  names are accepted. `#modern_http_protocol_error?` is the
+  Streamable-HTTP-specific predicate: it additionally recognizes an unknown
+  method answered with HTTP 404 and a JSON-RPC -32601 body, which that
+  transport's backward compatibility rules name as a modern-server signal.
+  That -32601 is typed as `MCPClient::Errors::MethodNotFoundError` (a plain
+  `ServerError` for every other purpose) and, like the reserved codes, only
+  when its error object is well-formed: a 404 page dressed up as
+  `{"error": {"code": -32601}}` with no `message` identifies nobody. It is
+  deliberately separate from `#modern_protocol_error?`, because on stdio a
+  bare -32601 is exactly what a legacy peer answers a modern probe with and
+  must keep the `initialize` fallback alive. When a modern-only server
+  rejects `initialize` with -32022, `connect` on every transport names the
+  versions it supports in the `ConnectionError` message (`server supports:
+  2026-07-28`), with the typed error as its `cause`; the list travels in the
+  error's `data`, so the peer's prose alone would not have shown it.
 - **`resultType`.** Every result is checked: an absent field is treated as
   `"complete"` (earlier-protocol servers, and modern ones that omit it), and
   any unrecognized value raises `MCPClient::Errors::InvalidResultError` (a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,17 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   with no JSON-RPC `message` at all is malformed at the JSON-RPC level and
   does not even earn a typed class — it stays a plain `ServerError` with its
   `code` and `data` preserved. A legacy endpoint or intermediary emitting a
-  bare -3202x code therefore cannot suppress the fallback.
+  bare -3202x code therefore cannot suppress the fallback. For -32021 that
+  check follows the schema all the way down: `requiredCapabilities` is typed
+  as `ClientCapabilities`, so its members must be objects too — a body
+  claiming `{"elicitation": []}` is malformed and does not identify a modern
+  server. `#modern_http_protocol_error?` is the Streamable-HTTP-specific
+  predicate: it additionally recognizes an unknown method answered with HTTP
+  404 and a JSON-RPC -32601 body, which that transport's backward
+  compatibility rules name as a modern-server signal. It is deliberately
+  separate from `#modern_protocol_error?`, because on stdio a bare -32601 is
+  exactly what a legacy peer answers a modern probe with and must keep the
+  `initialize` fallback alive.
 - **`resultType`.** Every result is checked: an absent field is treated as
   `"complete"` (earlier-protocol servers, and modern ones that omit it), and
   any unrecognized value raises `MCPClient::Errors::InvalidResultError` (a
@@ -41,10 +51,14 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   requires. `"input_required"` passes through for the multi round-trip
   handling that follows, but only on a modern session: the pattern exists
   only in 2026-07-28, so a handshake-era server claiming an unfinished result
-  is malformed. Operations that project a field out of the result
-  (`read_resource`) never flatten an unfinished one into an empty success —
-  they raise, with the whole result on the error's `data` so a host can drive
-  the round trip itself.
+  is malformed. No operation that projects a field out of the result
+  (`read_resource`, every `*/list` including each page of a paginated one,
+  and `completion/complete`) flattens an unfinished one into an empty
+  success — they raise, with the whole result on the error's `data` so a host
+  can drive the round trip itself. `call_tool` and `get_prompt` return the
+  whole result and so pass a continuation through untouched; `Client#call_tool`
+  skips its `outputSchema` conformance check for one, since an unfinished
+  result carries the continuation rather than the tool's output.
 - **Typed errors from HTTP error bodies.** 2026-07-28 servers carry their
   protocol errors in the body of an HTTP 400 (and an unknown method as a 404
   with -32601). The HTTP, Streamable HTTP and SSE transports now parse a
@@ -62,6 +76,18 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   generic `ResourceReadError`. On a legacy session `-32602` stays the
   generic Invalid params it always was. `protocol_version` / `modern?` are
   now readable on every transport.
+- **Protocol errors survive every public method.** `call_tool`, `get_prompt`,
+  `read_resource`, the list operations, `complete` and `log_level=` re-raise a
+  typed protocol error instead of wrapping it in a `ToolCallError` /
+  `PromptGetError` / `ResourceReadError` / bare `ServerError`, so the `code`,
+  the `data` and — for -32021 — `requiredCapabilities` reach the host that has
+  to act on them. Ordinary application errors are still wrapped as before.
+- **An SSE result of `null` or `false` is an answer.** The SSE transport
+  stored whatever `result` member arrived, and the waiter's truthiness check
+  could not tell one from "nothing has arrived yet": the caller waited out its
+  whole read timeout and sent a cancellation for a request the server had
+  already answered. Arrival is now tracked separately from the value, so such
+  a response is delivered (and `resultType`-validated) immediately.
 
 ## 2.1.0 — Hostile-Server Hardening (2026-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,12 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   body is read before the 2025-11-25 session rule: a 404 answering a request
   that carried an `Mcp-Session-Id` starts a fresh session only when it is NOT
   a well-formed -32601 — that one is the answer to the request itself (an
-  unknown method), and restarting on it would re-send the same method. It is
+  unknown method), and restarting on it would re-send the same method. The
+  404 body is read the way every other HTTP error body is: a JSON-RPC 2.0
+  envelope, size-bounded, gunzipped when the response says so — an "error"
+  member outside an envelope, an oversized or undecodable body is no answer
+  and leaves the 404 a session expiry, and a compressed well-formed -32601
+  is the typed error without a restart. It is
   deliberately separate from `#modern_protocol_error?`, because on stdio a
   bare -32601 is exactly what a legacy peer answers a modern probe with and
   must keep the `initialize` fallback alive. When a modern-only server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,16 +38,24 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   as `ClientCapabilities`, so its members must be objects too — a body
   claiming `{"elicitation": []}` is malformed and does not identify a modern
   server — and so is one whose nested members break the schema's types
-  (`elicitation`/`sampling` hold objects, `experimental`/`extensions` map
-  names to objects, `roots.listChanged` is a boolean); unknown capability
-  names are accepted. `#modern_http_protocol_error?` is the
+  (`elicitation.form`/`.url` and `sampling.context`/`.tools` are objects,
+  `experimental`/`extensions` map names to objects). Exactly the schema's
+  constraints, and no more: ClientCapabilities is an open object, so a
+  vendor member beside `form`, anything inside `roots`, or an unknown
+  capability of any shape is still well-formed, and such a rejection reaches
+  the caller as the typed error with its `#required_capabilities` readable
+  instead of being flattened into a `ToolCallError`. `#modern_http_protocol_error?` is the
   Streamable-HTTP-specific predicate: it additionally recognizes an unknown
   method answered with HTTP 404 and a JSON-RPC -32601 body, which that
   transport's backward compatibility rules name as a modern-server signal.
   That -32601 is typed as `MCPClient::Errors::MethodNotFoundError` (a plain
   `ServerError` for every other purpose) and, like the reserved codes, only
   when its error object is well-formed: a 404 page dressed up as
-  `{"error": {"code": -32601}}` with no `message` identifies nobody. It is
+  `{"error": {"code": -32601}}` with no `message` identifies nobody. That
+  body is read before the 2025-11-25 session rule: a 404 answering a request
+  that carried an `Mcp-Session-Id` starts a fresh session only when it is NOT
+  a well-formed -32601 — that one is the answer to the request itself (an
+  unknown method), and restarting on it would re-send the same method. It is
   deliberately separate from `#modern_protocol_error?`, because on stdio a
   bare -32601 is exactly what a legacy peer answers a modern probe with and
   must keep the `initialize` fallback alive. When a modern-only server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,15 +52,20 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   `ServerError` for every other purpose) and, like the reserved codes, only
   when its error object is well-formed: a 404 page dressed up as
   `{"error": {"code": -32601}}` with no `message` identifies nobody. That
-  body is read before the 2025-11-25 session rule: a 404 answering a request
-  that carried an `Mcp-Session-Id` starts a fresh session only when it is NOT
-  a well-formed -32601 — that one is the answer to the request itself (an
-  unknown method), and restarting on it would re-send the same method. The
-  404 body is read the way every other HTTP error body is: a JSON-RPC 2.0
-  envelope, size-bounded, gunzipped when the response says so — an "error"
-  member outside an envelope, an oversized or undecodable body is no answer
-  and leaves the 404 a session expiry, and a compressed well-formed -32601
-  is the typed error without a restart. It is
+  body is read according to the era the session was negotiated under. On a
+  session negotiated under 2025-11-25 the session rule is unconditional —
+  "when receiving HTTP 404 in response to a request containing an
+  `Mcp-Session-Id`, the client MUST start a new session" names the status and
+  the session id and takes no exception for what the body carries, and a
+  server on that revision answers the session rather than the request. Off
+  such a session (an era never established, or a modern one whose server
+  assigned a session id 2026-07-28 gives it no reason to assign) a
+  well-formed -32601 is the answer to the request itself (an unknown method),
+  and replaying it after a fresh initialize would only ask the unknown method
+  again. That body is read the way every other HTTP error body is: a JSON-RPC
+  2.0 envelope, size-bounded, gunzipped when the response says so — an
+  "error" member outside an envelope, an oversized or undecodable body is no
+  answer at all. It is
   deliberately separate from `#modern_protocol_error?`, because on stdio a
   bare -32601 is exactly what a legacy peer answers a modern probe with and
   must keep the `initialize` fallback alive. When a modern-only server
@@ -68,6 +73,17 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   versions it supports in the `ConnectionError` message (`server supports:
   2026-07-28`), with the typed error as its `cause`; the list travels in the
   error's `data`, so the peer's prose alone would not have shown it.
+- **A response answers with a result or an error, never with neither.**
+  JSON-RPC 2.0 section 5: "Either the result member or error member MUST be
+  included". An SSE envelope carrying neither answers nothing, and is raised
+  as `MCPClient::Errors::InvalidResultError` rather than delivered as a
+  successful `nil` — the member's presence is what decides, so an explicit
+  `"result": null` (or `false`) is still the answer it is.
+- **A host's `conn.response :json` middleware is respected on both paths.**
+  It decodes every body, not only the 4xx ones the error path reads, so a
+  successful result is taken from the decoded object instead of being parsed
+  a second time (`undefined method 'strip' for a Hash`), and a body already
+  decoded is described in logs by its type rather than measured in bytes.
 - **`resultType`.** Every result is checked: an absent field is treated as
   `"complete"` (earlier-protocol servers, and modern ones that omit it), and
   any unrecognized value raises `MCPClient::Errors::InvalidResultError` (a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,10 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   `"complete"` (earlier-protocol servers, and modern ones that omit it), and
   any unrecognized value raises `MCPClient::Errors::InvalidResultError` (a
   `ServerError`, so it is answered rather than re-sent), as the spec
-  requires. `"input_required"` passes through for the multi round-trip
+  requires — in every era: `resultType` is a name 2026-07-28 coined, so a
+  server that sends one is 2026-aware whatever version the session
+  negotiated, and a value this client cannot interpret is never silently
+  read as `"complete"`. `"input_required"` passes through for the multi round-trip
   handling that follows, but only on a modern session: the pattern exists
   only in 2026-07-28, so a handshake-era server claiming an unfinished result
   is malformed. No operation that projects a field out of the result

--- a/README.md
+++ b/README.md
@@ -457,6 +457,12 @@ MCPClient.http_config(base_url: 'https://internal.company.com') do |faraday|
 end
 ```
 
+Response middleware you add here is respected on the error path: if a
+`conn.response :json` middleware (with or without `conn.response :raise_error`)
+has already decoded an HTTP 4xx body, the JSON-RPC error it carries is still
+recognized, so a protocol rejection keeps its `code`, `data` and typed error
+class instead of degrading to a bare `ServerError`.
+
 ### Server Definition JSON
 
 ```json

--- a/README.md
+++ b/README.md
@@ -457,11 +457,12 @@ MCPClient.http_config(base_url: 'https://internal.company.com') do |faraday|
 end
 ```
 
-Response middleware you add here is respected on the error path: if a
+Response middleware you add here is respected on both paths: if a
 `conn.response :json` middleware (with or without `conn.response :raise_error`)
-has already decoded an HTTP 4xx body, the JSON-RPC error it carries is still
-recognized, so a protocol rejection keeps its `code`, `data` and typed error
-class instead of degrading to a bare `ServerError`.
+has already decoded the body, a successful result is read from the decoded
+object rather than parsed a second time, and the JSON-RPC error an HTTP 4xx
+carries is still recognized, so a protocol rejection keeps its `code`, `data`
+and typed error class instead of degrading to a bare `ServerError`.
 
 ### Server Definition JSON
 

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -994,8 +994,9 @@ module MCPClient
     # declared outputSchema (MCP 2025-11-25 server/tools spec: "Clients SHOULD
     # validate structured results against this schema"; a tool declaring an
     # outputSchema must return structuredContent in successful results). Error
-    # results (isError: true) are exempt: the conformance requirements apply to
-    # successful results only. Validation covers the common JSON Schema
+    # results (isError: true) and unfinished ones (resultType
+    # "input_required") are exempt: the conformance requirements apply to
+    # successful, finished results only. Validation covers the common JSON Schema
     # keywords; the full 2020-12 vocabulary is out of scope (see
     # MCPClient::SchemaValidator), and when the schema uses keywords outside
     # that subset a partial-coverage warning is logged in both modes so :strict
@@ -1010,6 +1011,12 @@ module MCPClient
     def validate_structured_content!(tool, result)
       return result unless tool.structured_output? && result.is_a?(Hash)
       return result if result['isError'] || result[:isError]
+      # An unfinished result (MCP 2026-07-28 resultType "input_required") is
+      # not a successful one either: it carries the continuation instead of
+      # the tool's output. Checking it for structuredContent would fail the
+      # call on a conformance rule that does not apply yet, and would throw
+      # the continuation away with it.
+      return result unless MCPClient::JsonRpcCommon.result_type(result) == 'complete'
 
       warn_partial_schema_coverage(tool)
 

--- a/lib/mcp_client/errors.rb
+++ b/lib/mcp_client/errors.rb
@@ -153,9 +153,13 @@ module MCPClient
       end
 
       # @param message [Object] the error object's `message` member
-      # @return [Boolean] whether it is the non-empty string JSON-RPC requires
+      # @return [Boolean] whether it is the string JSON-RPC requires
       def self.wire_message?(message)
-        message.is_a?(String) && !message.empty?
+        # JSON-RPC 2.0 types `message` as a String and says nothing about its
+        # length, so an empty one is well-formed. Nothing is discriminated by
+        # rejecting it either: a legacy endpoint misusing a reserved code
+        # would carry prose, not "".
+        message.is_a?(String)
       end
 
       # @param code [Integer, nil] a JSON-RPC error code
@@ -265,17 +269,18 @@ module MCPClient
       end
 
       # The schema types this error's data as `supported: string[]` and
-      # `requested: string`, and the client can only act on it — retry with a
-      # version the server named — when `supported` actually holds versions.
-      # Anything else is malformed, and must not pass for a modern server's
-      # rejection of the request.
+      # `requested: string`. Both members, with those types, are what a
+      # modern server's rejection carries and what a legacy endpoint emitting
+      # a bare -32022 does not — so they are the whole test. Their length is
+      # not: an empty `supported` means the server named no version this
+      # client can retry with, which is a failed negotiation with a modern
+      # server, not evidence of a legacy one.
       # @return [Boolean] whether data carries the shape the schema requires
       def well_formed?
         list = data_member('supported')
-        return false unless list.is_a?(Array) && !list.empty?
-        return false unless list.all? { |version| version.is_a?(String) && !version.empty? }
+        return false unless list.is_a?(Array) && list.all?(String)
 
-        requested.is_a?(String) && !requested.empty?
+        requested.is_a?(String)
       end
     end
 

--- a/lib/mcp_client/errors.rb
+++ b/lib/mcp_client/errors.rb
@@ -133,31 +133,52 @@ module MCPClient
       # Build the most specific error for a JSON-RPC error object: the typed
       # 2026-07-28 errors for the spec-reserved codes, a plain ServerError
       # otherwise. The message is peer-supplied and passed through as-is.
+      #
+      # A JSON-RPC 2.0 error object MUST carry a string `message`. One that
+      # does not is malformed at the JSON-RPC level, so it never earns a
+      # typed class — and so can never identify a modern server (see
+      # ModernProtocolError) — even though its code and data are still
+      # preserved on the plain ServerError for the caller to inspect.
       # @param error [Hash, nil] the JSON-RPC `error` member ('code', 'message', 'data')
       # @return [MCPClient::Errors::ServerError]
       def self.from_jsonrpc(error)
         error = {} unless error.is_a?(Hash)
-        message = error['message'] || error[:message] || 'Unknown server error'
+        message = error['message'] || error[:message]
         code = error['code'] || error[:code]
         code = nil unless code.is_a?(Integer)
         data = error.key?('data') ? error['data'] : error[:data]
 
-        klass = case code
-                when Codes::HEADER_MISMATCH then HeaderMismatchError
-                when Codes::MISSING_REQUIRED_CLIENT_CAPABILITY then MissingRequiredClientCapabilityError
-                when Codes::UNSUPPORTED_PROTOCOL_VERSION then UnsupportedProtocolVersionError
-                else ServerError
-                end
-        klass.new(message, code: code, data: data)
+        klass = wire_message?(message) ? error_class_for(code) : ServerError
+        klass.new(message || 'Unknown server error', code: code, data: data)
       end
 
+      # @param message [Object] the error object's `message` member
+      # @return [Boolean] whether it is the non-empty string JSON-RPC requires
+      def self.wire_message?(message)
+        message.is_a?(String) && !message.empty?
+      end
+
+      # @param code [Integer, nil] a JSON-RPC error code
+      # @return [Class] the error class that code maps to
+      def self.error_class_for(code)
+        case code
+        when Codes::HEADER_MISMATCH then HeaderMismatchError
+        when Codes::MISSING_REQUIRED_CLIENT_CAPABILITY then MissingRequiredClientCapabilityError
+        when Codes::UNSUPPORTED_PROTOCOL_VERSION then UnsupportedProtocolVersionError
+        else ServerError
+        end
+      end
+      private_class_method :wire_message?, :error_class_for
+
       # Whether this is one of the 2026-07-28 spec-defined protocol errors,
-      # carrying the data its schema mandates. Only such a well-formed error
-      # identifies a modern server: a legacy endpoint or intermediary that
-      # happens to emit a bare -3202x code must not suppress the fallback.
+      # carrying the wire shape its schema mandates. Only such a well-formed
+      # error identifies a modern server: a legacy endpoint or intermediary
+      # that happens to emit a bare -3202x code must not suppress the
+      # fallback. A plain ServerError never does — including the one
+      # from_jsonrpc builds for an error object with no string `message`.
       # @return [Boolean]
       def modern_protocol_error?
-        Codes.modern_error_code?(code) && well_formed?
+        false
       end
 
       # Whether the error is protocol-level (a modern spec error or an
@@ -173,27 +194,56 @@ module MCPClient
       def well_formed?
         true
       end
+
+      private
+
+      # A member of the error's `data` object, accepting both key spellings:
+      # JSON.parse yields String keys, but a host's response middleware may
+      # symbolize them before the body reaches us.
+      # @param name [String] the member name
+      # @return [Object, nil] the member's value, or nil when data has none
+      def data_member(name)
+        return nil unless data.is_a?(Hash)
+
+        data.key?(name) ? data[name] : data[name.to_sym]
+      end
+    end
+
+    # Recognition shared by the three 2026-07-28 spec-defined errors. Only
+    # ServerError.from_jsonrpc assigns these classes, and only to an error
+    # object that is well-formed at the JSON-RPC level (it carries a string
+    # `message`); #well_formed? adds the per-code data requirements from the
+    # spec's schema.
+    module ModernProtocolError
+      # @return [Boolean] whether the error identifies a modern (2026-07-28+) server
+      def modern_protocol_error?
+        Codes.modern_error_code?(code) && well_formed?
+      end
     end
 
     # -32020 HeaderMismatch (MCP 2026-07-28, Streamable HTTP): the HTTP
     # headers mirrored from the request body (Mcp-Method, Mcp-Name,
     # Mcp-Param-*, MCP-Protocol-Version) are missing, malformed, or do not
-    # match the body.
-    class HeaderMismatchError < ServerError; end
+    # match the body. Its schema mandates no data.
+    class HeaderMismatchError < ServerError
+      include ModernProtocolError
+    end
 
     # -32021 MissingRequiredClientCapability (MCP 2026-07-28): processing the
     # request needs a capability the client did not declare in its
     # per-request clientCapabilities.
     class MissingRequiredClientCapabilityError < ServerError
+      include ModernProtocolError
+
       # @return [Hash] the capabilities the server requires (data.requiredCapabilities)
       def required_capabilities
-        caps = data.is_a?(Hash) ? (data['requiredCapabilities'] || data[:requiredCapabilities]) : nil
+        caps = data_member('requiredCapabilities')
         caps.is_a?(Hash) ? caps : {}
       end
 
-      # @return [Boolean] whether data.requiredCapabilities is present, as the schema requires
+      # @return [Boolean] whether data.requiredCapabilities is the object the schema requires
       def well_formed?
-        data.is_a?(Hash) && (data['requiredCapabilities'] || data[:requiredCapabilities]).is_a?(Hash)
+        data_member('requiredCapabilities').is_a?(Hash)
       end
     end
 
@@ -201,20 +251,31 @@ module MCPClient
     # implement the protocol version the request declared. `supported` lists
     # the versions it does implement so the client can retry with one.
     class UnsupportedProtocolVersionError < ServerError
+      include ModernProtocolError
+
       # @return [Array<String>] protocol versions the server supports (data.supported)
       def supported
-        list = data.is_a?(Hash) ? (data['supported'] || data[:supported]) : nil
+        list = data_member('supported')
         list.is_a?(Array) ? list.grep(String) : []
       end
 
       # @return [String, nil] the protocol version the request asked for (data.requested)
       def requested
-        data.is_a?(Hash) ? (data['requested'] || data[:requested]) : nil
+        data_member('requested')
       end
 
-      # @return [Boolean] whether data.supported is present, as the schema requires
+      # The schema types this error's data as `supported: string[]` and
+      # `requested: string`, and the client can only act on it — retry with a
+      # version the server named — when `supported` actually holds versions.
+      # Anything else is malformed, and must not pass for a modern server's
+      # rejection of the request.
+      # @return [Boolean] whether data carries the shape the schema requires
       def well_formed?
-        data.is_a?(Hash) && (data['supported'] || data[:supported]).is_a?(Array)
+        list = data_member('supported')
+        return false unless list.is_a?(Array) && !list.empty?
+        return false unless list.all? { |version| version.is_a?(String) && !version.empty? }
+
+        requested.is_a?(String) && !requested.empty?
       end
     end
 

--- a/lib/mcp_client/errors.rb
+++ b/lib/mcp_client/errors.rb
@@ -117,6 +117,9 @@ module MCPClient
       attr_reader :code
       # @return [Object, nil] the JSON-RPC error data member, if any
       attr_reader :data
+      # @return [Integer, nil] the HTTP status the error arrived with, when it
+      #   was carried in an HTTP error response body
+      attr_accessor :http_status
 
       # @param message [String, nil] error message
       # @param code [Integer, nil] JSON-RPC error code
@@ -148,10 +151,27 @@ module MCPClient
         klass.new(message, code: code, data: data)
       end
 
-      # @return [Boolean] whether this is one of the 2026-07-28 spec-defined
-      #   protocol errors (which identify a modern server)
+      # Whether this is one of the 2026-07-28 spec-defined protocol errors,
+      # carrying the data its schema mandates. Only such a well-formed error
+      # identifies a modern server: a legacy endpoint or intermediary that
+      # happens to emit a bare -3202x code must not suppress the fallback.
+      # @return [Boolean]
       def modern_protocol_error?
-        Codes.modern_error_code?(code)
+        Codes.modern_error_code?(code) && well_formed?
+      end
+
+      # Whether the error is protocol-level (a modern spec error or an
+      # invalid result) rather than an application-level failure. Public
+      # transport methods let these propagate instead of wrapping them.
+      # @return [Boolean]
+      def protocol_error?
+        modern_protocol_error?
+      end
+
+      # Subclasses with a mandated data shape override this.
+      # @return [Boolean]
+      def well_formed?
+        true
       end
     end
 
@@ -170,6 +190,11 @@ module MCPClient
         caps = data.is_a?(Hash) ? (data['requiredCapabilities'] || data[:requiredCapabilities]) : nil
         caps.is_a?(Hash) ? caps : {}
       end
+
+      # @return [Boolean] whether data.requiredCapabilities is present, as the schema requires
+      def well_formed?
+        data.is_a?(Hash) && (data['requiredCapabilities'] || data[:requiredCapabilities]).is_a?(Hash)
+      end
     end
 
     # -32022 UnsupportedProtocolVersion (MCP 2026-07-28): the server does not
@@ -186,6 +211,11 @@ module MCPClient
       def requested
         data.is_a?(Hash) ? (data['requested'] || data[:requested]) : nil
       end
+
+      # @return [Boolean] whether data.supported is present, as the schema requires
+      def well_formed?
+        data.is_a?(Hash) && (data['supported'] || data[:supported]).is_a?(Array)
+      end
     end
 
     # Raised when a server result is malformed at the protocol level — e.g.
@@ -193,7 +223,12 @@ module MCPClient
     # 2026-07-28 says MUST be considered invalid. A ServerError (not a
     # TransportError) so it is never retried: the server processed the
     # request and answered; re-sending would not produce a different shape.
-    class InvalidResultError < ServerError; end
+    class InvalidResultError < ServerError
+      # @return [Boolean] always true: an invalid result is a protocol-level failure
+      def protocol_error?
+        true
+      end
+    end
 
     # Raised for a server-side failure that is plausibly transient and safe to
     # retry — chiefly HTTP 5xx responses, where the request likely did not

--- a/lib/mcp_client/errors.rb
+++ b/lib/mcp_client/errors.rb
@@ -84,7 +84,9 @@ module MCPClient
       MODERN_ERROR_CODES = [HEADER_MISMATCH, MISSING_REQUIRED_CLIENT_CAPABILITY,
                             UNSUPPORTED_PROTOCOL_VERSION].freeze
 
-      # Codes a resources/read error may carry to mean "resource not found".
+      # Codes a resources/read error may carry to mean "resource not found"
+      # on a modern (2026-07-28+) server. Legacy servers only ever used
+      # -32002; for them -32602 is plain Invalid params.
       RESOURCE_NOT_FOUND_CODES = [INVALID_PARAMS, LEGACY_RESOURCE_NOT_FOUND].freeze
 
       # @param code [Integer, nil] a JSON-RPC error code
@@ -93,10 +95,17 @@ module MCPClient
         MODERN_ERROR_CODES.include?(code)
       end
 
+      # Whether a resources/read error code means the resource does not
+      # exist. 2026-07-28 servers say -32602 (and clients SHOULD still accept
+      # the earlier -32002); a legacy session only ever meant not-found by
+      # -32002, so its -32602 stays a generic Invalid params.
       # @param code [Integer, nil] a JSON-RPC error code from resources/read
+      # @param modern [Boolean] whether the session is a modern protocol revision
       # @return [Boolean] whether it means the resource does not exist
-      def self.resource_not_found_code?(code)
-        RESOURCE_NOT_FOUND_CODES.include?(code)
+      def self.resource_not_found_code?(code, modern: true)
+        return true if code == LEGACY_RESOURCE_NOT_FOUND
+
+        modern && code == INVALID_PARAMS
       end
     end
 

--- a/lib/mcp_client/errors.rb
+++ b/lib/mcp_client/errors.rb
@@ -54,8 +54,137 @@ module MCPClient
       end
     end
 
-    # Raised when the MCP server returns an error response
-    class ServerError < MCPError; end
+    # JSON-RPC error codes used by MCP (basic/index.mdx "Error Codes").
+    #
+    # MCP partitions the JSON-RPC server-error range: -32000..-32019 is
+    # implementation-defined (legacy, no meaning may be assumed beyond
+    # -32002), and -32020..-32099 is reserved for codes defined by the MCP
+    # specification itself.
+    module Codes
+      # Standard JSON-RPC 2.0 codes
+      PARSE_ERROR = -32_700
+      INVALID_REQUEST = -32_600
+      METHOD_NOT_FOUND = -32_601
+      INVALID_PARAMS = -32_602
+      INTERNAL_ERROR = -32_603
+
+      # MCP 2026-07-28 spec-defined codes (reserved sub-range)
+      HEADER_MISMATCH = -32_020
+      MISSING_REQUIRED_CLIENT_CAPABILITY = -32_021
+      UNSUPPORTED_PROTOCOL_VERSION = -32_022
+
+      # Resource not found in protocol versions 2025-11-25 and earlier;
+      # replaced by INVALID_PARAMS but still accepted from older servers.
+      LEGACY_RESOURCE_NOT_FOUND = -32_002
+
+      # Codes that identify a modern (2026-07-28+) server. Receiving one of
+      # these means the peer speaks a per-request-metadata revision, so a
+      # dual-era client must retry or correct the request rather than fall
+      # back to the initialize handshake (basic/versioning.mdx).
+      MODERN_ERROR_CODES = [HEADER_MISMATCH, MISSING_REQUIRED_CLIENT_CAPABILITY,
+                            UNSUPPORTED_PROTOCOL_VERSION].freeze
+
+      # Codes a resources/read error may carry to mean "resource not found".
+      RESOURCE_NOT_FOUND_CODES = [INVALID_PARAMS, LEGACY_RESOURCE_NOT_FOUND].freeze
+
+      # @param code [Integer, nil] a JSON-RPC error code
+      # @return [Boolean] whether it is a recognized 2026-07-28 protocol error
+      def self.modern_error_code?(code)
+        MODERN_ERROR_CODES.include?(code)
+      end
+
+      # @param code [Integer, nil] a JSON-RPC error code from resources/read
+      # @return [Boolean] whether it means the resource does not exist
+      def self.resource_not_found_code?(code)
+        RESOURCE_NOT_FOUND_CODES.include?(code)
+      end
+    end
+
+    # Raised when the MCP server returns an error response. Carries the
+    # JSON-RPC error `code` and `data` so callers can distinguish protocol
+    # errors (e.g. -32602 resource not found) without parsing the message.
+    class ServerError < MCPError
+      # @return [Integer, nil] the JSON-RPC error code, if the response carried one
+      attr_reader :code
+      # @return [Object, nil] the JSON-RPC error data member, if any
+      attr_reader :data
+
+      # @param message [String, nil] error message
+      # @param code [Integer, nil] JSON-RPC error code
+      # @param data [Object, nil] JSON-RPC error data
+      def initialize(message = nil, code: nil, data: nil)
+        super(message)
+        @code = code
+        @data = data
+      end
+
+      # Build the most specific error for a JSON-RPC error object: the typed
+      # 2026-07-28 errors for the spec-reserved codes, a plain ServerError
+      # otherwise. The message is peer-supplied and passed through as-is.
+      # @param error [Hash, nil] the JSON-RPC `error` member ('code', 'message', 'data')
+      # @return [MCPClient::Errors::ServerError]
+      def self.from_jsonrpc(error)
+        error = {} unless error.is_a?(Hash)
+        message = error['message'] || error[:message] || 'Unknown server error'
+        code = error['code'] || error[:code]
+        code = nil unless code.is_a?(Integer)
+        data = error.key?('data') ? error['data'] : error[:data]
+
+        klass = case code
+                when Codes::HEADER_MISMATCH then HeaderMismatchError
+                when Codes::MISSING_REQUIRED_CLIENT_CAPABILITY then MissingRequiredClientCapabilityError
+                when Codes::UNSUPPORTED_PROTOCOL_VERSION then UnsupportedProtocolVersionError
+                else ServerError
+                end
+        klass.new(message, code: code, data: data)
+      end
+
+      # @return [Boolean] whether this is one of the 2026-07-28 spec-defined
+      #   protocol errors (which identify a modern server)
+      def modern_protocol_error?
+        Codes.modern_error_code?(code)
+      end
+    end
+
+    # -32020 HeaderMismatch (MCP 2026-07-28, Streamable HTTP): the HTTP
+    # headers mirrored from the request body (Mcp-Method, Mcp-Name,
+    # Mcp-Param-*, MCP-Protocol-Version) are missing, malformed, or do not
+    # match the body.
+    class HeaderMismatchError < ServerError; end
+
+    # -32021 MissingRequiredClientCapability (MCP 2026-07-28): processing the
+    # request needs a capability the client did not declare in its
+    # per-request clientCapabilities.
+    class MissingRequiredClientCapabilityError < ServerError
+      # @return [Hash] the capabilities the server requires (data.requiredCapabilities)
+      def required_capabilities
+        caps = data.is_a?(Hash) ? (data['requiredCapabilities'] || data[:requiredCapabilities]) : nil
+        caps.is_a?(Hash) ? caps : {}
+      end
+    end
+
+    # -32022 UnsupportedProtocolVersion (MCP 2026-07-28): the server does not
+    # implement the protocol version the request declared. `supported` lists
+    # the versions it does implement so the client can retry with one.
+    class UnsupportedProtocolVersionError < ServerError
+      # @return [Array<String>] protocol versions the server supports (data.supported)
+      def supported
+        list = data.is_a?(Hash) ? (data['supported'] || data[:supported]) : nil
+        list.is_a?(Array) ? list.grep(String) : []
+      end
+
+      # @return [String, nil] the protocol version the request asked for (data.requested)
+      def requested
+        data.is_a?(Hash) ? (data['requested'] || data[:requested]) : nil
+      end
+    end
+
+    # Raised when a server result is malformed at the protocol level — e.g.
+    # its `resultType` is a value this client does not recognize, which MCP
+    # 2026-07-28 says MUST be considered invalid. A ServerError (not a
+    # TransportError) so it is never retried: the server processed the
+    # request and answered; re-sending would not produce a different shape.
+    class InvalidResultError < ServerError; end
 
     # Raised for a server-side failure that is plausibly transient and safe to
     # retry — chiefly HTTP 5xx responses, where the request likely did not

--- a/lib/mcp_client/errors.rb
+++ b/lib/mcp_client/errors.rb
@@ -166,6 +166,7 @@ module MCPClient
       # @return [Class] the error class that code maps to
       def self.error_class_for(code)
         case code
+        when Codes::METHOD_NOT_FOUND then MethodNotFoundError
         when Codes::HEADER_MISMATCH then HeaderMismatchError
         when Codes::MISSING_REQUIRED_CLIENT_CAPABILITY then MissingRequiredClientCapabilityError
         when Codes::UNSUPPORTED_PROTOCOL_VERSION then UnsupportedProtocolVersionError
@@ -198,12 +199,14 @@ module MCPClient
       # #jsonrpc_error_from_http_response sets http_status, and it assigns a
       # code solely from a body that carried `"jsonrpc": "2.0"` and an error
       # object. An error that never arrived over HTTP has no status and is
-      # therefore never recognized here.
+      # therefore never recognized here. The 404 rule itself lives on
+      # MethodNotFoundError, which from_jsonrpc assigns only to a -32601 whose
+      # error object is well-formed (a string `message`): a 404 page dressed
+      # up as `{"error": {"code": -32601}}` is malformed at the JSON-RPC
+      # level and identifies nobody, exactly like a bare -3202x.
       # @return [Boolean]
       def modern_http_protocol_error?
-        return true if modern_protocol_error?
-
-        http_status == 404 && code == Codes::METHOD_NOT_FOUND
+        modern_protocol_error?
       end
 
       # Whether the error is protocol-level (a modern spec error or an
@@ -249,6 +252,19 @@ module MCPClient
       end
     end
 
+    # -32601 Method not found. A class of its own so that the Streamable HTTP
+    # backward-compatibility rule ("HTTP 404 with a JSON-RPC -32601 body is
+    # a modern server") can require a well-formed JSON-RPC error object the
+    # same way the reserved -3202x codes do: from_jsonrpc assigns this class
+    # only when the error carries a string `message`.
+    class MethodNotFoundError < ServerError
+      # @return [Boolean] whether this arrived as an HTTP 404, the pairing
+      #   Streamable HTTP names as a modern-server signal
+      def modern_http_protocol_error?
+        http_status == 404
+      end
+    end
+
     # -32020 HeaderMismatch (MCP 2026-07-28, Streamable HTTP): the HTTP
     # headers mirrored from the request body (Mcp-Method, Mcp-Name,
     # Mcp-Param-*, MCP-Protocol-Version) are missing, malformed, or do not
@@ -271,17 +287,46 @@ module MCPClient
 
       # The schema types this error's data as `requiredCapabilities:
       # ClientCapabilities`, an object whose members (experimental, roots,
-      # sampling, elicitation, and any extension) are themselves objects. A
-      # body whose members are arrays or scalars is not that type, and must
-      # not claim the signal that separates a well-formed modern rejection
-      # from a legacy peer or an intermediary emitting a bare -32021. The
-      # member NAMES are deliberately not checked: the capability set is
-      # extensible, and an unknown-but-well-typed one still comes from a peer
+      # sampling, elicitation, and any extension) are themselves objects, and
+      # it types those objects too: `elicitation` and `sampling` hold
+      # objects (form/url, context/tools), `experimental` and `extensions`
+      # map names to objects, and `roots.listChanged` is a boolean. A body
+      # that breaks any of that is not ClientCapabilities, and must not
+      # claim the signal that separates a well-formed modern rejection from
+      # a legacy peer or an intermediary emitting a bare -32021. Unknown
+      # member NAMES are deliberately accepted: the capability set is
+      # extensible, and an unknown-but-object one still comes from a peer
       # that speaks the schema.
       # @return [Boolean] whether data.requiredCapabilities is ClientCapabilities-shaped
       def well_formed?
         caps = data_member('requiredCapabilities')
-        caps.is_a?(Hash) && caps.each_value.all?(Hash)
+        caps.is_a?(Hash) && caps.all? { |name, value| capability_well_formed?(name, value) }
+      end
+
+      # Capabilities whose members the schema types as objects.
+      OBJECT_MEMBER_CAPABILITIES = %w[elicitation sampling experimental extensions].freeze
+
+      private
+
+      # @param name [String, Symbol] the capability name
+      # @param value [Object] its declared value
+      # @return [Boolean] whether the value has the shape the schema gives that capability
+      def capability_well_formed?(name, value)
+        return false unless value.is_a?(Hash)
+
+        case name.to_s
+        when *OBJECT_MEMBER_CAPABILITIES then value.each_value.all?(Hash)
+        when 'roots' then roots_well_formed?(value)
+        else true
+        end
+      end
+
+      # @param roots [Hash] the declared roots capability
+      # @return [Boolean] whether listChanged, when present, is a boolean
+      def roots_well_formed?(roots)
+        return true unless roots.key?('listChanged') || roots.key?(:listChanged)
+
+        [true, false].include?(roots.key?('listChanged') ? roots['listChanged'] : roots[:listChanged])
       end
     end
 

--- a/lib/mcp_client/errors.rb
+++ b/lib/mcp_client/errors.rb
@@ -286,25 +286,32 @@ module MCPClient
       end
 
       # The schema types this error's data as `requiredCapabilities:
-      # ClientCapabilities`, an object whose members (experimental, roots,
-      # sampling, elicitation, and any extension) are themselves objects, and
-      # it types those objects too: `elicitation` and `sampling` hold
-      # objects (form/url, context/tools), `experimental` and `extensions`
-      # map names to objects, and `roots.listChanged` is a boolean. A body
-      # that breaks any of that is not ClientCapabilities, and must not
-      # claim the signal that separates a well-formed modern rejection from
-      # a legacy peer or an intermediary emitting a bare -32021. Unknown
-      # member NAMES are deliberately accepted: the capability set is
-      # extensible, and an unknown-but-object one still comes from a peer
-      # that speaks the schema.
+      # ClientCapabilities` — an open object whose KNOWN members are typed:
+      # `elicitation` and `sampling` are objects holding objects under the
+      # names the schema gives them (form/url, context/tools) and nothing is
+      # said about their other members; `experimental` and `extensions` map
+      # names to objects; `roots` is an object with no typed member at all;
+      # and a capability the schema does not name may be anything. A body
+      # that breaks any of THAT is not ClientCapabilities, and must not claim
+      # the signal that separates a well-formed modern rejection from a legacy
+      # peer or an intermediary emitting a bare -32021 — but reading more
+      # into the schema than it says turns schema-valid rejections into
+      # "legacy" ones and strips their typed interface on the way to the
+      # caller, so exactly the schema's constraints are checked, no more.
       # @return [Boolean] whether data.requiredCapabilities is ClientCapabilities-shaped
       def well_formed?
         caps = data_member('requiredCapabilities')
         caps.is_a?(Hash) && caps.all? { |name, value| capability_well_formed?(name, value) }
       end
 
-      # Capabilities whose members the schema types as objects.
-      OBJECT_MEMBER_CAPABILITIES = %w[elicitation sampling experimental extensions].freeze
+      # Capabilities whose named members the schema types as objects.
+      TYPED_CAPABILITY_MEMBERS = { 'elicitation' => %w[form url], 'sampling' => %w[context tools] }.freeze
+
+      # Capabilities the schema types as maps from name to object.
+      OBJECT_MAP_CAPABILITIES = %w[experimental extensions].freeze
+
+      # Capabilities the schema types as objects with no typed member.
+      OPEN_OBJECT_CAPABILITIES = %w[roots].freeze
 
       private
 
@@ -312,21 +319,22 @@ module MCPClient
       # @param value [Object] its declared value
       # @return [Boolean] whether the value has the shape the schema gives that capability
       def capability_well_formed?(name, value)
+        key = name.to_s
+        members = TYPED_CAPABILITY_MEMBERS[key]
+        return true unless members || OBJECT_MAP_CAPABILITIES.include?(key) || OPEN_OBJECT_CAPABILITIES.include?(key)
         return false unless value.is_a?(Hash)
+        return value.each_value.all?(Hash) if OBJECT_MAP_CAPABILITIES.include?(key)
 
-        case name.to_s
-        when *OBJECT_MEMBER_CAPABILITIES then value.each_value.all?(Hash)
-        when 'roots' then roots_well_formed?(value)
-        else true
-        end
+        (members || []).all? { |member| typed_member_ok?(value, member) }
       end
 
-      # @param roots [Hash] the declared roots capability
-      # @return [Boolean] whether listChanged, when present, is a boolean
-      def roots_well_formed?(roots)
-        return true unless roots.key?('listChanged') || roots.key?(:listChanged)
+      # @param value [Hash] a capability object
+      # @param member [String] a member the schema types as an object
+      # @return [Boolean] whether the member, when present, is an object
+      def typed_member_ok?(value, member)
+        return true unless value.key?(member) || value.key?(member.to_sym)
 
-        [true, false].include?(roots.key?('listChanged') ? roots['listChanged'] : roots[:listChanged])
+        (value.key?(member) ? value[member] : value[member.to_sym]).is_a?(Hash)
       end
     end
 

--- a/lib/mcp_client/errors.rb
+++ b/lib/mcp_client/errors.rb
@@ -185,9 +185,33 @@ module MCPClient
         false
       end
 
+      # Whether the error identifies a modern server *on a Streamable HTTP
+      # POST*. Beyond the transport-agnostic reserved codes, Streamable HTTP
+      # backward compatibility names one more recognized modern error: an
+      # unknown method answered with HTTP 404 and a JSON-RPC -32601 body.
+      # That pairing is why this predicate is separate rather than a wider
+      # code list — on stdio a bare -32601 is exactly what a legacy peer
+      # answers a modern probe with, so folding it into #modern_protocol_error?
+      # would suppress the initialize fallback that must happen there.
+      #
+      # The JSON-RPC 2.0 envelope is already required upstream: only
+      # #jsonrpc_error_from_http_response sets http_status, and it assigns a
+      # code solely from a body that carried `"jsonrpc": "2.0"` and an error
+      # object. An error that never arrived over HTTP has no status and is
+      # therefore never recognized here.
+      # @return [Boolean]
+      def modern_http_protocol_error?
+        return true if modern_protocol_error?
+
+        http_status == 404 && code == Codes::METHOD_NOT_FOUND
+      end
+
       # Whether the error is protocol-level (a modern spec error or an
       # invalid result) rather than an application-level failure. Public
       # transport methods let these propagate instead of wrapping them.
+      # A 404 + -32601 is deliberately NOT one: it says the peer is modern,
+      # but "method not found" is an ordinary application failure that the
+      # calling wrapper should keep describing in its own terms.
       # @return [Boolean]
       def protocol_error?
         modern_protocol_error?
@@ -245,9 +269,19 @@ module MCPClient
         caps.is_a?(Hash) ? caps : {}
       end
 
-      # @return [Boolean] whether data.requiredCapabilities is the object the schema requires
+      # The schema types this error's data as `requiredCapabilities:
+      # ClientCapabilities`, an object whose members (experimental, roots,
+      # sampling, elicitation, and any extension) are themselves objects. A
+      # body whose members are arrays or scalars is not that type, and must
+      # not claim the signal that separates a well-formed modern rejection
+      # from a legacy peer or an intermediary emitting a bare -32021. The
+      # member NAMES are deliberately not checked: the capability set is
+      # extensible, and an unknown-but-well-typed one still comes from a peer
+      # that speaks the schema.
+      # @return [Boolean] whether data.requiredCapabilities is ClientCapabilities-shaped
       def well_formed?
-        data_member('requiredCapabilities').is_a?(Hash)
+        caps = data_member('requiredCapabilities')
+        caps.is_a?(Hash) && caps.each_value.all?(Hash)
       end
     end
 

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -11,7 +11,7 @@ module MCPClient
 
     # Lightweight response wrapper for Faraday exception payloads (Hashes),
     # so the exception path and the default path share one challenge pipeline.
-    NormalizedResponse = Struct.new(:status, :headers)
+    NormalizedResponse = Struct.new(:status, :headers, :body)
 
     # One auth-param (name = token / quoted-string) as it appears in a
     # WWW-Authenticate challenge (RFC 7235 §2.1, optional whitespace around '=').
@@ -273,7 +273,13 @@ module MCPClient
         # apply the same session-expiry recovery as the response path.
         return restart_session_and_resend(request, sent_session_id) if session_restart_applicable?(sent_session_id)
 
-        raise MCPClient::Errors::ServerError, "Client error: HTTP 404 #{e.message}"
+        raise client_error_from_exception(e, 404)
+      rescue Faraday::ClientError => e
+        # Other 4xx raised by raise_error middleware: same body inspection as
+        # the response path, so a 400 carrying a modern JSON-RPC error still
+        # becomes the typed error (never a retryable TransportError).
+        status = e.response.is_a?(Hash) ? (e.response[:status] || e.response['status']) : nil
+        raise client_error_from_exception(e, status || 400)
       rescue Faraday::ConnectionFailed => e
         raise MCPClient::Errors::ConnectionError, "Server connection lost: #{e.message}"
       rescue Faraday::TimeoutError => e
@@ -321,6 +327,18 @@ module MCPClient
       @mutex.synchronize { !@restarting_session }
     end
 
+    # Build the ServerError for a 4xx surfaced as a Faraday::ClientError by
+    # user-configured raise_error middleware, inspecting the body like the
+    # response path does.
+    # @param error [Faraday::ClientError] the middleware exception
+    # @param status [Integer] the HTTP status
+    # @return [MCPClient::Errors::ServerError]
+    def client_error_from_exception(error, status)
+      response = normalize_error_response(error.response) || NormalizedResponse.new(status, {}, nil)
+      response.status ||= status
+      jsonrpc_error_from_http_response(response, "Client error: HTTP #{status} #{error.message}".strip)
+    end
+
     # Apply headers to the HTTP request (can be overridden by subclasses)
     # @param req [Faraday::Request] HTTP request
     # @param _request [Hash] JSON-RPC request
@@ -363,7 +381,8 @@ module MCPClient
 
       status = raw[:status] || raw['status']
       headers = raw[:headers] || raw['headers'] || {}
-      NormalizedResponse.new(status, headers)
+      body = raw[:body] || raw['body']
+      NormalizedResponse.new(status, headers, body)
     end
 
     # Handle HTTP error responses

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -385,7 +385,11 @@ module MCPClient
       when 400..499
         # Deterministic client errors: the request was processed/rejected and
         # will not succeed on retry, so raise a plain (non-retryable) ServerError.
-        raise MCPClient::Errors::ServerError, "Client error: HTTP #{response.status}#{reason_text}"
+        # MCP 2026-07-28 carries its protocol errors in the body of a 400
+        # (HeaderMismatch, UnsupportedProtocolVersion,
+        # MissingRequiredClientCapability) and an unknown method as a 404
+        # with -32601, so a JSON-RPC error body becomes the typed error.
+        raise jsonrpc_error_from_http_response(response, "Client error: HTTP #{response.status}#{reason_text}")
       when 500..599
         # Server-side failures are plausibly transient: raise the retryable
         # subclass so with_retry can re-attempt them.

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -267,7 +267,11 @@ module MCPClient
         # MCP 2025-11-25 session management: HTTP 404 for a request carrying
         # Mcp-Session-Id means the session expired — the client MUST start a
         # new session with a fresh InitializeRequest (without a session ID).
-        if response.status == 404 && session_restart_applicable?(sent_session_id)
+        # Unless the 404 carries a well-formed -32601: that is MCP 2026-07-28's
+        # answer to THIS request (unknown method), not a session expiry, and
+        # restarting on it would re-send the same unknown method.
+        if response.status == 404 && session_restart_applicable?(sent_session_id) &&
+           !method_not_found_answer?(response)
           return restart_session_and_resend(request, sent_session_id)
         end
 
@@ -281,7 +285,10 @@ module MCPClient
       rescue Faraday::ResourceNotFound => e
         # User-configured raise_error middleware surfaces 404 as an exception;
         # apply the same session-expiry recovery as the response path.
-        return restart_session_and_resend(request, sent_session_id) if session_restart_applicable?(sent_session_id)
+        if session_restart_applicable?(sent_session_id) &&
+           !method_not_found_answer?(normalize_error_response(e.response))
+          return restart_session_and_resend(request, sent_session_id)
+        end
 
         raise client_error_from_exception(e, 404)
       rescue Faraday::ClientError => e
@@ -324,6 +331,23 @@ module MCPClient
       ensure
         @restarting_session = false
       end
+    end
+
+    # Whether a 404 body is a well-formed JSON-RPC -32601 — MCP 2026-07-28's
+    # "unknown method" answer to the request itself — rather than a
+    # 2025-11-25 session expiry, which answers nothing.
+    # @param response [#body, nil] the 404 response, if its body is readable
+    # @return [Boolean]
+    def method_not_found_answer?(response)
+      body = response.respond_to?(:body) ? response.body : nil
+      data = body.is_a?(Hash) ? body : JSON.parse(body.to_s)
+      error = data.is_a?(Hash) ? (data['error'] || data[:error]) : nil
+      return false unless error.is_a?(Hash)
+
+      (error['code'] || error[:code]) == MCPClient::Errors::Codes::METHOD_NOT_FOUND &&
+        (error['message'] || error[:message]).is_a?(String)
+    rescue JSON::ParserError, TypeError
+      false
     end
 
     # Whether a 404 should trigger a session restart: only when the 404'd

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -184,7 +184,17 @@ module MCPClient
       json_rpc_request = build_jsonrpc_request('initialize', initialization_params, request_id)
       @logger.debug("Performing initialize RPC: #{json_rpc_request}")
 
-      result = send_jsonrpc_request(json_rpc_request)
+      begin
+        result = send_jsonrpc_request(json_rpc_request)
+      rescue MCPClient::Errors::UnsupportedProtocolVersionError => e
+        # A modern-only server SHOULD name the versions it supports when
+        # rejecting initialize (basic/versioning), and this message may be
+        # the only diagnostic a legacy configuration can surface. The list
+        # travels in `data`, not in the peer's prose, so spell it out here
+        # (as stdio does) rather than letting connect's generic wrap drop it.
+        raise MCPClient::Errors::ConnectionError,
+              "Initialize failed: #{e.message} (server supports: #{e.supported.join(', ')})"
+      end
       unless result.is_a?(Hash)
         raise MCPClient::Errors::ConnectionError,
               "Server returned invalid initialize result: #{result.inspect}"

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -264,16 +264,7 @@ module MCPClient
           req.body = request.to_json
         end
 
-        # MCP 2025-11-25 session management: HTTP 404 for a request carrying
-        # Mcp-Session-Id means the session expired — the client MUST start a
-        # new session with a fresh InitializeRequest (without a session ID).
-        # Unless the 404 carries a well-formed -32601: that is MCP 2026-07-28's
-        # answer to THIS request (unknown method), not a session expiry, and
-        # restarting on it would re-send the same unknown method.
-        if response.status == 404 && session_restart_applicable?(sent_session_id) &&
-           !method_not_found_answer?(response)
-          return restart_session_and_resend(request, sent_session_id)
-        end
+        return restart_session_and_resend(request, sent_session_id) if expired_session?(response, sent_session_id)
 
         handle_http_error_response(response) unless response.success?
         handle_successful_response(response, request)
@@ -285,8 +276,8 @@ module MCPClient
       rescue Faraday::ResourceNotFound => e
         # User-configured raise_error middleware surfaces 404 as an exception;
         # apply the same session-expiry recovery as the response path.
-        if session_restart_applicable?(sent_session_id) &&
-           !method_not_found_answer?(normalize_error_response(e.response))
+        if expired_session?(normalize_error_response(e.response) || NormalizedResponse.new(404, {}, nil),
+                            sent_session_id)
           return restart_session_and_resend(request, sent_session_id)
         end
 
@@ -331,6 +322,39 @@ module MCPClient
       ensure
         @restarting_session = false
       end
+    end
+
+    # Whether a 404 means the session this request went out under has expired.
+    #
+    # MCP 2025-11-25 session management: "When receiving HTTP 404 in response
+    # to a request containing an Mcp-Session-Id, the client MUST start a new
+    # session by sending a new InitializeRequest without a session ID." The
+    # rule names the status and the session id and takes no exception for what
+    # the body carries, so on a session negotiated under that revision the 404
+    # is read as the expiry it is — a server on the era this session speaks
+    # answers the session, not the request.
+    #
+    # Off such a session — an era never established, or a modern one whose
+    # server assigned a session id 2026-07-28 gives it no reason to assign —
+    # a well-formed -32601 IS the answer to this very request (unknown
+    # method), and replaying it after a fresh initialize would only ask the
+    # unknown method a second time.
+    # @param response [#status, #body, nil] the normalized 404 response
+    # @param sent_session_id [String, nil] the session id the request carried
+    # @return [Boolean]
+    def expired_session?(response, sent_session_id)
+      return false unless response && response.status == 404
+      return false unless session_restart_applicable?(sent_session_id)
+
+      legacy_session? || !method_not_found_answer?(response)
+    end
+
+    # Whether this transport negotiated a handshake-era revision, which is
+    # what makes Mcp-Session-Id — and the session-expiry rule that goes with
+    # it — part of the protocol in force.
+    # @return [Boolean]
+    def legacy_session?
+      MCPClient::LEGACY_PROTOCOL_VERSIONS.include?(@protocol_version)
     end
 
     # Whether a 404 body is a well-formed JSON-RPC -32601 — MCP 2026-07-28's

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -336,18 +336,22 @@ module MCPClient
     # Whether a 404 body is a well-formed JSON-RPC -32601 — MCP 2026-07-28's
     # "unknown method" answer to the request itself — rather than a
     # 2025-11-25 session expiry, which answers nothing.
+    #
+    # Read the way every other HTTP error body is (jsonrpc_error_in_body): a
+    # JSON-RPC 2.0 envelope, size-bounded, gunzipped when the response says
+    # so. Anything else — an "error" member outside an envelope, an oversized
+    # or undecodable body — is not an answer to this request and leaves the
+    # 404 meaning what 2025-11-25 says it means.
     # @param response [#body, nil] the 404 response, if its body is readable
     # @return [Boolean]
     def method_not_found_answer?(response)
-      body = response.respond_to?(:body) ? response.body : nil
-      data = body.is_a?(Hash) ? body : JSON.parse(body.to_s)
-      error = data.is_a?(Hash) ? (data['error'] || data[:error]) : nil
+      return false unless response
+
+      error = jsonrpc_error_in_body(response)
       return false unless error.is_a?(Hash)
 
       (error['code'] || error[:code]) == MCPClient::Errors::Codes::METHOD_NOT_FOUND &&
         (error['message'] || error[:message]).is_a?(String)
-    rescue JSON::ParserError, TypeError
-      false
     end
 
     # Whether a 404 should trigger a session restart: only when the 404'd

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -299,6 +299,10 @@ module MCPClient
     # via #accepted_result_types once such an extension is negotiated.
     CORE_RESULT_TYPES = %w[complete input_required].freeze
 
+    # The only result type a handshake-era (legacy) server can validly send:
+    # the others were introduced with the discriminator itself.
+    LEGACY_RESULT_TYPES = %w[complete].freeze
+
     # The resultType of a result object. MCP 2026-07-28 makes the field
     # required, but "for backward compatibility with servers implementing
     # earlier protocol versions, which do not include resultType, clients
@@ -318,7 +322,32 @@ module MCPClient
     # that negotiated a result-type-adding extension.
     # @return [Array<String>]
     def accepted_result_types
-      CORE_RESULT_TYPES
+      # input_required names the multi round-trip pattern, which exists only
+      # in modern revisions: a handshake-era server answering with it is
+      # malformed, and treating it as valid would let a wrapper flatten an
+      # unfinished result into an empty successful one.
+      modern? ? CORE_RESULT_TYPES : LEGACY_RESULT_TYPES
+    end
+
+    # Project a payload out of a result that has to be finished. This client
+    # recognizes InputRequiredResult (resultType "input_required") but does
+    # not drive multi round-trip requests yet, so an operation that would
+    # extract a field from it — and so drop the server's inputRequests and
+    # opaque requestState — surfaces it instead of presenting an unfinished
+    # answer as an empty successful one. The whole result rides on the
+    # error's `data`, so a host can still drive the round trip itself.
+    # @param result [Object] the JSON-RPC result
+    # @param method [String] the request method, for the message
+    # @return [Object] the result, when it is complete
+    # @raise [MCPClient::Errors::InvalidResultError] when it is not
+    def require_complete_result!(result, method)
+      type = MCPClient::JsonRpcCommon.result_type(result)
+      return result if type == 'complete'
+
+      raise MCPClient::Errors::InvalidResultError.new(
+        "Invalid result: #{method} answered with resultType #{type.to_s[0, 64].inspect}, which this " \
+        'client cannot carry through (multi round-trip requests are not implemented)', data: result
+      )
     end
 
     # Build the error for a 4xx response: the typed JSON-RPC error when the

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -202,7 +202,9 @@ module MCPClient
     # @raise [MCPClient::Errors::ConnectionError] if the version is unsupported
     def validate_protocol_version!(result)
       version = result['protocolVersion']
-      return version if MCPClient::SUPPORTED_PROTOCOL_VERSIONS.include?(version)
+      # Only handshake-based revisions are valid here: a server answering
+      # initialize with a modern (per-request metadata) version is confused.
+      return version if MCPClient::LEGACY_PROTOCOL_VERSIONS.include?(version)
 
       begin
         cleanup if respond_to?(:cleanup)
@@ -211,7 +213,7 @@ module MCPClient
       end
       raise MCPClient::Errors::ConnectionError,
             "Server negotiated unsupported protocol version #{version.inspect} " \
-            "(supported: #{MCPClient::SUPPORTED_PROTOCOL_VERSIONS.join(', ')}); disconnecting"
+            "(supported: #{MCPClient::LEGACY_PROTOCOL_VERSIONS.join(', ')}); disconnecting"
     end
 
     # The Implementation object sent as clientInfo: the host-provided info
@@ -272,14 +274,58 @@ module MCPClient
       instance_variable_defined?(:@sampling_tools_supported) && @sampling_tools_supported
     end
 
+    # Result types defined by the core protocol (basic/index.mdx "ResultType").
+    # Extensions add more (e.g. "task"); transports widen the accepted set
+    # via #accepted_result_types once such an extension is negotiated.
+    CORE_RESULT_TYPES = %w[complete input_required].freeze
+
+    # The resultType of a result object. MCP 2026-07-28 makes the field
+    # required, but "for backward compatibility with servers implementing
+    # earlier protocol versions, which do not include resultType, clients
+    # MUST treat an absent resultType as 'complete'". Non-object results
+    # (lenient handling of older servers) are likewise complete.
+    # @param result [Object] a JSON-RPC result
+    # @return [Object] the resultType value, 'complete' when absent
+    def self.result_type(result)
+      return 'complete' unless result.is_a?(Hash)
+
+      type = result.key?('resultType') ? result['resultType'] : result[:resultType]
+      type.nil? ? 'complete' : type
+    end
+
+    # Result types this transport accepts. Overridden (widened) by transports
+    # that negotiated a result-type-adding extension.
+    # @return [Array<String>]
+    def accepted_result_types
+      CORE_RESULT_TYPES
+    end
+
     # Process JSON-RPC response
     # @param response [Hash] the parsed JSON-RPC response
     # @return [Object] the result field from the response
     # @raise [MCPClient::Errors::ServerError] if the response contains an error
+    # @raise [MCPClient::Errors::InvalidResultError] if the result's resultType is unrecognized
     def process_jsonrpc_response(response)
-      raise MCPClient::Errors::ServerError, response['error']['message'] if response['error']
+      raise MCPClient::Errors::ServerError.from_jsonrpc(response['error']) if response['error']
 
-      response['result']
+      result = response['result']
+      validate_result_type!(result)
+      result
+    end
+
+    # "A resultType of any value unrecognized by the client MUST be
+    # considered invalid" (basic/index.mdx). The value is peer-controlled, so
+    # only its class or a short prefix reaches the exception message.
+    # @param result [Object] a JSON-RPC result
+    # @return [void]
+    # @raise [MCPClient::Errors::InvalidResultError]
+    def validate_result_type!(result)
+      type = MCPClient::JsonRpcCommon.result_type(result)
+      return if accepted_result_types.include?(type)
+
+      shown = type.is_a?(String) ? type[0, 64].inspect : type.class.name
+      raise MCPClient::Errors::InvalidResultError,
+            "Invalid result: unrecognized resultType #{shown} (accepted: #{accepted_result_types.join(', ')})"
     end
   end
 end

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'zlib'
+require 'stringio'
 
 module MCPClient
   # Shared retry/backoff logic for JSON-RPC transports
@@ -307,9 +308,10 @@ module MCPClient
     # @return [Object] the resultType value, 'complete' when absent
     def self.result_type(result)
       return 'complete' unless result.is_a?(Hash)
+      return result['resultType'] if result.key?('resultType')
+      return result[:resultType] if result.key?(:resultType)
 
-      type = result.key?('resultType') ? result['resultType'] : result[:resultType]
-      type.nil? ? 'complete' : type
+      'complete'
     end
 
     # Result types this transport accepts. Overridden (widened) by transports
@@ -326,15 +328,24 @@ module MCPClient
     # @param fallback [String] message when the body carries no JSON-RPC error
     # @return [MCPClient::Errors::ServerError]
     def jsonrpc_error_from_http_response(response, fallback)
+      status = response.status
       error = jsonrpc_error_in_body(response)
-      return MCPClient::Errors::ServerError.new(fallback) unless error
+      return MCPClient::Errors::ServerError.new(fallback).tap { |e| e.http_status = status } unless error
 
       typed = MCPClient::Errors::ServerError.from_jsonrpc(error)
       typed.class.new("#{fallback}: #{typed.message}", code: typed.code, data: typed.data)
+           .tap { |e| e.http_status = status }
     end
 
+    # Ceiling on the size of an HTTP error body inspected for a JSON-RPC
+    # error. A protocol error response is a few hundred bytes; the body is
+    # peer-controlled, so anything larger is not parsed at all rather than
+    # handed to JSON.parse.
+    MAX_ERROR_BODY_BYTES = 64 * 1024
+
     # Extract a JSON-RPC error object from an HTTP error body, if there is one.
-    # Only a small, well-formed body is inspected; anything else is ignored.
+    # Only a small (MAX_ERROR_BODY_BYTES) JSON-RPC 2.0 error response is
+    # recognized; anything else is ignored.
     # @param response [Faraday::Response] the HTTP response
     # @return [Hash, nil] the JSON-RPC `error` member, or nil
     def jsonrpc_error_in_body(response)
@@ -342,17 +353,47 @@ module MCPClient
 
       body = response.body
       return nil unless body.is_a?(String) && !body.empty?
+      return nil if oversized_error_body?(body)
 
       headers = response.respond_to?(:headers) ? response.headers || {} : {}
       encoding = headers['content-encoding'] || headers['Content-Encoding'] || ''
-      body = decompress_gzip(body) if encoding.include?('gzip') && respond_to?(:decompress_gzip, true)
+      body = gunzip_bounded(body) if encoding.include?('gzip')
+      return nil if body.nil?
 
       data = JSON.parse(body)
-      error = data.is_a?(Hash) ? data['error'] : nil
+      # Only a JSON-RPC 2.0 error response counts; an arbitrary JSON body
+      # with an "error" member is not a protocol error.
+      return nil unless data.is_a?(Hash) && data['jsonrpc'] == '2.0'
+
+      error = data['error']
       error.is_a?(Hash) ? error : nil
-    rescue JSON::ParserError, Zlib::Error, MCPClient::Errors::ResponseTooLargeError => e
+    rescue JSON::ParserError, Zlib::Error => e
       @logger.debug("HTTP error body is not a JSON-RPC error: #{e.class}")
       nil
+    end
+
+    # @param body [String] an HTTP error body
+    # @return [Boolean] whether it exceeds the inspection ceiling (logged)
+    def oversized_error_body?(body)
+      return false if body.bytesize <= MAX_ERROR_BODY_BYTES
+
+      @logger.debug("Ignoring HTTP error body of #{body.bytesize} bytes (over #{MAX_ERROR_BODY_BYTES})")
+      true
+    end
+
+    # Decompress a gzip error body, giving up once the expansion passes the
+    # inspection ceiling (a compressed 4xx body is peer-controlled too).
+    # @param body [String] gzip data
+    # @return [String, nil] the decompressed body, or nil when too large
+    def gunzip_bounded(body)
+      reader = Zlib::GzipReader.new(StringIO.new(body))
+      expanded = reader.read(MAX_ERROR_BODY_BYTES + 1) || ''
+      return expanded if expanded.bytesize <= MAX_ERROR_BODY_BYTES
+
+      @logger.debug("Ignoring gzip HTTP error body expanding past #{MAX_ERROR_BODY_BYTES} bytes")
+      nil
+    ensure
+      reader&.close
     end
 
     # Process JSON-RPC response
@@ -375,8 +416,16 @@ module MCPClient
     # @return [void]
     # @raise [MCPClient::Errors::InvalidResultError]
     def validate_result_type!(result)
+      unless result.is_a?(Hash)
+        # A modern result MUST be an object. Legacy servers occasionally
+        # answered list requests with a bare array; keep tolerating that.
+        return unless modern?
+
+        raise MCPClient::Errors::InvalidResultError, "Invalid result: expected an object, got #{result.class}"
+      end
+
       type = MCPClient::JsonRpcCommon.result_type(result)
-      return if accepted_result_types.include?(type)
+      return if type.is_a?(String) && accepted_result_types.include?(type)
 
       shown = type.is_a?(String) ? type[0, 64].inspect : type.class.name
       raise MCPClient::Errors::InvalidResultError,

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'json'
+require 'zlib'
+
 module MCPClient
   # Shared retry/backoff logic for JSON-RPC transports
   module JsonRpcCommon
@@ -182,6 +185,22 @@ module MCPClient
       }
     end
 
+    # The protocol version in use with this server, once established: chosen
+    # via server/discover for a modern server or negotiated by initialize for
+    # a legacy one. nil until then.
+    # @return [String, nil]
+    def protocol_version
+      defined?(@protocol_version) ? @protocol_version : nil
+    end
+
+    # Whether this server speaks a modern (per-request metadata, no
+    # handshake) protocol revision (MCP 2026-07-28 basic/versioning
+    # "Terminology"). false until the era is established.
+    # @return [Boolean]
+    def modern?
+      MCPClient::MODERN_PROTOCOL_VERSIONS.include?(protocol_version)
+    end
+
     # Generate initialization parameters for MCP protocol
     # @return [Hash] the initialization parameters
     def initialization_params
@@ -298,6 +317,42 @@ module MCPClient
     # @return [Array<String>]
     def accepted_result_types
       CORE_RESULT_TYPES
+    end
+
+    # Build the error for a 4xx response: the typed JSON-RPC error when the
+    # body is a JSON-RPC error response (with the HTTP status prefixed to the
+    # peer's message), otherwise a plain ServerError with the fallback text.
+    # @param response [Faraday::Response] the 4xx response
+    # @param fallback [String] message when the body carries no JSON-RPC error
+    # @return [MCPClient::Errors::ServerError]
+    def jsonrpc_error_from_http_response(response, fallback)
+      error = jsonrpc_error_in_body(response)
+      return MCPClient::Errors::ServerError.new(fallback) unless error
+
+      typed = MCPClient::Errors::ServerError.from_jsonrpc(error)
+      typed.class.new("#{fallback}: #{typed.message}", code: typed.code, data: typed.data)
+    end
+
+    # Extract a JSON-RPC error object from an HTTP error body, if there is one.
+    # Only a small, well-formed body is inspected; anything else is ignored.
+    # @param response [Faraday::Response] the HTTP response
+    # @return [Hash, nil] the JSON-RPC `error` member, or nil
+    def jsonrpc_error_in_body(response)
+      return nil unless response.respond_to?(:body)
+
+      body = response.body
+      return nil unless body.is_a?(String) && !body.empty?
+
+      headers = response.respond_to?(:headers) ? response.headers || {} : {}
+      encoding = headers['content-encoding'] || headers['Content-Encoding'] || ''
+      body = decompress_gzip(body) if encoding.include?('gzip') && respond_to?(:decompress_gzip, true)
+
+      data = JSON.parse(body)
+      error = data.is_a?(Hash) ? data['error'] : nil
+      error.is_a?(Hash) ? error : nil
+    rescue JSON::ParserError, Zlib::Error, MCPClient::Errors::ResponseTooLargeError => e
+      @logger.debug("HTTP error body is not a JSON-RPC error: #{e.class}")
+      nil
     end
 
     # Process JSON-RPC response

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -344,14 +344,36 @@ module MCPClient
     MAX_ERROR_BODY_BYTES = 64 * 1024
 
     # Extract a JSON-RPC error object from an HTTP error body, if there is one.
-    # Only a small (MAX_ERROR_BODY_BYTES) JSON-RPC 2.0 error response is
-    # recognized; anything else is ignored.
+    # Only a JSON-RPC 2.0 error response is recognized; anything else is
+    # ignored.
     # @param response [Faraday::Response] the HTTP response
     # @return [Hash, nil] the JSON-RPC `error` member, or nil
     def jsonrpc_error_in_body(response)
       return nil unless response.respond_to?(:body)
 
+      data = decoded_error_body(response)
+      # Only a JSON-RPC 2.0 error response counts; an arbitrary JSON body
+      # with an "error" member is not a protocol error.
+      return nil unless data.is_a?(Hash) && (data['jsonrpc'] || data[:jsonrpc]) == '2.0'
+
+      error = data['error'] || data[:error]
+      error.is_a?(Hash) ? error : nil
+    end
+
+    # The error body as a decoded object.
+    #
+    # A host may configure the connection (faraday_config) with response
+    # middleware — `conn.response :json` — that decodes the body before it
+    # reaches this transport, on the exception path (`raise_error`) as well
+    # as the response path. That already-parsed body carries the same
+    # protocol error, so it is accepted as-is; only a raw String body is
+    # size-bounded, gunzipped and parsed here (the middleware has already
+    # spent the memory for the ones it decoded).
+    # @param response [Faraday::Response] the HTTP response
+    # @return [Object, nil] the decoded body, or nil when it cannot be read
+    def decoded_error_body(response)
       body = response.body
+      return body if body.is_a?(Hash)
       return nil unless body.is_a?(String) && !body.empty?
       return nil if oversized_error_body?(body)
 
@@ -360,13 +382,7 @@ module MCPClient
       body = gunzip_bounded(body) if encoding.include?('gzip')
       return nil if body.nil?
 
-      data = JSON.parse(body)
-      # Only a JSON-RPC 2.0 error response counts; an arbitrary JSON body
-      # with an "error" member is not a protocol error.
-      return nil unless data.is_a?(Hash) && data['jsonrpc'] == '2.0'
-
-      error = data['error']
-      error.is_a?(Hash) ? error : nil
+      JSON.parse(body)
     rescue JSON::ParserError, Zlib::Error => e
       @logger.debug("HTTP error body is not a JSON-RPC error: #{e.class}")
       nil

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -336,6 +336,13 @@ module MCPClient
     # opaque requestState — surfaces it instead of presenting an unfinished
     # answer as an empty successful one. The whole result rides on the
     # error's `data`, so a host can still drive the round trip itself.
+    #
+    # Every field projector goes through this, not just resources/read: MRTR
+    # permits an unfinished result on exactly tools/call, prompts/get and
+    # resources/read, so one on a list or a completion is malformed anyway —
+    # and reading it as a finished empty page would drop a whole page of a
+    # paginated list, or a completion, without a word. tools/call and
+    # prompts/get return the entire result and so never project.
     # @param result [Object] the JSON-RPC result
     # @param method [String] the request method, for the message
     # @return [Object] the result, when it is complete

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -457,11 +457,31 @@ module MCPClient
     # @raise [MCPClient::Errors::ServerError] if the response contains an error
     # @raise [MCPClient::Errors::InvalidResultError] if the result's resultType is unrecognized
     def process_jsonrpc_response(response)
-      raise MCPClient::Errors::ServerError.from_jsonrpc(response['error']) if response['error']
+      error = envelope_member(response, 'error')
+      raise MCPClient::Errors::ServerError.from_jsonrpc(error) if error
 
-      result = response['result']
+      result = envelope_member(response, 'result')
       validate_result_type!(result)
       result
+    end
+
+    # Read a member of a decoded JSON-RPC envelope.
+    #
+    # The README offers Faraday's JSON middleware for reading a server's error
+    # bodies, and that middleware decodes every response — under
+    # `symbolize_names` the envelope arrives keyed by Symbol. The members are
+    # the peer's, not the host's, so both spellings name the same thing: read
+    # the wire spelling first and fall back to the Symbol one. Anything that
+    # is no Hash is indexed as before, so a malformed envelope fails where it
+    # always did.
+    # @param response [Object] the decoded JSON-RPC envelope
+    # @param name [String] the member's name in its wire spelling
+    # @return [Object, nil] the member, or nil when the envelope carries none
+    def envelope_member(response, name)
+      return response[name] unless response.is_a?(Hash)
+      return response[name] if response.key?(name)
+
+      response[name.to_sym]
     end
 
     # "A resultType of any value unrecognized by the client MUST be

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -103,10 +103,13 @@ module MCPClient
     end
 
     # A log-safe description of a payload body: its size, never its content.
-    # @param body [String, nil] the response/request body
+    # A host's `conn.response :json` middleware hands the decoded object here
+    # instead of the bytes it came from; say so rather than measuring it.
+    # @param body [String, Object, nil] the response/request body
     # @return [String]
     def describe_body_size(body)
-      return 'empty body' if body.nil? || body.empty?
+      return 'empty body' if body.nil? || (body.respond_to?(:empty?) && body.empty?)
+      return "decoded #{body.class} body" unless body.is_a?(String)
 
       "#{body.bytesize} bytes"
     end

--- a/lib/mcp_client/server_base.rb
+++ b/lib/mcp_client/server_base.rb
@@ -210,6 +210,15 @@ module MCPClient
       MCPClient::Errors::ResourceNotFound.new("Resource '#{uri}' not found: #{error.message}")
     end
 
+    # Whether a resources/read error response means the resource does not
+    # exist, given this session's protocol era.
+    # @param error [MCPClient::Errors::ServerError] the server's error response
+    # @return [Boolean]
+    def resource_not_found_response?(error)
+      modern = respond_to?(:modern?) && modern?
+      MCPClient::Errors::Codes.resource_not_found_code?(error.code, modern: modern)
+    end
+
     # Safety bound on the number of pages followed when auto-paginating a
     # cursor-based list operation, to protect against a server that returns
     # a nextCursor indefinitely.

--- a/lib/mcp_client/server_base.rb
+++ b/lib/mcp_client/server_base.rb
@@ -199,6 +199,17 @@ module MCPClient
       @notification_callback = block
     end
 
+    # Map a resources/read error response to ResourceNotFound. MCP 2026-07-28
+    # (server/resources.mdx "Error Handling"): a missing resource is reported
+    # with -32602 (Invalid params); "for backwards compatibility, clients
+    # SHOULD also accept -32002 as a resource not found error".
+    # @param uri [String] the requested resource URI
+    # @param error [MCPClient::Errors::ServerError] the server's error response
+    # @return [MCPClient::Errors::ResourceNotFound]
+    def resource_not_found_error(uri, error)
+      MCPClient::Errors::ResourceNotFound.new("Resource '#{uri}' not found: #{error.message}")
+    end
+
     # Safety bound on the number of pages followed when auto-paginating a
     # cursor-based list operation, to protect against a server that returns
     # a nextCursor indefinitely.

--- a/lib/mcp_client/server_base.rb
+++ b/lib/mcp_client/server_base.rb
@@ -281,7 +281,7 @@ module MCPClient
     def request_paginated_list(method, key)
       collect_paginated(key) do |cursor|
         params = cursor ? { cursor: cursor } : {}
-        result = rpc_request(method, params)
+        result = require_complete_result!(rpc_request(method, params), method)
         case result
         when Hash
           [result[key] || [], result['nextCursor']]

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -318,7 +318,7 @@ module MCPClient
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
     rescue MCPClient::Errors::ServerError => e
-      raise resource_not_found_error(uri, e) if MCPClient::Errors::Codes.resource_not_found_code?(e.code)
+      raise resource_not_found_error(uri, e) if resource_not_found_response?(e)
 
       raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -317,6 +317,10 @@ module MCPClient
       result = rpc_request('resources/read', { uri: uri })
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
+    rescue MCPClient::Errors::ServerError => e
+      raise resource_not_found_error(uri, e) if MCPClient::Errors::Codes.resource_not_found_code?(e.code)
+
+      raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       raise
     rescue StandardError => e

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -326,7 +326,7 @@ module MCPClient
     # @return [Array<MCPClient::ResourceContent>] array of resource contents
     # @raise [MCPClient::Errors::ResourceReadError] if resource reading fails
     def read_resource(uri)
-      result = rpc_request('resources/read', { uri: uri })
+      result = require_complete_result!(rpc_request('resources/read', { uri: uri }), 'resources/read')
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
     rescue MCPClient::Errors::ServerError => e

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -187,6 +187,12 @@ module MCPClient
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       # Re-raise connection/transport errors directly to match test expectations
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors (typed -3202x, invalid result) carry
+      # actionable data such as requiredCapabilities; keep them intact.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ToolCallError, "Error calling tool '#{tool_name}': #{e.message}"
     rescue StandardError => e
       # For all other errors, wrap in ToolCallError
       raise MCPClient::Errors::ToolCallError, "Error calling tool '#{tool_name}': #{e.message}"
@@ -271,6 +277,12 @@ module MCPClient
       rpc_request('prompts/get', build_named_request_params(prompt_name, parameters))
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors (typed -3202x, invalid result) carry
+      # actionable data such as requiredCapabilities; keep them intact.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::PromptGetError, "Error getting prompt '#{prompt_name}': #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::PromptGetError, "Error getting prompt '#{prompt_name}': #{e.message}"
     end
@@ -318,6 +330,7 @@ module MCPClient
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
     rescue MCPClient::Errors::ServerError => e
+      raise if e.protocol_error?
       raise resource_not_found_error(uri, e) if resource_not_found_response?(e)
 
       raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -301,7 +301,7 @@ module MCPClient
 
         params = {}
         params['cursor'] = cursor if cursor
-        result = rpc_request('resources/list', params)
+        result = require_complete_result!(rpc_request('resources/list', params), 'resources/list')
 
         resources = (result['resources'] || []).map do |resource_data|
           MCPClient::Resource.from_json(resource_data, server: self)
@@ -351,11 +351,17 @@ module MCPClient
       require_capability!('completions', method: 'completion/complete')
       params = { ref: ref, argument: argument }
       params[:context] = context if context
-      result = rpc_request('completion/complete', params)
+      result = require_complete_result!(rpc_request('completion/complete', params), 'completion/complete')
       result['completion'] || { 'values' => [] }
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError,
            MCPClient::Errors::CapabilityError
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors (typed -3202x, invalid result) carry
+      # actionable data such as requiredCapabilities; keep them intact.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ServerError, "Error requesting completion: #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ServerError, "Error requesting completion: #{e.message}"
     end
@@ -372,6 +378,12 @@ module MCPClient
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError,
            MCPClient::Errors::CapabilityError
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors (typed -3202x, invalid result) carry
+      # actionable data such as requiredCapabilities; keep them intact.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ServerError, "Error setting log level: #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ServerError, "Error setting log level: #{e.message}"
     end
@@ -383,7 +395,8 @@ module MCPClient
     def list_resource_templates(cursor: nil)
       params = {}
       params['cursor'] = cursor if cursor
-      result = rpc_request('resources/templates/list', params)
+      result = require_complete_result!(rpc_request('resources/templates/list', params),
+                                        'resources/templates/list')
 
       templates = (result['resourceTemplates'] || []).map do |template_data|
         MCPClient::ResourceTemplate.from_json(template_data, server: self)

--- a/lib/mcp_client/server_http/json_rpc_transport.rb
+++ b/lib/mcp_client/server_http/json_rpc_transport.rb
@@ -16,9 +16,13 @@ module MCPClient
       # @return [Hash] the parsed result
       # @raise [MCPClient::Errors::TransportError] if parsing fails
       # @raise [MCPClient::Errors::ServerError] if the response contains an error
+      # A host's `conn.response :json` middleware decodes the body before it
+      # reaches here — the README offers that middleware for the error path,
+      # and it applies to every response — so an already-decoded object is
+      # taken as it is rather than parsed a second time.
       def parse_response(response, _request = nil)
-        body = response.body.strip
-        data = JSON.parse(body)
+        body = response.body
+        data = body.is_a?(String) ? JSON.parse(body.strip) : body
         process_jsonrpc_response(data)
       rescue JSON::ParserError => e
         raise MCPClient::Errors::TransportError, "Invalid JSON response from server: #{describe_parse_error(e)}"

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -236,7 +236,7 @@ module MCPClient
     # @raise [MCPClient::Errors::ResourceReadError] for other errors during resource reading
     # @raise [MCPClient::Errors::ConnectionError] if server is disconnected
     def read_resource(uri)
-      result = rpc_request('resources/read', { uri: uri })
+      result = require_complete_result!(rpc_request('resources/read', { uri: uri }), 'resources/read')
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
     rescue MCPClient::Errors::ServerError => e

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -233,6 +233,10 @@ module MCPClient
       result = rpc_request('resources/read', { uri: uri })
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
+    rescue MCPClient::Errors::ServerError => e
+      raise resource_not_found_error(uri, e) if MCPClient::Errors::Codes.resource_not_found_code?(e.code)
+
+      raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       # Re-raise connection/transport errors directly to match test expectations
       raise

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -234,7 +234,7 @@ module MCPClient
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
     rescue MCPClient::Errors::ServerError => e
-      raise resource_not_found_error(uri, e) if MCPClient::Errors::Codes.resource_not_found_code?(e.code)
+      raise resource_not_found_error(uri, e) if resource_not_found_response?(e)
 
       raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -180,6 +180,12 @@ module MCPClient
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       # Re-raise connection/transport errors directly to match test expectations
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors (typed -3202x, invalid result) carry
+      # actionable data such as requiredCapabilities; keep them intact.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::PromptGetError, "Error get prompt '#{prompt_name}': #{e.message}"
     rescue StandardError => e
       # For all other errors, wrap in PromptGetError
       raise MCPClient::Errors::PromptGetError, "Error get prompt '#{prompt_name}': #{e.message}"
@@ -234,6 +240,7 @@ module MCPClient
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
     rescue MCPClient::Errors::ServerError => e
+      raise if e.protocol_error?
       raise resource_not_found_error(uri, e) if resource_not_found_response?(e)
 
       raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"
@@ -343,6 +350,12 @@ module MCPClient
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       # Re-raise connection/transport errors directly to match test expectations
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors (typed -3202x, invalid result) carry
+      # actionable data such as requiredCapabilities; keep them intact.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ToolCallError, "Error calling tool '#{tool_name}': #{e.message}"
     rescue StandardError => e
       # For all other errors, wrap in ToolCallError
       raise MCPClient::Errors::ToolCallError, "Error calling tool '#{tool_name}': #{e.message}"

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -207,7 +207,7 @@ module MCPClient
 
         params = {}
         params['cursor'] = cursor if cursor
-        result = rpc_request('resources/list', params)
+        result = require_complete_result!(rpc_request('resources/list', params), 'resources/list')
 
         resources = (result['resources'] || []).map do |resource_data|
           MCPClient::Resource.from_json(resource_data, server: self)
@@ -261,7 +261,8 @@ module MCPClient
       ensure_initialized
       params = {}
       params['cursor'] = cursor if cursor
-      result = rpc_request('resources/templates/list', params)
+      result = require_complete_result!(rpc_request('resources/templates/list', params),
+                                        'resources/templates/list')
 
       templates = (result['resourceTemplates'] || []).map do |template_data|
         MCPClient::ResourceTemplate.from_json(template_data, server: self)
@@ -372,11 +373,17 @@ module MCPClient
       require_capability!('completions', method: 'completion/complete')
       params = { ref: ref, argument: argument }
       params[:context] = context if context
-      result = rpc_request('completion/complete', params)
+      result = require_complete_result!(rpc_request('completion/complete', params), 'completion/complete')
       result['completion'] || { 'values' => [] }
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError,
            MCPClient::Errors::CapabilityError
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors (typed -3202x, invalid result) carry
+      # actionable data such as requiredCapabilities; keep them intact.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ServerError, "Error requesting completion: #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ServerError, "Error requesting completion: #{e.message}"
     end
@@ -393,6 +400,12 @@ module MCPClient
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError,
            MCPClient::Errors::CapabilityError
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors (typed -3202x, invalid result) carry
+      # actionable data such as requiredCapabilities; keep them intact.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ServerError, "Error setting log level: #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ServerError, "Error setting log level: #{e.message}"
     end

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -308,6 +308,9 @@ module MCPClient
           # the Symbol :error key; deliver them to the caller as ServerError
           # (MCP lifecycle "Error Handling") instead of timing out.
           raise_sse_error_response(result[:error]) if result.is_a?(Hash) && result.key?(:error)
+          # Same resultType invariant as process_jsonrpc_response on the
+          # other transports: an unrecognized value is an invalid response.
+          validate_result_type!(result)
           return result
         end
 

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -319,10 +319,9 @@ module MCPClient
       # @param error [Hash, nil] the JSON-RPC error object ('code', 'message', 'data')
       # @raise [MCPClient::Errors::ServerError] always
       def raise_sse_error_response(error)
-        error ||= {}
-        message = error['message'] || 'Unknown server error'
-        message = "#{message} (code #{error['code']})" if error['code']
-        raise MCPClient::Errors::ServerError, message
+        typed = MCPClient::Errors::ServerError.from_jsonrpc(error)
+        message = typed.code ? "#{typed.message} (code #{typed.code})" : typed.message
+        raise typed.class.new(message, code: typed.code, data: typed.data)
       end
 
       # Parse a direct (non-SSE) JSON-RPC response

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -187,9 +187,13 @@ module MCPClient
 
           unless response.success?
             # 5xx failures are plausibly transient (retryable); 4xx and other
-            # statuses are deterministic and raise a plain (non-retryable) error.
-            error_class = (500..599).cover?(response.status) ? MCPClient::Errors::TransientServerError : MCPClient::Errors::ServerError
-            raise error_class, "Server returned error: #{response.status} #{response.reason_phrase}"
+            # statuses are deterministic and raise a plain (non-retryable)
+            # error — typed when the body carries a JSON-RPC error (MCP
+            # 2026-07-28 protocol errors ride in 400/404 bodies).
+            message = "Server returned error: #{response.status} #{response.reason_phrase}"
+            raise MCPClient::Errors::TransientServerError, message if (500..599).cover?(response.status)
+
+            raise jsonrpc_error_from_http_response(response, message)
           end
 
           response

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -11,6 +11,14 @@ module MCPClient
       include OriginPolicy
       include JsonRpcCommon
 
+      # Returned by #check_for_result when nothing has arrived for the
+      # request yet. The stored result is whatever `result` member the
+      # response carried, so `null` and `false` are answers the client must
+      # deliver (and validate) rather than truthiness the waiter can read as
+      # "still outstanding" — doing that waited out the whole read timeout
+      # and cancelled a request the server had already answered.
+      NO_RESULT = Object.new.freeze
+
       # Generic JSON-RPC request: send method with params and return result
       # @param method [String] JSON-RPC method name
       # @param params [Hash] parameters for the request
@@ -280,7 +288,7 @@ module MCPClient
       def wait_for_result_with_timeout(request_id, start_time, timeout)
         loop do
           result = check_for_result(request_id)
-          return result if result
+          return result unless result.equal?(NO_RESULT)
 
           unless connection_active?
             raise MCPClient::Errors::ConnectionError,
@@ -298,27 +306,28 @@ module MCPClient
 
       # Check if a result is available for the given request ID
       # @param request_id [Integer] the request ID to check
-      # @return [Hash, nil] the result if available, nil otherwise
+      # @return [Object] the result if one has arrived, NO_RESULT otherwise
       # @raise [MCPClient::Errors::ServerError] if the stored result is a JSON-RPC error response
       def check_for_result(request_id)
+        arrived = false
         result = nil
         @mutex.synchronize do
-          result = @sse_results.delete(request_id) if @sse_results.key?(request_id)
+          if @sse_results.key?(request_id)
+            arrived = true
+            result = @sse_results.delete(request_id)
+          end
         end
+        return NO_RESULT unless arrived
 
-        if result
-          record_activity
-          # SseParser#process_response? stores JSON-RPC error responses under
-          # the Symbol :error key; deliver them to the caller as ServerError
-          # (MCP lifecycle "Error Handling") instead of timing out.
-          raise_sse_error_response(result[:error]) if result.is_a?(Hash) && result.key?(:error)
-          # Same resultType invariant as process_jsonrpc_response on the
-          # other transports: an unrecognized value is an invalid response.
-          validate_result_type!(result)
-          return result
-        end
-
-        nil
+        record_activity
+        # SseParser#process_response? stores JSON-RPC error responses under
+        # the Symbol :error key; deliver them to the caller as ServerError
+        # (MCP lifecycle "Error Handling") instead of timing out.
+        raise_sse_error_response(result[:error]) if result.is_a?(Hash) && result.key?(:error)
+        # Same resultType invariant as process_jsonrpc_response on the
+        # other transports: an unrecognized value is an invalid response.
+        validate_result_type!(result)
+        result
       end
 
       # Raise a ServerError for a JSON-RPC error response received over SSE,

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -97,7 +97,15 @@ module MCPClient
         request_id = @mutex.synchronize { @request_id += 1 }
         json_rpc_request = build_jsonrpc_request('initialize', initialization_params, request_id)
         @logger.debug("Performing initialize RPC: #{json_rpc_request}")
-        result = send_jsonrpc_request(json_rpc_request)
+        begin
+          result = send_jsonrpc_request(json_rpc_request)
+        rescue MCPClient::Errors::UnsupportedProtocolVersionError => e
+          # As on the HTTP transports: the versions a modern-only server
+          # names in `data` are the diagnostic a legacy configuration needs,
+          # so they are spelled out rather than dropped by connect's wrap.
+          raise MCPClient::Errors::ConnectionError,
+                "Initialize failed: #{e.message} (server supports: #{e.supported.join(', ')})"
+        end
         unless result.is_a?(Hash)
           # A non-object initialize result means the handshake did not succeed.
           # Continuing would enter the Operation phase without ever sending the

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -332,6 +332,11 @@ module MCPClient
         # the Symbol :error key; deliver them to the caller as ServerError
         # (MCP lifecycle "Error Handling") instead of timing out.
         raise_sse_error_response(result[:error]) if result.is_a?(Hash) && result.key?(:error)
+        # …and an envelope that carried neither member under :no_answer.
+        if result.is_a?(Hash) && result[:no_answer]
+          raise MCPClient::Errors::InvalidResultError,
+                "Invalid result: the response to request #{request_id} carried neither a result nor an error member"
+        end
         # Same resultType invariant as process_jsonrpc_response on the
         # other transports: an unrecognized value is an invalid response.
         validate_result_type!(result)

--- a/lib/mcp_client/server_sse/sse_parser.rb
+++ b/lib/mcp_client/server_sse/sse_parser.rb
@@ -116,8 +116,16 @@ module MCPClient
               # (JSON.parse only produces String keys, so this cannot collide
               # with a success result) for the waiter to raise ServerError.
               { error: data['error'] }
-            else
+            elsif data.key?('result')
+              # An explicit null (or false) result is an answer; only the
+              # member's presence decides that.
               data['result']
+            else
+              # JSON-RPC 2.0 section 5: "Either the result member or error
+              # member MUST be included". An envelope carrying neither answers
+              # nothing, and reading its absent result as a delivered nil
+              # would turn a malformed response into a successful call.
+              { no_answer: true }
             end
         end
 

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -214,11 +214,7 @@ module MCPClient
         req = { 'jsonrpc' => '2.0', 'id' => req_id, 'method' => 'prompts/list', 'params' => params }
         send_request(req)
         res = wait_response(req_id)
-        if (err = res['error'])
-          raise MCPClient::Errors::ServerError, err['message']
-        end
-
-        result = res['result'] || {}
+        result = process_jsonrpc_response(res) || {}
         prompts = (result['prompts'] || []).map { |td| MCPClient::Prompt.from_json(td, server: self) }
         [prompts, result['nextCursor']]
       end
@@ -244,11 +240,7 @@ module MCPClient
       }
       send_request(req)
       res = wait_response(req_id)
-      if (err = res['error'])
-        raise MCPClient::Errors::ServerError, err['message']
-      end
-
-      res['result']
+      process_jsonrpc_response(res)
     rescue StandardError => e
       raise MCPClient::Errors::PromptGetError, "Error calling prompt '#{prompt_name}': #{e.message}"
     end
@@ -266,11 +258,7 @@ module MCPClient
       req = { 'jsonrpc' => '2.0', 'id' => req_id, 'method' => 'resources/list', 'params' => params }
       send_request(req)
       res = wait_response(req_id)
-      if (err = res['error'])
-        raise MCPClient::Errors::ServerError, err['message']
-      end
-
-      result = res['result'] || {}
+      result = process_jsonrpc_response(res) || {}
       resources = (result['resources'] || []).map { |td| MCPClient::Resource.from_json(td, server: self) }
       { 'resources' => resources, 'nextCursor' => result['nextCursor'] }
     rescue StandardError => e
@@ -294,13 +282,13 @@ module MCPClient
       }
       send_request(req)
       res = wait_response(req_id)
-      if (err = res['error'])
-        raise MCPClient::Errors::ServerError, err['message']
-      end
-
-      result = res['result'] || {}
+      result = process_jsonrpc_response(res) || {}
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
+    rescue MCPClient::Errors::ServerError => e
+      raise resource_not_found_error(uri, e) if MCPClient::Errors::Codes.resource_not_found_code?(e.code)
+
+      raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"
     end
@@ -318,11 +306,7 @@ module MCPClient
       req = { 'jsonrpc' => '2.0', 'id' => req_id, 'method' => 'resources/templates/list', 'params' => params }
       send_request(req)
       res = wait_response(req_id)
-      if (err = res['error'])
-        raise MCPClient::Errors::ServerError, err['message']
-      end
-
-      result = res['result'] || {}
+      result = process_jsonrpc_response(res) || {}
       templates = (result['resourceTemplates'] || []).map { |td| MCPClient::ResourceTemplate.from_json(td, server: self) }
       { 'resourceTemplates' => templates, 'nextCursor' => result['nextCursor'] }
     rescue StandardError => e
@@ -346,10 +330,7 @@ module MCPClient
       }
       send_request(req)
       res = wait_response(req_id)
-      if (err = res['error'])
-        raise MCPClient::Errors::ServerError, err['message']
-      end
-
+      process_jsonrpc_response(res)
       true
     rescue MCPClient::Errors::CapabilityError
       raise
@@ -374,10 +355,7 @@ module MCPClient
       }
       send_request(req)
       res = wait_response(req_id)
-      if (err = res['error'])
-        raise MCPClient::Errors::ServerError, err['message']
-      end
-
+      process_jsonrpc_response(res)
       true
     rescue MCPClient::Errors::CapabilityError
       raise
@@ -399,11 +377,7 @@ module MCPClient
         req = { 'jsonrpc' => '2.0', 'id' => req_id, 'method' => 'tools/list', 'params' => params }
         send_request(req)
         res = wait_response(req_id)
-        if (err = res['error'])
-          raise MCPClient::Errors::ServerError, err['message']
-        end
-
-        result = res['result'] || {}
+        result = process_jsonrpc_response(res) || {}
         tools = (result['tools'] || []).map { |td| MCPClient::Tool.from_json(td, server: self) }
         [tools, result['nextCursor']]
       end
@@ -429,11 +403,7 @@ module MCPClient
       }
       send_request(req)
       res = wait_response(req_id)
-      if (err = res['error'])
-        raise MCPClient::Errors::ServerError, err['message']
-      end
-
-      res['result']
+      process_jsonrpc_response(res)
     rescue StandardError => e
       raise MCPClient::Errors::ToolCallError, "Error calling tool '#{tool_name}': #{e.message}"
     end
@@ -458,11 +428,7 @@ module MCPClient
       }
       send_request(req)
       res = wait_response(req_id)
-      if (err = res['error'])
-        raise MCPClient::Errors::ServerError, err['message']
-      end
-
-      res.dig('result', 'completion') || { 'values' => [] }
+      (process_jsonrpc_response(res) || {})['completion'] || { 'values' => [] }
     rescue MCPClient::Errors::CapabilityError
       raise
     rescue StandardError => e
@@ -486,11 +452,7 @@ module MCPClient
       }
       send_request(req)
       res = wait_response(req_id)
-      if (err = res['error'])
-        raise MCPClient::Errors::ServerError, err['message']
-      end
-
-      res['result'] || {}
+      process_jsonrpc_response(res) || {}
     rescue MCPClient::Errors::CapabilityError
       raise
     rescue StandardError => e

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -286,7 +286,7 @@ module MCPClient
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
     rescue MCPClient::Errors::ServerError => e
-      raise resource_not_found_error(uri, e) if MCPClient::Errors::Codes.resource_not_found_code?(e.code)
+      raise resource_not_found_error(uri, e) if resource_not_found_response?(e)
 
       raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"
     rescue StandardError => e

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -300,7 +300,7 @@ module MCPClient
       }
       send_request(req)
       res = wait_response(req_id)
-      result = process_jsonrpc_response(res) || {}
+      result = require_complete_result!(process_jsonrpc_response(res) || {}, 'resources/read')
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
     rescue MCPClient::Errors::ServerError => e

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -218,6 +218,12 @@ module MCPClient
         prompts = (result['prompts'] || []).map { |td| MCPClient::Prompt.from_json(td, server: self) }
         [prompts, result['nextCursor']]
       end
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors carry actionable data (requiredCapabilities,
+      # supported versions); keep them intact instead of wrapping.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::PromptGetError, "Error listing prompts: #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::PromptGetError, "Error listing prompts: #{e.message}"
     end
@@ -241,6 +247,12 @@ module MCPClient
       send_request(req)
       res = wait_response(req_id)
       process_jsonrpc_response(res)
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors carry actionable data (requiredCapabilities,
+      # supported versions); keep them intact instead of wrapping.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::PromptGetError, "Error calling prompt '#{prompt_name}': #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::PromptGetError, "Error calling prompt '#{prompt_name}': #{e.message}"
     end
@@ -261,6 +273,12 @@ module MCPClient
       result = process_jsonrpc_response(res) || {}
       resources = (result['resources'] || []).map { |td| MCPClient::Resource.from_json(td, server: self) }
       { 'resources' => resources, 'nextCursor' => result['nextCursor'] }
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors carry actionable data (requiredCapabilities,
+      # supported versions); keep them intact instead of wrapping.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ResourceReadError, "Error listing resources: #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ResourceReadError, "Error listing resources: #{e.message}"
     end
@@ -286,6 +304,7 @@ module MCPClient
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
     rescue MCPClient::Errors::ServerError => e
+      raise if e.protocol_error?
       raise resource_not_found_error(uri, e) if resource_not_found_response?(e)
 
       raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"
@@ -309,6 +328,12 @@ module MCPClient
       result = process_jsonrpc_response(res) || {}
       templates = (result['resourceTemplates'] || []).map { |td| MCPClient::ResourceTemplate.from_json(td, server: self) }
       { 'resourceTemplates' => templates, 'nextCursor' => result['nextCursor'] }
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors carry actionable data (requiredCapabilities,
+      # supported versions); keep them intact instead of wrapping.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ResourceReadError, "Error listing resource templates: #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ResourceReadError, "Error listing resource templates: #{e.message}"
     end
@@ -334,6 +359,12 @@ module MCPClient
       true
     rescue MCPClient::Errors::CapabilityError
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors carry actionable data (requiredCapabilities,
+      # supported versions); keep them intact instead of wrapping.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ResourceReadError, "Error subscribing to resource '#{uri}': #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ResourceReadError, "Error subscribing to resource '#{uri}': #{e.message}"
     end
@@ -359,6 +390,12 @@ module MCPClient
       true
     rescue MCPClient::Errors::CapabilityError
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors carry actionable data (requiredCapabilities,
+      # supported versions); keep them intact instead of wrapping.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ResourceReadError, "Error unsubscribing from resource '#{uri}': #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ResourceReadError, "Error unsubscribing from resource '#{uri}': #{e.message}"
     end
@@ -381,6 +418,12 @@ module MCPClient
         tools = (result['tools'] || []).map { |td| MCPClient::Tool.from_json(td, server: self) }
         [tools, result['nextCursor']]
       end
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors carry actionable data (requiredCapabilities,
+      # supported versions); keep them intact instead of wrapping.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ToolCallError, "Error listing tools: #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ToolCallError, "Error listing tools: #{e.message}"
     end
@@ -404,6 +447,12 @@ module MCPClient
       send_request(req)
       res = wait_response(req_id)
       process_jsonrpc_response(res)
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors carry actionable data (requiredCapabilities,
+      # supported versions); keep them intact instead of wrapping.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ToolCallError, "Error calling tool '#{tool_name}': #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ToolCallError, "Error calling tool '#{tool_name}': #{e.message}"
     end
@@ -431,6 +480,12 @@ module MCPClient
       (process_jsonrpc_response(res) || {})['completion'] || { 'values' => [] }
     rescue MCPClient::Errors::CapabilityError
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors carry actionable data (requiredCapabilities,
+      # supported versions); keep them intact instead of wrapping.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ServerError, "Error requesting completion: #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ServerError, "Error requesting completion: #{e.message}"
     end
@@ -455,6 +510,12 @@ module MCPClient
       process_jsonrpc_response(res) || {}
     rescue MCPClient::Errors::CapabilityError
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors carry actionable data (requiredCapabilities,
+      # supported versions); keep them intact instead of wrapping.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ServerError, "Error setting log level: #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ServerError, "Error setting log level: #{e.message}"
     end

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -214,7 +214,7 @@ module MCPClient
         req = { 'jsonrpc' => '2.0', 'id' => req_id, 'method' => 'prompts/list', 'params' => params }
         send_request(req)
         res = wait_response(req_id)
-        result = process_jsonrpc_response(res) || {}
+        result = require_complete_result!(process_jsonrpc_response(res) || {}, 'prompts/list')
         prompts = (result['prompts'] || []).map { |td| MCPClient::Prompt.from_json(td, server: self) }
         [prompts, result['nextCursor']]
       end
@@ -270,7 +270,7 @@ module MCPClient
       req = { 'jsonrpc' => '2.0', 'id' => req_id, 'method' => 'resources/list', 'params' => params }
       send_request(req)
       res = wait_response(req_id)
-      result = process_jsonrpc_response(res) || {}
+      result = require_complete_result!(process_jsonrpc_response(res) || {}, 'resources/list')
       resources = (result['resources'] || []).map { |td| MCPClient::Resource.from_json(td, server: self) }
       { 'resources' => resources, 'nextCursor' => result['nextCursor'] }
     rescue MCPClient::Errors::ServerError => e
@@ -325,7 +325,7 @@ module MCPClient
       req = { 'jsonrpc' => '2.0', 'id' => req_id, 'method' => 'resources/templates/list', 'params' => params }
       send_request(req)
       res = wait_response(req_id)
-      result = process_jsonrpc_response(res) || {}
+      result = require_complete_result!(process_jsonrpc_response(res) || {}, 'resources/templates/list')
       templates = (result['resourceTemplates'] || []).map { |td| MCPClient::ResourceTemplate.from_json(td, server: self) }
       { 'resourceTemplates' => templates, 'nextCursor' => result['nextCursor'] }
     rescue MCPClient::Errors::ServerError => e
@@ -414,7 +414,7 @@ module MCPClient
         req = { 'jsonrpc' => '2.0', 'id' => req_id, 'method' => 'tools/list', 'params' => params }
         send_request(req)
         res = wait_response(req_id)
-        result = process_jsonrpc_response(res) || {}
+        result = require_complete_result!(process_jsonrpc_response(res) || {}, 'tools/list')
         tools = (result['tools'] || []).map { |td| MCPClient::Tool.from_json(td, server: self) }
         [tools, result['nextCursor']]
       end
@@ -477,7 +477,8 @@ module MCPClient
       }
       send_request(req)
       res = wait_response(req_id)
-      (process_jsonrpc_response(res) || {})['completion'] || { 'values' => [] }
+      result = require_complete_result!(process_jsonrpc_response(res) || {}, 'completion/complete')
+      result['completion'] || { 'values' => [] }
     rescue MCPClient::Errors::CapabilityError
       raise
     rescue MCPClient::Errors::ServerError => e

--- a/lib/mcp_client/server_stdio/json_rpc_transport.rb
+++ b/lib/mcp_client/server_stdio/json_rpc_transport.rb
@@ -33,6 +33,12 @@ module MCPClient
         res = wait_response(init_id)
         begin
           result = process_jsonrpc_response(res) || {}
+        rescue MCPClient::Errors::UnsupportedProtocolVersionError => e
+          # A modern-only server SHOULD name the versions it supports when
+          # rejecting initialize (basic/versioning): surface them, since a
+          # legacy-only configuration has no fall-forward path.
+          raise MCPClient::Errors::ConnectionError,
+                "Initialize failed: #{e.message} (server supports: #{e.supported.join(', ')})"
         rescue MCPClient::Errors::ServerError => e
           raise MCPClient::Errors::ConnectionError, "Initialize failed: #{e.message}"
         end

--- a/lib/mcp_client/server_stdio/json_rpc_transport.rb
+++ b/lib/mcp_client/server_stdio/json_rpc_transport.rb
@@ -31,13 +31,14 @@ module MCPClient
         init_req = build_jsonrpc_request('initialize', initialization_params, init_id)
         send_request(init_req)
         res = wait_response(init_id)
-        if (err = res['error'])
-          raise MCPClient::Errors::ConnectionError, "Initialize failed: #{err['message']}"
+        begin
+          result = process_jsonrpc_response(res) || {}
+        rescue MCPClient::Errors::ServerError => e
+          raise MCPClient::Errors::ConnectionError, "Initialize failed: #{e.message}"
         end
 
         # Store negotiated protocol version, server info and capabilities.
         # Disconnects if the server negotiated a version we cannot speak.
-        result = res['result'] || {}
         @protocol_version = validate_protocol_version!(result)
         @server_info = result['serverInfo']
         @capabilities = result['capabilities']

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -400,7 +400,7 @@ module MCPClient
     # @return [Array<MCPClient::ResourceContent>] array of resource contents
     # @raise [MCPClient::Errors::ResourceReadError] if resource reading fails
     def read_resource(uri)
-      result = rpc_request('resources/read', { uri: uri })
+      result = require_complete_result!(rpc_request('resources/read', { uri: uri }), 'resources/read')
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
     rescue MCPClient::Errors::ServerError => e

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -392,7 +392,7 @@ module MCPClient
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
     rescue MCPClient::Errors::ServerError => e
-      raise resource_not_found_error(uri, e) if MCPClient::Errors::Codes.resource_not_found_code?(e.code)
+      raise resource_not_found_error(uri, e) if resource_not_found_response?(e)
 
       raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -391,6 +391,10 @@ module MCPClient
       result = rpc_request('resources/read', { uri: uri })
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
+    rescue MCPClient::Errors::ServerError => e
+      raise resource_not_found_error(uri, e) if MCPClient::Errors::Codes.resource_not_found_code?(e.code)
+
+      raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       # Re-raise connection/transport errors directly
       raise

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -255,6 +255,12 @@ module MCPClient
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       # Re-raise connection/transport errors directly to match test expectations
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors (typed -3202x, invalid result) carry
+      # actionable data such as requiredCapabilities; keep them intact.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ToolCallError, "Error calling tool '#{tool_name}': #{e.message}"
     rescue StandardError => e
       # For all other errors, wrap in ToolCallError
       raise MCPClient::Errors::ToolCallError, "Error calling tool '#{tool_name}': #{e.message}"
@@ -343,6 +349,12 @@ module MCPClient
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError
       # Re-raise connection/transport errors directly
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors (typed -3202x, invalid result) carry
+      # actionable data such as requiredCapabilities; keep them intact.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::PromptGetError, "Error getting prompt '#{prompt_name}': #{e.message}"
     rescue StandardError => e
       # For all other errors, wrap in PromptGetError
       raise MCPClient::Errors::PromptGetError, "Error getting prompt '#{prompt_name}': #{e.message}"
@@ -392,6 +404,7 @@ module MCPClient
       contents = result['contents'] || []
       contents.map { |content| MCPClient::ResourceContent.from_json(content) }
     rescue MCPClient::Errors::ServerError => e
+      raise if e.protocol_error?
       raise resource_not_found_error(uri, e) if resource_not_found_response?(e)
 
       raise MCPClient::Errors::ResourceReadError, "Error reading resource '#{uri}': #{e.message}"

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -287,11 +287,17 @@ module MCPClient
       require_capability!('completions', method: 'completion/complete')
       params = { ref: ref, argument: argument }
       params[:context] = context if context
-      result = rpc_request('completion/complete', params)
+      result = require_complete_result!(rpc_request('completion/complete', params), 'completion/complete')
       result['completion'] || { 'values' => [] }
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError,
            MCPClient::Errors::CapabilityError
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors (typed -3202x, invalid result) carry
+      # actionable data such as requiredCapabilities; keep them intact.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ServerError, "Error requesting completion: #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ServerError, "Error requesting completion: #{e.message}"
     end
@@ -308,6 +314,12 @@ module MCPClient
     rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError,
            MCPClient::Errors::CapabilityError
       raise
+    rescue MCPClient::Errors::ServerError => e
+      # 2026-07-28 protocol errors (typed -3202x, invalid result) carry
+      # actionable data such as requiredCapabilities; keep them intact.
+      raise if e.protocol_error?
+
+      raise MCPClient::Errors::ServerError, "Error setting log level: #{e.message}"
     rescue StandardError => e
       raise MCPClient::Errors::ServerError, "Error setting log level: #{e.message}"
     end
@@ -374,7 +386,7 @@ module MCPClient
 
         params = {}
         params['cursor'] = cursor if cursor
-        result = rpc_request('resources/list', params)
+        result = require_complete_result!(rpc_request('resources/list', params), 'resources/list')
 
         resources = (result['resources'] || []).map do |resource_data|
           MCPClient::Resource.from_json(resource_data, server: self)
@@ -423,7 +435,8 @@ module MCPClient
     def list_resource_templates(cursor: nil)
       params = {}
       params['cursor'] = cursor if cursor
-      result = rpc_request('resources/templates/list', params)
+      result = require_complete_result!(rpc_request('resources/templates/list', params),
+                                        'resources/templates/list')
 
       templates = (result['resourceTemplates'] || []).map do |template_data|
         MCPClient::ResourceTemplate.from_json(template_data, server: self)

--- a/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
+++ b/lib/mcp_client/server_streamable_http/json_rpc_transport.rb
@@ -65,15 +65,22 @@ module MCPClient
         content_encoding = response.headers['content-encoding'] || response.headers['Content-Encoding'] || ''
 
         body = decompress_gzip(body) if content_encoding.include?('gzip')
-        body = body&.strip
 
         # Determine response format based on Content-Type header per MCP 2025 spec
         data = if content_type.include?('text/event-stream')
                  # Parse SSE-formatted response for streaming
                  parse_sse_response(body, request && request['id'])
-               else
+               elsif body.is_a?(String)
                  # Parse regular JSON response (default for Streamable HTTP)
-                 JSON.parse(body)
+                 JSON.parse(body.strip)
+               else
+                 # A host's `conn.response :json` middleware decodes the body
+                 # before it reaches here — the README offers that middleware
+                 # for the error path, and it applies to every response — so an
+                 # already-decoded object is taken as it is rather than parsed
+                 # a second time. An event-stream body is not JSON and reaches
+                 # the branch above as the text it was sent as.
+                 body
                end
 
         process_jsonrpc_response(data)

--- a/lib/mcp_client/version.rb
+++ b/lib/mcp_client/version.rb
@@ -4,11 +4,26 @@ module MCPClient
   # Current version of the MCP client gem
   VERSION = '2.1.0'
 
-  # MCP protocol version (date-based) - unified across all transports
+  # Latest MCP protocol revision this client implements (basic/versioning).
+  # Modern revisions (2026-07-28 and later) carry the protocol version,
+  # client identity and capabilities as per-request `_meta` fields instead
+  # of negotiating them once in an `initialize` handshake.
+  LATEST_PROTOCOL_VERSION = '2026-07-28'
+
+  # Protocol revisions that use per-request metadata (no handshake), newest
+  # first. Every request to a modern server declares one of these in
+  # `_meta["io.modelcontextprotocol/protocolVersion"]`.
+  MODERN_PROTOCOL_VERSIONS = %w[2026-07-28].freeze
+
+  # Protocol revisions that establish a session with an `initialize`
+  # handshake (2025-11-25 and earlier), newest first.
+  LEGACY_PROTOCOL_VERSIONS = %w[2025-11-25 2025-06-18 2025-03-26 2024-11-05].freeze
+
+  # Protocol version sent in the legacy `initialize` request: the newest
+  # handshake-based revision. A legacy server may negotiate down to any
+  # other LEGACY_PROTOCOL_VERSIONS entry.
   PROTOCOL_VERSION = '2025-11-25'
 
-  # Protocol revisions this client can speak, newest first. Used during
-  # version negotiation: if the server answers initialize with a version
-  # outside this set, the client must disconnect (MCP lifecycle).
-  SUPPORTED_PROTOCOL_VERSIONS = %w[2025-11-25 2025-06-18 2025-03-26 2024-11-05].freeze
+  # Every protocol version this client can speak, in preference order.
+  SUPPORTED_PROTOCOL_VERSIONS = (MODERN_PROTOCOL_VERSIONS + LEGACY_PROTOCOL_VERSIONS).freeze
 end

--- a/spec/lib/mcp_client/http_transport_base_spec.rb
+++ b/spec/lib/mcp_client/http_transport_base_spec.rb
@@ -322,7 +322,10 @@ RSpec.describe MCPClient::HttpTransportBase do
     before do
       allow(response).to receive(:respond_to?).with(:reason_phrase).and_return(true)
       allow(response).to receive(:respond_to?).with(:headers).and_return(true)
+      allow(response).to receive(:respond_to?).with(:body).and_return(true)
       allow(response).to receive(:reason_phrase).and_return('Test Error')
+      allow(response).to receive(:body).and_return('')
+      allow(response).to receive(:headers).and_return({})
     end
 
     describe '#handle_http_error_response' do

--- a/spec/lib/mcp_client/protocol_foundations_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_round5_spec.rb
@@ -73,11 +73,11 @@ end
 
 # --- requiredCapabilities is ClientCapabilities all the way down -----------
 #
-# ClientCapabilities types its members: `elicitation` and `sampling` are
-# objects OF objects (form/url, context/tools), `experimental` and
-# `extensions` are maps to objects, and `roots.listChanged` is a boolean.
-# Checking only the first level let {"elicitation": {"form": []}} claim the
-# modern-server signal.
+# ClientCapabilities types its members: `elicitation` and `sampling` hold
+# objects under the names the schema gives them (form/url, context/tools),
+# and `experimental` and `extensions` map names to objects. Checking only
+# the first level let {"elicitation": {"form": []}} claim the modern-server
+# signal. (Round 6 pins the other direction: nothing beyond that is checked.)
 RSpec.describe 'a -32021 is well formed only when its capability members follow the schema' do
   def build(caps)
     MCPClient::Errors::ServerError.from_jsonrpc(
@@ -90,8 +90,7 @@ RSpec.describe 'a -32021 is well formed only when its capability members follow 
     'an elicitation mode that is an array' => { 'elicitation' => { 'form' => [] } },
     'a sampling feature that is a boolean' => { 'sampling' => { 'tools' => false } },
     'an extension entry that is an array' => { 'extensions' => { 'io.example/test' => [] } },
-    'an experimental entry that is a number' => { 'experimental' => { 'x' => 1 } },
-    'a roots.listChanged that is not a boolean' => { 'roots' => { 'listChanged' => 'yes' } }
+    'an experimental entry that is a number' => { 'experimental' => { 'x' => 1 } }
   }.each do |description, caps|
     it "rejects #{description}" do
       error = build(caps)
@@ -108,7 +107,7 @@ RSpec.describe 'a -32021 is well formed only when its capability members follow 
                                      'sampling' => { 'context' => {}, 'tools' => {} } },
     'extension and experimental objects' => { 'extensions' => { 'io.example/test' => { 'v' => 1 } },
                                               'experimental' => { 'x' => {} } },
-    'a boolean roots.listChanged' => { 'roots' => { 'listChanged' => true } },
+    'a roots object, whose members the schema leaves open' => { 'roots' => { 'listChanged' => 'yes' } },
     'an unknown capability with whatever members it likes' => { 'io.example/custom' => { 'anything' => 1 } }
   }.each do |description, caps|
     it "accepts #{description}" do
@@ -239,10 +238,13 @@ end
 # InputRequests wire shape: a map from identifier to request.
 RSpec.describe 'an unfinished tool or prompt result survives stdio and SSE off the wire' do
   let(:city_schema) { { 'type' => 'object', 'properties' => { 'city' => { 'type' => 'string' } } } }
+  # The published InputRequests wire shape: a map from server-assigned key to
+  # a request object (here an ElicitRequest).
   let(:unfinished) do
     { 'resultType' => 'input_required', 'requestState' => 'continue-later',
-      'inputRequests' => { 'city' => { 'type' => 'elicitation', 'mode' => 'form', 'message' => 'which city?',
-                                       'requestedSchema' => city_schema } } }
+      'inputRequests' => { 'city' => { 'method' => 'elicitation/create',
+                                       'params' => { 'mode' => 'form', 'message' => 'which city?',
+                                                     'requestedSchema' => city_schema } } } }
   end
 
   shared_examples 'accepts and preserves a continuation' do
@@ -262,7 +264,16 @@ RSpec.describe 'an unfinished tool or prompt result survives stdio and SSE off t
       answer_with('result' => unfinished)
 
       expect(server.call_tool('t', {})['inputRequests'].keys).to eq(['city'])
-      expect(server.call_tool('t', {}).dig('inputRequests', 'city', 'type')).to eq('elicitation')
+      expect(server.call_tool('t', {}).dig('inputRequests', 'city', 'method')).to eq('elicitation/create')
+    end
+
+    # "At least one of inputRequests or requestState MUST be present": a
+    # continuation may carry the requests alone.
+    it 'keeps a continuation that carries inputRequests without requestState' do
+      stateless = unfinished.except('requestState')
+      answer_with('result' => stateless)
+
+      expect(server.call_tool('t', {})).to eq(stateless)
     end
 
     it 'surfaces it from read_resource with the continuation on the error data' do

--- a/spec/lib/mcp_client/protocol_foundations_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_round5_spec.rb
@@ -1,0 +1,396 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 protocol foundations, fifth review round: a 404 + -32601 body
+# with no JSON-RPC message is malformed and identifies nobody, -32021's
+# requiredCapabilities is checked against ClientCapabilities all the way
+# down, and the unfinished-result guards and continuations are pinned on
+# every transport through its real delivery path.
+
+# --- 404 + -32601 needs a well-formed JSON-RPC error object ----------------
+#
+# Streamable HTTP backward compatibility recognizes an unknown method answered
+# with HTTP 404 and a JSON-RPC -32601 body. JSON-RPC 2.0 requires the error
+# object to carry a string `message`; a body without one is malformed at the
+# JSON-RPC level — an intermediary's 404 page dressed as JSON-RPC, say — and
+# must not be taken for the modern-server signal any more than a bare -3202x.
+RSpec.describe 'a 404 + -32601 without a JSON-RPC message identifies no modern server' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  def error_response(status, error)
+    stub_request(:post, "#{base_url}#{endpoint}")
+      .to_return(status: status, body: JSON.generate('jsonrpc' => '2.0', 'id' => 1, 'error' => error),
+                 headers: { 'Content-Type' => 'application/json' })
+  end
+
+  [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+    context "with #{klass}" do
+      let(:server) { klass.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+      def send_request
+        server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} })
+      end
+
+      it 'does not recognize a 404 + -32601 whose error object has no message' do
+        error_response(404, { 'code' => -32_601 })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+          expect(e.http_status).to eq(404)
+          expect(e.code).to eq(-32_601)
+          expect(e.modern_http_protocol_error?).to be(false)
+        end
+      end
+
+      it 'does not recognize a 404 + -32601 whose message is not a string' do
+        error_response(404, { 'code' => -32_601, 'message' => ['Method not found'] })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+          expect(e.code).to eq(-32_601)
+          expect(e.modern_http_protocol_error?).to be(false)
+        end
+      end
+
+      it 'still recognizes a 404 + -32601 with an empty string message' do
+        error_response(404, { 'code' => -32_601, 'message' => '' })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+          expect(e.modern_http_protocol_error?).to be(true)
+        end
+      end
+    end
+  end
+
+  it 'is false straight from the factory when the message is missing, whatever the status' do
+    error = MCPClient::Errors::ServerError.from_jsonrpc('code' => -32_601)
+    error.http_status = 404
+
+    expect(error.modern_http_protocol_error?).to be(false)
+  end
+end
+
+# --- requiredCapabilities is ClientCapabilities all the way down -----------
+#
+# ClientCapabilities types its members: `elicitation` and `sampling` are
+# objects OF objects (form/url, context/tools), `experimental` and
+# `extensions` are maps to objects, and `roots.listChanged` is a boolean.
+# Checking only the first level let {"elicitation": {"form": []}} claim the
+# modern-server signal.
+RSpec.describe 'a -32021 is well formed only when its capability members follow the schema' do
+  def build(caps)
+    MCPClient::Errors::ServerError.from_jsonrpc(
+      'code' => -32_021, 'message' => 'Missing required client capability',
+      'data' => { 'requiredCapabilities' => caps }
+    )
+  end
+
+  {
+    'an elicitation mode that is an array' => { 'elicitation' => { 'form' => [] } },
+    'a sampling feature that is a boolean' => { 'sampling' => { 'tools' => false } },
+    'an extension entry that is an array' => { 'extensions' => { 'io.example/test' => [] } },
+    'an experimental entry that is a number' => { 'experimental' => { 'x' => 1 } },
+    'a roots.listChanged that is not a boolean' => { 'roots' => { 'listChanged' => 'yes' } }
+  }.each do |description, caps|
+    it "rejects #{description}" do
+      error = build(caps)
+
+      expect(error.well_formed?).to be(false)
+      expect(error.modern_protocol_error?).to be(false)
+      # The peer's claim still reaches the caller.
+      expect(error.required_capabilities).to eq(caps)
+    end
+  end
+
+  {
+    'nested capability objects' => { 'elicitation' => { 'form' => {}, 'url' => {} },
+                                     'sampling' => { 'context' => {}, 'tools' => {} } },
+    'extension and experimental objects' => { 'extensions' => { 'io.example/test' => { 'v' => 1 } },
+                                              'experimental' => { 'x' => {} } },
+    'a boolean roots.listChanged' => { 'roots' => { 'listChanged' => true } },
+    'an unknown capability with whatever members it likes' => { 'io.example/custom' => { 'anything' => 1 } }
+  }.each do |description, caps|
+    it "accepts #{description}" do
+      error = build(caps)
+
+      expect(error.well_formed?).to be(true)
+      expect(error.modern_protocol_error?).to be(true)
+    end
+  end
+end
+
+# --- the unfinished-result guards on ServerSSE and ServerStreamableHTTP ----
+#
+# Round 4 pinned "no wrapper flattens an unfinished result" on stdio and
+# ServerHTTP only; the SSE and Streamable HTTP wrappers duplicate that code
+# and their guards could be removed without a failure.
+RSpec.describe 'ServerSSE and ServerStreamableHTTP surface an unfinished list or completion' do
+  let(:incomplete) { { 'resultType' => 'input_required', 'requestState' => 'continue-later' } }
+  let(:tool) { { 'name' => 't', 'description' => 'd', 'inputSchema' => {} } }
+
+  shared_examples 'surfaces an unfinished list or completion' do
+    it 'raises instead of returning an empty tool list' do
+      answer_with([incomplete])
+
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+        expect(e.data).to eq(incomplete)
+        expect(e).not_to be_a(MCPClient::Errors::ToolCallError)
+      end
+    end
+
+    it 'raises instead of returning an empty prompt list' do
+      answer_with([incomplete])
+
+      expect { server.list_prompts }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+        expect(e.data).to eq(incomplete)
+      end
+    end
+
+    it 'raises instead of returning an empty resource list' do
+      answer_with([incomplete])
+
+      expect { server.list_resources }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+        expect(e.data).to eq(incomplete)
+      end
+    end
+
+    it 'raises instead of returning an empty resource template list' do
+      answer_with([incomplete])
+
+      expect { server.list_resource_templates }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+        expect(e.data).to eq(incomplete)
+      end
+    end
+
+    it 'raises instead of returning an empty completion' do
+      answer_with([incomplete])
+      request = lambda do
+        server.complete(ref: { 'type' => 'ref/prompt', 'name' => 'p' }, argument: { 'name' => 'a', 'value' => '' })
+      end
+
+      expect(&request).to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+        expect(e.data).to eq(incomplete)
+      end
+    end
+
+    it 'raises instead of silently dropping an unfinished second page' do
+      answer_with([{ 'resultType' => 'complete', 'tools' => [tool], 'nextCursor' => 'p2' }, incomplete])
+
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+        expect(e.data).to eq(incomplete)
+      end
+    end
+  end
+
+  context 'with ServerStreamableHTTP (SSE responses off the wire)' do
+    let(:server) { MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/rpc', retries: 0) }
+
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      server.instance_variable_set(:@capabilities, { 'completions' => {}, 'logging' => {} })
+    end
+
+    def answer_with(results)
+      stub_request(:post, 'https://example.com/rpc').to_return do |request|
+        id = JSON.parse(request.body)['id']
+        payload = JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => results.shift)
+        { status: 200, body: "event: message\ndata: #{payload}\n\n",
+          headers: { 'Content-Type' => 'text/event-stream' } }
+      end
+    end
+
+    include_examples 'surfaces an unfinished list or completion'
+  end
+
+  context 'with ServerSSE (POST -> SSE event -> result store -> waiter)' do
+    let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 5, retries: 0) }
+
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@sse_connected, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      server.instance_variable_set(:@capabilities, { 'completions' => {}, 'logging' => {} })
+      server.instance_variable_set(:@rpc_endpoint, 'https://example.com/messages')
+    end
+
+    def answer_with(results)
+      allow(server).to receive(:post_json_rpc_request) do |request|
+        body = JSON.generate('jsonrpc' => '2.0', 'id' => request['id'], 'result' => results.shift)
+        server.send(:parse_and_handle_sse_event, "event: message\ndata: #{body}\n\n")
+        nil
+      end
+    end
+
+    include_examples 'surfaces an unfinished list or completion'
+  end
+end
+
+# --- a continuation survives stdio and SSE through their real parsers ------
+#
+# Round 4 proved the HTTP transports accept an input_required tool/prompt
+# result off the wire; stdio's reader path and the SSE result store were
+# left to stubbed rpc_request examples, so rejecting every input_required
+# result there left the whole suite green. The fixture is the schema's
+# InputRequests wire shape: a map from identifier to request.
+RSpec.describe 'an unfinished tool or prompt result survives stdio and SSE off the wire' do
+  let(:city_schema) { { 'type' => 'object', 'properties' => { 'city' => { 'type' => 'string' } } } }
+  let(:unfinished) do
+    { 'resultType' => 'input_required', 'requestState' => 'continue-later',
+      'inputRequests' => { 'city' => { 'type' => 'elicitation', 'mode' => 'form', 'message' => 'which city?',
+                                       'requestedSchema' => city_schema } } }
+  end
+
+  shared_examples 'accepts and preserves a continuation' do
+    it 'returns the whole continuation from call_tool' do
+      answer_with('result' => unfinished)
+
+      expect(server.call_tool('t', {})).to eq(unfinished)
+    end
+
+    it 'returns the whole continuation from get_prompt' do
+      answer_with('result' => unfinished)
+
+      expect(server.get_prompt('p', {})).to eq(unfinished)
+    end
+
+    it 'keeps the InputRequests map intact' do
+      answer_with('result' => unfinished)
+
+      expect(server.call_tool('t', {})['inputRequests'].keys).to eq(['city'])
+      expect(server.call_tool('t', {}).dig('inputRequests', 'city', 'type')).to eq('elicitation')
+    end
+
+    it 'surfaces it from read_resource with the continuation on the error data' do
+      answer_with('result' => unfinished)
+
+      expect { server.read_resource('file:///x') }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+          expect(e.data).to eq(unfinished)
+        end
+    end
+
+    it 'rejects it on a session that negotiated a handshake revision' do
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      answer_with('result' => unfinished)
+
+      expect { server.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /unrecognized resultType/)
+    end
+  end
+
+  context 'with ServerStdio (line -> reader dispatch -> waiter)' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 5) }
+
+    before do
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+    end
+
+    def answer_with(payload)
+      allow(server).to receive(:send_request) do |request|
+        line = JSON.generate({ 'jsonrpc' => '2.0', 'id' => request['id'] }.merge(payload))
+        server.send(:handle_line, "#{line}\n")
+      end
+    end
+
+    include_examples 'accepts and preserves a continuation'
+  end
+
+  context 'with ServerSSE (POST -> SSE event -> result store -> waiter)' do
+    let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 5, retries: 0) }
+
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@sse_connected, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      server.instance_variable_set(:@rpc_endpoint, 'https://example.com/messages')
+    end
+
+    def answer_with(payload)
+      allow(server).to receive(:post_json_rpc_request) do |request|
+        body = JSON.generate({ 'jsonrpc' => '2.0', 'id' => request['id'] }.merge(payload))
+        server.send(:parse_and_handle_sse_event, "event: message\ndata: #{body}\n\n")
+        nil
+      end
+    end
+
+    include_examples 'accepts and preserves a continuation'
+  end
+end
+
+# --- the SSE result store: false is an answer, a bad answer is one waiter's -
+RSpec.describe 'the SSE result store delivers false and isolates an invalid result' do
+  let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 5, retries: 0) }
+
+  before do
+    server.instance_variable_set(:@initialized, true)
+    server.instance_variable_set(:@protocol_version, '2025-11-25')
+  end
+
+  def deliver(id, result)
+    body = JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result)
+    server.send(:parse_and_handle_sse_event, "event: message\ndata: #{body}\n\n")
+  end
+
+  it 'delivers a legacy `result: false` as the answer rather than waiting it out' do
+    server.send(:register_pending_request, 7)
+    deliver(7, false)
+
+    expect(server.send(:check_for_result, 7)).to be(false)
+    expect(server.send(:check_for_result, 7)).to be(MCPClient::ServerSSE::JsonRpcTransport::NO_RESULT)
+  end
+
+  it 'raises an invalid result to its own waiter and leaves another caller outstanding' do
+    server.instance_variable_set(:@protocol_version, '2026-07-28')
+    server.send(:register_pending_request, 1)
+    server.send(:register_pending_request, 2)
+    deliver(1, { 'resultType' => 'bogus' })
+
+    expect { server.send(:check_for_result, 1) }
+      .to raise_error(MCPClient::Errors::InvalidResultError, /unrecognized resultType/)
+    expect(server.send(:check_for_result, 2)).to be(MCPClient::ServerSSE::JsonRpcTransport::NO_RESULT)
+
+    deliver(2, { 'resultType' => 'complete', 'ok' => true })
+    expect(server.send(:check_for_result, 2)).to eq({ 'resultType' => 'complete', 'ok' => true })
+  end
+end
+
+# --- connect surfaces the versions a modern-only server names -------------
+#
+# A modern-only server SHOULD name the versions it supports when rejecting
+# initialize, "so this message may be the only diagnostic legacy clients
+# can surface to users". Stdio surfaced them; the HTTP transports wrapped
+# the typed -32022 into a generic ConnectionError whose message carried only
+# the peer's prose — the list lives in `data`, not in `message`.
+RSpec.describe 'HTTP connect surfaces the versions a modern-only server supports' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  before do
+    stub_request(:post, "#{base_url}#{endpoint}").to_return(
+      status: 400, headers: { 'Content-Type' => 'application/json' },
+      body: JSON.generate('jsonrpc' => '2.0', 'id' => 1,
+                          'error' => { 'code' => -32_022, 'message' => 'Unsupported protocol version',
+                                       'data' => { 'supported' => ['2026-07-28'], 'requested' => '2025-11-25' } })
+    )
+  end
+
+  [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+    it "names the supported versions and keeps the typed error as the cause on #{klass}" do
+      server = klass.new(base_url: base_url, endpoint: endpoint, retries: 0)
+
+      expect { server.connect }.to raise_error(MCPClient::Errors::ConnectionError) do |e|
+        expect(e.message).to include('server supports: 2026-07-28')
+        expect(e.cause).to be_a(MCPClient::Errors::UnsupportedProtocolVersionError)
+        expect(e.cause.supported).to eq(['2026-07-28'])
+      end
+      expect(server.protocol_version).to be_nil
+    end
+  end
+end

--- a/spec/lib/mcp_client/protocol_foundations_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_round6_spec.rb
@@ -237,9 +237,14 @@ RSpec.describe 'concurrent SSE waiters settle independently' do
     expect(ids.keys).to contain_exactly('one', 'two')
 
     deliver(ids['one'], { 'resultType' => 'bogus' })
-    deliver(ids['two'], { 'resultType' => 'complete', 'ok' => true })
 
+    # The invalid caller finishes on its own answer while its sibling is
+    # still waiting: nothing about the bad result touches the other slot.
     expect(invalid.value).to be_a(MCPClient::Errors::InvalidResultError)
+    expect(valid).to be_alive
+    expect(valid.join(0.2)).to be_nil
+
+    deliver(ids['two'], { 'resultType' => 'complete', 'ok' => true })
     expect(valid.value).to eq({ 'resultType' => 'complete', 'ok' => true })
     expect(server.instance_variable_get(:@sse_results)).to be_empty
     expect(server.instance_variable_get(:@pending_request_ids)).to be_empty

--- a/spec/lib/mcp_client/protocol_foundations_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_round6_spec.rb
@@ -1,0 +1,312 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 protocol foundations, sixth review round: the shape check on
+# a -32021 follows the published ClientCapabilities schema exactly (and no
+# further), a 404 answering with a well-formed -32601 is that answer even on
+# a session that carries an id, the SSE waiter hands a legacy `false` back
+# promptly through the public request path, concurrent SSE waiters settle
+# independently, and ServerSSE's direct JSON responses obey the same rules
+# as its event stream.
+
+# --- requiredCapabilities: exactly the schema's constraints -----------------
+#
+# ClientCapabilities is an open object: `elicitation` types only its `form`
+# and `url` members, `sampling` only `context` and `tools`, `experimental`
+# and `extensions` map names to objects, `roots` constrains nothing inside
+# it, and unknown capabilities may be anything. Round 5 read more into the
+# schema than it says (every elicitation member an object, roots.listChanged
+# a boolean), which turned schema-valid modern rejections into "legacy" ones
+# and stripped their typed interface on the way to the caller.
+RSpec.describe 'a -32021 is well formed exactly when requiredCapabilities fits the schema' do
+  def build(caps)
+    MCPClient::Errors::ServerError.from_jsonrpc(
+      'code' => -32_021, 'message' => 'Missing required client capability',
+      'data' => { 'requiredCapabilities' => caps }
+    )
+  end
+
+  {
+    'an elicitation object with a vendor member beside form' => { 'elicitation' => { 'form' => {},
+                                                                                     'vendorHint' => true } },
+    'a sampling object with a scalar member the schema does not name' => { 'sampling' => { 'tools' => {},
+                                                                                           'flag' => 1 } },
+    'a roots object with whatever member it likes' => { 'roots' => { 'listChanged' => 'yes' } },
+    'an unknown capability that is a scalar' => { 'io.example/flag' => true },
+    'an empty capability set' => {}
+  }.each do |description, caps|
+    it "accepts #{description}" do
+      error = build(caps)
+
+      expect(error.well_formed?).to be(true)
+      expect(error.modern_protocol_error?).to be(true)
+      expect(error.required_capabilities).to eq(caps)
+    end
+  end
+
+  {
+    'an elicitation url that is not an object' => { 'elicitation' => { 'url' => 1 } },
+    'a sampling context that is an array' => { 'sampling' => { 'context' => [] } },
+    'a roots capability that is not an object' => { 'roots' => 1 },
+    'an experimental entry that is a scalar' => { 'experimental' => { 'x' => 1 } },
+    'an extension entry that is an array' => { 'extensions' => { 'io.example/t' => [] } },
+    'a requiredCapabilities that is an array' => []
+  }.each do |description, caps|
+    it "rejects #{description}" do
+      error = build(caps)
+
+      expect(error.well_formed?).to be(false)
+      expect(error.modern_protocol_error?).to be(false)
+    end
+  end
+
+  # The public interface: a schema-valid -32021 reaches the caller of
+  # call_tool as the typed error, with its code and capabilities readable,
+  # rather than flattened into a ToolCallError message.
+  [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+    it "keeps the typed error and its capabilities through #{klass}#call_tool" do
+      caps = { 'elicitation' => { 'form' => {}, 'vendorHint' => true } }
+      server = klass.new(base_url: 'https://example.com', endpoint: '/rpc', retries: 0)
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+      stub_request(:post, 'https://example.com/rpc').to_return do |request|
+        { status: 400, headers: { 'Content-Type' => 'application/json' },
+          body: JSON.generate('jsonrpc' => '2.0', 'id' => JSON.parse(request.body)['id'],
+                              'error' => { 'code' => -32_021, 'message' => 'Missing required client capability',
+                                           'data' => { 'requiredCapabilities' => caps } }) }
+      end
+
+      expect { server.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+          expect(e.code).to eq(-32_021)
+          expect(e.required_capabilities).to eq(caps)
+          expect(e.protocol_error?).to be(true)
+        end
+    end
+  end
+end
+
+# --- 404 + well-formed -32601 answers the request, session id or not --------
+#
+# MCP 2025-11-25 lets a server answer 404 to a request carrying an expired
+# Mcp-Session-Id, and the client then starts a new session. MCP 2026-07-28
+# reports an unknown method as 404 with a well-formed -32601 body. The body
+# is what tells them apart: a JSON-RPC error answering THIS request is that
+# answer, not a session expiry, and restarting the session on it would send
+# a fresh initialize and the very same unknown method again.
+RSpec.describe 'a 404 answering a well-formed -32601 is method-not-found even on a session with an id' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  def session_server(klass)
+    server = klass.new(base_url: base_url, endpoint: endpoint, retries: 0)
+    server.instance_variable_set(:@connection_established, true)
+    server.instance_variable_set(:@initialized, true)
+    server.instance_variable_set(:@protocol_version, '2025-11-25')
+    server.instance_variable_set(:@session_id, 'session-abc')
+    server
+  end
+
+  def posted_methods
+    WebMock::RequestRegistry.instance.requested_signatures.hash.keys
+                            .map { |signature| JSON.parse(signature.body)['method'] }
+  end
+
+  [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+    it "raises MethodNotFoundError without restarting the session on #{klass}" do
+      server = session_server(klass)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        { status: 404, headers: { 'Content-Type' => 'application/json' },
+          body: JSON.generate('jsonrpc' => '2.0', 'id' => JSON.parse(request.body)['id'],
+                              'error' => { 'code' => -32_601, 'message' => 'Method not found' }) }
+      end
+
+      expect { server.rpc_request('vendor/unknown') }
+        .to raise_error(MCPClient::Errors::MethodNotFoundError) do |e|
+          expect(e.code).to eq(-32_601)
+          expect(e.http_status).to eq(404)
+        end
+      expect(posted_methods).to eq(['vendor/unknown'])
+      expect(server.instance_variable_get(:@session_id)).to eq('session-abc')
+    end
+
+    it "still restarts the session on a 404 that is not a JSON-RPC answer, on #{klass}" do
+      server = session_server(klass)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'initialize'
+          { status: 200, headers: { 'Content-Type' => 'application/json', 'Mcp-Session-Id' => 'session-fresh' },
+            body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'],
+                                'result' => { 'protocolVersion' => '2025-11-25', 'capabilities' => {},
+                                              'serverInfo' => { 'name' => 's', 'version' => '1' } }) }
+        when 'notifications/initialized'
+          { status: 202, body: '' }
+        else
+          if request.headers['Mcp-Session-Id'] == 'session-abc'
+            { status: 404, headers: { 'Content-Type' => 'text/plain' }, body: 'session expired' }
+          else
+            { status: 200, headers: { 'Content-Type' => 'application/json' },
+              body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'], 'result' => { 'answered' => true }) }
+          end
+        end
+      end
+
+      expect(server.rpc_request('ping')).to eq({ 'answered' => true })
+      expect(posted_methods.count('ping')).to eq(2)
+      expect(posted_methods.count('initialize')).to eq(1)
+      expect(server.instance_variable_get(:@session_id)).to eq('session-fresh')
+    end
+  end
+end
+
+# --- the SSE waiter and a legacy `false` -----------------------------------
+#
+# Round 5 pinned `false` on the result store; the waiting loop above it was
+# never driven, and a loop that discards `false` and waits out the timeout
+# survived every example.
+RSpec.describe 'the SSE waiter hands a legacy false back through the public request path' do
+  let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 5, retries: 0) }
+  let(:posted) { [] }
+
+  before do
+    server.instance_variable_set(:@connection_established, true)
+    server.instance_variable_set(:@sse_connected, true)
+    server.instance_variable_set(:@initialized, true)
+    server.instance_variable_set(:@protocol_version, '2025-11-25')
+    server.instance_variable_set(:@rpc_endpoint, 'https://example.com/messages')
+    allow(server).to receive(:connection_active?).and_return(true)
+  end
+
+  def deliver(id, result)
+    body = JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result)
+    server.send(:parse_and_handle_sse_event, "event: message\ndata: #{body}\n\n")
+  end
+
+  it 'returns false promptly, sends no cancellation and leaves nothing pending' do
+    allow(server).to receive(:post_json_rpc_request) do |request|
+      posted << request
+      deliver(request['id'], false) if request['method'] == 'ping'
+      nil
+    end
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    expect(server.rpc_request('ping')).to be(false)
+
+    expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).to be < 1
+    expect(posted.map { |request| request['method'] }).to eq(['ping'])
+    expect(server.instance_variable_get(:@sse_results)).to be_empty
+    expect(server.instance_variable_get(:@pending_request_ids)).to be_empty
+  end
+end
+
+# --- concurrent SSE waiters settle independently ---------------------------
+RSpec.describe 'concurrent SSE waiters settle independently' do
+  let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 5, retries: 0) }
+  let(:ids) { {} }
+
+  before do
+    server.instance_variable_set(:@connection_established, true)
+    server.instance_variable_set(:@sse_connected, true)
+    server.instance_variable_set(:@initialized, true)
+    server.instance_variable_set(:@protocol_version, '2026-07-28')
+    server.instance_variable_set(:@rpc_endpoint, 'https://example.com/messages')
+    allow(server).to receive(:connection_active?).and_return(true)
+    allow(server).to receive(:post_json_rpc_request) do |request|
+      server.instance_variable_get(:@mutex).synchronize { ids[request['method']] = request['id'] }
+      nil
+    end
+  end
+
+  def deliver(id, result)
+    body = JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result)
+    server.send(:parse_and_handle_sse_event, "event: message\ndata: #{body}\n\n")
+  end
+
+  it 'raises the invalid result to its own waiter and answers the other' do
+    invalid = Thread.new do
+      server.rpc_request('one')
+    rescue MCPClient::Errors::MCPError => e
+      e
+    end
+    valid = Thread.new { server.rpc_request('two') }
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+    sleep 0.01 until ids.size == 2 || Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+    expect(ids.keys).to contain_exactly('one', 'two')
+
+    deliver(ids['one'], { 'resultType' => 'bogus' })
+    deliver(ids['two'], { 'resultType' => 'complete', 'ok' => true })
+
+    expect(invalid.value).to be_a(MCPClient::Errors::InvalidResultError)
+    expect(valid.value).to eq({ 'resultType' => 'complete', 'ok' => true })
+    expect(server.instance_variable_get(:@sse_results)).to be_empty
+    expect(server.instance_variable_get(:@pending_request_ids)).to be_empty
+  end
+end
+
+# --- ServerSSE direct JSON responses -----------------------------------------
+#
+# A POST to the SSE transport's message endpoint may be answered directly
+# with JSON instead of over the stream; that path shares nothing with the
+# event store and has to apply the same rules.
+RSpec.describe 'ServerSSE direct JSON responses obey the same rules as the stream' do
+  let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 5, retries: 0) }
+
+  def direct(payload)
+    server.send(:parse_direct_response, double('response', body: JSON.generate({ 'jsonrpc' => '2.0',
+                                                                                 'id' => 1 }.merge(payload))))
+  end
+
+  it 'raises a well-formed -32021 as the typed error' do
+    caps = { 'elicitation' => { 'form' => {} } }
+    expect { direct('error' => { 'code' => -32_021, 'message' => 'm', 'data' => { 'requiredCapabilities' => caps } }) }
+      .to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+        expect(e.modern_protocol_error?).to be(true)
+        expect(e.required_capabilities).to eq(caps)
+      end
+  end
+
+  it 'rejects an unrecognized resultType on a modern session' do
+    server.instance_variable_set(:@protocol_version, '2026-07-28')
+
+    expect { direct('result' => { 'resultType' => 'bogus' }) }
+      .to raise_error(MCPClient::Errors::InvalidResultError, /bogus/)
+  end
+
+  it 'returns a complete result on a legacy session' do
+    server.instance_variable_set(:@protocol_version, '2025-11-25')
+
+    expect(direct('result' => { 'resultType' => 'complete', 'ok' => true }))
+      .to eq({ 'resultType' => 'complete', 'ok' => true })
+  end
+
+  %w[2026-07-28 2025-11-25].each do |version|
+    it "rejects an empty-string resultType, which is present and so not \"complete\", on #{version}" do
+      server.instance_variable_set(:@protocol_version, version)
+
+      expect { direct('result' => { 'resultType' => '' }) }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /resultType ""/)
+    end
+  end
+end
+
+# --- an invalid result is never retried on Streamable HTTP either -----------
+RSpec.describe 'an invalid result is never retried on Streamable HTTP' do
+  it 'sends tools/list exactly once even with retries configured' do
+    server = MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 3,
+                                                 retry_backoff: 0)
+    server.instance_variable_set(:@connection_established, true)
+    server.instance_variable_set(:@initialized, true)
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      { status: 200,
+        body: JSON.generate('jsonrpc' => '2.0', 'id' => JSON.parse(request.body)['id'],
+                            'result' => { 'resultType' => 'vendor_summary', 'tools' => [] }),
+        headers: { 'Content-Type' => 'application/json' } }
+    end
+
+    expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError)
+    expect(a_request(:post, 'https://example.com/mcp')).to have_been_made.once
+  end
+end

--- a/spec/lib/mcp_client/protocol_foundations_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_round6_spec.rb
@@ -96,15 +96,20 @@ end
 # is what tells them apart: a JSON-RPC error answering THIS request is that
 # answer, not a session expiry, and restarting the session on it would send
 # a fresh initialize and the very same unknown method again.
-RSpec.describe 'a 404 answering a well-formed -32601 is method-not-found even on a session with an id' do
+# Off a session negotiated under 2025-11-25 — an era never established, or a
+# modern one whose server assigned a session id anyway — a well-formed -32601
+# under 404 is MCP 2026-07-28's answer to the request itself. On such a
+# session the expiry rule of that revision is unconditional instead; round 8
+# pins that side.
+RSpec.describe 'a 404 answering a well-formed -32601 is method-not-found off a negotiated legacy session' do
   let(:base_url) { 'https://example.com' }
   let(:endpoint) { '/rpc' }
 
-  def session_server(klass)
+  def session_server(klass, era: nil)
     server = klass.new(base_url: base_url, endpoint: endpoint, retries: 0)
     server.instance_variable_set(:@connection_established, true)
     server.instance_variable_set(:@initialized, true)
-    server.instance_variable_set(:@protocol_version, '2025-11-25')
+    server.instance_variable_set(:@protocol_version, era)
     server.instance_variable_set(:@session_id, 'session-abc')
     server
   end
@@ -133,7 +138,7 @@ RSpec.describe 'a 404 answering a well-formed -32601 is method-not-found even on
     end
 
     it "still restarts the session on a 404 that is not a JSON-RPC answer, on #{klass}" do
-      server = session_server(klass)
+      server = session_server(klass, era: '2025-11-25')
       stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
         body = JSON.parse(request.body)
         case body['method']

--- a/spec/lib/mcp_client/protocol_foundations_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_round6_spec.rb
@@ -268,6 +268,15 @@ RSpec.describe 'ServerSSE direct JSON responses obey the same rules as the strea
       end
   end
 
+  it 'raises a well-formed -32022 as the typed error naming the supported versions' do
+    data = { 'supported' => ['2026-07-28'], 'requested' => '2025-11-25' }
+    expect { direct('error' => { 'code' => -32_022, 'message' => 'Unsupported protocol version', 'data' => data }) }
+      .to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) do |e|
+        expect(e.supported).to eq(['2026-07-28'])
+        expect(e.modern_protocol_error?).to be(true)
+      end
+  end
+
   it 'rejects an unrecognized resultType on a modern session' do
     server.instance_variable_set(:@protocol_version, '2026-07-28')
 

--- a/spec/lib/mcp_client/protocol_foundations_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_round7_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+require 'zlib'
+
+# MCP 2026-07-28 protocol foundations, seventh review round: the 404 that
+# tells a session expiry (2025-11-25) from a modern server's well-formed
+# -32601 answer is read the way every other HTTP error body is — a JSON-RPC
+# 2.0 envelope, size-bounded, gunzipped when compressed — on the response
+# path and through a host's raise_error middleware alike; the stdio
+# subscription operations validate the result discriminator; an invalid
+# result never holds up a sibling waiter.
+RSpec.describe 'MCP 2026-07-28 protocol foundations — round 7' do
+  describe 'a session-bearing 404 read like every other HTTP error body' do
+    let(:base_url) { 'https://example.com' }
+    let(:endpoint) { '/rpc' }
+    let(:method_not_found) { { 'code' => -32_601, 'message' => 'Method not found' } }
+
+    def session_server(klass, **opts)
+      server = klass.new(base_url: base_url, endpoint: endpoint, retries: 0, **opts)
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      server.instance_variable_set(:@session_id, 'session-abc')
+      server
+    end
+
+    def posted_methods
+      WebMock::RequestRegistry.instance.requested_signatures.hash.keys
+                              .map { |signature| JSON.parse(signature.body)['method'] }
+    end
+
+    def gzip(text)
+      StringIO.new.tap { |io| Zlib::GzipWriter.wrap(io) { |gz| gz.write(text) } }.string
+    end
+
+    # The old session answers the request with `expired`; a fresh initialize
+    # is accepted and the replayed request answered.
+    def serve_expiry(expired)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'initialize'
+          { status: 200, headers: { 'Content-Type' => 'application/json', 'Mcp-Session-Id' => 'session-fresh' },
+            body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'],
+                                'result' => { 'protocolVersion' => '2025-11-25', 'capabilities' => {},
+                                              'serverInfo' => { 'name' => 's', 'version' => '1' } }) }
+        when 'notifications/initialized'
+          { status: 202, body: '' }
+        else
+          if request.headers['Mcp-Session-Id'] == 'session-abc'
+            expired
+          else
+            { status: 200, headers: { 'Content-Type' => 'application/json' },
+              body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'], 'result' => { 'answered' => true }) }
+          end
+        end
+      end
+    end
+
+    def not_found(payload, headers = {})
+      { status: 404, headers: { 'Content-Type' => 'application/json' }.merge(headers), body: payload }
+    end
+
+    shared_examples 'classifies the 404 by its decoded JSON-RPC body' do
+      it 'restarts the session on a 404 whose body is not a JSON-RPC 2.0 envelope' do
+        serve_expiry(not_found(JSON.generate('error' => { 'code' => -32_601, 'message' => 'gone' })))
+
+        expect(server.rpc_request('vendor/unknown')).to eq({ 'answered' => true })
+        expect(posted_methods).to eq(%w[vendor/unknown initialize notifications/initialized vendor/unknown])
+        expect(server.instance_variable_get(:@session_id)).to eq('session-fresh')
+      end
+
+      it 'restarts the session on a 404 whose envelope names another JSON-RPC version' do
+        serve_expiry(not_found(JSON.generate('jsonrpc' => '1.0', 'id' => 1, 'error' => method_not_found)))
+
+        expect(server.rpc_request('vendor/unknown')).to eq({ 'answered' => true })
+        expect(posted_methods.count('initialize')).to eq(1)
+      end
+
+      it 'restarts the session on a malformed -32601 (no message) even with a session id' do
+        serve_expiry(not_found(JSON.generate('jsonrpc' => '2.0', 'id' => 1, 'error' => { 'code' => -32_601 })))
+
+        expect(server.rpc_request('vendor/unknown')).to eq({ 'answered' => true })
+        expect(posted_methods.count('initialize')).to eq(1)
+      end
+
+      it 'restarts the session on a 404 whose body is over the inspection ceiling' do
+        padding = 'x' * (MCPClient::JsonRpcCommon::MAX_ERROR_BODY_BYTES + 1)
+        oversized = JSON.generate('jsonrpc' => '2.0', 'id' => 1, 'error' => method_not_found.merge('data' => padding))
+        serve_expiry(not_found(oversized))
+
+        expect(server.rpc_request('vendor/unknown')).to eq({ 'answered' => true })
+        expect(posted_methods.count('initialize')).to eq(1)
+      end
+
+      it 'answers a gzip-encoded well-formed -32601 as MethodNotFoundError without a restart' do
+        serve_expiry(not_found(gzip(JSON.generate('jsonrpc' => '2.0', 'id' => 1, 'error' => method_not_found)),
+                               'Content-Encoding' => 'gzip'))
+
+        expect { server.rpc_request('vendor/unknown') }
+          .to raise_error(MCPClient::Errors::MethodNotFoundError) { |e| expect(e.http_status).to eq(404) }
+        expect(posted_methods).to eq(['vendor/unknown'])
+        expect(server.instance_variable_get(:@session_id)).to eq('session-abc')
+      end
+
+      it 'treats a gzip 404 body that inflates past the ceiling as a session expiry' do
+        padding = 'x' * (MCPClient::JsonRpcCommon::MAX_ERROR_BODY_BYTES + 1)
+        huge = JSON.generate('jsonrpc' => '2.0', 'id' => 1, 'error' => method_not_found.merge('data' => padding))
+        serve_expiry(not_found(gzip(huge), 'Content-Encoding' => 'gzip'))
+
+        expect(server.rpc_request('vendor/unknown')).to eq({ 'answered' => true })
+        expect(posted_methods.count('initialize')).to eq(1)
+      end
+    end
+
+    [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+      context "with #{klass} on the response path" do
+        let(:server) { session_server(klass) }
+
+        include_examples 'classifies the 404 by its decoded JSON-RPC body'
+      end
+
+      context "with #{klass} through a host's raise_error middleware" do
+        let(:server) { session_server(klass, faraday_config: ->(conn) { conn.response :raise_error }) }
+
+        include_examples 'classifies the 404 by its decoded JSON-RPC body'
+      end
+    end
+  end
+
+  describe 'the stdio subscription operations validate the result discriminator' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'echo test') }
+
+    def answer(result)
+      allow(server).to receive(:send_request)
+      allow(server).to receive(:wait_response).and_return({ 'jsonrpc' => '2.0', 'id' => 1, 'result' => result })
+    end
+
+    before do
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@capabilities, { 'resources' => { 'subscribe' => true } })
+    end
+
+    %i[subscribe_resource unsubscribe_resource].each do |operation|
+      it "raises InvalidResultError from #{operation} for an unknown discriminator on a legacy session" do
+        server.instance_variable_set(:@protocol_version, '2025-11-25')
+        answer({ 'resultType' => 'weird' })
+
+        expect { server.public_send(operation, 'file:///x') }
+          .to raise_error(MCPClient::Errors::InvalidResultError, /weird/)
+      end
+
+      it "accepts a #{operation} result without a discriminator on a legacy session" do
+        server.instance_variable_set(:@protocol_version, '2025-11-25')
+        answer({})
+
+        expect(server.public_send(operation, 'file:///x')).to be(true)
+      end
+
+      it "raises InvalidResultError from #{operation} for an unknown discriminator on a modern session" do
+        server.instance_variable_set(:@protocol_version, '2026-07-28')
+        answer({ 'resultType' => 'weird' })
+
+        expect { server.public_send(operation, 'file:///x') }.to raise_error(MCPClient::Errors::InvalidResultError)
+      end
+    end
+  end
+
+  describe 'the SSE handshake names the versions a modern-only server supports' do
+    let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 5, retries: 0) }
+    let(:rejection) do
+      MCPClient::Errors::ServerError.from_jsonrpc(
+        'code' => -32_022, 'message' => 'Unsupported protocol version',
+        'data' => { 'supported' => ['2026-07-28'], 'requested' => '2025-11-25' }
+      )
+    end
+
+    it 'raises a ConnectionError naming them, with the typed error as the cause' do
+      allow(server).to receive(:send_jsonrpc_request).and_raise(rejection)
+
+      expect { server.send(:perform_initialize) }.to raise_error(MCPClient::Errors::ConnectionError) do |e|
+        expect(e.message).to include('server supports: 2026-07-28')
+        expect(e.cause).to be_a(MCPClient::Errors::UnsupportedProtocolVersionError)
+        expect(e.cause.supported).to eq(['2026-07-28'])
+      end
+      expect(server.protocol_version).to be_nil
+    end
+  end
+end

--- a/spec/lib/mcp_client/protocol_foundations_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_round7_spec.rb
@@ -17,11 +17,13 @@ RSpec.describe 'MCP 2026-07-28 protocol foundations — round 7' do
     let(:endpoint) { '/rpc' }
     let(:method_not_found) { { 'code' => -32_601, 'message' => 'Method not found' } }
 
+    # The era is deliberately left unestablished: these examples are about
+    # how the 404 BODY is decoded, and on a session negotiated under
+    # 2025-11-25 the expiry rule is unconditional on the body (round 8).
     def session_server(klass, **opts)
       server = klass.new(base_url: base_url, endpoint: endpoint, retries: 0, **opts)
       server.instance_variable_set(:@connection_established, true)
       server.instance_variable_set(:@initialized, true)
-      server.instance_variable_set(:@protocol_version, '2025-11-25')
       server.instance_variable_set(:@session_id, 'session-abc')
       server
     end

--- a/spec/lib/mcp_client/protocol_foundations_2026_round8_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_round8_spec.rb
@@ -1,0 +1,279 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 protocol foundations, eighth review round: the 2025-11-25
+# session-expiry rule is unconditional on an established legacy session (a
+# modern server's -32601 answer never overrides it, because a modern session
+# carries no session id to expire); a JSON-RPC envelope carrying neither a
+# result nor an error member is malformed rather than a successful nil; and
+# the discriminator is validated on the paths a caller actually reaches —
+# ServerSSE's direct JSON responses and every page of a stdio list, not only
+# the first.
+RSpec.describe 'MCP 2026-07-28 protocol foundations — round 8' do
+  describe 'the session-expiry rule of the era the session was negotiated under' do
+    let(:base_url) { 'https://example.com' }
+    let(:endpoint) { '/rpc' }
+    let(:method_not_found) { { 'code' => -32_601, 'message' => 'Method not found' } }
+
+    def posted_methods
+      WebMock::RequestRegistry.instance.requested_signatures.hash.keys
+                              .map { |signature| JSON.parse(signature.body)['method'] }
+    end
+
+    # The old session answers `vendor/unknown` with a well-formed -32601
+    # under HTTP 404; a fresh initialize is accepted and the replay answered.
+    def serve_unknown_method_not_found
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'initialize'
+          { status: 200, headers: { 'Content-Type' => 'application/json', 'Mcp-Session-Id' => 'session-fresh' },
+            body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'],
+                                'result' => { 'protocolVersion' => '2025-11-25', 'capabilities' => {},
+                                              'serverInfo' => { 'name' => 's', 'version' => '1' } }) }
+        when 'notifications/initialized'
+          { status: 202, body: '' }
+        else
+          if request.headers['Mcp-Session-Id'] == 'session-abc'
+            { status: 404, headers: { 'Content-Type' => 'application/json' },
+              body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'], 'error' => method_not_found) }
+          else
+            { status: 200, headers: { 'Content-Type' => 'application/json' },
+              body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'], 'result' => { 'answered' => true }) }
+          end
+        end
+      end
+    end
+
+    def server_for(klass, era, **opts)
+      server = klass.new(base_url: base_url, endpoint: endpoint, retries: 0, **opts)
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, era)
+      server.instance_variable_set(:@session_id, 'session-abc')
+      server
+    end
+
+    [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+      [nil, ->(conn) { conn.response :raise_error }].each do |config|
+        path = config ? "through a host's raise_error middleware" : 'on the response path'
+
+        context "with #{klass} #{path}" do
+          let(:options) { config ? { faraday_config: config } : {} }
+
+          # 2025-11-25 session management: "When receiving HTTP 404 in response
+          # to a request containing an Mcp-Session-Id, the client MUST start a
+          # new session by sending a new InitializeRequest without a session
+          # ID." The rule names the status and the session id, and takes no
+          # exception for what the body carries: a server on the revision this
+          # session negotiated answers an expired session, not the request.
+          it 'restarts a negotiated 2025-11-25 session on a 404 however its body reads' do
+            server = server_for(klass, '2025-11-25', **options)
+            serve_unknown_method_not_found
+
+            expect(server.rpc_request('vendor/unknown')).to eq({ 'answered' => true })
+            expect(posted_methods).to eq(%w[vendor/unknown initialize notifications/initialized vendor/unknown])
+            expect(server.instance_variable_get(:@session_id)).to eq('session-fresh')
+          end
+
+          # Off that session — an era never established, or a modern one whose
+          # server assigned a session id it has no business assigning — the
+          # 404 is MCP 2026-07-28's answer to this very request, and replaying
+          # it after a fresh initialize would only ask the unknown method again.
+          it 'answers a well-formed -32601 without a restart when no legacy session was negotiated' do
+            server = server_for(klass, nil, **options)
+            serve_unknown_method_not_found
+
+            expect { server.rpc_request('vendor/unknown') }
+              .to raise_error(MCPClient::Errors::MethodNotFoundError) { |e| expect(e.http_status).to eq(404) }
+            expect(posted_methods).to eq(['vendor/unknown'])
+            expect(server.instance_variable_get(:@session_id)).to eq('session-abc')
+          end
+        end
+      end
+    end
+  end
+
+  describe 'a JSON-RPC envelope that answers with neither a result nor an error' do
+    let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 2, retries: 0) }
+
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@sse_connected, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      server.instance_variable_set(:@rpc_endpoint, 'https://example.com/messages')
+    end
+
+    # JSON-RPC 2.0 section 5: "Either the result member or error member MUST
+    # be included". An envelope with neither answers nothing; taking its
+    # absent result for a delivered nil turns a malformed response into a
+    # successful call.
+    def deliver(payload)
+      allow(server).to receive(:post_json_rpc_request) do |request|
+        body = JSON.generate({ 'jsonrpc' => '2.0', 'id' => request['id'] }.merge(payload))
+        server.send(:parse_and_handle_sse_event, "event: message\ndata: #{body}\n\n")
+        nil
+      end
+    end
+
+    it 'is invalid rather than a successful nil result' do
+      deliver({})
+
+      expect { server.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /neither a result nor an error/)
+    end
+
+    it 'leaves an explicit null result delivered as the answer it is' do
+      deliver('result' => nil)
+
+      expect(server.rpc_request('vendor/thing')).to be_nil
+    end
+
+    it 'still delivers an explicit false result' do
+      deliver('result' => false)
+
+      expect(server.rpc_request('vendor/thing')).to be(false)
+    end
+  end
+
+  describe "ServerSSE's direct JSON responses, through the path a caller takes" do
+    let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 2, retries: 0) }
+
+    # A ServerSSE whose endpoint answers the POST directly (no stream) takes
+    # the parse_direct_response branch of send_jsonrpc_request. Reaching it
+    # through rpc_request is what pins that the branch validates at all: a
+    # test that calls the parser itself stays green when the branch stops
+    # using it.
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@sse_connected, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      server.instance_variable_set(:@rpc_endpoint, 'https://example.com/messages')
+      server.instance_variable_set(:@use_sse, false)
+    end
+
+    def answer_with(payload)
+      stub_request(:post, 'https://example.com/messages')
+        .to_return(status: 200, headers: { 'Content-Type' => 'application/json' },
+                   body: JSON.generate({ 'jsonrpc' => '2.0', 'id' => 1 }.merge(payload)))
+    end
+
+    it 'rejects an unknown discriminator' do
+      answer_with('result' => { 'resultType' => 'weird' })
+
+      expect { server.rpc_request('vendor/thing') }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /weird/)
+    end
+
+    it 'accepts a complete result' do
+      answer_with('result' => { 'resultType' => 'complete', 'ok' => true })
+
+      expect(server.rpc_request('vendor/thing')).to eq({ 'resultType' => 'complete', 'ok' => true })
+    end
+
+    it 'raises the typed error a modern server answers with' do
+      answer_with('error' => { 'code' => -32_021, 'message' => 'Missing capability',
+                               'data' => { 'requiredCapabilities' => { 'roots' => {} } } })
+
+      expect { server.rpc_request('vendor/thing') }
+        .to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) { |e|
+              expect(e.required_capabilities).to eq({ 'roots' => {} })
+            }
+    end
+  end
+
+  describe "a host's conn.response :json middleware, on the success path too" do
+    let(:base_url) { 'https://example.com' }
+    let(:endpoint) { '/rpc' }
+
+    # The README offers this middleware for the error path; a host who adds it
+    # decodes every body, so the success path meets a Hash where it used to
+    # meet a String. Reading the already-decoded body is what makes the offer
+    # good for the whole exchange rather than half of it.
+    def server_with_json_middleware(klass)
+      server = klass.new(base_url: base_url, endpoint: endpoint, retries: 0,
+                         faraday_config: ->(conn) { conn.response :json })
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      server
+    end
+
+    it 'answers a decoded 200 body on ServerHTTP' do
+      server = server_with_json_middleware(MCPClient::ServerHTTP)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        { status: 200, headers: { 'Content-Type' => 'application/json' },
+          body: JSON.generate('jsonrpc' => '2.0', 'id' => JSON.parse(request.body)['id'],
+                              'result' => { 'ok' => true }) }
+      end
+
+      expect(server.rpc_request('vendor/thing')).to eq({ 'ok' => true })
+    end
+
+    it 'still raises the typed error a decoded 4xx body carries on ServerHTTP' do
+      server = server_with_json_middleware(MCPClient::ServerHTTP)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return(
+        status: 400, headers: { 'Content-Type' => 'application/json' },
+        body: JSON.generate('jsonrpc' => '2.0', 'id' => 1,
+                            'error' => { 'code' => -32_022, 'message' => 'Unsupported protocol version',
+                                         'data' => { 'supported' => ['2026-07-28'] } })
+      )
+
+      expect { server.rpc_request('vendor/thing') }
+        .to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) { |e|
+              expect(e.supported).to eq(['2026-07-28'])
+            }
+    end
+  end
+
+  describe 'every page of a stdio list, not only the first' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 2) }
+
+    before do
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+    end
+
+    # The page loop asks the server again for every cursor it is handed; a
+    # discriminator checked only on the first answer lets everything after it
+    # through, and the pages are concatenated into one list the caller cannot
+    # tell apart.
+    def answer_pages(kind, first, second)
+      pages = [first, second]
+      allow(server).to receive(:send_request)
+      allow(server).to receive(:wait_response) do
+        { 'jsonrpc' => '2.0', 'id' => 1, 'result' => pages.shift }
+      end
+      kind
+    end
+
+    it 'rejects an unknown discriminator on the second prompts/list page' do
+      answer_pages('prompts',
+                   { 'prompts' => [{ 'name' => 'p1', 'description' => 'd' }], 'nextCursor' => 'page-2' },
+                   { 'resultType' => 'weird', 'prompts' => [] })
+
+      expect { server.list_prompts }.to raise_error(MCPClient::Errors::InvalidResultError, /weird/)
+    end
+
+    it 'rejects an unknown discriminator on the second tools/list page' do
+      answer_pages('tools',
+                   { 'tools' => [{ 'name' => 't1', 'description' => 'd', 'inputSchema' => {} }],
+                     'nextCursor' => 'page-2' },
+                   { 'resultType' => 'weird', 'tools' => [] })
+
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /weird/)
+    end
+
+    it 'returns both pages when every one of them is well formed' do
+      answer_pages('prompts',
+                   { 'prompts' => [{ 'name' => 'p1', 'description' => 'd' }], 'nextCursor' => 'page-2' },
+                   { 'prompts' => [{ 'name' => 'p2', 'description' => 'd' }] })
+
+      expect(server.list_prompts.map(&:name)).to eq(%w[p1 p2])
+    end
+  end
+end

--- a/spec/lib/mcp_client/protocol_foundations_2026_round9_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_round9_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 protocol foundations, ninth review round: the README offers
+# Faraday's JSON middleware for reading a server's error bodies, and that
+# middleware decodes EVERY response, so the success path must survive it too —
+# on both HTTP transports, and whichever spelling the middleware was told to
+# produce. A decoded envelope is read for the same members as a parsed one,
+# and a decoded body is never handed to a string parser a second time.
+RSpec.describe 'MCP 2026-07-28 protocol foundations — round 9' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  def server_for(klass, config, era: '2025-11-25')
+    server = klass.new(base_url: base_url, endpoint: endpoint, retries: 0, faraday_config: config)
+    server.instance_variable_set(:@connection_established, true)
+    server.instance_variable_set(:@initialized, true)
+    server.instance_variable_set(:@protocol_version, era)
+    server
+  end
+
+  def answer(payload)
+    stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+      body = JSON.parse(request.body)
+      { status: 200, headers: { 'Content-Type' => 'application/json' },
+        body: JSON.generate({ 'jsonrpc' => '2.0', 'id' => body['id'] }.merge(payload)) }
+    end
+  end
+
+  # The two spellings a host can ask Faraday's JSON middleware for. The
+  # client reads the envelope the peer sent, not the spelling the host's
+  # middleware happened to produce.
+  {
+    'a decoding JSON response middleware' => ->(conn) { conn.response :json },
+    'a symbolizing JSON response middleware' => lambda { |conn|
+      conn.response :json, parser_options: { symbolize_names: true }
+    }
+  }.each do |middleware_name, config|
+    [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+      context "with #{klass} and #{middleware_name}" do
+        it 'hands the caller the result the server sent' do
+          server = server_for(klass, config)
+          answer('result' => { 'content' => [{ 'type' => 'text', 'text' => 'hi' }] })
+
+          result = server.rpc_request('tools/call', { 'name' => 't' })
+
+          expect(MCPClient::JsonRpcCommon.result_type(result)).to eq('complete')
+          expect(result.to_a.flatten.map(&:to_s)).to include('content')
+        end
+
+        # A 200 carrying a JSON-RPC error is a failed call, never a success:
+        # reporting it as one would hand the caller a nil result for a tool
+        # the server refused to run.
+        it 'raises the error a 200 envelope carries rather than reporting success' do
+          server = server_for(klass, config)
+          answer('error' => { 'code' => -32_020, 'message' => 'Tool failed' })
+
+          expect { server.rpc_request('tools/call', { 'name' => 't' }) }
+            .to raise_error(MCPClient::Errors::ServerError) { |e| expect(e.code).to eq(-32_020) }
+        end
+
+        # "A resultType of any value unrecognized by the client MUST be
+        # considered invalid" — the discriminator is read off the envelope the
+        # middleware produced, so an unknown one is still refused.
+        it 'refuses an unrecognized resultType on a modern session' do
+          server = server_for(klass, config, era: '2026-07-28')
+          answer('result' => { 'resultType' => 'bogus' })
+
+          expect { server.rpc_request('tools/call', { 'name' => 't' }) }
+            .to raise_error(MCPClient::Errors::InvalidResultError, /unrecognized resultType/)
+        end
+      end
+    end
+  end
+
+  # The SSE branch of Streamable HTTP is untouched by that middleware: an
+  # event-stream body is not JSON, so it arrives as the text it was sent as.
+  context 'with ServerStreamableHTTP answering an SSE stream under the same middleware' do
+    it 'still reads the response out of the stream' do
+      server = server_for(MCPClient::ServerStreamableHTTP, ->(conn) { conn.response :json })
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        id = JSON.parse(request.body)['id']
+        { status: 200, headers: { 'Content-Type' => 'text/event-stream' },
+          body: "event: message\ndata: #{JSON.generate('jsonrpc' => '2.0', 'id' => id,
+                                                       'result' => { 'ok' => true })}\n\n" }
+      end
+
+      expect(server.rpc_request('tools/call', { 'name' => 't' })).to eq({ 'ok' => true })
+    end
+  end
+end

--- a/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
@@ -1,0 +1,324 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 base-protocol foundations (basic/index.mdx):
+# - protocol version constants for the modern (per-request metadata) era
+# - the error-code allocation policy and the three spec-defined codes
+#   (-32020 HeaderMismatch, -32021 MissingRequiredClientCapability,
+#   -32022 UnsupportedProtocolVersion), surfaced as typed errors
+# - the required `resultType` field: absent means "complete" (older servers),
+#   unrecognized values MUST be considered invalid
+# - resource not found is -32602 (Invalid params); -32002 is still accepted
+RSpec.describe 'MCP 2026-07-28 protocol foundations' do
+  describe 'protocol version constants' do
+    it 'names 2026-07-28 as the latest protocol version' do
+      expect(MCPClient::LATEST_PROTOCOL_VERSION).to eq('2026-07-28')
+    end
+
+    it 'lists 2026-07-28 among the modern (per-request metadata) versions' do
+      expect(MCPClient::MODERN_PROTOCOL_VERSIONS).to include('2026-07-28')
+    end
+
+    it 'keeps every initialize-handshake revision in the legacy set' do
+      expect(MCPClient::LEGACY_PROTOCOL_VERSIONS).to eq(%w[2025-11-25 2025-06-18 2025-03-26 2024-11-05])
+    end
+
+    it 'supports the union of modern and legacy versions' do
+      expect(MCPClient::SUPPORTED_PROTOCOL_VERSIONS)
+        .to match_array(MCPClient::MODERN_PROTOCOL_VERSIONS + MCPClient::LEGACY_PROTOCOL_VERSIONS)
+    end
+
+    it 'keeps PROTOCOL_VERSION (the initialize request version) on the latest legacy revision' do
+      expect(MCPClient::PROTOCOL_VERSION).to eq('2025-11-25')
+      expect(MCPClient::LEGACY_PROTOCOL_VERSIONS.first).to eq(MCPClient::PROTOCOL_VERSION)
+    end
+  end
+
+  describe 'error codes' do
+    it 'defines the codes reserved by the 2026-07-28 specification' do
+      expect(MCPClient::Errors::Codes::HEADER_MISMATCH).to eq(-32_020)
+      expect(MCPClient::Errors::Codes::MISSING_REQUIRED_CLIENT_CAPABILITY).to eq(-32_021)
+      expect(MCPClient::Errors::Codes::UNSUPPORTED_PROTOCOL_VERSION).to eq(-32_022)
+    end
+
+    it 'defines the standard JSON-RPC codes' do
+      expect(MCPClient::Errors::Codes::PARSE_ERROR).to eq(-32_700)
+      expect(MCPClient::Errors::Codes::INVALID_REQUEST).to eq(-32_600)
+      expect(MCPClient::Errors::Codes::METHOD_NOT_FOUND).to eq(-32_601)
+      expect(MCPClient::Errors::Codes::INVALID_PARAMS).to eq(-32_602)
+      expect(MCPClient::Errors::Codes::INTERNAL_ERROR).to eq(-32_603)
+    end
+
+    it 'recognizes exactly the spec-defined modern codes' do
+      expect(MCPClient::Errors::Codes.modern_error_code?(-32_020)).to be(true)
+      expect(MCPClient::Errors::Codes.modern_error_code?(-32_021)).to be(true)
+      expect(MCPClient::Errors::Codes.modern_error_code?(-32_022)).to be(true)
+      # Reserved for the spec but not (yet) defined: unknown to this client.
+      expect(MCPClient::Errors::Codes.modern_error_code?(-32_023)).to be(false)
+      # Legacy sub-range and standard JSON-RPC codes are not "modern".
+      expect(MCPClient::Errors::Codes.modern_error_code?(-32_001)).to be(false)
+      expect(MCPClient::Errors::Codes.modern_error_code?(-32_601)).to be(false)
+      expect(MCPClient::Errors::Codes.modern_error_code?(nil)).to be(false)
+    end
+
+    it 'treats -32602 and the legacy -32002 as resource-not-found codes' do
+      expect(MCPClient::Errors::Codes.resource_not_found_code?(-32_602)).to be(true)
+      expect(MCPClient::Errors::Codes.resource_not_found_code?(-32_002)).to be(true)
+      expect(MCPClient::Errors::Codes.resource_not_found_code?(-32_603)).to be(false)
+    end
+  end
+
+  describe MCPClient::Errors::ServerError do
+    it 'still accepts a bare message' do
+      error = described_class.new('boom')
+      expect(error.message).to eq('boom')
+      expect(error.code).to be_nil
+      expect(error.data).to be_nil
+    end
+
+    it 'carries the JSON-RPC error code and data' do
+      error = described_class.new('bad', code: -32_602, data: { 'uri' => 'file:///x' })
+      expect(error.code).to eq(-32_602)
+      expect(error.data).to eq({ 'uri' => 'file:///x' })
+    end
+
+    describe '.from_jsonrpc' do
+      it 'builds an UnsupportedProtocolVersionError exposing supported and requested versions' do
+        error = described_class.from_jsonrpc(
+          'code' => -32_022, 'message' => 'Unsupported protocol version',
+          'data' => { 'supported' => %w[2026-07-28 2025-11-25], 'requested' => '1900-01-01' }
+        )
+        expect(error).to be_a(MCPClient::Errors::UnsupportedProtocolVersionError)
+        expect(error).to be_a(described_class)
+        expect(error.code).to eq(-32_022)
+        expect(error.supported).to eq(%w[2026-07-28 2025-11-25])
+        expect(error.requested).to eq('1900-01-01')
+        expect(error.message).to eq('Unsupported protocol version')
+      end
+
+      it 'tolerates an UnsupportedProtocolVersionError without data' do
+        error = described_class.from_jsonrpc('code' => -32_022, 'message' => 'nope')
+        expect(error.supported).to eq([])
+        expect(error.requested).to be_nil
+      end
+
+      it 'builds a MissingRequiredClientCapabilityError exposing the required capabilities' do
+        error = described_class.from_jsonrpc(
+          'code' => -32_021, 'message' => 'Missing required client capability',
+          'data' => { 'requiredCapabilities' => { 'elicitation' => {} } }
+        )
+        expect(error).to be_a(MCPClient::Errors::MissingRequiredClientCapabilityError)
+        expect(error.required_capabilities).to eq({ 'elicitation' => {} })
+      end
+
+      it 'defaults required capabilities to an empty object when data is absent' do
+        error = described_class.from_jsonrpc('code' => -32_021, 'message' => 'missing')
+        expect(error.required_capabilities).to eq({})
+      end
+
+      it 'builds a HeaderMismatchError for -32020' do
+        error = described_class.from_jsonrpc('code' => -32_020, 'message' => 'Header mismatch')
+        expect(error).to be_a(MCPClient::Errors::HeaderMismatchError)
+        expect(error.code).to eq(-32_020)
+      end
+
+      it 'builds a plain ServerError for any other code, keeping code and data' do
+        error = described_class.from_jsonrpc('code' => -32_601, 'message' => 'Method not found', 'data' => 'x')
+        expect(error.class).to eq(described_class)
+        expect(error.code).to eq(-32_601)
+        expect(error.data).to eq('x')
+        expect(error.message).to eq('Method not found')
+      end
+
+      it 'copes with a malformed error object' do
+        expect(described_class.from_jsonrpc(nil).message).to eq('Unknown server error')
+        expect(described_class.from_jsonrpc('code' => 'x').code).to be_nil
+      end
+
+      it 'reports whether the error is a recognized modern protocol error' do
+        expect(described_class.from_jsonrpc('code' => -32_022, 'message' => 'v').modern_protocol_error?).to be(true)
+        expect(described_class.from_jsonrpc('code' => -32_601, 'message' => 'm').modern_protocol_error?).to be(false)
+      end
+    end
+  end
+
+  describe 'JSON-RPC response processing' do
+    let(:transport) do
+      Class.new do
+        include MCPClient::JsonRpcCommon
+
+        def initialize
+          @logger = Logger.new(StringIO.new)
+        end
+      end.new
+    end
+
+    it 'raises the typed error for a modern error response' do
+      response = { 'jsonrpc' => '2.0', 'id' => 1,
+                   'error' => { 'code' => -32_022, 'message' => 'Unsupported protocol version',
+                                'data' => { 'supported' => ['2026-07-28'], 'requested' => 'x' } } }
+      expect { transport.process_jsonrpc_response(response) }
+        .to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) { |e| expect(e.supported).to eq(['2026-07-28']) }
+    end
+
+    it 'keeps the code on a plain error response' do
+      response = { 'jsonrpc' => '2.0', 'id' => 1, 'error' => { 'code' => -32_602, 'message' => 'Resource not found' } }
+      expect { transport.process_jsonrpc_response(response) }
+        .to raise_error(MCPClient::Errors::ServerError, 'Resource not found') { |e| expect(e.code).to eq(-32_602) }
+    end
+
+    it 'returns a result whose resultType is "complete"' do
+      result = { 'resultType' => 'complete', 'tools' => [] }
+      expect(transport.process_jsonrpc_response({ 'id' => 1, 'result' => result })).to eq(result)
+    end
+
+    it 'treats an absent resultType as "complete" (earlier-protocol servers)' do
+      result = { 'tools' => [] }
+      expect(transport.process_jsonrpc_response({ 'id' => 1, 'result' => result })).to eq(result)
+      expect(MCPClient::JsonRpcCommon.result_type(result)).to eq('complete')
+    end
+
+    it 'passes through an "input_required" result for the caller to handle' do
+      result = { 'resultType' => 'input_required', 'requestState' => 'blob' }
+      expect(transport.process_jsonrpc_response({ 'id' => 1, 'result' => result })).to eq(result)
+      expect(MCPClient::JsonRpcCommon.result_type(result)).to eq('input_required')
+    end
+
+    it 'rejects an unrecognized resultType as an invalid response' do
+      result = { 'resultType' => 'bogus' }
+      expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => result }) }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /resultType.*bogus/)
+    end
+
+    it 'rejects a non-string resultType' do
+      expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => { 'resultType' => 42 } }) }
+        .to raise_error(MCPClient::Errors::InvalidResultError)
+    end
+
+    it 'lets a transport widen the accepted result types (extensions)' do
+      transport.define_singleton_method(:accepted_result_types) { %w[complete input_required task] }
+      result = { 'resultType' => 'task', 'taskId' => 't1' }
+      expect(transport.process_jsonrpc_response({ 'id' => 1, 'result' => result })).to eq(result)
+    end
+
+    it 'is lenient with non-object results from older servers' do
+      expect(transport.process_jsonrpc_response({ 'id' => 1, 'result' => [] })).to eq([])
+      expect(MCPClient::JsonRpcCommon.result_type([])).to eq('complete')
+    end
+
+    it 'InvalidResultError is a ServerError, so it is never retried as transient' do
+      expect(MCPClient::Errors::InvalidResultError).to be < MCPClient::Errors::ServerError
+      expect(MCPClient::Errors::InvalidResultError).not_to be < MCPClient::Errors::TransientServerError
+    end
+  end
+
+  describe 'resource not found mapping' do
+    shared_examples 'maps resource-not-found codes' do
+      it 'raises ResourceNotFound for -32602 (Invalid params)' do
+        stub_read_error(-32_602, 'Resource not found')
+        expect { server.read_resource('file:///missing.txt') }
+          .to raise_error(MCPClient::Errors::ResourceNotFound, %r{file:///missing.txt.*Resource not found})
+      end
+
+      it 'raises ResourceNotFound for the legacy -32002 code' do
+        stub_read_error(-32_002, 'Resource not found')
+        expect { server.read_resource('file:///missing.txt') }.to raise_error(MCPClient::Errors::ResourceNotFound)
+      end
+
+      it 'keeps other server errors as ResourceReadError' do
+        stub_read_error(-32_603, 'Internal error')
+        expect { server.read_resource('file:///missing.txt') }
+          .to raise_error(MCPClient::Errors::ResourceReadError, /Internal error/)
+      end
+    end
+
+    context 'with ServerStdio' do
+      let(:server) { MCPClient::ServerStdio.new(command: 'echo test') }
+
+      def stub_read_error(code, message)
+        server.instance_variable_set(:@initialized, true)
+        allow(server).to receive(:send_request)
+        allow(server).to receive(:wait_response).and_return(
+          { 'jsonrpc' => '2.0', 'id' => 1, 'error' => { 'code' => code, 'message' => message } }
+        )
+      end
+
+      include_examples 'maps resource-not-found codes'
+    end
+
+    context 'with ServerHTTP' do
+      let(:server) { MCPClient::ServerHTTP.new(base_url: 'https://example.com') }
+
+      def stub_read_error(code, message)
+        allow(server).to receive(:rpc_request).and_raise(MCPClient::Errors::ServerError.new(message, code: code))
+      end
+
+      include_examples 'maps resource-not-found codes'
+    end
+
+    context 'with ServerStreamableHTTP' do
+      let(:server) { MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com') }
+
+      def stub_read_error(code, message)
+        allow(server).to receive(:rpc_request).and_raise(MCPClient::Errors::ServerError.new(message, code: code))
+      end
+
+      include_examples 'maps resource-not-found codes'
+    end
+
+    context 'with ServerSSE' do
+      let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse') }
+
+      def stub_read_error(code, message)
+        allow(server).to receive(:rpc_request).and_raise(MCPClient::Errors::ServerError.new(message, code: code))
+      end
+
+      include_examples 'maps resource-not-found codes'
+    end
+  end
+
+  describe 'stdio error responses' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'echo test') }
+
+    it 'surfaces the JSON-RPC error code from rpc_request' do
+      server.instance_variable_set(:@initialized, true)
+      allow(server).to receive(:send_request)
+      allow(server).to receive(:wait_response).and_return(
+        { 'jsonrpc' => '2.0', 'id' => 1,
+          'error' => { 'code' => -32_021, 'message' => 'Missing required client capability',
+                       'data' => { 'requiredCapabilities' => { 'elicitation' => {} } } } }
+      )
+
+      expect { server.rpc_request('tools/call', { name: 'x' }) }
+        .to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+          expect(e.required_capabilities).to eq({ 'elicitation' => {} })
+        end
+    end
+
+    it 'rejects an unrecognized resultType on list responses' do
+      server.instance_variable_set(:@initialized, true)
+      allow(server).to receive(:send_request)
+      allow(server).to receive(:wait_response).and_return(
+        { 'jsonrpc' => '2.0', 'id' => 1, 'result' => { 'resultType' => 'weird', 'tools' => [] } }
+      )
+
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::ToolCallError, /resultType/)
+    end
+  end
+
+  describe 'SSE error responses' do
+    let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse') }
+
+    it 'surfaces the JSON-RPC error code' do
+      error = { 'code' => -32_022, 'message' => 'Unsupported protocol version',
+                'data' => { 'supported' => ['2026-07-28'], 'requested' => 'x' } }
+      expect { server.send(:raise_sse_error_response, error) }
+        .to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) do |e|
+          expect(e.code).to eq(-32_022)
+          expect(e.supported).to eq(['2026-07-28'])
+          expect(e.message).to eq('Unsupported protocol version (code -32022)')
+        end
+    end
+  end
+end

--- a/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
@@ -183,6 +183,10 @@ RSpec.describe 'MCP 2026-07-28 protocol foundations' do
     end
 
     it 'passes through an "input_required" result for the caller to handle' do
+      # Only a modern session has the multi round-trip pattern; a legacy one
+      # answering with it is malformed (see the era examples in the
+      # verification spec).
+      transport.instance_variable_set(:@protocol_version, '2026-07-28')
       result = { 'resultType' => 'input_required', 'requestState' => 'blob' }
       expect(transport.process_jsonrpc_response({ 'id' => 1, 'result' => result })).to eq(result)
       expect(MCPClient::JsonRpcCommon.result_type(result)).to eq('input_required')
@@ -231,7 +235,32 @@ RSpec.describe 'MCP 2026-07-28 protocol foundations' do
           .to raise_error(MCPClient::Errors::ResourceNotFound, %r{file:///missing.txt.*Resource not found})
       end
 
+      it 'keeps -32602 a ResourceReadError on a legacy session' do
+        # -32602 only means "no such resource" from 2026-07-28 on; on a
+        # handshake session it is still plain Invalid params.
+        server.instance_variable_set(:@protocol_version, '2025-11-25')
+        stub_read_error(-32_602, 'Invalid params')
+        expect { server.read_resource('file:///missing.txt') }
+          .to raise_error(MCPClient::Errors::ResourceReadError, /Invalid params/) do |e|
+            expect(e).not_to be_a(MCPClient::Errors::ResourceNotFound)
+          end
+      end
+
+      it 'keeps -32602 a ResourceReadError before any session is established' do
+        stub_read_error(-32_602, 'Invalid params')
+        expect { server.read_resource('file:///missing.txt') }
+          .to raise_error(MCPClient::Errors::ResourceReadError) do |e|
+            expect(e).not_to be_a(MCPClient::Errors::ResourceNotFound)
+          end
+      end
+
       it 'raises ResourceNotFound for the legacy -32002 code' do
+        stub_read_error(-32_002, 'Resource not found')
+        expect { server.read_resource('file:///missing.txt') }.to raise_error(MCPClient::Errors::ResourceNotFound)
+      end
+
+      it 'raises ResourceNotFound for -32002 on a modern session too' do
+        server.instance_variable_set(:@protocol_version, '2026-07-28')
         stub_read_error(-32_002, 'Resource not found')
         expect { server.read_resource('file:///missing.txt') }.to raise_error(MCPClient::Errors::ResourceNotFound)
       end
@@ -526,11 +555,22 @@ RSpec.describe 'resource-not-found mapping is protocol-era aware' do
   end
 
   it 'exposes the protocol era on every transport' do
-    server = MCPClient::ServerStdio.new(command: 'echo')
-    expect(server.protocol_version).to be_nil
-    expect(server.modern?).to be(false)
-    server.instance_variable_set(:@protocol_version, '2026-07-28')
-    expect(server.modern?).to be(true)
+    servers = [MCPClient::ServerStdio.new(command: 'echo'),
+               MCPClient::ServerHTTP.new(base_url: 'https://example.com'),
+               MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com'),
+               MCPClient::ServerSSE.new(base_url: 'https://example.com/sse')]
+
+    servers.each do |server|
+      expect(server.protocol_version).to be_nil, "#{server.class}: expected no era before connecting"
+      expect(server.modern?).to be(false), "#{server.class}: nil is not a modern era"
+
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      expect(server.modern?).to be(false), "#{server.class}: a handshake revision is not modern"
+
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      expect(server.protocol_version).to eq('2026-07-28')
+      expect(server.modern?).to be(true), "#{server.class}: 2026-07-28 is modern"
+    end
   end
 end
 

--- a/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
@@ -322,3 +322,40 @@ RSpec.describe 'MCP 2026-07-28 protocol foundations' do
     end
   end
 end
+
+# Every response path validates resultType, not only rpc_request: the SSE
+# transport delivers stored results through check_for_result, and the stdio
+# initialize handshake reads its result directly.
+RSpec.describe 'resultType validation on every transport response path' do
+  it 'rejects an unrecognized resultType delivered through the SSE result store' do
+    server = MCPClient::ServerSSE.new(base_url: 'https://example.com/sse')
+    server.instance_variable_get(:@mutex).synchronize do
+      server.instance_variable_get(:@sse_results)[7] = { 'resultType' => 'bogus', 'tools' => [] }
+    end
+
+    expect { server.send(:check_for_result, 7) }.to raise_error(MCPClient::Errors::InvalidResultError)
+  end
+
+  it 'rejects an unrecognized resultType on the stdio initialize result' do
+    server = MCPClient::ServerStdio.new(command: 'echo test')
+    allow(server).to receive(:next_id).and_return(1)
+    allow(server).to receive(:send_request)
+    allow(server).to receive(:wait_response).and_return(
+      { 'result' => { 'resultType' => 'bogus', 'protocolVersion' => '2025-11-25', 'capabilities' => {} } }
+    )
+
+    expect { server.send(:perform_initialize) }.to raise_error(MCPClient::Errors::ConnectionError, /resultType/)
+  end
+
+  it 'reports a stdio initialize error response as a ConnectionError carrying the message' do
+    server = MCPClient::ServerStdio.new(command: 'echo test')
+    allow(server).to receive(:next_id).and_return(1)
+    allow(server).to receive(:send_request)
+    allow(server).to receive(:wait_response).and_return(
+      { 'error' => { 'code' => -32_602, 'message' => 'bad init' } }
+    )
+
+    expect { server.send(:perform_initialize) }
+      .to raise_error(MCPClient::Errors::ConnectionError, /Initialize failed: bad init/)
+  end
+end

--- a/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
@@ -97,10 +97,11 @@ RSpec.describe 'MCP 2026-07-28 protocol foundations' do
         expect(error.message).to eq('Unsupported protocol version')
       end
 
-      it 'tolerates an UnsupportedProtocolVersionError without data' do
+      it 'tolerates an UnsupportedProtocolVersionError without data (but does not call it modern)' do
         error = described_class.from_jsonrpc('code' => -32_022, 'message' => 'nope')
         expect(error.supported).to eq([])
         expect(error.requested).to be_nil
+        expect(error.modern_protocol_error?).to be(false)
       end
 
       it 'builds a MissingRequiredClientCapabilityError exposing the required capabilities' do
@@ -137,7 +138,9 @@ RSpec.describe 'MCP 2026-07-28 protocol foundations' do
       end
 
       it 'reports whether the error is a recognized modern protocol error' do
-        expect(described_class.from_jsonrpc('code' => -32_022, 'message' => 'v').modern_protocol_error?).to be(true)
+        modern = described_class.from_jsonrpc('code' => -32_022, 'message' => 'v',
+                                              'data' => { 'supported' => ['2026-07-28'], 'requested' => 'x' })
+        expect(modern.modern_protocol_error?).to be(true)
         expect(described_class.from_jsonrpc('code' => -32_601, 'message' => 'm').modern_protocol_error?).to be(false)
       end
     end
@@ -205,6 +208,12 @@ RSpec.describe 'MCP 2026-07-28 protocol foundations' do
     it 'is lenient with non-object results from older servers' do
       expect(transport.process_jsonrpc_response({ 'id' => 1, 'result' => [] })).to eq([])
       expect(MCPClient::JsonRpcCommon.result_type([])).to eq('complete')
+    end
+
+    it 'treats -32022 without the schema-mandated data as not modern' do
+      response = { 'jsonrpc' => '2.0', 'id' => 1, 'error' => { 'code' => -32_022, 'message' => 'v' } }
+      expect { transport.process_jsonrpc_response(response) }
+        .to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) { |e| expect(e.modern_protocol_error?).to be(false) }
     end
 
     it 'InvalidResultError is a ServerError, so it is never retried as transient' do
@@ -304,7 +313,7 @@ RSpec.describe 'MCP 2026-07-28 protocol foundations' do
         { 'jsonrpc' => '2.0', 'id' => 1, 'result' => { 'resultType' => 'weird', 'tools' => [] } }
       )
 
-      expect { server.list_tools }.to raise_error(MCPClient::Errors::ToolCallError, /resultType/)
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /resultType/)
     end
   end
 
@@ -550,5 +559,232 @@ RSpec.describe 'initialize handshake against the modern era' do
 
     expect { server.send(:perform_initialize) }
       .to raise_error(MCPClient::Errors::ConnectionError, /server supports: 2026-07-28, 2027-01-01/)
+  end
+end
+
+# Second review round: only a well-formed JSON-RPC error identifies a modern
+# server; Faraday raise_error middleware must not bypass body parsing; typed
+# protocol errors survive the public wrappers; a modern result must be an
+# object with a string resultType.
+RSpec.describe 'modern error recognition is strict' do
+  it 'requires the data the schema mandates before an error counts as modern' do
+    no_data = MCPClient::Errors::ServerError.from_jsonrpc('code' => -32_022, 'message' => 'blocked')
+    expect(no_data).to be_a(MCPClient::Errors::UnsupportedProtocolVersionError)
+    expect(no_data.modern_protocol_error?).to be(false)
+
+    with_data = MCPClient::Errors::ServerError.from_jsonrpc(
+      'code' => -32_022, 'message' => 'v', 'data' => { 'supported' => ['2026-07-28'], 'requested' => 'x' }
+    )
+    expect(with_data.modern_protocol_error?).to be(true)
+
+    caps_missing = MCPClient::Errors::ServerError.from_jsonrpc('code' => -32_021, 'message' => 'm')
+    expect(caps_missing.modern_protocol_error?).to be(false)
+    caps = MCPClient::Errors::ServerError.from_jsonrpc('code' => -32_021, 'message' => 'm',
+                                                       'data' => { 'requiredCapabilities' => {} })
+    expect(caps.modern_protocol_error?).to be(true)
+
+    # HeaderMismatch carries no data in the schema.
+    expect(MCPClient::Errors::ServerError.from_jsonrpc('code' => -32_020, 'message' => 'h').modern_protocol_error?)
+      .to be(true)
+  end
+
+  it 'ignores a 400 body that is not a JSON-RPC 2.0 error response' do
+    server = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/rpc', retries: 0)
+    stub_request(:post, 'https://example.com/rpc')
+      .to_return(status: 400, body: '{"error":{"code":-32022,"message":"blocked"}}',
+                 headers: { 'Content-Type' => 'application/json' })
+
+    expect { server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} }) }
+      .to raise_error(MCPClient::Errors::ServerError) do |e|
+        expect(e.class).to eq(MCPClient::Errors::ServerError)
+        expect(e.code).to be_nil
+      end
+  end
+end
+
+RSpec.describe 'typed errors with Faraday raise_error middleware' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  def error_body(code, message, data = nil)
+    error = { 'code' => code, 'message' => message }
+    error['data'] = data if data
+    JSON.generate('jsonrpc' => '2.0', 'id' => 1, 'error' => error)
+  end
+
+  [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+    context "with #{klass}" do
+      let(:server) do
+        klass.new(base_url: base_url, endpoint: endpoint, retries: 0,
+                  faraday_config: ->(conn) { conn.response :raise_error })
+      end
+
+      def send_request
+        server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} })
+      end
+
+      it 'still raises the typed error for a 400 carrying -32022' do
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .to_return(status: 400, body: error_body(-32_022, 'Unsupported protocol version',
+                                                   { 'supported' => ['2026-07-28'], 'requested' => 'x' }),
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) do |e|
+          expect(e.supported).to eq(['2026-07-28'])
+          expect(e.http_status).to eq(400)
+        end
+      end
+
+      it 'still keeps the code of a 404 carrying -32601' do
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .to_return(status: 404, body: error_body(-32_601, 'Method not found'),
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+          expect(e.code).to eq(-32_601)
+          expect(e.http_status).to eq(404)
+        end
+      end
+
+      it 'raises a plain, non-retryable ServerError for a 400 without a JSON-RPC body' do
+        stub_request(:post, "#{base_url}#{endpoint}").to_return(status: 400, body: 'nope')
+
+        expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+          expect(e).not_to be_a(MCPClient::Errors::TransientServerError)
+          expect(e).not_to be_a(MCPClient::Errors::TransportError)
+          expect(e.http_status).to eq(400)
+        end
+      end
+    end
+  end
+end
+
+RSpec.describe 'typed protocol errors survive the public transport methods' do
+  let(:capability_error) do
+    MCPClient::Errors::ServerError.from_jsonrpc(
+      'code' => -32_021, 'message' => 'Missing required client capability',
+      'data' => { 'requiredCapabilities' => { 'elicitation' => {} } }
+    )
+  end
+
+  [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+    it "propagates them from #{klass}#call_tool, #get_prompt and #read_resource" do
+      server = klass.new(base_url: 'https://example.com')
+      allow(server).to receive(:rpc_request).and_raise(capability_error)
+
+      expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError)
+      expect { server.get_prompt('p', {}) }.to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError)
+      expect { server.read_resource('file:///x') }.to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError)
+    end
+  end
+
+  it 'propagates them from ServerSSE#call_tool' do
+    server = MCPClient::ServerSSE.new(base_url: 'https://example.com/sse')
+    allow(server).to receive(:rpc_request).and_raise(capability_error)
+
+    expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError)
+  end
+
+  it 'propagates them from every ServerStdio method' do
+    server = MCPClient::ServerStdio.new(command: 'echo test')
+    server.instance_variable_set(:@initialized, true)
+    server.instance_variable_set(:@capabilities, { 'completions' => {}, 'logging' => {},
+                                                   'resources' => { 'subscribe' => true } })
+    allow(server).to receive(:send_request)
+    allow(server).to receive(:wait_response).and_return(
+      { 'jsonrpc' => '2.0', 'id' => 1,
+        'error' => { 'code' => -32_021, 'message' => 'Missing required client capability',
+                     'data' => { 'requiredCapabilities' => { 'elicitation' => {} } } } }
+    )
+
+    [-> { server.call_tool('t', {}) }, -> { server.list_tools }, -> { server.get_prompt('p', {}) },
+     -> { server.list_prompts }, -> { server.list_resources }, -> { server.read_resource('file:///x') },
+     -> { server.list_resource_templates }, -> { server.subscribe_resource('file:///x') },
+     -> { server.unsubscribe_resource('file:///x') },
+     -> { server.complete(ref: { 'type' => 'ref/prompt', 'name' => 'p' }, argument: { 'name' => 'a', 'value' => '' }) },
+     -> { server.log_level = 'debug' }].each do |call|
+      expect(&call).to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+        expect(e.required_capabilities).to eq({ 'elicitation' => {} })
+      end
+    end
+  end
+
+  it 'propagates InvalidResultError from the public stdio methods' do
+    server = MCPClient::ServerStdio.new(command: 'echo test')
+    server.instance_variable_set(:@initialized, true)
+    allow(server).to receive(:send_request)
+    allow(server).to receive(:wait_response).and_return(
+      { 'jsonrpc' => '2.0', 'id' => 1, 'result' => { 'resultType' => 'weird', 'tools' => [] } }
+    )
+
+    expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError)
+  end
+
+  it 'exposes protocol_error? on ServerError' do
+    expect(MCPClient::Errors::ServerError.new('x', code: -32_601).protocol_error?).to be(false)
+    expect(MCPClient::Errors::InvalidResultError.new('x').protocol_error?).to be(true)
+    expect(MCPClient::Errors::HeaderMismatchError.new('x', code: -32_020).protocol_error?).to be(true)
+  end
+end
+
+RSpec.describe 'result shape validation' do
+  let(:transport) do
+    Class.new do
+      include MCPClient::JsonRpcCommon
+
+      attr_accessor :protocol_version
+
+      def initialize
+        @logger = Logger.new(StringIO.new)
+      end
+    end.new
+  end
+
+  it 'rejects an explicit null resultType in either era' do
+    expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => { 'resultType' => nil } }) }
+      .to raise_error(MCPClient::Errors::InvalidResultError)
+    expect(MCPClient::JsonRpcCommon.result_type({ 'resultType' => nil })).to be_nil
+  end
+
+  it 'rejects a missing, null or non-object result from a modern server' do
+    transport.protocol_version = '2026-07-28'
+    expect { transport.process_jsonrpc_response({ 'id' => 1 }) }
+      .to raise_error(MCPClient::Errors::InvalidResultError, /object/)
+    expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => nil }) }
+      .to raise_error(MCPClient::Errors::InvalidResultError)
+    expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => [] }) }
+      .to raise_error(MCPClient::Errors::InvalidResultError)
+  end
+
+  it 'stays lenient with non-object results from legacy servers' do
+    transport.protocol_version = '2025-11-25'
+    expect(transport.process_jsonrpc_response({ 'id' => 1, 'result' => [] })).to eq([])
+    expect(transport.process_jsonrpc_response({ 'id' => 1, 'result' => nil })).to be_nil
+  end
+end
+
+RSpec.describe 'HTTP error bodies are inspected within a bound' do
+  let(:server) { MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/rpc', retries: 0) }
+
+  def send_request
+    server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} })
+  end
+
+  it 'does not parse an oversized 4xx body' do
+    huge = "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32022,\"message\":\"#{'x' * (70 * 1024)}\"}}"
+    stub_request(:post, 'https://example.com/rpc')
+      .to_return(status: 400, body: huge, headers: { 'Content-Type' => 'application/json' })
+    expect(JSON).not_to receive(:parse)
+
+    expect { send_request }.to raise_error(MCPClient::Errors::ServerError) { |e| expect(e.code).to be_nil }
+  end
+
+  it 'gives up on a gzip 4xx body that expands past the bound' do
+    payload = "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32022,\"message\":\"#{'x' * (200 * 1024)}\"}}"
+    gz = StringIO.new.tap { |io| Zlib::GzipWriter.wrap(io) { |w| w.write(payload) } }.string
+    stub_request(:post, 'https://example.com/rpc')
+      .to_return(status: 400, body: gz, headers: { 'Content-Type' => 'application/json', 'Content-Encoding' => 'gzip' })
+
+    expect { send_request }.to raise_error(MCPClient::Errors::ServerError) { |e| expect(e.code).to be_nil }
   end
 end

--- a/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
@@ -215,7 +215,8 @@ RSpec.describe 'MCP 2026-07-28 protocol foundations' do
 
   describe 'resource not found mapping' do
     shared_examples 'maps resource-not-found codes' do
-      it 'raises ResourceNotFound for -32602 (Invalid params)' do
+      it 'raises ResourceNotFound for -32602 (Invalid params) on a modern session' do
+        server.instance_variable_set(:@protocol_version, '2026-07-28')
         stub_read_error(-32_602, 'Resource not found')
         expect { server.read_resource('file:///missing.txt') }
           .to raise_error(MCPClient::Errors::ResourceNotFound, %r{file:///missing.txt.*Resource not found})
@@ -357,5 +358,197 @@ RSpec.describe 'resultType validation on every transport response path' do
 
     expect { server.send(:perform_initialize) }
       .to raise_error(MCPClient::Errors::ConnectionError, /Initialize failed: bad init/)
+  end
+end
+
+# MCP 2026-07-28 Streamable HTTP: the spec-defined protocol errors travel in
+# the body of an HTTP 400 (HeaderMismatch, UnsupportedProtocolVersion,
+# MissingRequiredClientCapability) and an unknown method is a 404 carrying
+# -32601. A dual-era client must read those bodies: a recognized modern
+# error identifies a modern server, and must not be mistaken for a legacy
+# rejection.
+RSpec.describe 'typed JSON-RPC errors carried in HTTP error bodies' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  def error_body(code, message, data = nil)
+    error = { 'code' => code, 'message' => message }
+    error['data'] = data if data
+    JSON.generate('jsonrpc' => '2.0', 'id' => 1, 'error' => error)
+  end
+
+  shared_examples 'parses JSON-RPC errors out of HTTP error responses' do
+    it 'raises UnsupportedProtocolVersionError for a 400 carrying -32022' do
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .to_return(status: 400, body: error_body(-32_022, 'Unsupported protocol version',
+                                                 { 'supported' => ['2026-07-28'], 'requested' => 'x' }),
+                   headers: { 'Content-Type' => 'application/json' })
+
+      expect { send_request }.to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) do |e|
+        expect(e.code).to eq(-32_022)
+        expect(e.supported).to eq(['2026-07-28'])
+        expect(e.modern_protocol_error?).to be(true)
+        expect(e.message).to include('400').and include('Unsupported protocol version')
+      end
+    end
+
+    it 'raises HeaderMismatchError for a 400 carrying -32020' do
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .to_return(status: 400, body: error_body(-32_020, 'Header mismatch'),
+                   headers: { 'Content-Type' => 'application/json' })
+
+      expect { send_request }.to raise_error(MCPClient::Errors::HeaderMismatchError)
+    end
+
+    it 'raises MissingRequiredClientCapabilityError for a 400 carrying -32021' do
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .to_return(status: 400, body: error_body(-32_021, 'Missing capability',
+                                                 { 'requiredCapabilities' => { 'elicitation' => {} } }),
+                   headers: { 'Content-Type' => 'application/json' })
+
+      expect { send_request }.to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+        expect(e.required_capabilities).to eq({ 'elicitation' => {} })
+      end
+    end
+
+    it 'keeps the JSON-RPC code of a 404 carrying -32601 (unknown method on a modern server)' do
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .to_return(status: 404, body: error_body(-32_601, 'Method not found'),
+                   headers: { 'Content-Type' => 'application/json' })
+
+      expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+        expect(e.code).to eq(-32_601)
+        expect(e.modern_protocol_error?).to be(false)
+      end
+    end
+
+    it 'raises a plain ServerError without a code for a 400 with no JSON-RPC body' do
+      stub_request(:post, "#{base_url}#{endpoint}").to_return(status: 400, body: 'Bad Request')
+
+      expect { send_request }.to raise_error(MCPClient::Errors::ServerError, /\b400\b/) do |e|
+        expect(e.code).to be_nil
+      end
+    end
+
+    it 'raises a plain ServerError for a 400 whose JSON body is not a JSON-RPC error' do
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .to_return(status: 400, body: '{"detail":"nope"}', headers: { 'Content-Type' => 'application/json' })
+
+      expect { send_request }.to raise_error(MCPClient::Errors::ServerError) { |e| expect(e.code).to be_nil }
+    end
+
+    it 'does not turn a 5xx into a typed error (it stays retryable)' do
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .to_return(status: 503, body: error_body(-32_022, 'x'), headers: { 'Content-Type' => 'application/json' })
+
+      expect { send_request }.to raise_error(MCPClient::Errors::TransientServerError)
+    end
+  end
+
+  context 'with ServerStreamableHTTP' do
+    let(:server) { MCPClient::ServerStreamableHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+    def send_request
+      server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize', 'params' => {} })
+    end
+
+    include_examples 'parses JSON-RPC errors out of HTTP error responses'
+
+    it 'decodes a gzip-encoded error body' do
+      body = StringIO.new.tap { |io| Zlib::GzipWriter.wrap(io) { |gz| gz.write(error_body(-32_022, 'v')) } }.string
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .to_return(status: 400, body: body,
+                   headers: { 'Content-Type' => 'application/json', 'Content-Encoding' => 'gzip' })
+
+      expect { send_request }.to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError)
+    end
+  end
+
+  context 'with ServerHTTP' do
+    let(:server) { MCPClient::ServerHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+    def send_request
+      server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize', 'params' => {} })
+    end
+
+    include_examples 'parses JSON-RPC errors out of HTTP error responses'
+  end
+
+  context 'with ServerSSE (POST leg)' do
+    let(:endpoint) { '/messages' }
+    let(:server) { MCPClient::ServerSSE.new(base_url: "#{base_url}/sse", retries: 0) }
+
+    def send_request
+      server.instance_variable_set(:@rpc_endpoint, endpoint)
+      server.send(:post_json_rpc_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize', 'params' => {} })
+    end
+
+    include_examples 'parses JSON-RPC errors out of HTTP error responses'
+  end
+end
+
+RSpec.describe 'resource-not-found mapping is protocol-era aware' do
+  # On a legacy (2025-11-25 and earlier) session -32602 is plain Invalid
+  # params — not found was -32002 — so only a modern server's -32602 means
+  # the resource does not exist.
+  it 'treats -32602 as not found only on modern sessions' do
+    expect(MCPClient::Errors::Codes.resource_not_found_code?(-32_602, modern: true)).to be(true)
+    expect(MCPClient::Errors::Codes.resource_not_found_code?(-32_602, modern: false)).to be(false)
+    expect(MCPClient::Errors::Codes.resource_not_found_code?(-32_002, modern: true)).to be(true)
+    expect(MCPClient::Errors::Codes.resource_not_found_code?(-32_002, modern: false)).to be(true)
+  end
+
+  it 'keeps a legacy server -32602 as ResourceReadError' do
+    server = MCPClient::ServerHTTP.new(base_url: 'https://example.com')
+    server.instance_variable_set(:@protocol_version, '2025-11-25')
+    allow(server).to receive(:rpc_request).and_raise(MCPClient::Errors::ServerError.new('Invalid params',
+                                                                                        code: -32_602))
+
+    expect { server.read_resource('file:///x') }.to raise_error(MCPClient::Errors::ResourceReadError, /Invalid params/)
+  end
+
+  it 'maps a modern server -32602 to ResourceNotFound' do
+    server = MCPClient::ServerHTTP.new(base_url: 'https://example.com')
+    server.instance_variable_set(:@protocol_version, '2026-07-28')
+    allow(server).to receive(:rpc_request).and_raise(MCPClient::Errors::ServerError.new('Resource not found',
+                                                                                        code: -32_602))
+
+    expect { server.read_resource('file:///x') }.to raise_error(MCPClient::Errors::ResourceNotFound)
+  end
+
+  it 'exposes the protocol era on every transport' do
+    server = MCPClient::ServerStdio.new(command: 'echo')
+    expect(server.protocol_version).to be_nil
+    expect(server.modern?).to be(false)
+    server.instance_variable_set(:@protocol_version, '2026-07-28')
+    expect(server.modern?).to be(true)
+  end
+end
+
+RSpec.describe 'initialize handshake against the modern era' do
+  it 'disconnects when a server answers initialize with a modern (per-request metadata) version' do
+    server = MCPClient::ServerStdio.new(command: 'echo test')
+    allow(server).to receive(:next_id).and_return(1)
+    allow(server).to receive(:send_request)
+    allow(server).to receive(:wait_response).and_return(
+      { 'result' => { 'protocolVersion' => '2026-07-28', 'capabilities' => {} } }
+    )
+    expect(server).to receive(:cleanup)
+
+    expect { server.send(:perform_initialize) }
+      .to raise_error(MCPClient::Errors::ConnectionError, /2026-07-28/)
+  end
+
+  it 'names the versions a modern-only server advertises when it rejects initialize' do
+    server = MCPClient::ServerStdio.new(command: 'echo test')
+    allow(server).to receive(:next_id).and_return(1)
+    allow(server).to receive(:send_request)
+    allow(server).to receive(:wait_response).and_return(
+      { 'error' => { 'code' => -32_022, 'message' => 'Unsupported protocol version',
+                     'data' => { 'supported' => %w[2026-07-28 2027-01-01], 'requested' => '2025-11-25' } } }
+    )
+
+    expect { server.send(:perform_initialize) }
+      .to raise_error(MCPClient::Errors::ConnectionError, /server supports: 2026-07-28, 2027-01-01/)
   end
 end

--- a/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
@@ -125,11 +125,20 @@ RSpec.describe 'MCP 2026-07-28 protocol foundations' do
       end
 
       it 'builds a plain ServerError for any other code, keeping code and data' do
-        error = described_class.from_jsonrpc('code' => -32_601, 'message' => 'Method not found', 'data' => 'x')
+        error = described_class.from_jsonrpc('code' => -32_000, 'message' => 'Server error', 'data' => 'x')
         expect(error.class).to eq(described_class)
-        expect(error.code).to eq(-32_601)
+        expect(error.code).to eq(-32_000)
         expect(error.data).to eq('x')
-        expect(error.message).to eq('Method not found')
+        expect(error.message).to eq('Server error')
+      end
+
+      it 'builds a MethodNotFoundError for a well-formed -32601, which is still a plain protocol error' do
+        error = described_class.from_jsonrpc('code' => -32_601, 'message' => 'Method not found')
+        expect(error).to be_a(MCPClient::Errors::MethodNotFoundError)
+        expect(error.modern_protocol_error?).to be(false)
+        expect(error.protocol_error?).to be(false)
+        # Off the HTTP wire it is nothing more than "method not found".
+        expect(error.modern_http_protocol_error?).to be(false)
       end
 
       it 'copes with a malformed error object' do

--- a/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
@@ -161,13 +161,24 @@ RSpec.describe 'modern protocol error recognition matches the schema wire shape'
         .to be(false)
     end
 
-    it 'rejects an empty supported list (no version left to retry with)' do
-      expect(unsupported({ 'supported' => [], 'requested' => 'x' }).modern_protocol_error?).to be(false)
+    # The schema types these members, it does not constrain their length. A
+    # server that names no mutually usable version has still identified
+    # itself as modern: "no compatible version" and "not a modern server"
+    # are different conditions, and conflating them would send the client
+    # back to an initialize handshake this server does not implement.
+    it 'accepts an empty supported list: no compatible version is still a modern rejection' do
+      error = unsupported({ 'supported' => [], 'requested' => 'x' })
+      expect(error.modern_protocol_error?).to be(true)
+      expect(error.supported).to eq([])
     end
 
-    it 'rejects a supported list carrying an empty version string' do
+    it 'accepts a supported list carrying an empty version string' do
       expect(unsupported({ 'supported' => ['2026-07-28', ''], 'requested' => 'x' }).modern_protocol_error?)
-        .to be(false)
+        .to be(true)
+    end
+
+    it 'accepts an empty requested version' do
+      expect(unsupported({ 'supported' => ['2026-07-28'], 'requested' => '' }).modern_protocol_error?).to be(true)
     end
 
     it 'rejects a supported member that is not an array' do
@@ -216,9 +227,21 @@ RSpec.describe 'modern protocol error recognition matches the schema wire shape'
       expect(MCPClient::Errors::ServerError.from_jsonrpc(raw).modern_protocol_error?).to be(false)
     end
 
-    it 'rejects an empty message' do
+    # JSON-RPC 2.0 requires `message` to be a String; it does not require it
+    # to be a non-empty one, and an empty one still discriminates nothing —
+    # a legacy endpoint misusing a reserved code would send prose, not "".
+    it 'accepts an empty message, which JSON-RPC still counts as a string' do
       raw = { 'code' => -32_020, 'message' => '' }
-      expect(MCPClient::Errors::ServerError.from_jsonrpc(raw).modern_protocol_error?).to be(false)
+      error = MCPClient::Errors::ServerError.from_jsonrpc(raw)
+      expect(error).to be_a(MCPClient::Errors::HeaderMismatchError)
+      expect(error.modern_protocol_error?).to be(true)
+    end
+
+    it 'accepts an empty message on an otherwise schema-valid -32022' do
+      error = unsupported({ 'supported' => ['2026-07-28'], 'requested' => '2025-11-25' }, message: '')
+      expect(error).to be_a(MCPClient::Errors::UnsupportedProtocolVersionError)
+      expect(error.modern_protocol_error?).to be(true)
+      expect(error.supported).to eq(['2026-07-28'])
     end
 
     it 'still recognizes -32020, which mandates no data, when the message is there' do
@@ -578,20 +601,34 @@ RSpec.describe 'a gzip HTTP error body is decompressed within the inspection bou
     server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} })
   end
 
-  # Record every size argument the production code asks the gzip reader for.
-  # An implementation that inflated the whole body before measuring it would
-  # read with no bound (nil) — which is exactly the mutation this kills.
+  # Record what the production code asks the gzip reader for AND what it got
+  # back. An implementation that inflated the whole body before measuring it
+  # would read with no bound (nil); one that looped would stay under the
+  # per-read bound while producing far more than it — both are killed here.
+  # @return [Hash{Symbol=>Array<Integer, nil>}] :requested sizes, :produced bytes
   def record_gzip_reads
-    reads = []
+    reads = { requested: [], produced: [] }
     allow(Zlib::GzipReader).to receive(:new).and_wrap_original do |original, *args|
       reader = original.call(*args)
       allow(reader).to receive(:read).and_wrap_original do |original_read, *read_args|
-        reads << read_args.first
-        original_read.call(*read_args)
+        reads[:requested] << read_args.first
+        original_read.call(*read_args).tap { |chunk| reads[:produced] << chunk.to_s.bytesize }
       end
       reader
     end
     reads
+  end
+
+  # A JSON-RPC error response whose serialization is exactly `size` bytes.
+  def payload_of_size(size)
+    error = { 'code' => -32_022, 'message' => '',
+              'data' => { 'supported' => ['2026-07-28'], 'requested' => '2025-11-25' } }
+    body = { 'jsonrpc' => '2.0', 'id' => 1, 'error' => error }
+    padding = size - JSON.generate(body).bytesize
+    raise ArgumentError, "cannot build a payload of #{size} bytes" if padding.negative?
+
+    error['message'] = 'x' * padding
+    JSON.generate(body)
   end
 
   it 'never asks the reader for more than the bound, even for a 4 MiB expansion' do
@@ -601,9 +638,12 @@ RSpec.describe 'a gzip HTTP error body is decompressed within the inspection bou
     reads = record_gzip_reads
 
     expect { send_request }.to raise_error(MCPClient::Errors::ServerError) { |e| expect(e.code).to be_nil }
-    expect(reads).not_to be_empty
-    expect(reads).to all(be_a(Integer))
-    expect(reads.max).to be <= bound + 1
+    expect(reads[:requested]).not_to be_empty
+    expect(reads[:requested]).to all(be_a(Integer))
+    expect(reads[:requested].max).to be <= bound + 1
+    # The cumulative bound, not just the per-read one: however many reads it
+    # takes, the client never materializes more than the inspection ceiling.
+    expect(reads[:produced].sum).to be <= bound + 1
   end
 
   it 'still reads a small gzip error body through the same bounded path' do
@@ -616,6 +656,519 @@ RSpec.describe 'a gzip HTTP error body is decompressed within the inspection bou
     expect { send_request }.to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) do |e|
       expect(e.supported).to eq(['2026-07-28'])
     end
-    expect(reads).to all(be_a(Integer))
+    expect(reads[:requested]).to all(be_a(Integer))
+    expect(reads[:produced].sum).to be <= bound + 1
+  end
+
+  it 'still parses a body that expands to exactly the bound' do
+    payload = payload_of_size(bound)
+    expect(payload.bytesize).to eq(bound)
+    stub_gzip_body(payload)
+    reads = record_gzip_reads
+
+    expect { send_request }.to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) do |e|
+      expect(e.code).to eq(-32_022)
+      expect(e.supported).to eq(['2026-07-28'])
+    end
+    expect(reads[:produced].sum).to eq(bound)
+  end
+
+  it 'gives up on a body one byte past the bound' do
+    payload = payload_of_size(bound + 1)
+    expect(payload.bytesize).to eq(bound + 1)
+    stub_gzip_body(payload)
+
+    expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+      expect(e.code).to be_nil
+      expect(e.message).to include('400')
+    end
+  end
+
+  it 'falls back to a plain error when the gzip body is malformed' do
+    stub_request(:post, 'https://example.com/rpc')
+      .to_return(status: 400, body: 'not gzip at all',
+                 headers: { 'Content-Type' => 'application/json', 'Content-Encoding' => 'gzip' })
+
+    expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+      expect(e.code).to be_nil
+      expect(e).not_to be_a(MCPClient::Errors::TransientServerError)
+    end
+  end
+end
+
+# --- Round 3, finding A: input_required belongs to the modern era only ------
+#
+# `resultType` and the multi round-trip pattern that "input_required" names
+# were introduced by 2026-07-28. A session that negotiated a handshake
+# revision has no such pattern, so a legacy answer claiming an unfinished
+# result is malformed — and must never be quietly flattened into an empty
+# successful one by a wrapper that projects a field out of the result.
+RSpec.describe 'input_required is a modern-era result type' do
+  let(:transport) do
+    Class.new do
+      include MCPClient::JsonRpcCommon
+
+      attr_accessor :protocol_version
+
+      def initialize
+        @logger = Logger.new(StringIO.new)
+      end
+    end.new
+  end
+
+  def process(result)
+    transport.process_jsonrpc_response({ 'jsonrpc' => '2.0', 'id' => 1, 'result' => result })
+  end
+
+  it 'accepts it once a modern revision is established' do
+    transport.protocol_version = '2026-07-28'
+    result = { 'resultType' => 'input_required', 'requestState' => 'continue-later' }
+
+    expect(process(result)).to eq(result)
+    expect(transport.accepted_result_types).to include('input_required')
+  end
+
+  it 'rejects it from a session that negotiated a handshake revision' do
+    transport.protocol_version = '2025-11-25'
+
+    expect { process({ 'resultType' => 'input_required', 'requestState' => 'continue-later' }) }
+      .to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
+    expect(transport.accepted_result_types).to eq(['complete'])
+  end
+
+  it 'rejects it before any revision is established' do
+    expect { process({ 'resultType' => 'input_required' }) }
+      .to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
+  end
+
+  it 'still accepts a complete result in the legacy era' do
+    transport.protocol_version = '2025-11-25'
+    expect(process({ 'resultType' => 'complete', 'tools' => [] })).to eq({ 'resultType' => 'complete', 'tools' => [] })
+  end
+end
+
+# --- Round 3, finding B: a read must never be flattened while incomplete ----
+#
+# read_resource projects `contents` out of the result. This client does not
+# drive multi round-trip requests yet, so an InputRequiredResult reaching the
+# wrapper must surface — presenting a continuation as an empty successful
+# read loses the requestState and lies about the outcome.
+RSpec.describe 'read_resource never presents an unfinished read as an empty one' do
+  let(:incomplete) { { 'resultType' => 'input_required', 'requestState' => 'continue-later' } }
+
+  shared_examples 'surfaces an incomplete resources/read result' do
+    it 'raises instead of returning an empty content list on a modern session' do
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      stub_read_result(incomplete)
+
+      expect { server.read_resource('file:///x.txt') }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+          expect(e).not_to be_a(MCPClient::Errors::ResourceReadError)
+          expect(e.protocol_error?).to be(true)
+          # The continuation is preserved, not discarded: a host can drive
+          # the round trip itself from the opaque requestState.
+          expect(e.data).to eq(incomplete)
+          expect(e.data['requestState']).to eq('continue-later')
+        end
+    end
+
+    it 'still returns the contents of a completed read' do
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      stub_read_result({ 'resultType' => 'complete',
+                         'contents' => [{ 'uri' => 'file:///x.txt', 'text' => 'hi' }] })
+
+      expect(server.read_resource('file:///x.txt').map(&:uri)).to eq(['file:///x.txt'])
+    end
+  end
+
+  context 'with ServerStdio' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'echo test') }
+
+    def stub_read_result(result)
+      server.instance_variable_set(:@initialized, true)
+      allow(server).to receive(:send_request)
+      allow(server).to receive(:wait_response).and_return({ 'jsonrpc' => '2.0', 'id' => 1, 'result' => result })
+    end
+
+    include_examples 'surfaces an incomplete resources/read result'
+  end
+
+  [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP, MCPClient::ServerSSE].each do |klass|
+    context "with #{klass}" do
+      let(:server) do
+        if klass == MCPClient::ServerSSE
+          klass.new(base_url: 'https://example.com/sse')
+        else
+          klass.new(base_url: 'https://example.com')
+        end
+      end
+
+      def stub_read_result(result)
+        allow(server).to receive(:rpc_request).and_return(result)
+      end
+
+      include_examples 'surfaces an incomplete resources/read result'
+    end
+  end
+end
+
+# --- Round 3, finding C: an unrecognized discriminator stays invalid --------
+#
+# Deliberate policy, pinned here so it cannot be relaxed by accident:
+# `resultType` is a name the 2026-07-28 revision coined, so a server that
+# sends one at all is 2026-aware whatever era this client believes it
+# negotiated. Treating a value it does not recognize as "complete" is the
+# silent-truncation failure the spec's MUST exists to prevent, so the rule
+# is applied in every era — unlike the bare-array results legacy servers were
+# actually observed to send, which stay tolerated.
+RSpec.describe 'an unrecognized resultType is invalid in every era' do
+  let(:transport) do
+    Class.new do
+      include MCPClient::JsonRpcCommon
+
+      attr_accessor :protocol_version
+
+      def initialize
+        @logger = Logger.new(StringIO.new)
+      end
+    end.new
+  end
+
+  ['2026-07-28', '2025-11-25', '2024-11-05', nil].each do |version|
+    it "rejects it with the session version #{version.inspect}" do
+      transport.protocol_version = version
+
+      expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => { 'resultType' => 'vendor_summary' } }) }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /vendor_summary/)
+    end
+  end
+
+  it 'reads a symbol-keyed resultType, as a symbolizing middleware would leave it' do
+    expect(MCPClient::JsonRpcCommon.result_type({ resultType: 'input_required' })).to eq('input_required')
+    expect(MCPClient::JsonRpcCommon.result_type({ resultType: 'vendor_summary' })).to eq('vendor_summary')
+
+    transport.protocol_version = '2026-07-28'
+    expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => { resultType: 'vendor_summary' } }) }
+      .to raise_error(MCPClient::Errors::InvalidResultError, /vendor_summary/)
+    expect(transport.process_jsonrpc_response({ 'id' => 1, 'result' => { resultType: 'complete' } }))
+      .to eq({ resultType: 'complete' })
+  end
+
+  it 'rejects a symbol-keyed input_required from a legacy session too' do
+    transport.protocol_version = '2025-11-25'
+    expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => { resultType: 'input_required' } }) }
+      .to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
+  end
+end
+
+# --- Round 3, finding D: an invalid result is answered, never re-sent -------
+#
+# InvalidResultError being a ServerError is only half the guarantee; this
+# drives a real request with retries configured and counts the wire sends.
+RSpec.describe 'an invalid result is never retried on the wire' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  it 'sends tools/list exactly once even with retries configured' do
+    server = MCPClient::ServerHTTP.new(base_url: base_url, endpoint: endpoint, retries: 3, retry_backoff: 0)
+    server.instance_variable_set(:@connection_established, true)
+    server.instance_variable_set(:@initialized, true)
+    stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+      { status: 200,
+        body: JSON.generate('jsonrpc' => '2.0', 'id' => JSON.parse(request.body)['id'],
+                            'result' => { 'resultType' => 'vendor_summary', 'tools' => [] }),
+        headers: { 'Content-Type' => 'application/json' } }
+    end
+
+    expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError)
+    expect(a_request(:post, "#{base_url}#{endpoint}")).to have_been_made.once
+  end
+
+  it 'still retries a 5xx for the same request, so the count means something' do
+    server = MCPClient::ServerHTTP.new(base_url: base_url, endpoint: endpoint, retries: 2, retry_backoff: 0)
+    server.instance_variable_set(:@connection_established, true)
+    server.instance_variable_set(:@initialized, true)
+    stub_request(:post, "#{base_url}#{endpoint}").to_return(status: 503, body: 'nope')
+
+    expect { server.list_tools }.to raise_error(MCPClient::Errors::TransientServerError)
+    expect(a_request(:post, "#{base_url}#{endpoint}")).to have_been_made.times(3)
+  end
+end
+
+# --- Round 3, finding E: typed errors keep their data through call_tool -----
+RSpec.describe 'a typed HTTP error keeps code, data and status through the public wrappers' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+  let(:capability_data) { { 'requiredCapabilities' => { 'elicitation' => { 'form' => {} } } } }
+
+  [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+    context "with #{klass}" do
+      let(:server) { klass.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+      before do
+        server.instance_variable_set(:@connection_established, true)
+        server.instance_variable_set(:@initialized, true)
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .to_return(status: 400,
+                     body: JSON.generate('jsonrpc' => '2.0', 'id' => 1,
+                                         'error' => { 'code' => -32_021, 'message' => 'Missing capability',
+                                                      'data' => capability_data }),
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'keeps them through call_tool rather than wrapping them in ToolCallError' do
+        expect { server.call_tool('t', {}) }
+          .to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+            expect(e).not_to be_a(MCPClient::Errors::ToolCallError)
+            expect(e.code).to eq(-32_021)
+            expect(e.data).to eq(capability_data)
+            expect(e.required_capabilities).to eq({ 'elicitation' => { 'form' => {} } })
+            expect(e.http_status).to eq(400)
+          end
+      end
+
+      it 'keeps them through read_resource rather than wrapping them in ResourceReadError' do
+        expect { server.read_resource('file:///x') }
+          .to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+            expect(e).not_to be_a(MCPClient::Errors::ResourceReadError)
+            expect(e.code).to eq(-32_021)
+            expect(e.http_status).to eq(400)
+          end
+      end
+
+      it 'keeps them through get_prompt rather than wrapping them in PromptGetError' do
+        expect { server.get_prompt('p', {}) }
+          .to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+            expect(e).not_to be_a(MCPClient::Errors::PromptGetError)
+            expect(e.data).to eq(capability_data)
+            expect(e.http_status).to eq(400)
+          end
+      end
+    end
+  end
+end
+
+# --- Round 3, finding F: two outstanding requests, answered out of order ----
+#
+# The earlier SSE and stdio examples answer inside the mocked send, so one
+# waiter is never actually blocked while another request is outstanding.
+# These leave two requests in flight, answer the SECOND one first, and check
+# that each answer reaches its own caller and that the pending bookkeeping is
+# emptied either way.
+RSpec.describe 'two outstanding requests are answered independently and out of order' do
+  # Take one posted request, failing loudly instead of blocking forever.
+  def take(queue)
+    deadline = Time.now + 5
+    loop do
+      begin
+        return queue.pop(true)
+      rescue ThreadError
+        raise 'no request was sent within 5s' if Time.now > deadline
+      end
+      sleep 0.01
+    end
+  end
+
+  let(:capability_error) do
+    { 'code' => -32_021, 'message' => 'Missing required client capability',
+      'data' => { 'requiredCapabilities' => { 'elicitation' => {} } } }
+  end
+  let(:tool_listing) do
+    { 'resultType' => 'complete', 'tools' => [{ 'name' => 't', 'description' => 'd', 'inputSchema' => {} }] }
+  end
+
+  context 'with ServerSSE (stream reader -> waiter)' do
+    let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 5, retries: 0) }
+
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@sse_connected, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@rpc_endpoint, 'https://example.com/messages')
+    end
+
+    def answer(id, payload)
+      body = JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(payload))
+      server.send(:parse_and_handle_sse_event, "event: message\ndata: #{body}\n\n")
+    end
+
+    it 'gives each waiter its own answer and leaves no pending state behind' do
+      sent = Queue.new
+      allow(server).to receive(:post_json_rpc_request) { |request| sent << request and nil }
+
+      listing = Thread.new { server.list_tools }
+      calling = Thread.new do
+        server.call_tool('t', {})
+      rescue MCPClient::Errors::ServerError => e
+        e
+      end
+
+      ids = {}
+      2.times do
+        request = take(sent)
+        ids[request['method']] = request['id']
+      end
+      expect(ids.keys).to contain_exactly('tools/list', 'tools/call')
+
+      answer(ids['tools/call'], 'error' => capability_error)
+      answer(ids['tools/list'], 'result' => tool_listing)
+
+      expect(listing.join(5)).not_to be_nil
+      expect(calling.join(5)).not_to be_nil
+      expect(listing.value.map(&:name)).to eq(['t'])
+      expect(calling.value).to be_a(MCPClient::Errors::MissingRequiredClientCapabilityError)
+      expect(calling.value.required_capabilities).to eq({ 'elicitation' => {} })
+      expect(server.instance_variable_get(:@sse_results)).to be_empty
+      expect(server.instance_variable_get(:@pending_request_ids)).to be_empty
+    end
+  end
+
+  context 'with ServerStdio (reader thread -> waiter)' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 5) }
+
+    before { server.instance_variable_set(:@initialized, true) }
+
+    def answer(id, payload)
+      server.send(:handle_line, "#{JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(payload))}\n")
+    end
+
+    it 'gives each waiter its own answer and leaves no pending state behind' do
+      sent = Queue.new
+      allow(server).to receive(:send_request) { |request| sent << request and nil }
+
+      listing = Thread.new { server.list_tools }
+      calling = Thread.new do
+        server.call_tool('t', {})
+      rescue MCPClient::Errors::ServerError => e
+        e
+      end
+
+      ids = {}
+      2.times do
+        request = take(sent)
+        ids[request['method']] = request['id']
+      end
+      expect(ids.keys).to contain_exactly('tools/list', 'tools/call')
+
+      answer(ids['tools/call'], 'error' => capability_error)
+      answer(ids['tools/list'], 'result' => tool_listing)
+
+      expect(listing.join(5)).not_to be_nil
+      expect(calling.join(5)).not_to be_nil
+      expect(listing.value.map(&:name)).to eq(['t'])
+      expect(calling.value).to be_a(MCPClient::Errors::MissingRequiredClientCapabilityError)
+      expect(calling.value.required_capabilities).to eq({ 'elicitation' => {} })
+      expect(server.instance_variable_get(:@pending)).to be_empty
+      expect(server.instance_variable_get(:@awaiting)).to be_empty
+    end
+  end
+end
+
+# --- Round 3, finding G: resource errors and pages off the real wire --------
+#
+# The resource-not-found mapping and the discriminator check are exercised
+# here against stubbed HTTP responses (JSON for ServerHTTP, SSE for
+# ServerStreamableHTTP) rather than a mocked rpc_request, and across a
+# paginated list where only the SECOND page is malformed.
+RSpec.describe 'resource errors and paginated results off the wire' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  shared_examples 'maps wire-level resource errors' do
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+    end
+
+    it 'maps a modern -32602 to ResourceNotFound' do
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      respond_with('error' => { 'code' => -32_602, 'message' => 'No such resource' })
+
+      expect { server.read_resource('file:///gone') }
+        .to raise_error(MCPClient::Errors::ResourceNotFound, %r{file:///gone})
+    end
+
+    it 'keeps a legacy -32602 a ResourceReadError' do
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      respond_with('error' => { 'code' => -32_602, 'message' => 'Invalid params' })
+
+      expect { server.read_resource('file:///gone') }
+        .to raise_error(MCPClient::Errors::ResourceReadError, /Invalid params/) do |e|
+          expect(e).not_to be_a(MCPClient::Errors::ResourceNotFound)
+        end
+    end
+
+    it 'maps the legacy -32002 to ResourceNotFound in either era' do
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      respond_with('error' => { 'code' => -32_002, 'message' => 'Resource not found' })
+
+      expect { server.read_resource('file:///gone') }.to raise_error(MCPClient::Errors::ResourceNotFound)
+    end
+
+    it 'treats an absent resultType as complete on a modern session too' do
+      # "clients MUST treat an absent resultType as 'complete'" is a
+      # backward-compatibility rule, not a legacy-only one.
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      respond_with('result' => { 'contents' => [{ 'uri' => 'file:///x', 'text' => 'hi' }] })
+
+      expect(server.read_resource('file:///x').map(&:uri)).to eq(['file:///x'])
+    end
+
+    it 'rejects an unrecognized discriminator on a later pagination page' do
+      pages = [
+        { 'result' => { 'resultType' => 'complete', 'nextCursor' => 'page-2',
+                        'tools' => [{ 'name' => 'first', 'description' => 'd', 'inputSchema' => {} }] } },
+        { 'result' => { 'resultType' => 'vendor_summary',
+                        'tools' => [{ 'name' => 'second', 'description' => 'd', 'inputSchema' => {} }] } }
+      ]
+      respond_in_sequence(pages)
+
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /vendor_summary/)
+    end
+  end
+
+  context 'with ServerHTTP (JSON responses)' do
+    let(:server) { MCPClient::ServerHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+    def encode(id, payload)
+      { status: 200, body: JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(payload)),
+        headers: { 'Content-Type' => 'application/json' } }
+    end
+
+    def respond_with(payload)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return { |r| encode(JSON.parse(r.body)['id'], payload) }
+    end
+
+    def respond_in_sequence(payloads)
+      remaining = payloads.dup
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        encode(JSON.parse(request.body)['id'], remaining.shift || payloads.last)
+      end
+    end
+
+    include_examples 'maps wire-level resource errors'
+  end
+
+  context 'with ServerStreamableHTTP (SSE responses)' do
+    let(:server) { MCPClient::ServerStreamableHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+    def encode(id, payload)
+      body = JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(payload))
+      { status: 200, body: "event: message\ndata: #{body}\n\n",
+        headers: { 'Content-Type' => 'text/event-stream' } }
+    end
+
+    def respond_with(payload)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return { |r| encode(JSON.parse(r.body)['id'], payload) }
+    end
+
+    def respond_in_sequence(payloads)
+      remaining = payloads.dup
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        encode(JSON.parse(request.body)['id'], remaining.shift || payloads.last)
+      end
+    end
+
+    include_examples 'maps wire-level resource errors'
   end
 end

--- a/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
@@ -1,0 +1,621 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Verification pass over the MCP 2026-07-28 protocol foundations.
+#
+# These examples pin behaviour the first round left unpinned:
+# - a JSON-RPC error carried in an HTTP error body must still be recognized
+#   when host-configured Faraday middleware has already parsed that body
+# - only an error carrying the wire shape its schema mandates (a string
+#   message, `supported: string[]`, `requested: string`) may identify a
+#   modern server and suppress the legacy fallback
+# - `resultType` validation runs on the REAL HTTP transports, through their
+#   public operations, for both the JSON and the SSE response shape
+# - typed errors keep their code, data and HTTP status through the public
+#   wrappers, and reach the SSE caller through parser -> pending request ->
+#   waiter rather than through a hand-called helper
+# - a peer-controlled gzip error body is never inflated past the inspection
+#   bound
+
+# --- Finding 1: a parsed (middleware-decoded) HTTP error body ---------------
+#
+# Hosts customize the connection (faraday_config) with response middleware.
+# With `conn.response :json` the body reaching the transport is a Hash, not a
+# String; a 400 carrying -32022 and its data is just as valid then, and must
+# not degrade to ServerError(code: nil, data: nil).
+RSpec.describe 'JSON-RPC errors in an HTTP error body decoded by response middleware' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  def error_body(code, message, data = nil)
+    error = { 'code' => code, 'message' => message }
+    error['data'] = data if data
+    JSON.generate('jsonrpc' => '2.0', 'id' => 1, 'error' => error)
+  end
+
+  def version_body
+    error_body(-32_022, 'Unsupported protocol version',
+               { 'supported' => %w[2026-07-28 2025-11-25], 'requested' => '1999-01-01' })
+  end
+
+  shared_examples 'reads a parsed JSON-RPC error body' do
+    it 'raises the typed error with its data intact for a 400 carrying -32022' do
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .to_return(status: 400, body: version_body, headers: { 'Content-Type' => 'application/json' })
+
+      expect { send_request }.to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) do |e|
+        expect(e.code).to eq(-32_022)
+        expect(e.supported).to eq(%w[2026-07-28 2025-11-25])
+        expect(e.requested).to eq('1999-01-01')
+        expect(e.data).to eq({ 'supported' => %w[2026-07-28 2025-11-25], 'requested' => '1999-01-01' })
+        expect(e.http_status).to eq(400)
+        expect(e.modern_protocol_error?).to be(true)
+      end
+    end
+
+    it 'keeps the JSON-RPC code of a 404 whose body arrives already parsed' do
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .to_return(status: 404, body: error_body(-32_601, 'Method not found'),
+                   headers: { 'Content-Type' => 'application/json' })
+
+      expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+        expect(e.code).to eq(-32_601)
+        expect(e.http_status).to eq(404)
+      end
+    end
+
+    it 'still ignores a parsed body that is not a JSON-RPC 2.0 error response' do
+      stub_request(:post, "#{base_url}#{endpoint}")
+        .to_return(status: 400, body: '{"error":{"code":-32022,"message":"blocked"}}',
+                   headers: { 'Content-Type' => 'application/json' })
+
+      expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+        expect(e.class).to eq(MCPClient::Errors::ServerError)
+        expect(e.code).to be_nil
+      end
+    end
+  end
+
+  [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+    context "with #{klass} and a JSON response middleware" do
+      let(:server) do
+        klass.new(base_url: base_url, endpoint: endpoint, retries: 0,
+                  faraday_config: ->(conn) { conn.response :json })
+      end
+
+      def send_request
+        server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} })
+      end
+
+      include_examples 'reads a parsed JSON-RPC error body'
+    end
+
+    context "with #{klass}, raise_error and a JSON response middleware" do
+      let(:server) do
+        klass.new(base_url: base_url, endpoint: endpoint, retries: 0,
+                  faraday_config: lambda { |conn|
+                    conn.response :raise_error
+                    conn.response :json
+                  })
+      end
+
+      def send_request
+        server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} })
+      end
+
+      include_examples 'reads a parsed JSON-RPC error body'
+    end
+
+    context "with #{klass} and a symbolizing JSON response middleware" do
+      let(:server) do
+        klass.new(base_url: base_url, endpoint: endpoint, retries: 0,
+                  faraday_config: lambda { |conn|
+                    conn.response :json, parser_options: { symbolize_names: true }
+                  })
+      end
+
+      def send_request
+        server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} })
+      end
+
+      it 'reads the symbol-keyed error just as well' do
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .to_return(status: 400, body: version_body, headers: { 'Content-Type' => 'application/json' })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) do |e|
+          expect(e.code).to eq(-32_022)
+          expect(e.supported).to eq(%w[2026-07-28 2025-11-25])
+          expect(e.requested).to eq('1999-01-01')
+        end
+      end
+    end
+  end
+end
+
+# --- Finding 2: modern-error recognition matches the schema's wire shape ----
+#
+# `modern_protocol_error?` suppresses the legacy initialize fallback, so it
+# must only answer true for an error the client can actually act on: a string
+# message (JSON-RPC 2.0 requires one) plus the data members the 2026-07-28
+# schema mandates.
+RSpec.describe 'modern protocol error recognition matches the schema wire shape' do
+  def unsupported(data, message: 'Unsupported protocol version')
+    error = { 'code' => -32_022 }
+    error['message'] = message unless message.nil?
+    error['data'] = data unless data.nil?
+    MCPClient::Errors::ServerError.from_jsonrpc(error)
+  end
+
+  describe 'UnsupportedProtocolVersion data' do
+    it 'rejects a supported list that is not string[]' do
+      error = unsupported({ 'supported' => [42], 'requested' => '2025-11-25' })
+      expect(error).to be_a(MCPClient::Errors::UnsupportedProtocolVersionError)
+      expect(error.supported).to eq([])
+      expect(error.modern_protocol_error?).to be(false)
+      expect(error.protocol_error?).to be(false)
+    end
+
+    it 'rejects a supported list mixing strings with other types' do
+      expect(unsupported({ 'supported' => ['2026-07-28', 42], 'requested' => 'x' }).modern_protocol_error?)
+        .to be(false)
+    end
+
+    it 'rejects an empty supported list (no version left to retry with)' do
+      expect(unsupported({ 'supported' => [], 'requested' => 'x' }).modern_protocol_error?).to be(false)
+    end
+
+    it 'rejects a supported list carrying an empty version string' do
+      expect(unsupported({ 'supported' => ['2026-07-28', ''], 'requested' => 'x' }).modern_protocol_error?)
+        .to be(false)
+    end
+
+    it 'rejects a supported member that is not an array' do
+      expect(unsupported({ 'supported' => '2026-07-28', 'requested' => 'x' }).modern_protocol_error?).to be(false)
+    end
+
+    it 'rejects an absent requested member' do
+      error = unsupported({ 'supported' => ['2026-07-28'] })
+      expect(error.requested).to be_nil
+      expect(error.modern_protocol_error?).to be(false)
+    end
+
+    it 'rejects a non-string requested member' do
+      expect(unsupported({ 'supported' => ['2026-07-28'], 'requested' => 20_260_728 }).modern_protocol_error?)
+        .to be(false)
+    end
+
+    it 'accepts the shape the schema defines' do
+      error = unsupported({ 'supported' => ['2026-07-28'], 'requested' => '2025-11-25' })
+      expect(error.modern_protocol_error?).to be(true)
+      expect(error.protocol_error?).to be(true)
+    end
+
+    it 'accepts the symbol-keyed spelling of the same shape' do
+      error = MCPClient::Errors::ServerError.from_jsonrpc(
+        code: -32_022, message: 'v', data: { supported: ['2026-07-28'], requested: '2025-11-25' }
+      )
+      expect(error.modern_protocol_error?).to be(true)
+    end
+  end
+
+  describe 'the JSON-RPC message member' do
+    it 'does not let the substituted message stand in for a missing one' do
+      error = unsupported({ 'supported' => ['2026-07-28'], 'requested' => 'x' }, message: nil)
+      expect(error.message).to eq('Unknown server error')
+      expect(error.modern_protocol_error?).to be(false)
+      # Malformed at the JSON-RPC level: no typed class, but code and data
+      # still reach the caller.
+      expect(error.class).to eq(MCPClient::Errors::ServerError)
+      expect(error.code).to eq(-32_022)
+      expect(error.data).to eq({ 'supported' => ['2026-07-28'], 'requested' => 'x' })
+    end
+
+    it 'rejects a non-string message' do
+      raw = { 'code' => -32_021, 'message' => 42, 'data' => { 'requiredCapabilities' => { 'elicitation' => {} } } }
+      expect(MCPClient::Errors::ServerError.from_jsonrpc(raw).modern_protocol_error?).to be(false)
+    end
+
+    it 'rejects an empty message' do
+      raw = { 'code' => -32_020, 'message' => '' }
+      expect(MCPClient::Errors::ServerError.from_jsonrpc(raw).modern_protocol_error?).to be(false)
+    end
+
+    it 'still recognizes -32020, which mandates no data, when the message is there' do
+      expect(MCPClient::Errors::ServerError.from_jsonrpc('code' => -32_020, 'message' => 'h')
+                                           .modern_protocol_error?).to be(true)
+    end
+
+    it 'requires requiredCapabilities to be an object for -32021' do
+      raw = { 'code' => -32_021, 'message' => 'm', 'data' => { 'requiredCapabilities' => ['elicitation'] } }
+      error = MCPClient::Errors::ServerError.from_jsonrpc(raw)
+      expect(error.required_capabilities).to eq({})
+      expect(error.modern_protocol_error?).to be(false)
+    end
+  end
+
+  describe 'the legacy fallback a malformed error must not suppress' do
+    it 'leaves a malformed -32022 out of the modern-server signal' do
+      malformed = unsupported({ 'supported' => [42] })
+      well_formed = unsupported({ 'supported' => ['2026-07-28'], 'requested' => 'x' })
+
+      expect([malformed.modern_protocol_error?, well_formed.modern_protocol_error?]).to eq([false, true])
+    end
+  end
+end
+
+# --- Finding 3: resultType validation on the real HTTP transports -----------
+#
+# Disabling validate_result_type! on ServerHTTP/ServerStreamableHTTP must
+# break something: these examples drive the PUBLIC operations against stubbed
+# HTTP responses (JSON for ServerHTTP, SSE for ServerStreamableHTTP), so the
+# guarantee is pinned end to end rather than through a mocked rpc_request.
+RSpec.describe 'resultType validation on the real HTTP transports' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  shared_examples 'validates resultType through public operations' do
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+    end
+
+    it 'raises InvalidResultError from list_tools for an unknown discriminator' do
+      respond_with('result' => { 'resultType' => 'partial_stream', 'tools' => [] })
+
+      expect { server.list_tools }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /partial_stream/)
+    end
+
+    it 'raises InvalidResultError from call_tool for an unknown discriminator' do
+      respond_with('result' => { 'resultType' => 'partial_stream', 'content' => [] })
+
+      expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InvalidResultError) do |e|
+        expect(e).not_to be_a(MCPClient::Errors::ToolCallError)
+        expect(e.protocol_error?).to be(true)
+      end
+    end
+
+    it 'raises InvalidResultError from read_resource for an unknown discriminator' do
+      respond_with('result' => { 'resultType' => 'partial_stream', 'contents' => [] })
+
+      expect { server.read_resource('file:///x') }.to raise_error(MCPClient::Errors::InvalidResultError)
+    end
+
+    it 'raises InvalidResultError for an explicit null resultType' do
+      respond_with('result' => { 'resultType' => nil, 'tools' => [] })
+
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError)
+    end
+
+    it 'raises InvalidResultError for a non-string resultType' do
+      respond_with('result' => { 'resultType' => 42, 'tools' => [] })
+
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError)
+    end
+
+    it 'accepts a complete result' do
+      respond_with('result' => { 'resultType' => 'complete',
+                                 'tools' => [{ 'name' => 't', 'description' => 'd', 'inputSchema' => {} }] })
+
+      expect(server.list_tools.map(&:name)).to eq(['t'])
+    end
+
+    it 'accepts an absent resultType from an established legacy session' do
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      respond_with('result' => { 'tools' => [{ 'name' => 't', 'description' => 'd', 'inputSchema' => {} }] })
+
+      expect(server.list_tools.map(&:name)).to eq(['t'])
+    end
+
+    it 'rejects a non-object result from an established modern session' do
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      respond_with('result' => [])
+
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /object/)
+    end
+  end
+
+  context 'with ServerHTTP (JSON responses)' do
+    let(:server) { MCPClient::ServerHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+    def respond_with(response)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        id = JSON.parse(request.body)['id']
+        { status: 200, body: JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(response)),
+          headers: { 'Content-Type' => 'application/json' } }
+      end
+    end
+
+    include_examples 'validates resultType through public operations'
+  end
+
+  context 'with ServerStreamableHTTP (SSE responses)' do
+    let(:server) { MCPClient::ServerStreamableHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+    def respond_with(response)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        id = JSON.parse(request.body)['id']
+        payload = JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(response))
+        { status: 200, body: "event: message\ndata: #{payload}\n\n",
+          headers: { 'Content-Type' => 'text/event-stream' } }
+      end
+    end
+
+    include_examples 'validates resultType through public operations'
+  end
+end
+
+# --- Finding 4d: an explicit null resultType is invalid in EITHER era -------
+RSpec.describe 'an explicit null resultType is invalid in every protocol era' do
+  let(:transport) do
+    Class.new do
+      include MCPClient::JsonRpcCommon
+
+      attr_accessor :protocol_version
+
+      def initialize
+        @logger = Logger.new(StringIO.new)
+      end
+    end.new
+  end
+
+  [nil, '2025-11-25', '2026-07-28'].each do |version|
+    it "rejects it when the session version is #{version.inspect}" do
+      transport.protocol_version = version
+
+      expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => { 'resultType' => nil } }) }
+        .to raise_error(MCPClient::Errors::InvalidResultError)
+      expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => { 'resultType' => 42 } }) }
+        .to raise_error(MCPClient::Errors::InvalidResultError)
+      expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => { 'resultType' => 'partial' } }) }
+        .to raise_error(MCPClient::Errors::InvalidResultError)
+    end
+  end
+end
+
+# --- Finding 4a: the HTTP wrappers preserve every actionable field ----------
+RSpec.describe 'typed errors keep code, data and HTTP status through the HTTP wrappers' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+  let(:capability_data) { { 'requiredCapabilities' => { 'elicitation' => { 'form' => {} } } } }
+
+  def capability_body
+    JSON.generate('jsonrpc' => '2.0', 'id' => 1,
+                  'error' => { 'code' => -32_021, 'message' => 'Missing required client capability',
+                               'data' => capability_data })
+  end
+
+  [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+    context "with #{klass}" do
+      let(:server) { klass.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+      let(:raise_error_server) do
+        klass.new(base_url: base_url, endpoint: endpoint, retries: 0,
+                  faraday_config: ->(conn) { conn.response :raise_error })
+      end
+
+      before do
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .to_return(status: 400, body: capability_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      def send_request(target)
+        target.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} })
+      end
+
+      it 'preserves code, data and status on the response path' do
+        expect { send_request(server) }
+          .to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+            expect(e.code).to eq(-32_021)
+            expect(e.data).to eq(capability_data)
+            expect(e.required_capabilities).to eq({ 'elicitation' => { 'form' => {} } })
+            expect(e.http_status).to eq(400)
+            expect(e.modern_protocol_error?).to be(true)
+            expect(e.message).to include('400').and include('Missing required client capability')
+          end
+      end
+
+      it 'preserves code, data and status on the raise_error middleware path' do
+        expect { send_request(raise_error_server) }
+          .to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+            expect(e.code).to eq(-32_021)
+            expect(e.data).to eq(capability_data)
+            expect(e.required_capabilities).to eq({ 'elicitation' => { 'form' => {} } })
+            expect(e.http_status).to eq(400)
+            expect(e.modern_protocol_error?).to be(true)
+          end
+      end
+    end
+  end
+
+  def raise_from_body(error)
+    server = MCPClient::ServerHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0)
+    stub_request(:post, "#{base_url}#{endpoint}")
+      .to_return(status: 400, body: JSON.generate('jsonrpc' => '2.0', 'id' => 1, 'error' => error),
+                 headers: { 'Content-Type' => 'application/json' })
+    server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} })
+  end
+
+  it 'does not let the wrapper promote an error with malformed data to a modern one' do
+    expect { raise_from_body('code' => -32_022, 'message' => 'v', 'data' => { 'supported' => ['2026-07-28'] }) }
+      .to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) do |e|
+        expect(e.code).to eq(-32_022)
+        expect(e.supported).to eq(['2026-07-28'])
+        expect(e.http_status).to eq(400)
+        expect(e.modern_protocol_error?).to be(false)
+      end
+  end
+
+  it 'does not let the wrapper promote an error with no JSON-RPC message to a modern one' do
+    expect { raise_from_body('code' => -32_022, 'data' => { 'supported' => ['2026-07-28'], 'requested' => 'x' }) }
+      .to raise_error(MCPClient::Errors::ServerError) do |e|
+        expect(e.class).to eq(MCPClient::Errors::ServerError)
+        expect(e.code).to eq(-32_022)
+        expect(e.data).to eq({ 'supported' => ['2026-07-28'], 'requested' => 'x' })
+        expect(e.http_status).to eq(400)
+        expect(e.modern_protocol_error?).to be(false)
+      end
+  end
+end
+
+# --- Finding 4b: the SSE transport delivers through parser -> waiter --------
+#
+# The response is fed in as a raw SSE chunk, exactly as the stream reader
+# would, and collected by the caller blocked in wait_for_sse_result: nothing
+# is written into @sse_results by hand and no error helper is called directly.
+RSpec.describe 'SSE responses reach the caller through the parser and the pending-request waiter' do
+  let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 2, retries: 0) }
+
+  before do
+    server.instance_variable_set(:@connection_established, true)
+    server.instance_variable_set(:@sse_connected, true)
+    server.instance_variable_set(:@initialized, true)
+    server.instance_variable_set(:@rpc_endpoint, 'https://example.com/messages')
+  end
+
+  # Stand in for the POST leg: the server answers on the SSE stream, so the
+  # raw event chunk is handed to the wire parser while the caller waits.
+  def stream_back(payload)
+    allow(server).to receive(:post_json_rpc_request) do |request|
+      body = JSON.generate({ 'jsonrpc' => '2.0', 'id' => request['id'] }.merge(payload))
+      server.send(:parse_and_handle_sse_event, "event: message\ndata: #{body}\n\n")
+      nil
+    end
+  end
+
+  it 'delivers a typed protocol error with its data to the waiting caller' do
+    stream_back('error' => { 'code' => -32_021, 'message' => 'Missing required client capability',
+                             'data' => { 'requiredCapabilities' => { 'elicitation' => {} } } })
+
+    expect { server.call_tool('t', {}) }
+      .to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+        expect(e.code).to eq(-32_021)
+        expect(e.required_capabilities).to eq({ 'elicitation' => {} })
+        expect(e.modern_protocol_error?).to be(true)
+        expect(e.message).to include('Missing required client capability').and include('-32021')
+      end
+  end
+
+  it 'delivers an unsupported-version error with the versions to retry with' do
+    stream_back('error' => { 'code' => -32_022, 'message' => 'Unsupported protocol version',
+                             'data' => { 'supported' => ['2026-07-28'], 'requested' => '2025-11-25' } })
+
+    expect { server.list_tools }.to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) do |e|
+      expect(e.supported).to eq(['2026-07-28'])
+      expect(e.requested).to eq('2025-11-25')
+      expect(e.modern_protocol_error?).to be(true)
+    end
+  end
+
+  it 'rejects an unrecognized resultType arriving on the stream' do
+    stream_back('result' => { 'resultType' => 'partial_stream', 'tools' => [] })
+
+    expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /partial_stream/)
+  end
+
+  it 'rejects an explicit null resultType arriving on the stream' do
+    stream_back('result' => { 'resultType' => nil, 'content' => [] })
+
+    expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InvalidResultError)
+  end
+
+  it 'passes a complete result through' do
+    stream_back('result' => { 'resultType' => 'complete', 'content' => [{ 'type' => 'text', 'text' => 'ok' }] })
+
+    expect(server.call_tool('t', {})).to eq({ 'resultType' => 'complete',
+                                              'content' => [{ 'type' => 'text', 'text' => 'ok' }] })
+  end
+
+  it 'passes a result with no resultType through (earlier-protocol server)' do
+    stream_back('result' => { 'content' => [{ 'type' => 'text', 'text' => 'ok' }] })
+
+    expect(server.call_tool('t', {})).to eq({ 'content' => [{ 'type' => 'text', 'text' => 'ok' }] })
+  end
+end
+
+# --- Finding 4c: InvalidResultError propagates out of EVERY stdio method ----
+RSpec.describe 'InvalidResultError propagates from every public stdio method' do
+  let(:server) { MCPClient::ServerStdio.new(command: 'echo test') }
+
+  before do
+    server.instance_variable_set(:@initialized, true)
+    server.instance_variable_set(:@capabilities, { 'completions' => {}, 'logging' => {},
+                                                   'resources' => { 'subscribe' => true } })
+    allow(server).to receive(:send_request)
+    allow(server).to receive(:wait_response).and_return(
+      { 'jsonrpc' => '2.0', 'id' => 1, 'result' => { 'resultType' => 'partial_stream', 'tools' => [] } }
+    )
+  end
+
+  it 'never degrades it into a ToolCallError, PromptGetError or ResourceReadError' do
+    [-> { server.call_tool('t', {}) }, -> { server.list_tools }, -> { server.get_prompt('p', {}) },
+     -> { server.list_prompts }, -> { server.list_resources }, -> { server.read_resource('file:///x') },
+     -> { server.list_resource_templates }, -> { server.subscribe_resource('file:///x') },
+     -> { server.unsubscribe_resource('file:///x') },
+     -> { server.complete(ref: { 'type' => 'ref/prompt', 'name' => 'p' }, argument: { 'name' => 'a', 'value' => '' }) },
+     -> { server.log_level = 'debug' }].each do |call|
+      expect(&call).to raise_error(MCPClient::Errors::InvalidResultError, /partial_stream/)
+    end
+  end
+end
+
+# --- Finding 4e: the gzip error body is never fully inflated ----------------
+RSpec.describe 'a gzip HTTP error body is decompressed within the inspection bound' do
+  let(:bound) { MCPClient::JsonRpcCommon::MAX_ERROR_BODY_BYTES }
+  let(:server) { MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/rpc', retries: 0) }
+
+  def gzip(payload)
+    StringIO.new.tap { |io| Zlib::GzipWriter.wrap(io) { |w| w.write(payload) } }.string
+  end
+
+  def stub_gzip_body(payload)
+    stub_request(:post, 'https://example.com/rpc')
+      .to_return(status: 400, body: gzip(payload),
+                 headers: { 'Content-Type' => 'application/json', 'Content-Encoding' => 'gzip' })
+  end
+
+  def send_request
+    server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} })
+  end
+
+  # Record every size argument the production code asks the gzip reader for.
+  # An implementation that inflated the whole body before measuring it would
+  # read with no bound (nil) — which is exactly the mutation this kills.
+  def record_gzip_reads
+    reads = []
+    allow(Zlib::GzipReader).to receive(:new).and_wrap_original do |original, *args|
+      reader = original.call(*args)
+      allow(reader).to receive(:read).and_wrap_original do |original_read, *read_args|
+        reads << read_args.first
+        original_read.call(*read_args)
+      end
+      reader
+    end
+    reads
+  end
+
+  it 'never asks the reader for more than the bound, even for a 4 MiB expansion' do
+    payload = "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32022,\"message\":\"#{'x' * (4 * 1024 * 1024)}\"}}"
+    expect(payload.bytesize).to be > bound
+    stub_gzip_body(payload)
+    reads = record_gzip_reads
+
+    expect { send_request }.to raise_error(MCPClient::Errors::ServerError) { |e| expect(e.code).to be_nil }
+    expect(reads).not_to be_empty
+    expect(reads).to all(be_a(Integer))
+    expect(reads.max).to be <= bound + 1
+  end
+
+  it 'still reads a small gzip error body through the same bounded path' do
+    stub_gzip_body(JSON.generate('jsonrpc' => '2.0', 'id' => 1,
+                                 'error' => { 'code' => -32_022, 'message' => 'v',
+                                              'data' => { 'supported' => ['2026-07-28'],
+                                                          'requested' => '2025-11-25' } }))
+    reads = record_gzip_reads
+
+    expect { send_request }.to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) do |e|
+      expect(e.supported).to eq(['2026-07-28'])
+    end
+    expect(reads).to all(be_a(Integer))
+  end
+end

--- a/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
@@ -977,6 +977,75 @@ RSpec.describe 'two outstanding requests are answered independently and out of o
     { 'resultType' => 'complete', 'tools' => [{ 'name' => 't', 'description' => 'd', 'inputSchema' => {} }] }
   end
 
+  # Leave two requests in flight and take the ids off the send queue.
+  # @return [Hash{String=>Integer}] request id by method
+  def two_outstanding_ids(sent)
+    ids = {}
+    2.times do
+      request = take(sent)
+      ids[request['method']] = request['id']
+    end
+    expect(ids.keys).to contain_exactly('tools/list', 'tools/call')
+    ids
+  end
+
+  shared_examples 'answers each waiter on its own' do
+    it 'gives each waiter its own answer and leaves no pending state behind' do
+      sent = Queue.new
+      intercept_sends(sent)
+
+      listing = Thread.new { server.list_tools }
+      calling = Thread.new do
+        server.call_tool('t', {})
+      rescue MCPClient::Errors::ServerError => e
+        e
+      end
+
+      ids = two_outstanding_ids(sent)
+      answer(ids['tools/call'], 'error' => capability_error)
+      answer(ids['tools/list'], 'result' => tool_listing)
+
+      expect(listing.join(5)).not_to be_nil
+      expect(calling.join(5)).not_to be_nil
+      expect(listing.value.map(&:name)).to eq(['t'])
+      expect(calling.value).to be_a(MCPClient::Errors::MissingRequiredClientCapabilityError)
+      expect(calling.value.required_capabilities).to eq({ 'elicitation' => {} })
+      expect(pending_state.values).to all(be_empty)
+    end
+
+    # The example above answers BOTH requests before joining either thread,
+    # so a waiter that (wrongly) blocked until every outstanding request had
+    # a response would still finish. This one holds the second answer back:
+    # the answered caller must return while the other request is still in
+    # flight, which is the whole point of routing responses by id.
+    it 'completes the answered caller while the other request is still outstanding' do
+      sent = Queue.new
+      intercept_sends(sent)
+
+      listing = Thread.new { server.list_tools }
+      calling = Thread.new do
+        server.call_tool('t', {})
+      rescue MCPClient::Errors::ServerError => e
+        e
+      end
+
+      ids = two_outstanding_ids(sent)
+      answer(ids['tools/call'], 'error' => capability_error)
+
+      # Well inside the 5s read timeout: the answer has to be delivered when
+      # it arrives, not after waiting the other request out.
+      expect(calling.join(2)).not_to be_nil
+      expect(calling.value).to be_a(MCPClient::Errors::MissingRequiredClientCapabilityError)
+      # tools/list has had no answer at all, so its caller is still waiting.
+      expect(listing.join(0.2)).to be_nil
+
+      answer(ids['tools/list'], 'result' => tool_listing)
+      expect(listing.join(5)).not_to be_nil
+      expect(listing.value.map(&:name)).to eq(['t'])
+      expect(pending_state.values).to all(be_empty)
+    end
+  end
+
   context 'with ServerSSE (stream reader -> waiter)' do
     let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 5, retries: 0) }
 
@@ -992,35 +1061,16 @@ RSpec.describe 'two outstanding requests are answered independently and out of o
       server.send(:parse_and_handle_sse_event, "event: message\ndata: #{body}\n\n")
     end
 
-    it 'gives each waiter its own answer and leaves no pending state behind' do
-      sent = Queue.new
-      allow(server).to receive(:post_json_rpc_request) { |request| sent << request and nil }
-
-      listing = Thread.new { server.list_tools }
-      calling = Thread.new do
-        server.call_tool('t', {})
-      rescue MCPClient::Errors::ServerError => e
-        e
-      end
-
-      ids = {}
-      2.times do
-        request = take(sent)
-        ids[request['method']] = request['id']
-      end
-      expect(ids.keys).to contain_exactly('tools/list', 'tools/call')
-
-      answer(ids['tools/call'], 'error' => capability_error)
-      answer(ids['tools/list'], 'result' => tool_listing)
-
-      expect(listing.join(5)).not_to be_nil
-      expect(calling.join(5)).not_to be_nil
-      expect(listing.value.map(&:name)).to eq(['t'])
-      expect(calling.value).to be_a(MCPClient::Errors::MissingRequiredClientCapabilityError)
-      expect(calling.value.required_capabilities).to eq({ 'elicitation' => {} })
-      expect(server.instance_variable_get(:@sse_results)).to be_empty
-      expect(server.instance_variable_get(:@pending_request_ids)).to be_empty
+    def pending_state
+      { results: server.instance_variable_get(:@sse_results),
+        ids: server.instance_variable_get(:@pending_request_ids) }
     end
+
+    def intercept_sends(queue)
+      allow(server).to receive(:post_json_rpc_request) { |request| queue << request and nil }
+    end
+
+    include_examples 'answers each waiter on its own'
   end
 
   context 'with ServerStdio (reader thread -> waiter)' do
@@ -1032,35 +1082,16 @@ RSpec.describe 'two outstanding requests are answered independently and out of o
       server.send(:handle_line, "#{JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(payload))}\n")
     end
 
-    it 'gives each waiter its own answer and leaves no pending state behind' do
-      sent = Queue.new
-      allow(server).to receive(:send_request) { |request| sent << request and nil }
-
-      listing = Thread.new { server.list_tools }
-      calling = Thread.new do
-        server.call_tool('t', {})
-      rescue MCPClient::Errors::ServerError => e
-        e
-      end
-
-      ids = {}
-      2.times do
-        request = take(sent)
-        ids[request['method']] = request['id']
-      end
-      expect(ids.keys).to contain_exactly('tools/list', 'tools/call')
-
-      answer(ids['tools/call'], 'error' => capability_error)
-      answer(ids['tools/list'], 'result' => tool_listing)
-
-      expect(listing.join(5)).not_to be_nil
-      expect(calling.join(5)).not_to be_nil
-      expect(listing.value.map(&:name)).to eq(['t'])
-      expect(calling.value).to be_a(MCPClient::Errors::MissingRequiredClientCapabilityError)
-      expect(calling.value.required_capabilities).to eq({ 'elicitation' => {} })
-      expect(server.instance_variable_get(:@pending)).to be_empty
-      expect(server.instance_variable_get(:@awaiting)).to be_empty
+    def pending_state
+      { pending: server.instance_variable_get(:@pending),
+        awaiting: server.instance_variable_get(:@awaiting) }
     end
+
+    def intercept_sends(queue)
+      allow(server).to receive(:send_request) { |request| queue << request and nil }
+    end
+
+    include_examples 'answers each waiter on its own'
   end
 end
 
@@ -1170,5 +1201,796 @@ RSpec.describe 'resource errors and paginated results off the wire' do
     end
 
     include_examples 'maps wire-level resource errors'
+  end
+end
+
+# --- Round 4, finding A: the optional-feature wrappers keep typed errors ----
+#
+# call_tool, get_prompt and read_resource re-raise a protocol error on every
+# transport; completion/complete and logging/setLevel only did so on stdio.
+# A -32021 is how a server names the capabilities the client omitted, so
+# flattening it into a fresh ServerError (code and data nil) discards the one
+# thing a host could act on. These drive the real transports: HTTP and
+# Streamable HTTP off stubbed HTTP responses, SSE through its stream reader.
+RSpec.describe 'complete and log_level= keep typed protocol errors on every transport' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+  let(:capability_data) { { 'requiredCapabilities' => { 'elicitation' => { 'form' => {} } } } }
+  let(:capability_error) do
+    { 'code' => -32_021, 'message' => 'Missing required client capability', 'data' => capability_data }
+  end
+
+  def request_completion
+    server.complete(ref: { 'type' => 'ref/prompt', 'name' => 'p' }, argument: { 'name' => 'a', 'value' => '' })
+  end
+
+  shared_examples 'never flattens a protocol error out of an optional feature' do
+    it 'keeps the typed -32021 through #complete' do
+      answer_with('error' => capability_error)
+
+      expect { request_completion }.to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+        expect(e.code).to eq(-32_021)
+        expect(e.data).to eq(capability_data)
+        expect(e.required_capabilities).to eq({ 'elicitation' => { 'form' => {} } })
+      end
+    end
+
+    it 'keeps the typed -32021 through #log_level=' do
+      answer_with('error' => capability_error)
+
+      expect { server.log_level = 'debug' }
+        .to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+          expect(e.code).to eq(-32_021)
+          expect(e.required_capabilities).to eq({ 'elicitation' => { 'form' => {} } })
+        end
+    end
+
+    it 'keeps an InvalidResultError through #complete' do
+      answer_with('result' => { 'resultType' => 'partial_stream', 'completion' => { 'values' => [] } })
+
+      expect { request_completion }.to raise_error(MCPClient::Errors::InvalidResultError, /partial_stream/) do |e|
+        expect(e.protocol_error?).to be(true)
+      end
+    end
+
+    it 'keeps an InvalidResultError through #log_level=' do
+      answer_with('result' => { 'resultType' => 'partial_stream' })
+
+      expect { server.log_level = 'debug' }.to raise_error(MCPClient::Errors::InvalidResultError, /partial_stream/)
+    end
+
+    it 'still wraps an ordinary application error from #complete' do
+      answer_with('error' => { 'code' => -32_000, 'message' => 'boom' })
+
+      expect { request_completion }.to raise_error(MCPClient::Errors::ServerError, /Error requesting completion/)
+    end
+
+    it 'still returns the completion of a well-formed answer' do
+      answer_with('result' => { 'resultType' => 'complete', 'completion' => { 'values' => %w[a b] } })
+
+      expect(request_completion).to eq({ 'values' => %w[a b] })
+    end
+  end
+
+  context 'with ServerHTTP (JSON responses)' do
+    let(:server) { MCPClient::ServerHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@capabilities, { 'completions' => {}, 'logging' => {} })
+    end
+
+    def answer_with(payload)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        id = JSON.parse(request.body)['id']
+        { status: payload.key?('error') ? 400 : 200,
+          body: JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(payload)),
+          headers: { 'Content-Type' => 'application/json' } }
+      end
+    end
+
+    include_examples 'never flattens a protocol error out of an optional feature'
+  end
+
+  context 'with ServerStreamableHTTP (SSE responses)' do
+    let(:server) { MCPClient::ServerStreamableHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@capabilities, { 'completions' => {}, 'logging' => {} })
+    end
+
+    def answer_with(payload)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        id = JSON.parse(request.body)['id']
+        body = JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(payload))
+        if payload.key?('error')
+          { status: 400, body: body, headers: { 'Content-Type' => 'application/json' } }
+        else
+          { status: 200, body: "event: message\ndata: #{body}\n\n",
+            headers: { 'Content-Type' => 'text/event-stream' } }
+        end
+      end
+    end
+
+    include_examples 'never flattens a protocol error out of an optional feature'
+  end
+
+  context 'with ServerSSE (stream reader -> waiter)' do
+    let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 5, retries: 0) }
+
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@sse_connected, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@rpc_endpoint, 'https://example.com/messages')
+      server.instance_variable_set(:@capabilities, { 'completions' => {}, 'logging' => {} })
+    end
+
+    # The id is registered before the POST, so answering inside the stubbed
+    # post drives the real parser -> result store -> waiter path.
+    def answer_with(payload)
+      allow(server).to receive(:post_json_rpc_request) do |request|
+        body = JSON.generate({ 'jsonrpc' => '2.0', 'id' => request['id'] }.merge(payload))
+        server.send(:parse_and_handle_sse_event, "event: message\ndata: #{body}\n\n")
+        nil
+      end
+    end
+
+    include_examples 'never flattens a protocol error out of an optional feature'
+  end
+end
+
+# --- Round 4, finding B: 404 + -32601 identifies a modern Streamable server -
+#
+# Streamable HTTP backward compatibility names three answers that mean "this
+# peer is modern, do not fall back to initialize / HTTP+SSE": an unsupported
+# version, a header-validation failure, and an UNKNOWN METHOD returned as
+# HTTP 404 with a JSON-RPC -32601 body. The first two are transport-agnostic
+# reserved codes; the third is not, because on stdio a bare -32601 is exactly
+# what a legacy peer answers a modern probe with. So it needs a predicate of
+# its own rather than a wider code list.
+RSpec.describe 'a modern Streamable HTTP server is also identified by 404 + -32601' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  def error_response(status, error)
+    stub_request(:post, "#{base_url}#{endpoint}")
+      .to_return(status: status, body: JSON.generate('jsonrpc' => '2.0', 'id' => 1, 'error' => error),
+                 headers: { 'Content-Type' => 'application/json' })
+  end
+
+  [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+    context "with #{klass}" do
+      let(:server) { klass.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+      def send_request
+        server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} })
+      end
+
+      it 'recognizes an unknown method answered with 404' do
+        error_response(404, { 'code' => -32_601, 'message' => 'Method not found' })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+          expect(e.modern_http_protocol_error?).to be(true)
+          # Still not a transport-agnostic modern signal: stdio must keep
+          # falling back to initialize when a peer answers -32601.
+          expect(e.modern_protocol_error?).to be(false)
+          # And it is an ordinary application error for wrapping purposes.
+          expect(e.protocol_error?).to be(false)
+        end
+      end
+
+      it 'does not recognize -32601 on any other status' do
+        error_response(400, { 'code' => -32_601, 'message' => 'Method not found' })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+          expect(e.modern_http_protocol_error?).to be(false)
+        end
+      end
+
+      it 'does not recognize a 404 carrying some other code' do
+        error_response(404, { 'code' => -32_603, 'message' => 'Internal error' })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+          expect(e.modern_http_protocol_error?).to be(false)
+        end
+      end
+
+      it 'does not recognize a 404 whose body is not a JSON-RPC error response' do
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .to_return(status: 404, body: '{"error":{"code":-32601,"message":"Method not found"}}',
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::ServerError) do |e|
+          expect(e.code).to be_nil
+          expect(e.modern_http_protocol_error?).to be(false)
+        end
+      end
+
+      it 'still recognizes the reserved codes it recognized before' do
+        error_response(400, { 'code' => -32_020, 'message' => 'Header mismatch' })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::HeaderMismatchError) do |e|
+          expect(e.modern_protocol_error?).to be(true)
+          expect(e.modern_http_protocol_error?).to be(true)
+        end
+      end
+    end
+  end
+
+  it 'is false for a -32601 that never arrived over HTTP (stdio, SSE stream)' do
+    expect(MCPClient::Errors::ServerError.new('Method not found', code: -32_601)
+             .modern_http_protocol_error?).to be(false)
+  end
+end
+
+# --- Round 4, finding C: an SSE result of null or false IS an answer --------
+#
+# The SSE result store keeps whatever `result` member arrived, so a response
+# of `{"result": null}` or `{"result": false}` was stored as nil/false and the
+# waiter's truthiness check could not tell it from "nothing has arrived yet".
+# The caller waited out its whole read timeout and sent a cancellation for a
+# request the server had already answered.
+RSpec.describe 'an SSE response whose result is null or false is delivered, not waited out' do
+  let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 2, retries: 0) }
+
+  before do
+    server.instance_variable_set(:@connection_established, true)
+    server.instance_variable_set(:@sse_connected, true)
+    server.instance_variable_set(:@initialized, true)
+    server.instance_variable_set(:@rpc_endpoint, 'https://example.com/messages')
+  end
+
+  def answer_with(payload)
+    allow(server).to receive(:post_json_rpc_request) do |request|
+      next nil if request['method'] == 'notifications/cancelled'
+
+      body = JSON.generate({ 'jsonrpc' => '2.0', 'id' => request['id'] }.merge(payload))
+      server.send(:parse_and_handle_sse_event, "event: message\ndata: #{body}\n\n")
+      nil
+    end
+  end
+
+  it 'raises the invalid-result error for a null result on a modern session' do
+    server.instance_variable_set(:@protocol_version, '2026-07-28')
+    answer_with('result' => nil)
+
+    expect { server.send(:rpc_request, 'tools/list', {}) }
+      .to raise_error(MCPClient::Errors::InvalidResultError, /object/)
+  end
+
+  it 'raises the invalid-result error for a false result on a modern session' do
+    server.instance_variable_set(:@protocol_version, '2026-07-28')
+    answer_with('result' => false)
+
+    expect { server.send(:rpc_request, 'tools/list', {}) }
+      .to raise_error(MCPClient::Errors::InvalidResultError, /object/)
+  end
+
+  it 'never times out or cancels a request the server already answered' do
+    server.instance_variable_set(:@protocol_version, '2026-07-28')
+    answer_with('result' => nil)
+    cancellations = []
+    allow(server).to receive(:send_cancellation_notification) { |id| cancellations << id }
+
+    started = Time.now
+    expect { server.send(:rpc_request, 'tools/list', {}) }.to raise_error(MCPClient::Errors::InvalidResultError)
+    expect(Time.now - started).to be < 2
+    expect(cancellations).to be_empty
+  end
+
+  it 'delivers a null result to the caller on a legacy session' do
+    server.instance_variable_set(:@protocol_version, '2025-11-25')
+    answer_with('result' => nil)
+
+    expect(server.send(:rpc_request, 'logging/setLevel', {})).to be_nil
+  end
+
+  it 'still waits when nothing has arrived for the request' do
+    allow(server).to receive(:post_json_rpc_request).and_return(nil)
+
+    expect { server.send(:rpc_request, 'tools/list', {}) }
+      .to raise_error(MCPClient::Errors::RequestTimeoutError)
+  end
+end
+
+# --- Round 4, finding D: requiredCapabilities must BE ClientCapabilities ----
+#
+# The schema types -32021's data.requiredCapabilities as ClientCapabilities,
+# whose members are all objects. "Is a Hash" alone let a malformed body
+# ({"elicitation": []}) claim the signal that is supposed to separate a
+# well-formed modern rejection from a legacy peer or an intermediary.
+RSpec.describe 'a -32021 is well formed only when requiredCapabilities is ClientCapabilities' do
+  def build(data)
+    MCPClient::Errors::ServerError.from_jsonrpc(
+      'code' => -32_021, 'message' => 'Missing required client capability', 'data' => data
+    )
+  end
+
+  it 'accepts capability members that are objects' do
+    error = build({ 'requiredCapabilities' => { 'elicitation' => { 'form' => {} }, 'sampling' => {} } })
+
+    expect(error).to be_a(MCPClient::Errors::MissingRequiredClientCapabilityError)
+    expect(error.modern_protocol_error?).to be(true)
+    expect(error.well_formed?).to be(true)
+  end
+
+  it 'accepts an empty capability object' do
+    expect(build({ 'requiredCapabilities' => {} }).modern_protocol_error?).to be(true)
+  end
+
+  it 'rejects a capability member that is an array' do
+    error = build({ 'requiredCapabilities' => { 'elicitation' => [] } })
+
+    expect(error.well_formed?).to be(false)
+    expect(error.modern_protocol_error?).to be(false)
+  end
+
+  it 'rejects a capability member that is a scalar' do
+    expect(build({ 'requiredCapabilities' => { 'elicitation' => true } }).modern_protocol_error?).to be(false)
+    expect(build({ 'requiredCapabilities' => { 'sampling' => 'yes' } }).modern_protocol_error?).to be(false)
+  end
+
+  it 'rejects a capability member that is null' do
+    expect(build({ 'requiredCapabilities' => { 'elicitation' => nil } }).modern_protocol_error?).to be(false)
+  end
+
+  it 'still rejects requiredCapabilities that is not an object at all' do
+    expect(build({ 'requiredCapabilities' => [] }).modern_protocol_error?).to be(false)
+    expect(build({}).modern_protocol_error?).to be(false)
+  end
+
+  it 'keeps the code and data of a malformed one for the caller to inspect' do
+    error = build({ 'requiredCapabilities' => { 'elicitation' => [] } })
+
+    expect(error.code).to eq(-32_021)
+    expect(error.data).to eq({ 'requiredCapabilities' => { 'elicitation' => [] } })
+    # required_capabilities still answers with the object it was handed, so a
+    # host inspecting it sees the peer's claim rather than a silent {}.
+    expect(error.required_capabilities).to eq({ 'elicitation' => [] })
+  end
+end
+
+# --- Round 4, finding E: no wrapper flattens an unfinished result -----------
+#
+# MRTR permits an InputRequiredResult only on tools/call, prompts/get and
+# resources/read. read_resource was pinned in round 3; every other wrapper
+# that projects a field out of the result still turned an unfinished answer
+# into a successful empty one -- an empty tool list, a dropped second page,
+# or an empty completion -- discarding the requestState with it.
+RSpec.describe 'no list or completion wrapper flattens an unfinished result' do
+  let(:incomplete) { { 'resultType' => 'input_required', 'requestState' => 'continue-later' } }
+
+  shared_examples 'surfaces an unfinished list or completion' do
+    it 'raises instead of returning an empty tool list' do
+      answer_with(incomplete)
+
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+        expect(e.data).to eq(incomplete)
+        expect(e).not_to be_a(MCPClient::Errors::ToolCallError)
+      end
+    end
+
+    it 'raises instead of returning an empty prompt list' do
+      answer_with(incomplete)
+
+      expect { server.list_prompts }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+        expect(e.data).to eq(incomplete)
+        expect(e).not_to be_a(MCPClient::Errors::PromptGetError)
+      end
+    end
+
+    it 'raises instead of returning an empty resource list' do
+      answer_with(incomplete)
+
+      expect { server.list_resources }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
+    end
+
+    it 'raises instead of returning an empty resource template list' do
+      answer_with(incomplete)
+
+      expect { server.list_resource_templates }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
+    end
+
+    it 'raises instead of returning an empty completion' do
+      answer_with(incomplete)
+      request = lambda do
+        server.complete(ref: { 'type' => 'ref/prompt', 'name' => 'p' }, argument: { 'name' => 'a', 'value' => '' })
+      end
+
+      expect(&request).to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+        expect(e.data).to eq(incomplete)
+      end
+    end
+  end
+
+  context 'with ServerStdio' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'echo test') }
+
+    before do
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      server.instance_variable_set(:@capabilities, { 'completions' => {}, 'logging' => {} })
+      allow(server).to receive(:send_request)
+    end
+
+    def answer_with(result)
+      allow(server).to receive(:wait_response).and_return({ 'jsonrpc' => '2.0', 'id' => 1, 'result' => result })
+    end
+
+    include_examples 'surfaces an unfinished list or completion'
+  end
+
+  context 'with ServerHTTP (JSON responses)' do
+    let(:server) { MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/rpc', retries: 0) }
+
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      server.instance_variable_set(:@capabilities, { 'completions' => {}, 'logging' => {} })
+    end
+
+    def answer_with(result)
+      stub_request(:post, 'https://example.com/rpc').to_return do |request|
+        id = JSON.parse(request.body)['id']
+        { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result),
+          headers: { 'Content-Type' => 'application/json' } }
+      end
+    end
+
+    include_examples 'surfaces an unfinished list or completion'
+
+    it 'raises instead of silently dropping an unfinished second page' do
+      tool = { 'name' => 't', 'description' => 'd', 'inputSchema' => {} }
+      pages = [{ 'resultType' => 'complete', 'tools' => [tool], 'nextCursor' => 'p2' }, incomplete]
+      stub_request(:post, 'https://example.com/rpc').to_return do |request|
+        id = JSON.parse(request.body)['id']
+        { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => pages.shift),
+          headers: { 'Content-Type' => 'application/json' } }
+      end
+
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
+    end
+  end
+end
+
+# --- Round 4, finding F: final-output validation waits for a finished result
+#
+# A tool declaring an outputSchema must carry structuredContent in a
+# SUCCESSFUL result. An InputRequiredResult is not one: it carries the
+# continuation instead. Running the conformance check on it raised a
+# ValidationError that named the wrong problem and dropped the continuation
+# in :strict mode, and logged a false conformance warning in :warn mode.
+RSpec.describe 'Client#call_tool does not run output validation on an unfinished result' do
+  let(:log_output) { StringIO.new }
+  let(:logger) { Logger.new(log_output) }
+  let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+  let(:tool) do
+    MCPClient::Tool.new(
+      name: 'get_weather', description: 'Get weather data',
+      schema: { 'type' => 'object', 'properties' => {} },
+      output_schema: { 'type' => 'object', 'properties' => { 'temperature' => { 'type' => 'number' } },
+                       'required' => ['temperature'] },
+      server: mock_server
+    )
+  end
+  let(:unfinished) do
+    { 'resultType' => 'input_required', 'requestState' => 'continue-later',
+      'inputRequests' => [{ 'type' => 'elicitation' }] }
+  end
+
+  before do
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+    allow(mock_server).to receive(:on_notification)
+    allow(mock_server).to receive(:list_tools).and_return([tool])
+    allow(mock_server).to receive(:call_tool).and_return(unfinished)
+  end
+
+  def build_client(**opts)
+    MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger, **opts)
+  end
+
+  it 'returns the continuation untouched in :strict mode' do
+    expect(build_client(validate_structured_content: :strict).call_tool('get_weather', {})).to eq(unfinished)
+  end
+
+  it 'logs no conformance warning in :warn mode' do
+    expect(build_client.call_tool('get_weather', {})).to eq(unfinished)
+    expect(log_output.string).not_to include('structuredContent')
+  end
+
+  it 'still validates a completed result' do
+    allow(mock_server).to receive(:call_tool).and_return({ 'resultType' => 'complete', 'content' => [] })
+
+    expect { build_client(validate_structured_content: :strict).call_tool('get_weather', {}) }
+      .to raise_error(MCPClient::Errors::ValidationError, /no structuredContent/)
+  end
+end
+
+# --- Round 4, finding G: an unfinished result off the real HTTP wire --------
+#
+# The round-3 examples stubbed rpc_request on the HTTP transports, so nothing
+# proved those transports ACCEPT an input_required result at all: making them
+# reject every resultType but "complete" left the whole file green. These
+# drive the public operations against stubbed HTTP responses instead, and
+# assert the continuation itself rather than merely that something raised.
+RSpec.describe 'an unfinished result survives the HTTP transports off the wire' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+  let(:unfinished) do
+    { 'resultType' => 'input_required', 'requestState' => 'continue-later',
+      'inputRequests' => [{ 'type' => 'elicitation', 'message' => 'which city?' }] }
+  end
+
+  shared_examples 'accepts and preserves a continuation' do
+    before do
+      server.instance_variable_set(:@connection_established, true)
+      server.instance_variable_set(:@initialized, true)
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+    end
+
+    it 'returns the whole continuation from call_tool' do
+      respond_with('result' => unfinished)
+
+      expect(server.call_tool('t', {})).to eq(unfinished)
+    end
+
+    it 'returns the whole continuation from get_prompt' do
+      respond_with('result' => unfinished)
+
+      expect(server.get_prompt('p', {})).to eq(unfinished)
+    end
+
+    it 'surfaces it from read_resource with the continuation on the error data' do
+      respond_with('result' => unfinished)
+
+      expect { server.read_resource('file:///x') }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+          # Not the "unrecognized resultType" rejection: the transport
+          # accepted the discriminator and the WRAPPER declined to flatten it.
+          expect(e.data).to eq(unfinished)
+          expect(e.data['inputRequests']).to eq([{ 'type' => 'elicitation', 'message' => 'which city?' }])
+        end
+    end
+
+    it 'rejects it on a session that negotiated a handshake revision' do
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      respond_with('result' => unfinished)
+
+      expect { server.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /unrecognized resultType/) do |e|
+          expect(e.data).to be_nil
+        end
+    end
+  end
+
+  context 'with ServerHTTP (JSON responses)' do
+    let(:server) { MCPClient::ServerHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+    def respond_with(response)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        id = JSON.parse(request.body)['id']
+        { status: 200, body: JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(response)),
+          headers: { 'Content-Type' => 'application/json' } }
+      end
+    end
+
+    include_examples 'accepts and preserves a continuation'
+  end
+
+  context 'with ServerStreamableHTTP (SSE responses)' do
+    let(:server) { MCPClient::ServerStreamableHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+    def respond_with(response)
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        id = JSON.parse(request.body)['id']
+        payload = JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(response))
+        { status: 200, body: "event: message\ndata: #{payload}\n\n",
+          headers: { 'Content-Type' => 'text/event-stream' } }
+      end
+    end
+
+    include_examples 'accepts and preserves a continuation'
+  end
+end
+
+# --- Round 4, finding H: SSE resource errors off the real stream ------------
+#
+# The era-aware not-found mapping and the unfinished-read guard were pinned
+# on ServerSSE against a stubbed rpc_request, so a broken SSE error store or
+# result store would not have failed them. These drive the whole path:
+# POST -> registered id -> SSE event -> parser -> result store -> waiter ->
+# wrapper.
+RSpec.describe 'ServerSSE resource errors and unfinished reads off the stream' do
+  let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 5, retries: 0) }
+
+  before do
+    server.instance_variable_set(:@connection_established, true)
+    server.instance_variable_set(:@sse_connected, true)
+    server.instance_variable_set(:@initialized, true)
+    server.instance_variable_set(:@rpc_endpoint, 'https://example.com/messages')
+  end
+
+  def answer_with(payload)
+    allow(server).to receive(:post_json_rpc_request) do |request|
+      body = JSON.generate({ 'jsonrpc' => '2.0', 'id' => request['id'] }.merge(payload))
+      server.send(:parse_and_handle_sse_event, "event: message\ndata: #{body}\n\n")
+      nil
+    end
+  end
+
+  it 'maps -32602 to ResourceNotFound on a modern session' do
+    server.instance_variable_set(:@protocol_version, '2026-07-28')
+    answer_with('error' => { 'code' => -32_602, 'message' => 'Resource not found' })
+
+    expect { server.read_resource('file:///missing') }
+      .to raise_error(MCPClient::Errors::ResourceNotFound, %r{file:///missing})
+  end
+
+  it 'leaves -32602 a generic read error on a handshake-era session' do
+    server.instance_variable_set(:@protocol_version, '2025-11-25')
+    answer_with('error' => { 'code' => -32_602, 'message' => 'Invalid params' })
+
+    expect { server.read_resource('file:///missing') }.to raise_error(MCPClient::Errors::ResourceReadError) do |e|
+      expect(e).not_to be_a(MCPClient::Errors::ResourceNotFound)
+    end
+  end
+
+  %w[2026-07-28 2025-11-25].each do |version|
+    it "still accepts the legacy -32002 as not-found on a #{version} session" do
+      server.instance_variable_set(:@protocol_version, version)
+      answer_with('error' => { 'code' => -32_002, 'message' => 'Resource not found' })
+
+      expect { server.read_resource('file:///missing') }.to raise_error(MCPClient::Errors::ResourceNotFound)
+    end
+  end
+
+  it 'keeps a typed -32021 whole rather than turning it into a read error' do
+    answer_with('error' => { 'code' => -32_021, 'message' => 'Missing capability',
+                             'data' => { 'requiredCapabilities' => { 'elicitation' => {} } } })
+
+    expect { server.read_resource('file:///x') }
+      .to raise_error(MCPClient::Errors::MissingRequiredClientCapabilityError) do |e|
+        expect(e).not_to be_a(MCPClient::Errors::ResourceReadError)
+        expect(e.required_capabilities).to eq({ 'elicitation' => {} })
+      end
+  end
+
+  it 'surfaces an unfinished read with the continuation on the error data' do
+    server.instance_variable_set(:@protocol_version, '2026-07-28')
+    unfinished = { 'resultType' => 'input_required', 'requestState' => 'continue-later' }
+    answer_with('result' => unfinished)
+
+    expect { server.read_resource('file:///x') }
+      .to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
+        expect(e.data).to eq(unfinished)
+      end
+  end
+
+  it 'still returns the contents of a completed read' do
+    answer_with('result' => { 'resultType' => 'complete',
+                              'contents' => [{ 'uri' => 'file:///x', 'text' => 'hi' }] })
+
+    expect(server.read_resource('file:///x').map(&:uri)).to eq(['file:///x'])
+  end
+end
+
+# --- Round 4, finding I: a 4xx other than 400/404 carries the same body -----
+#
+# Streamable HTTP backward compatibility lists 405 next to 400 and 404 as an
+# answer a modern server can give a legacy request. The body parser covers
+# the whole 4xx range; nothing pinned that.
+RSpec.describe 'a JSON-RPC error body is read from any 4xx status' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+    context "with #{klass}" do
+      let(:server) { klass.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+      def send_request
+        server.send(:send_http_request, { 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'x', 'params' => {} })
+      end
+
+      it 'reads a typed -32022 out of a 405' do
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .to_return(status: 405,
+                     body: JSON.generate('jsonrpc' => '2.0', 'id' => 1,
+                                         'error' => { 'code' => -32_022, 'message' => 'Unsupported version',
+                                                      'data' => { 'supported' => ['2026-07-28'],
+                                                                  'requested' => '2025-11-25' } }),
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::UnsupportedProtocolVersionError) do |e|
+          expect(e.supported).to eq(['2026-07-28'])
+          expect(e.http_status).to eq(405)
+          expect(e.modern_protocol_error?).to be(true)
+        end
+      end
+
+      it 'leaves a 5xx a retryable transport failure even with a JSON-RPC body' do
+        stub_request(:post, "#{base_url}#{endpoint}")
+          .to_return(status: 503,
+                     body: JSON.generate('jsonrpc' => '2.0', 'id' => 1,
+                                         'error' => { 'code' => -32_022, 'message' => 'Unsupported version' }),
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect { send_request }.to raise_error(MCPClient::Errors::TransientServerError) do |e|
+          expect(e.modern_protocol_error?).to be(false)
+        end
+      end
+    end
+  end
+end
+
+# --- Round 4, finding J: the HTTP handshake rejects a modern era ------------
+#
+# initialize is a handshake-era method: a server answering it with
+# "2026-07-28" has not negotiated a modern session, it has answered with a
+# version this client cannot speak that way. Only stdio pinned that. On the
+# HTTP transports the connection must also be left unusable and the
+# mandatory initialized notification must never be sent.
+RSpec.describe 'the HTTP handshake refuses an initialize result naming a modern version' do
+  let(:base_url) { 'https://example.com' }
+  let(:endpoint) { '/rpc' }
+
+  shared_examples 'refuses a modern initialize result' do
+    it 'raises, stays disconnected and never sends notifications/initialized' do
+      posted = respond_to_initialize_with('protocolVersion' => '2026-07-28', 'capabilities' => {},
+                                          'serverInfo' => { 'name' => 's', 'version' => '1' })
+
+      expect { server.connect }.to raise_error(MCPClient::Errors::ConnectionError, /2026-07-28/)
+      expect(posted).to eq(['initialize'])
+      expect(server.instance_variable_get(:@initialized)).to be_falsey
+      expect(server.instance_variable_get(:@connection_established)).to be_falsey
+    end
+
+    it 'still completes the handshake for a legacy version' do
+      posted = respond_to_initialize_with('protocolVersion' => '2025-11-25', 'capabilities' => {},
+                                          'serverInfo' => { 'name' => 's', 'version' => '1' })
+
+      expect(server.connect).to be(true)
+      expect(posted).to include('initialize', 'notifications/initialized')
+    end
+  end
+
+  context 'with ServerHTTP (JSON responses)' do
+    let(:server) { MCPClient::ServerHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+    def respond_to_initialize_with(result)
+      posted = []
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        body = JSON.parse(request.body)
+        posted << body['method']
+        { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'], 'result' => result),
+          headers: { 'Content-Type' => 'application/json' } }
+      end
+      posted
+    end
+
+    include_examples 'refuses a modern initialize result'
+  end
+
+  context 'with ServerStreamableHTTP (SSE responses)' do
+    let(:server) { MCPClient::ServerStreamableHTTP.new(base_url: base_url, endpoint: endpoint, retries: 0) }
+
+    def respond_to_initialize_with(result)
+      posted = []
+      stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
+        body = JSON.parse(request.body)
+        posted << body['method']
+        payload = JSON.generate('jsonrpc' => '2.0', 'id' => body['id'], 'result' => result)
+        { status: 200, body: "event: message\ndata: #{payload}\n\n",
+          headers: { 'Content-Type' => 'text/event-stream' } }
+      end
+      posted
+    end
+
+    include_examples 'refuses a modern initialize result'
   end
 end

--- a/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
@@ -257,7 +257,10 @@ RSpec.describe 'modern protocol error recognition matches the schema wire shape'
     end
   end
 
-  describe 'the legacy fallback a malformed error must not suppress' do
+  # The predicate alone: the transport that consults it to decide between a
+  # modern verdict and the legacy handshake is the Streamable HTTP branch's,
+  # and its examples drive the wire sequence.
+  describe 'the modern-server signal a malformed error must not raise' do
     it 'leaves a malformed -32022 out of the modern-server signal' do
       malformed = unsupported({ 'supported' => [42] })
       well_formed = unsupported({ 'supported' => ['2026-07-28'], 'requested' => 'x' })

--- a/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
@@ -1681,7 +1681,7 @@ RSpec.describe 'Client#call_tool does not run output validation on an unfinished
   end
   let(:unfinished) do
     { 'resultType' => 'input_required', 'requestState' => 'continue-later',
-      'inputRequests' => [{ 'type' => 'elicitation' }] }
+      'inputRequests' => { 'city' => { 'type' => 'elicitation', 'mode' => 'form', 'message' => 'which city?' } } }
   end
 
   before do
@@ -1722,9 +1722,10 @@ end
 RSpec.describe 'an unfinished result survives the HTTP transports off the wire' do
   let(:base_url) { 'https://example.com' }
   let(:endpoint) { '/rpc' }
+  # The schema's InputRequests wire shape: a map from identifier to request.
   let(:unfinished) do
     { 'resultType' => 'input_required', 'requestState' => 'continue-later',
-      'inputRequests' => [{ 'type' => 'elicitation', 'message' => 'which city?' }] }
+      'inputRequests' => { 'city' => { 'type' => 'elicitation', 'mode' => 'form', 'message' => 'which city?' } } }
   end
 
   shared_examples 'accepts and preserves a continuation' do
@@ -1754,7 +1755,8 @@ RSpec.describe 'an unfinished result survives the HTTP transports off the wire' 
           # Not the "unrecognized resultType" rejection: the transport
           # accepted the discriminator and the WRAPPER declined to flatten it.
           expect(e.data).to eq(unfinished)
-          expect(e.data['inputRequests']).to eq([{ 'type' => 'elicitation', 'message' => 'which city?' }])
+          expect(e.data['inputRequests'])
+            .to eq({ 'city' => { 'type' => 'elicitation', 'mode' => 'form', 'message' => 'which city?' } })
         end
     end
 

--- a/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
@@ -1722,10 +1722,15 @@ end
 RSpec.describe 'an unfinished result survives the HTTP transports off the wire' do
   let(:base_url) { 'https://example.com' }
   let(:endpoint) { '/rpc' }
-  # The schema's InputRequests wire shape: a map from identifier to request.
+  # The schema's InputRequests wire shape: a map from server-assigned key to
+  # a request object (here an ElicitRequest).
+  let(:city_request) do
+    { 'method' => 'elicitation/create',
+      'params' => { 'mode' => 'form', 'message' => 'which city?', 'requestedSchema' => { 'type' => 'object' } } }
+  end
   let(:unfinished) do
     { 'resultType' => 'input_required', 'requestState' => 'continue-later',
-      'inputRequests' => { 'city' => { 'type' => 'elicitation', 'mode' => 'form', 'message' => 'which city?' } } }
+      'inputRequests' => { 'city' => city_request } }
   end
 
   shared_examples 'accepts and preserves a continuation' do
@@ -1755,9 +1760,15 @@ RSpec.describe 'an unfinished result survives the HTTP transports off the wire' 
           # Not the "unrecognized resultType" rejection: the transport
           # accepted the discriminator and the WRAPPER declined to flatten it.
           expect(e.data).to eq(unfinished)
-          expect(e.data['inputRequests'])
-            .to eq({ 'city' => { 'type' => 'elicitation', 'mode' => 'form', 'message' => 'which city?' } })
+          expect(e.data['inputRequests']).to eq({ 'city' => city_request })
         end
+    end
+
+    it 'keeps a continuation that carries inputRequests without requestState' do
+      stateless = unfinished.except('requestState')
+      respond_with('result' => stateless)
+
+      expect(server.call_tool('t', {})).to eq(stateless)
     end
 
     it 'rejects it on a session that negotiated a handshake revision' do

--- a/spec/lib/mcp_client/server_sse/json_rpc_transport_spec.rb
+++ b/spec/lib/mcp_client/server_sse/json_rpc_transport_spec.rb
@@ -116,10 +116,20 @@ RSpec.describe MCPClient::ServerSSE::JsonRpcTransport do
       expect(transport.instance_variable_get(:@sse_results)).to be_empty
     end
 
-    it 'returns nil when no result' do
+    it 'returns the no-result sentinel when nothing has arrived' do
       transport.instance_variable_set(:@mutex, Mutex.new)
       transport.instance_variable_set(:@sse_results, {})
-      expect(transport.send(:check_for_result, 2)).to be_nil
+      expect(transport.send(:check_for_result, 2))
+        .to be(MCPClient::ServerSSE::JsonRpcTransport::NO_RESULT)
+    end
+
+    it 'distinguishes a stored nil result from nothing having arrived' do
+      # A JSON-RPC `result: null` is an answer; reading it as "still
+      # outstanding" made the caller wait out its whole read timeout.
+      transport.instance_variable_set(:@mutex, Mutex.new)
+      transport.instance_variable_set(:@sse_results, { 3 => nil })
+      expect(transport.send(:check_for_result, 3)).to be_nil
+      expect(transport.instance_variable_get(:@sse_results)).to be_empty
     end
   end
 end


### PR DESCRIPTION
## Summary

First of a stacked series implementing the [MCP 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/changelog) revision. This PR lays the base-protocol groundwork the later feature PRs build on; nothing changes on the wire yet.

- **Version constants** — `LATEST_PROTOCOL_VERSION` (`2026-07-28`), `MODERN_PROTOCOL_VERSIONS`, `LEGACY_PROTOCOL_VERSIONS`; `SUPPORTED_PROTOCOL_VERSIONS` is their union. `PROTOCOL_VERSION` stays `2025-11-25` (the legacy `initialize` request version), and `initialize` now only accepts a *legacy* negotiated version.
- **Error-code allocation policy** (basic/index "Error Codes") — `Errors::Codes` constants; `ServerError` gains `code`/`data` (backward-compatible ctor); `ServerError.from_jsonrpc` builds the typed `HeaderMismatchError` (-32020), `MissingRequiredClientCapabilityError` (-32021, `#required_capabilities`) and `UnsupportedProtocolVersionError` (-32022, `#supported`/`#requested`). All four transports raise them; stdio now routes every response through `process_jsonrpc_response` so codes are never dropped.
- **`resultType`** — absent ⇒ `"complete"` (earlier-protocol servers), `"input_required"` passes through (handled by the MRTR PR), anything unrecognized raises `InvalidResultError` (a non-retried `ServerError`). Transports can widen the accepted set via `accepted_result_types` (used by the tasks extension PR).
- **Resource not found** — `resources/read` errors with `-32602` (or legacy `-32002`) raise `ResourceNotFound` on every transport.

## Spec references

- basic/index: Result responses / ResultType, Error Codes
- basic/versioning: terminology (modern vs legacy)
- server/resources: Error Handling (-32602, accept -32002)

## Test plan

- [x] `bundle exec rspec` — 1701 examples, 0 failures (44 new)
- [x] `bundle exec rubocop` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoErzDypnq7hhuFBtueML7