### PR TITLE
MCP 2026-07-28 (5/11): multi round-trip requests — InputRequiredResult, inputResponses, requestState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@
 Groundwork for the 2026-07-28 protocol revision (stateless, per-request
 metadata). Each feature lands in its own PR; this section accumulates them.
 
+### Multi round-trip requests (InputRequiredResult)
+
+- **Server-to-client interactions on modern servers.** `tools/call`,
+  `resources/read` and `prompts/get` may now be answered with
+  `resultType: "input_required"`. The client fulfils every entry of
+  `inputRequests` through the handlers it already has — `elicitation/create`
+  via the elicitation handler, `sampling/createMessage` via the sampling
+  handler, `roots/list` from the client's roots — and retries the original
+  request as a new request (new id, same params) carrying `inputResponses`
+  keyed like the requests and the opaque `requestState` echoed verbatim
+  (omitted when the server sent none). A result without `inputRequests` is
+  retried immediately; the round trip never leaks into other requests.
+- **Capabilities.** Modern requests once again declare `elicitation`
+  (`form` and `url`), `roots` (without `listChanged`) and `sampling` (with
+  `tools` when opted in) when the corresponding handler is registered.
+- **Limits and errors.** More than 10 consecutive `input_required` answers,
+  an input request this client cannot honour (unknown method, no handler,
+  handler error) or a malformed `inputRequests` raise
+  `MCPClient::Errors::InputRequiredError` (exposing `input_requests` and
+  `request_state`) without a retry; `input_required` on any other method is
+  an `InvalidResultError`.
+
 ### Custom headers from tool parameters (`x-mcp-header`)
 
 - **`Mcp-Param-{name}` headers.** On a modern Streamable HTTP (or plain HTTP)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 - **Capabilities.** Modern requests once again declare `elicitation`
   (`form` and `url`), `roots` (without `listChanged`) and `sampling` (with
   `tools` when opted in) when the corresponding handler is registered.
+- **Recovery keeps the round trip.** Transport-level recovery of an attempt
+  (retries, version renegotiation, the HeaderMismatch refresh, a re-issued
+  stream) re-sends the attempt's own `inputResponses`/`requestState`. An
+  answer that carries only `requestState` (an out-of-band interaction still
+  in progress) is retried with a growing pause (0.5 s doubling to 5 s) rather
+  than in a tight loop. The plain HTTP transport now accepts the elicitation,
+  roots and sampling handlers so `MCPClient::Client` can serve round trips on
+  it too.
 - **Limits and errors.** More than 10 consecutive `input_required` answers,
   an input request this client cannot honour (unknown method, no handler,
   handler error) or a malformed `inputRequests` raise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   request as a new request (new id, same params) carrying `inputResponses`
   keyed like the requests and the opaque `requestState` echoed verbatim
   (omitted when the server sent none). A result without `inputRequests` is
-  retried immediately; the round trip never leaks into other requests.
+  retried after a short pause (see below); the round trip never leaks into
+  other requests, and every attempt is rebuilt from the caller's own params,
+  so a continuation field the server stops sending is dropped.
 - **Capabilities.** Modern requests once again declare `elicitation`
   (`form` and `url`), `roots` (without `listChanged`) and `sampling` (with
   `tools` when opted in) when the corresponding handler is registered. Only
@@ -43,7 +45,11 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   handler error) or a malformed `inputRequests` raise
   `MCPClient::Errors::InputRequiredError` (exposing `input_requests` and
   `request_state`) without a retry; `input_required` on any other method is
-  an `InvalidResultError`.
+  an `InvalidResultError`. `server/discover` is not one of the three methods
+  that may be answered with `input_required` either: such an answer is
+  refused before any protocol version or capability it carries is applied or
+  cached, so a probe can never adopt a version out of an unfinished result
+  and hand that result back as the first heartbeat.
 
 ### Custom headers from tool parameters (`x-mcp-header`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,17 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   retried immediately; the round trip never leaks into other requests.
 - **Capabilities.** Modern requests once again declare `elicitation`
   (`form` and `url`), `roots` (without `listChanged`) and `sampling` (with
-  `tools` when opted in) when the corresponding handler is registered.
+  `tools` when opted in) when the corresponding handler is registered. Only
+  declared capabilities are used: a `sampling/createMessage` input request
+  carrying `tools` or `toolChoice` fails the round trip (the sampler is never
+  invoked) unless the host opted into `sampling.tools`, and
+  `notifications/roots/list_changed` is sent only to a session that declared
+  `roots` — registering the plain HTTP handlers, which serve the modern round
+  trips, does not make a legacy plain HTTP session a recipient.
+- **URL-mode elicitation answers keep `_meta`.** An ElicitResult carries
+  `_meta` in every mode; a URL-mode answer now passes the handler's `_meta`
+  through (on both the round-trip and the legacy server-request path) while
+  `content`, which is form-mode only, is still stripped.
 - **Recovery keeps the round trip.** Transport-level recovery of an attempt
   (retries, version renegotiation, the HeaderMismatch refresh, a re-issued
   stream) re-sends the attempt's own `inputResponses`/`requestState`. An

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,29 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   than in a tight loop. The plain HTTP transport now accepts the elicitation,
   roots and sampling handlers so `MCPClient::Client` can serve round trips on
   it too.
+- **The out-of-band wait is the host's to steer.** Clients SHOULD provide
+  manual controls that let the user retry or cancel a request waiting on an
+  out-of-band interaction (client/elicitation "URL Mode"). Before each paced
+  retry of an answer that carries only `requestState` the transport calls the
+  block registered with `on_input_required_wait` (on a transport or on
+  `MCPClient::Client`, for every server) with an `InputRequiredWait` — the
+  method, the round trip, the pause, the `requestState`, the result and the
+  seconds waited — and the block answers `:retry` (retry now), `:cancel`
+  (stop) or anything else (wait the pace). A wait never runs past the
+  request's own timeout either. Every `InputRequiredError` the round trip
+  raises — cancelled, timed out, unfulfillable, over the round-trip ceiling —
+  carries the continuation (`request_method`, `request_params`, `transport`,
+  `resumable?`), and `resume_input_required(error)` (transport or Client)
+  re-issues the original request with the `requestState` echoed and no
+  `inputResponses`, continuing the round trip from where it stopped.
+- **Sampling histories are validated before they reach the host.** Both
+  parties SHOULD validate sampling message content (client/sampling
+  "Security Considerations"): a message without a `"user"`/`"assistant"`
+  role or without content, a user message mixing tool results with other
+  content, and an assistant tool use not answered by the user message that
+  follows it are refused with
+  `-32602` on a 2025-11-25 session and fail the round trip locally on a
+  2026-07-28 one, and the host's sampler is never invoked for them.
 - **Limits and errors.** More than 10 consecutive `input_required` answers,
   an input request this client cannot honour (unknown method, no handler,
   handler error) or a malformed `inputRequests` raise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,10 +59,26 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   parties SHOULD validate sampling message content (client/sampling
   "Security Considerations"): a message without a `"user"`/`"assistant"`
   role or without content, a user message mixing tool results with other
-  content, and an assistant tool use not answered by the user message that
-  follows it are refused with
+  content, an assistant tool use not answered by the user message that
+  follows it (the last message included), and a content block of a known
+  type without the fields that type needs — a `text` block with no text, an
+  `image` or `audio` block with no data or mimeType, a `tool_use` with no
+  `id`, a `tool_result` with no `toolUseId` — are refused with
   `-32602` on a 2025-11-25 session and fail the round trip locally on a
-  2026-07-28 one, and the host's sampler is never invoked for them.
+  2026-07-28 one, and the host's sampler is never invoked for them. Two
+  identifiers that are merely absent no longer correlate a use with a
+  result. A block of a type this client does not know is passed through: the
+  content types are an open set, and refusing one would break a session with
+  a server using a type added after this release. The refusal names the
+  block's type, never its content.
+- **An out-of-band wait is bounded by the timeout its request runs under.**
+  A call that named no `timeout:` still runs under the transport's
+  configured `read_timeout`, and that now bounds its waits as an explicit
+  timeout does; the time the host's own `on_input_required_wait` control
+  spends deciding counts against the bound, so a control that deliberates
+  for most of the timeout can no longer buy a full pause and another request
+  on top of it. A transport that configures no read timeout is unbounded as
+  before, with the round-trip ceiling as its only limit.
 - **Limits and errors.** More than 10 consecutive `input_required` answers,
   an input request this client cannot honour (unknown method, no handler,
   handler error) or a malformed `inputRequests` raise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,24 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   that may be answered with `input_required` either: such an answer is
   refused before any protocol version or capability it carries is applied or
   cached, so a probe can never adopt a version out of an unfinished result
-  and hand that result back as the first heartbeat.
+  and hand that result back as the first heartbeat. Because `resultType`
+  exists only in 2026-07-28, that refusal settles the era: it raises
+  `MCPClient::Errors::ModernServerError`, so neither the probe's `initialize`
+  fallback nor `MCPClient.connect`'s legacy SSE/HTTP+POST fallbacks are tried
+  against a server that answered `server/discover` — whether or not the
+  unfinished answer also carried a `supportedVersions` list.
+- **Round trips survive the transports they run on.** The keys of an
+  `InputRequiredResult` are read in the protocol's own spelling however the
+  host's JSON middleware parsed them, so a symbolizing response parser cannot
+  make `inputRequests`/`requestState` invisible and produce a retry that
+  fulfils nothing. On stdio, a subprocess that exits between two rounds (a
+  handler waiting for a person takes as long as it takes) is restarted for
+  the continuation rather than written to as a dead pipe.
+- **Elicitation actions.** `ElicitResult.action` is `accept`, `decline` or
+  `cancel`; a handler that answers with anything else is now taken as `cancel`
+  (consent is explicit) instead of having its answer rewritten to `accept`. A
+  handler that returns bare content and no action at all is unchanged: that is
+  still an `accept` carrying the content.
 
 ### Custom headers from tool parameters (`x-mcp-header`)
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,10 @@ Sampling tool calling (SEP-1577) is opt-in: pass `sampling_supports_tools: true`
 to declare the `sampling.tools` capability. The handler then receives the full
 request params (including `tools`/`toolChoice`) as an optional fifth argument;
 without the opt-in, tool-enabled sampling requests are rejected with `-32602`
-as the spec requires:
+as the spec requires. On a 2026-07-28 server, where sampling arrives as an
+input request inside a multi round-trip answer and `inputResponses` has no
+per-request error channel, the same rejection fails the whole round trip with
+`MCPClient::Errors::InputRequiredError` and the handler is never invoked:
 
 ```ruby
 client = MCPClient::Client.new(
@@ -301,7 +304,11 @@ that negotiated the corresponding capability; otherwise
 capabilities that were not negotiated). `Client#log_level=` skips
 non-logging servers instead of failing. Declared *client* capabilities are
 derived from what the host actually registered (handlers, roots), never
-hardcoded.
+hardcoded — and they gate the client's own traffic too:
+`notifications/roots/list_changed` goes only to a session that declared
+`roots` (never to a 2026-07-28 server, which removed the notification, and
+never to plain HTTP on a legacy session, which has no server-request channel
+to serve roots on).
 
 ### Completion (Autocomplete)
 
@@ -384,6 +391,13 @@ client = MCPClient::Client.new(
   }
 )
 ```
+
+In URL mode the handler's second argument is
+`{ 'mode' => 'url', 'url' => ..., 'elicitationId' => ... }` and its answer is
+consent, not data: only an explicit `action` of `accept`, `decline` or `cancel`
+(or a literal `true` for accept) counts — anything else is answered `cancel`.
+`content` is dropped, since it is form-mode only, while a handler-supplied
+`_meta` is passed through.
 
 ## Advanced Configuration
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,38 @@ client = MCPClient.connect('http://server/mcp',
 )
 ```
 
+Sampling histories are checked before the handler runs (MCP 2026-07-28
+client/sampling: both parties SHOULD validate message content): every message
+needs a `"user"`/`"assistant"` role and content, a user message holding tool
+results holds nothing else, and each assistant tool use is answered by the user
+message that follows it. A malformed history is refused with `-32602` (or fails
+the multi round-trip locally on a 2026-07-28 server) and the handler is not
+invoked.
+
+A multi round-trip request may wait on an interaction that happens out of band
+(a URL-mode elicitation): the server keeps answering with only a
+`requestState`, and the client retries with a growing pause. The host steers
+that wait, and can resume a request it stopped:
+
+```ruby
+client.on_input_required_wait do |wait|
+  # wait.rpc_method, wait.round_trip, wait.delay, wait.request_state,
+  # wait.result, wait.elapsed
+  :cancel if user_pressed_cancel?   # :retry retries now; anything else waits the pace
+end
+
+begin
+  client.call_tool('checkout', { 'cart' => cart })
+rescue MCPClient::Errors::InputRequiredError => e
+  # e.resumable? — the continuation (e.request_method, e.request_params,
+  # e.request_state) is carried by every error the round trip raises
+  client.resume_input_required(e) if e.resumable? && user_pressed_retry?
+end
+```
+
+A wait never runs past the request's own timeout either; the error it raises
+then is resumable in the same way.
+
 Sampling tool calling (SEP-1577) is opt-in: pass `sampling_supports_tools: true`
 to declare the `sampling.tools` capability. The handler then receives the full
 request params (including `tools`/`toolChoice`) as an optional fifth argument;

--- a/README.md
+++ b/README.md
@@ -257,8 +257,10 @@ rescue MCPClient::Errors::InputRequiredError => e
 end
 ```
 
-A wait never runs past the request's own timeout either; the error it raises
-then is resumable in the same way.
+A wait never runs past the timeout the request runs under either — the one
+given to the call, or the transport's configured `read_timeout` when the call
+named none — and the time your own control spends deciding counts against it.
+The error it raises then is resumable in the same way.
 
 Sampling tool calling (SEP-1577) is opt-in: pass `sampling_supports_tools: true`
 to declare the `sampling.tools` capability. The handler then receives the full

--- a/README.md
+++ b/README.md
@@ -392,6 +392,11 @@ client = MCPClient::Client.new(
 )
 ```
 
+In form mode the handler may return the content on its own (`{ 'field' =>
+'value' }`), which is sent as an `accept`. An explicit `action` must be one of
+`accept`, `decline` or `cancel` — any other value is answered `cancel`, since
+it is not consent the user gave.
+
 In URL mode the handler's second argument is
 `{ 'mode' => 'url', 'url' => ..., 'elicitationId' => ... }` and its answer is
 consent, not data: only an explicit `action` of `accept`, `decline` or `cancel`

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -427,6 +427,34 @@ module MCPClient
       @notification_listeners << block
     end
 
+    # Register the host's control over a multi round-trip request's
+    # out-of-band wait on every server (MCP 2026-07-28 client/elicitation
+    # "URL Mode": manual retry/cancel controls). See
+    # {MCPClient::JsonRpcCommon#on_input_required_wait} for the contract.
+    # @param block [Proc] callback that receives an InputRequiredWait
+    # @return [void]
+    def on_input_required_wait(&block)
+      @input_required_wait_handler = block
+      @servers.each do |server|
+        server.on_input_required_wait(&block) if server.respond_to?(:on_input_required_wait)
+      end
+    end
+
+    # Resume a multi round-trip request from the continuation an
+    # {MCPClient::Errors::InputRequiredError} carries, on the transport that
+    # raised it. The result is the transport's, as {#call_tool} would have
+    # returned it before validation.
+    # @param error [MCPClient::Errors::InputRequiredError] a resumable error
+    # @param timeout [Numeric, nil] per-request timeout for the resumed request
+    # @return [Object] the final (complete) result
+    # @raise [ArgumentError] if the error carries no continuation or names no transport
+    def resume_input_required(error, timeout: nil)
+      transport = error.respond_to?(:transport) ? error.transport : nil
+      raise ArgumentError, 'the error names no transport to resume on' unless transport
+
+      transport.resume_input_required(error, timeout: timeout)
+    end
+
     # Set the roots for this client (MCP 2025-06-18)
     # When roots are changed, a notification is sent to all connected servers
     # @param new_roots [Array<MCPClient::Root, Hash>] the new roots to set
@@ -1624,6 +1652,15 @@ module MCPClient
       end
 
       messages = params['messages'] || []
+      # Both parties SHOULD validate message content (sampling.mdx
+      # "Security Considerations"): the role, the content, a user message of
+      # tool results carrying nothing else, and every assistant tool use
+      # answered by the message that follows it.
+      if (problem = sampling_history_problem(messages))
+        @logger.warn("Rejecting sampling request with a malformed history: #{problem}")
+        return jsonrpc_error_result(-32_602, "Invalid params: #{problem}")
+      end
+
       model_preferences = normalize_model_preferences(params['modelPreferences'])
       system_prompt = params['systemPrompt']
       max_tokens = params['maxTokens']
@@ -1644,6 +1681,91 @@ module MCPClient
         # and stays in the local log rather than crossing to the server.
         jsonrpc_error_result(-32_603, 'Sampling error')
       end
+    end
+
+    # What is wrong with a sampling history, if anything, by the rules of
+    # MCP 2026-07-28 client/sampling: every message has a role of "user" or
+    # "assistant" and content; a user message containing tool results
+    # contains only tool results; every assistant message with tool uses is
+    # followed by a user message consisting entirely of the matching tool
+    # results before any other message.
+    # @param messages [Array<Hash>] the sampling messages
+    # @return [String, nil] the problem, nil when the history is well formed
+    def sampling_history_problem(messages)
+      return 'messages must be an array' unless messages.is_a?(Array)
+
+      pending = nil
+      messages.each_with_index do |message, index|
+        problem, pending = sampling_message_problem(message, index, pending)
+        return problem if problem
+      end
+      return "the last message leaves its tool uses (#{pending.join(', ')}) unanswered" if pending
+
+      nil
+    end
+
+    # @param message [Object] a sampling message
+    # @param index [Integer] its position
+    # @param pending [Array<String>, nil] the tool use ids the previous message left to answer
+    # @return [Array(String, nil), Array(nil, Array<String>)] the problem, or the tool uses now pending
+    def sampling_message_problem(message, index, pending)
+      blocks = sampling_message_blocks(message)
+      unless blocks
+        return ["message #{index} must be an object with a role of \"user\" or \"assistant\" and content", nil]
+      end
+
+      role = message['role'] || message[:role]
+      uses = blocks.select { |block| sampling_block_type(block) == 'tool_use' }
+      results = blocks.select { |block| sampling_block_type(block) == 'tool_result' }
+      return ["message #{index} carries tool uses in a #{role} message", nil] if uses.any? && role != 'assistant'
+
+      if pending
+        problem = sampling_tool_results_problem(index, role, blocks, results, pending)
+        return [problem, nil] if problem
+      elsif results.any? && results.size != blocks.size
+        # The spec forbids the mixing, not a results-only message on its own:
+        # a server may hand over the results without the history before them.
+        return ["message #{index} mixes tool results with other content", nil]
+      end
+      [nil, (uses.map { |block| (block['id'] || block[:id]).to_s } if uses.any?)]
+    end
+
+    # @param index [Integer] the position of the message answering the tool uses
+    # @param role [String] its role
+    # @param blocks [Array<Hash>] its content blocks
+    # @param results [Array<Hash>] the tool results among them
+    # @param pending [Array<String>] the tool use ids to answer
+    # @return [String, nil] the problem, nil when the message answers exactly those uses
+    def sampling_tool_results_problem(index, role, blocks, results, pending)
+      unless role == 'user' && results.size == blocks.size
+        return "message #{index} must consist only of the tool results answering message #{index - 1}"
+      end
+
+      ids = results.map { |block| (block['toolUseId'] || block[:toolUseId]).to_s }
+      return nil if ids.sort == pending.sort
+
+      "message #{index} tool results do not match the tool uses of message #{index - 1}"
+    end
+
+    # @param message [Object] a sampling message
+    # @return [Array<Hash>, nil] its content blocks, nil unless the message is well formed
+    def sampling_message_blocks(message)
+      return nil unless message.is_a?(Hash) && %w[user assistant].include?(message['role'] || message[:role])
+
+      blocks = message['content'] || message[:content]
+      blocks = [blocks] if blocks.is_a?(Hash)
+      return nil unless blocks.is_a?(Array) && !blocks.empty? && blocks.all? { |block| sampling_block_type(block) }
+
+      blocks
+    end
+
+    # @param block [Object] a content block
+    # @return [String, nil] its type, nil unless it is an object with a String type
+    def sampling_block_type(block)
+      return nil unless block.is_a?(Hash)
+
+      type = block['type'] || block[:type]
+      type.is_a?(String) ? type : nil
     end
 
     # Call sampling handler with appropriate arity

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1710,9 +1710,7 @@ module MCPClient
     # @return [Array(String, nil), Array(nil, Array<String>)] the problem, or the tool uses now pending
     def sampling_message_problem(message, index, pending)
       blocks = sampling_message_blocks(message)
-      unless blocks
-        return ["message #{index} must be an object with a role of \"user\" or \"assistant\" and content", nil]
-      end
+      return [sampling_shape_problem(message, index), nil] unless blocks
 
       role = message['role'] || message[:role]
       uses = blocks.select { |block| sampling_block_type(block) == 'tool_use' }
@@ -1747,6 +1745,25 @@ module MCPClient
       "message #{index} tool results do not match the tool uses of message #{index - 1}"
     end
 
+    # Which half of the message's shape is wrong, so the host is told what to
+    # look at: the envelope, or a content block that carries no meaning.
+    # @param message [Object] a sampling message
+    # @param index [Integer] its position
+    # @return [String] the problem
+    def sampling_shape_problem(message, index)
+      blocks = message.is_a?(Hash) ? (message['content'] || message[:content]) : nil
+      blocks = [blocks] if blocks.is_a?(Hash)
+      if blocks.is_a?(Array)
+        bad = blocks.find { |block| !sampling_block_well_formed?(block) }
+        if bad
+          type = sampling_block_type(bad)
+          named = type ? "a #{type.inspect} content block" : 'a content block'
+          return "message #{index} carries #{named} without the fields its type requires"
+        end
+      end
+      "message #{index} must be an object with a role of \"user\" or \"assistant\" and content"
+    end
+
     # @param message [Object] a sampling message
     # @return [Array<Hash>, nil] its content blocks, nil unless the message is well formed
     def sampling_message_blocks(message)
@@ -1754,9 +1771,40 @@ module MCPClient
 
       blocks = message['content'] || message[:content]
       blocks = [blocks] if blocks.is_a?(Hash)
-      return nil unless blocks.is_a?(Array) && !blocks.empty? && blocks.all? { |block| sampling_block_type(block) }
+      return nil unless blocks.is_a?(Array) && !blocks.empty?
+      return nil unless blocks.all? { |block| sampling_block_well_formed?(block) }
 
       blocks
+    end
+
+    # The fields a content block of a known type must carry for the message
+    # rules to mean anything: the text of a text block, the payload of an
+    # image or audio block, and — the reason the correlation rules can be
+    # checked at all — the identifier of a tool use and of the tool result
+    # answering it. A type this client does not know is the host's to read,
+    # not this client's to refuse: refusing it would break a session with a
+    # server using a content type added after this release.
+    # @param block [Object] a content block
+    # @return [Boolean] whether the block can be handed to the host
+    def sampling_block_well_formed?(block)
+      type = sampling_block_type(block)
+      return false unless type
+
+      case type
+      when 'text' then sampling_block_string?(block, 'text')
+      when 'image', 'audio' then sampling_block_string?(block, 'data') && sampling_block_string?(block, 'mimeType')
+      when 'tool_use' then sampling_block_string?(block, 'id')
+      when 'tool_result' then sampling_block_string?(block, 'toolUseId')
+      else true
+      end
+    end
+
+    # @param block [Hash] a content block
+    # @param field [String] the field it must carry
+    # @return [Boolean] whether the field is a non-empty String
+    def sampling_block_string?(block, field)
+      value = block[field] || block[field.to_sym]
+      value.is_a?(String) && !value.empty?
     end
 
     # @param block [Object] a content block

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1467,7 +1467,12 @@ module MCPClient
       return { 'action' => 'accept' } if result == true
 
       action = result.is_a?(Hash) ? (result['action'] || result[:action]) : nil
-      return { 'action' => action.to_s } if %w[accept decline cancel].include?(action.to_s)
+      if %w[accept decline cancel].include?(action.to_s)
+        # ElicitResult carries `_meta` in every mode; only `content` is
+        # form-mode-specific, and format_elicitation_response strips it.
+        meta = result['_meta'] || result[:_meta]
+        return { 'action' => action.to_s, '_meta' => meta }.compact
+      end
 
       unless result.nil? || result == false
         @logger.warn('URL-mode elicitation handler gave no explicit action; answering cancel (consent is explicit)')
@@ -1547,23 +1552,35 @@ module MCPClient
       { 'roots' => @roots.map(&:to_h) }
     end
 
+    # Whether a server may be told the roots list changed. MCP forbids using a
+    # capability that was not declared during initialization, so the
+    # notification goes only to sessions whose declared client capabilities
+    # include roots: a transport that registers the handlers for the modern
+    # multi round-trip pattern but has no server-request channel to serve
+    # them on (plain HTTP on a legacy session) declares none, however it
+    # answers respond_to?.
+    # @param server [Object] an MCP server transport
+    # @return [Boolean]
+    def roots_list_changed_recipient?(server)
+      return false unless server.respond_to?(:on_roots_list_request)
+      # notifications/roots/list_changed was removed in MCP 2026-07-28: a
+      # modern server reads roots through the multi round-trip pattern when it
+      # needs them, and has no channel to be told they changed.
+      # Judged by the ESTABLISHED era: while a probe is in flight the version
+      # is only a proposal, and a server that then falls back to the handshake
+      # can still ask for roots — so the transport, which settles the era
+      # before it writes anything, makes the call.
+      return false if server.respond_to?(:protocol_era) && server.protocol_era == :modern
+      return true unless server.respond_to?(:client_capabilities)
+
+      server.client_capabilities.key?('roots')
+    end
+
     # Send notification to all servers that roots have changed (MCP 2025-06-18)
     # @return [void]
     def notify_roots_changed
       @servers.each do |server|
-        # Only notify sessions where the roots capability could be declared:
-        # MCP forbids using capabilities that were not negotiated, and
-        # transports without a server-request channel (plain HTTP) never
-        # declare roots.
-        next unless server.respond_to?(:on_roots_list_request)
-        # notifications/roots/list_changed was removed in MCP 2026-07-28: a
-        # modern server reads roots through the multi round-trip pattern
-        # when it needs them, and has no channel to be told they changed.
-        # Judged by the ESTABLISHED era: while a probe is in flight the
-        # version is only a proposal, and a server that then falls back to
-        # the handshake can still ask for roots — so the transport, which
-        # settles the era before it writes anything, makes the call.
-        next if server.respond_to?(:protocol_era) && server.protocol_era == :modern
+        next unless roots_list_changed_recipient?(server)
 
         begin
           server.rpc_notify('notifications/roots/list_changed', {})

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1516,14 +1516,21 @@ module MCPClient
       ElicitationValidator.validate_content(response['content'], schema)
     end
 
-    # Ensure the action value conforms to MCP spec (accept, decline, cancel)
-    # Falls back to accept for unknown action values.
+    # Ensure the action value conforms to MCP spec (accept, decline, cancel).
+    # An action outside that set is not consent the user gave, so it is
+    # answered as cancel — the verdict URL mode reaches for the same handler
+    # result — rather than rewritten into an accept. (A handler that returns
+    # bare content and no action at all is the documented convenience shape
+    # and never reaches here; see #normalize_elicitation_result.)
+    # @param result [Hash] the normalized ElicitResult
+    # @return [Hash] the result, with an unrecognized action answered as cancel
     def normalised_action_response(result)
       action = result['action']
       return result if %w[accept decline cancel].include?(action)
 
-      @logger.warn("Unknown elicitation action '#{sanitize_peer_log_text(action.to_s)}', defaulting to accept")
-      result.merge('action' => 'accept')
+      @logger.warn("Unknown elicitation action '#{sanitize_peer_log_text(action.to_s)}'; answering cancel " \
+                   '(consent is explicit)')
+      result.merge('action' => 'cancel')
     end
 
     # Normalize roots array - convert Hashes to Root objects (MCP 2025-06-18)

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1331,7 +1331,7 @@ module MCPClient
       # precedes everything else — an undeclared mode is -32602 even when no
       # handler is configured.
       unless SUPPORTED_ELICITATION_MODES.include?(mode)
-        @logger.warn("Rejecting elicitation request with unsupported mode '#{mode}'")
+        @logger.warn("Rejecting elicitation request with unsupported mode '#{sanitize_peer_log_text(mode.to_s)}'")
         return jsonrpc_error_result(-32_602, "Elicitation mode '#{mode}' is not supported")
       end
 
@@ -1383,7 +1383,9 @@ module MCPClient
       # Validate schema if present
       if schema
         schema_errors = ElicitationValidator.validate_schema(schema)
-        @logger.warn("Elicitation schema validation warnings: #{schema_errors.join('; ')}") unless schema_errors.empty?
+        unless schema_errors.empty?
+          @logger.warn("Elicitation schema validation warnings: #{sanitize_peer_log_text(schema_errors.join('; '))}")
+        end
       end
 
       # Call the user-defined handler
@@ -1426,7 +1428,11 @@ module MCPClient
     # @param params [Hash] original request params (for schema validation)
     # @return [Hash] formatted response
     def format_elicitation_response(result, params)
-      response = normalize_elicitation_result(result)
+      response = if (params['mode'] || 'form') == 'url'
+                   normalize_url_elicitation_result(result)
+                 else
+                   normalize_elicitation_result(result)
+                 end
 
       # Per the ElicitResult schema, content is only present when the action
       # is accept and the mode was form; it is omitted for decline/cancel and
@@ -1449,6 +1455,24 @@ module MCPClient
       end
 
       response
+    end
+
+    # A URL-mode elicitation reports the user's consent to open the URL, so
+    # only an explicit answer counts: `true` or an ElicitResult with an
+    # `action` of accept/decline/cancel. Anything else — a bare value, a form
+    # style content hash, nil — is not consent and is answered with cancel.
+    # @param result [Object] handler result
+    # @return [Hash] normalized ElicitResult without content
+    def normalize_url_elicitation_result(result)
+      return { 'action' => 'accept' } if result == true
+
+      action = result.is_a?(Hash) ? (result['action'] || result[:action]) : nil
+      return { 'action' => action.to_s } if %w[accept decline cancel].include?(action.to_s)
+
+      unless result.nil? || result == false
+        @logger.warn('URL-mode elicitation handler gave no explicit action; answering cancel (consent is explicit)')
+      end
+      { 'action' => 'cancel' }
     end
 
     # Normalize a handler's return value into a string-keyed ElicitResult
@@ -1493,7 +1517,7 @@ module MCPClient
       action = result['action']
       return result if %w[accept decline cancel].include?(action)
 
-      @logger.warn("Unknown elicitation action '#{action}', defaulting to accept")
+      @logger.warn("Unknown elicitation action '#{sanitize_peer_log_text(action.to_s)}', defaulting to accept")
       result.merge('action' => 'accept')
     end
 

--- a/lib/mcp_client/errors.rb
+++ b/lib/mcp_client/errors.rb
@@ -410,6 +410,21 @@ module MCPClient
     # the server could have asked for. Exposes the server's input requests
     # and opaque request state so a host can drive the round trip itself.
     class InputRequiredError < ServerError
+      # The request the round trip was driving, when the error was raised by
+      # the round-trip resolver: what {JsonRpcCommon#resume_input_required}
+      # re-issues, with the requestState echoed and no inputResponses.
+      # @return [String, nil] the JSON-RPC method
+      attr_accessor :request_method
+      # @return [Hash, nil] the original request params
+      attr_accessor :request_params
+      # @return [Object, nil] the transport that raised the error
+      attr_accessor :transport
+
+      # @return [Boolean] whether the error carries a continuation to resume from
+      def resumable?
+        request_method.is_a?(String)
+      end
+
       # @return [Hash] the InputRequests map (key => request object)
       def input_requests
         requests = data.is_a?(Hash) ? (data['inputRequests'] || data[:inputRequests]) : nil

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -385,10 +385,14 @@ module MCPClient
         @logger.warn("#{e.message}; re-issuing server/discover as a new request")
         send_discover_request(deadline)
       end
-      # A 2xx that is not a DiscoverResult (e.g. a permissive legacy endpoint
-      # answering any method) is not a modern answer: let the probe treat it
-      # as legacy rather than fail on a malformed modern result. A result
-      # carrying a resultType is the exception — see #invalid_discover_answer.
+      # The input_required rejection comes first: an InputRequiredResult need
+      # only carry `requestState`, so an unfinished discover answer does not
+      # have to look like a DiscoverResult at all, and testing the shape first
+      # would classify it as a permissive legacy endpoint. Any other 2xx that
+      # is not a DiscoverResult is a legacy answer the probe may fall back on
+      # — unless it carries a resultType, which only a modern server writes
+      # (see #invalid_discover_answer).
+      reject_input_required_discover!(result)
       raise invalid_discover_answer(result, 'answered without a DiscoverResult') unless discover_result?(result)
 
       apply_discover_result(result)

--- a/lib/mcp_client/http_transport_base.rb
+++ b/lib/mcp_client/http_transport_base.rb
@@ -87,13 +87,14 @@ module MCPClient
         method = 'server/discover'
       end
 
-      result = with_retry(method) do
-        # One budget for the exchange and every replacement it may need: the
-        # maximum timeout the spec asks for holds "regardless of progress",
-        # and neither a lost stream nor a rejected header set is progress. The
-        # probe already shares its deadline with its own replacement.
-        budget = timeout || @read_timeout
-        send_with_recovery(method, params, timeout, budget && (monotonic_now + budget))
+      header_refresh_done = false
+      # The multi round-trip resolver sits outside the per-attempt recovery,
+      # so a retry carrying inputResponses/requestState keeps them through
+      # version renegotiation, the HeaderMismatch refresh and a re-issued
+      # stream. Each attempt is a request of its own, with its own id and its
+      # own budget; the deadline lives in attempt_request.
+      result = resolve_input_round_trips(method, params, timeout) do |attempt_params|
+        attempt_request(method, attempt_params, timeout, header_refresh_done) { header_refresh_done = true }
       end
       # Every server/discover answer is validated and applied: a later
       # heartbeat may advertise new versions or capabilities.

--- a/lib/mcp_client/http_transport_base/request_recovery.rb
+++ b/lib/mcp_client/http_transport_base/request_recovery.rb
@@ -18,66 +18,76 @@ module MCPClient
 
       private
 
-      # One with_retry attempt: the request itself plus the two 2026-07-28
-      # recoveries it may need.
+      # One attempt of a request with the transport-level recoveries that
+      # re-send the same params: version renegotiation, HeaderMismatch refresh
+      # and a response stream that closed without the response.
       #
       # Both re-sends `retry` the same guarded block rather than running inside
-      # their own rescue clause, so either recovery's re-send is still covered by
-      # the other — a HeaderMismatch retry whose stream closes is re-issued, and
-      # a re-issue that is rejected for its headers still refreshes tools/list.
-      # Each recovery fires at most once, so the pair is bounded at three sends.
+      # their own rescue clause, so either recovery's re-send is still covered
+      # by the other — a HeaderMismatch retry whose stream closes is re-issued,
+      # and a re-issue that is rejected for its headers still refreshes
+      # tools/list. Each recovery fires at most once, so the pair is bounded at
+      # three sends.
       #
-      # Both flags are scoped to this attempt, which is all a tools/call ever
-      # gets — with_retry refuses to re-attempt a NON_IDEMPOTENT_METHODS
-      # request — and gives an idempotent method one re-issue per attempt.
+      # The refresh is spent once for the whole logical request: the caller's
+      # flag rides in, and the block marks it. A re-issue is scoped to the
+      # attempt, which is all a tools/call ever gets — with_retry refuses to
+      # re-attempt a NON_IDEMPOTENT_METHODS request.
       #
-      # The deadline is the caller's, shared by every send this attempt makes:
-      # a recovery replaces the request, it does not buy it more time.
+      # The deadline is this attempt's, shared by every send it makes: a
+      # recovery replaces the request, it does not buy it more time.
       # @param method [String] JSON-RPC method name
-      # @param params [Hash] parameters for the request
+      # @param params [Hash] parameters for this attempt (may carry inputResponses)
       # @param timeout [Numeric, nil] per-request timeout override
-      # @param deadline [Float, nil] monotonic instant this attempt must finish by
-      # @return [Object] result from the JSON-RPC response
-      def send_with_recovery(method, params, timeout, deadline = nil)
-        stream_reissued = false
-        header_refreshed = false
-        begin
-          send_request_with_version_retry(method, params, timeout, deadline)
-        rescue MCPClient::Errors::HeaderMismatchError => e
-          # A rejection that escaped host code reached from this response -- a
-          # listener's own tools/call -- rejects that request, not this one.
-          # This one the server has already executed, and re-sending it on
-          # someone else's error would execute it twice.
-          raise if e.is_a?(NestedExchange)
-          raise unless modern? && method == 'tools/call' && !header_refreshed
+      # @param header_refresh_done [Boolean] whether the one HeaderMismatch refresh was spent
+      # @yield marks the HeaderMismatch refresh as spent
+      # @return [Object] the attempt's result
+      def attempt_request(method, params, timeout, header_refresh_done)
+        with_retry(method) do
+          # One budget for this request and every replacement it may need: the
+          # maximum timeout the spec asks for holds "regardless of progress",
+          # and neither a lost stream nor a rejected header set is progress.
+          # A continuation is a request of its own and gets its own budget --
+          # the wait before it is bounded separately (see InputWaits).
+          budget = timeout || @read_timeout
+          deadline = budget && (monotonic_now + budget)
+          stream_reissued = false
+          header_refreshed = header_refresh_done
+          begin
+            send_request_with_version_retry(method, params, timeout, deadline)
+          rescue MCPClient::Errors::HeaderMismatchError => e
+            # A rejection that escaped host code reached from this response --
+            # a listener's own tools/call -- rejects that request, not this
+            # one. This one the server has already executed, and re-sending it
+            # on someone else's error would execute it twice.
+            raise if e.is_a?(NestedExchange)
+            raise unless modern? && method == 'tools/call' && !header_refreshed
 
-          header_refreshed = true
-          refresh_tools_after_header_mismatch(e)
-          retry
-        rescue MCPClient::Errors::ResponseStreamClosedError => e
-          # Modern Streamable HTTP has no resumption: "a broken response stream
-          # loses the in-flight request; clients MUST re-issue it as a new
-          # request with a new request ID" (2026-07-28 changelog, major change
-          # 9). The rule has no exception for tools/call, and this revision
-          # makes closing the response stream itself the cancellation signal —
-          # the server MUST treat the broken stream as a cancellation and stop
-          # work — so the re-issue is the behaviour the protocol expects rather
-          # than a blind replay. Exactly one re-issue happens, for every method:
-          # this flag bounds the attempt, and with_retry never re-attempts a
-          # ResponseStreamClosedError, so a second broken stream surfaces
-          # instead of looping.
-          #
-          # A stream that closed between (or inside) SSE events reaches here
-          # from the parser; one that died at the socket reaches here from
-          # connection_failure_error. Both are the same loss.
-          #
-          # A stream a listener's own request lost is that request's to
-          # re-issue, and it already did: this exchange still has its response.
-          raise if stream_reissued || e.is_a?(NestedExchange)
+            header_refreshed = true
+            yield
+            refresh_tools_after_header_mismatch(e)
+            retry
+          rescue MCPClient::Errors::ResponseStreamClosedError => e
+            # Modern Streamable HTTP has no resumption: "a broken response
+            # stream loses the in-flight request; clients MUST re-issue it as a
+            # new request with a new request ID" (2026-07-28 changelog, major
+            # change 9). The rule has no exception for tools/call, and this
+            # revision makes closing the response stream itself the
+            # cancellation signal — the server MUST treat the broken stream as
+            # a cancellation and stop work — so the re-issue is the behaviour
+            # the protocol expects rather than a blind replay.
+            #
+            # A stream that closed between (or inside) SSE events reaches here
+            # from the parser; one that died at the socket reaches here from
+            # connection_failure_error. Both are the same loss. A stream a
+            # listener's own request lost is that request's to re-issue, and it
+            # already did: this exchange still has its response.
+            raise if stream_reissued || e.is_a?(NestedExchange)
 
-          stream_reissued = true
-          @logger.warn("#{e.message}; re-issuing #{method} as a new request")
-          retry
+            stream_reissued = true
+            @logger.warn("#{e.message}; re-issuing #{method} as a new request")
+            retry
+          end
         end
       end
 

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -935,6 +935,13 @@ module MCPClient
     # Servers MAY keep asking, but an unbounded loop is a hostile server.
     MAX_INPUT_ROUND_TRIPS = 10
 
+    # Pause before retrying an InputRequiredResult that asked for nothing
+    # (requestState only — e.g. a URL-mode elicitation still in progress out
+    # of band). The client MAY retry immediately, but a tight loop would just
+    # burn the round-trip budget; doubles up to the maximum.
+    INPUT_RETRY_DELAY = 0.5
+    INPUT_RETRY_MAX_DELAY = 5
+
     # Input request methods and the transport callback that fulfils each.
     INPUT_REQUEST_HANDLERS = {
       'elicitation/create' => :@elicitation_request_callback,
@@ -960,10 +967,12 @@ module MCPClient
     def resolve_input_round_trips(method, params, _timeout = nil)
       result = yield(params)
       round_trips = 0
+      delay = INPUT_RETRY_DELAY
       while MCPClient::JsonRpcCommon.result_type(result) == 'input_required'
-        unless MRTR_METHODS.include?(method)
+        unless modern? && MRTR_METHODS.include?(method)
           raise MCPClient::Errors::InvalidResultError,
-                "Invalid result: input_required is only valid for #{MRTR_METHODS.join(', ')}, not #{method}"
+                "Invalid result: input_required is only valid for #{MRTR_METHODS.join(', ')} " \
+                "on an MCP 2026-07-28 server, not #{method} (#{protocol_version})"
         end
 
         round_trips += 1
@@ -974,7 +983,12 @@ module MCPClient
         end
 
         @logger.debug("#{method} requires input (round trip #{round_trips}); fulfilling and retrying")
-        result = yield(retry_params_for(params, result))
+        retry_params = retry_params_for(params, result)
+        unless retry_params.key?('inputResponses')
+          sleep(delay)
+          delay = [delay * 2, INPUT_RETRY_MAX_DELAY].min
+        end
+        result = yield(retry_params)
       end
       result
     end
@@ -992,8 +1006,9 @@ module MCPClient
       retry_params.delete('requestState')
       retry_params.delete(:requestState)
 
-      input_requests = result['inputRequests']
-      retry_params['inputResponses'] = fulfil_input_requests(input_requests, result) unless input_requests.nil?
+      if result.key?('inputRequests')
+        retry_params['inputResponses'] = fulfil_input_requests(result['inputRequests'], result)
+      end
       state = result['requestState']
       retry_params['requestState'] = state unless state.nil?
       retry_params
@@ -1023,35 +1038,45 @@ module MCPClient
     # @return [Hash] the handler's result
     # @raise [MCPClient::Errors::InputRequiredError]
     def fulfil_input_request(key, request, result)
+      shown_key = sanitize_log_text(key.to_s.inspect)
       unless request.is_a?(Hash) && request['method'].is_a?(String)
-        raise MCPClient::Errors::InputRequiredError.new("Malformed input request #{key.inspect}", data: result)
+        raise MCPClient::Errors::InputRequiredError.new("Malformed input request #{shown_key}", data: result)
       end
 
       request_method = request['method']
+      shown_method = sanitize_log_text(request_method.inspect)
       handler_ivar = INPUT_REQUEST_HANDLERS[request_method]
       unless handler_ivar
         raise MCPClient::Errors::InputRequiredError.new(
-          "Unsupported input request method #{request_method.inspect} for key #{key.inspect}", data: result
+          "Unsupported input request method #{shown_method} for key #{shown_key}", data: result
         )
       end
       unless registered_callback?(handler_ivar)
         raise MCPClient::Errors::InputRequiredError.new(
-          "Server requested #{request_method} (key #{key.inspect}) but no handler is registered for it " \
+          "Server requested #{shown_method} (key #{shown_key}) but no handler is registered for it " \
           '(the capability was not declared)', data: result
         )
       end
 
-      response = instance_variable_get(handler_ivar).call(key, request['params'] || {})
+      begin
+        response = instance_variable_get(handler_ivar).call(key, request['params'] || {})
+      rescue StandardError => e
+        # The exception text is host-internal; it stays in the local log.
+        @logger.error("Handler for #{shown_method} (key #{shown_key}) raised: #{e.message}")
+        raise MCPClient::Errors::InputRequiredError.new(
+          "Handler for #{shown_method} (key #{shown_key}) failed", data: result
+        )
+      end
       unless response.is_a?(Hash)
         raise MCPClient::Errors::InputRequiredError.new(
-          "Handler for #{request_method} (key #{key.inspect}) returned #{response.class}, expected a result object",
+          "Handler for #{shown_method} (key #{shown_key}) returned #{response.class}, expected a result object",
           data: result
         )
       end
       if (error = response['error'] || response[:error])
         message = error.is_a?(Hash) ? (error['message'] || error[:message]) : error
         raise MCPClient::Errors::InputRequiredError.new(
-          "Handler for #{request_method} (key #{key.inspect}) failed: #{message}", data: result
+          "Handler for #{shown_method} (key #{shown_key}) failed: #{sanitize_log_text(message)}", data: result
         )
       end
 

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -1039,8 +1039,10 @@ module MCPClient
     # @raise [MCPClient::Errors::InputRequiredError]
     def fulfil_input_request(key, request, result)
       shown_key = sanitize_log_text(key.to_s.inspect)
-      unless request.is_a?(Hash) && request['method'].is_a?(String)
-        raise MCPClient::Errors::InputRequiredError.new("Malformed input request #{shown_key}", data: result)
+      unless request.is_a?(Hash) && request['method'].is_a?(String) &&
+             (request['params'].nil? || request['params'].is_a?(Hash))
+        raise MCPClient::Errors::InputRequiredError.new("Malformed input request #{shown_key} (method/params)",
+                                                        data: result)
       end
 
       request_method = request['method']

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -1059,6 +1059,12 @@ module MCPClient
           '(the capability was not declared)', data: result
         )
       end
+      if undeclared_sampling_tool_use?(request_method, request['params'])
+        raise MCPClient::Errors::InputRequiredError.new(
+          "Server requested tool-enabled #{shown_method} (key #{shown_key}) but the sampling.tools " \
+          'capability was not declared', data: result
+        )
+      end
 
       begin
         response = instance_variable_get(handler_ivar).call(key, request['params'] || {})
@@ -1083,6 +1089,21 @@ module MCPClient
       end
 
       response
+    end
+
+    # SEP-1577 (sampling tool calling): a server MUST NOT send `tools` or
+    # `toolChoice` to a client that did not declare the sampling.tools
+    # sub-capability. On a server-initiated request the client answers -32602;
+    # InputResponses has no per-request error channel, so on the multi
+    # round-trip path the whole round trip fails instead — the sampler is
+    # never invoked with a request this client never advertised support for.
+    # @param method [String] the input request method
+    # @param params [Hash, nil] the input request params
+    # @return [Boolean] whether this is tool-enabled sampling without the declaration
+    def undeclared_sampling_tool_use?(method, params)
+      return false unless method == 'sampling/createMessage' && !sampling_tools_supported?
+
+      params.is_a?(Hash) && (params.key?('tools') || params.key?('toolChoice'))
     end
 
     # Notifications the 2026-07-28 revision removed; never written to a

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -608,23 +608,25 @@ module MCPClient
     # @return [Hash] the capabilities object for the initialize request
     def client_capabilities
       capabilities = {}
-      # MCP 2026-07-28 delivers roots/sampling/elicitation through the multi
-      # round-trip pattern (InputRequiredResult), not server-initiated
-      # requests. Until that pattern is implemented, modern requests declare
-      # none of these: a server MUST NOT ask for what the client did not
-      # declare, so an unfulfillable input request is never provoked.
-      unless modern?
-        if registered_callback?(:@elicitation_request_callback)
-          # Both defined elicitation modes are implemented (an empty object
-          # would mean form-only per the spec's backwards-compatibility rule).
-          capabilities['elicitation'] = { 'form' => {}, 'url' => {} }
-        end
-        capabilities['roots'] = { 'listChanged' => true } if registered_callback?(:@roots_list_request_callback)
-        if registered_callback?(:@sampling_request_callback)
-          # SEP-1577: servers may only send tool-enabled sampling requests when
-          # the client declares the sampling.tools sub-capability.
-          capabilities['sampling'] = sampling_tools_supported? ? { 'tools' => {} } : {}
-        end
+      # On a modern server these features are served through the multi
+      # round-trip pattern (InputRequiredResult), on a legacy one through
+      # server-initiated requests; either way they are declared only when
+      # the host registered a handler, since the server MUST NOT ask for
+      # what the client did not declare.
+      if registered_callback?(:@elicitation_request_callback)
+        # Both defined elicitation modes are implemented (an empty object
+        # would mean form-only per the spec's backwards-compatibility rule).
+        capabilities['elicitation'] = { 'form' => {}, 'url' => {} }
+      end
+      if registered_callback?(:@roots_list_request_callback)
+        # notifications/roots/list_changed was removed in 2026-07-28, so the
+        # modern roots capability has no listChanged flag.
+        capabilities['roots'] = modern? ? {} : { 'listChanged' => true }
+      end
+      if registered_callback?(:@sampling_request_callback)
+        # SEP-1577: servers may only send tool-enabled sampling requests when
+        # the client declares the sampling.tools sub-capability.
+        capabilities['sampling'] = sampling_tools_supported? ? { 'tools' => {} } : {}
       end
       capabilities['extensions'] = declared_extensions.dup unless declared_extensions.empty?
       # NOTE: we intentionally do NOT declare a client `tasks` capability. That
@@ -924,6 +926,138 @@ module MCPClient
       response[name.to_sym]
     end
 
+    # Client requests a server MAY answer with an InputRequiredResult (MCP
+    # 2026-07-28 basic/patterns/mrtr "Supported Requests"); on any other
+    # request such a result is invalid.
+    MRTR_METHODS = %w[tools/call resources/read prompts/get].freeze
+
+    # Ceiling on consecutive input_required answers to one logical request.
+    # Servers MAY keep asking, but an unbounded loop is a hostile server.
+    MAX_INPUT_ROUND_TRIPS = 10
+
+    # Input request methods and the transport callback that fulfils each.
+    INPUT_REQUEST_HANDLERS = {
+      'elicitation/create' => :@elicitation_request_callback,
+      'sampling/createMessage' => :@sampling_request_callback,
+      'roots/list' => :@roots_list_request_callback
+    }.freeze
+
+    # Drive a request through the multi round-trip pattern (MCP 2026-07-28
+    # basic/patterns/mrtr): while the server answers with an
+    # InputRequiredResult, fulfil its inputRequests through the registered
+    # handlers and retry the original request — as an independent request
+    # with a new id — carrying inputResponses keyed like the requests and
+    # the opaque requestState echoed verbatim (omitted when the server sent
+    # none). A result without inputRequests is retried immediately.
+    # @param method [String] the JSON-RPC method
+    # @param params [Hash] the original params
+    # @param timeout [Numeric, nil] per-request timeout
+    # @yieldparam params [Hash] params for one attempt (original, or with inputResponses)
+    # @yieldreturn [Object] the attempt's result
+    # @return [Object] the final (complete) result
+    # @raise [MCPClient::Errors::InvalidResultError] input_required on an unsupported method
+    # @raise [MCPClient::Errors::InputRequiredError] when a round trip cannot be fulfilled or too many occur
+    def resolve_input_round_trips(method, params, _timeout = nil)
+      result = yield(params)
+      round_trips = 0
+      while MCPClient::JsonRpcCommon.result_type(result) == 'input_required'
+        unless MRTR_METHODS.include?(method)
+          raise MCPClient::Errors::InvalidResultError,
+                "Invalid result: input_required is only valid for #{MRTR_METHODS.join(', ')}, not #{method}"
+        end
+
+        round_trips += 1
+        if round_trips > MAX_INPUT_ROUND_TRIPS
+          raise MCPClient::Errors::InputRequiredError.new(
+            "Server kept requesting input for #{method} after #{MAX_INPUT_ROUND_TRIPS} round trips", data: result
+          )
+        end
+
+        @logger.debug("#{method} requires input (round trip #{round_trips}); fulfilling and retrying")
+        result = yield(retry_params_for(params, result))
+      end
+      result
+    end
+
+    # The params for a multi round-trip retry: the original params plus the
+    # fulfilled inputResponses and the server's requestState. Both fields
+    # affect only this retry; the caller's params are not mutated.
+    # @param params [Hash] the original params
+    # @param result [Hash] the InputRequiredResult
+    # @return [Hash]
+    def retry_params_for(params, result)
+      retry_params = (params.is_a?(Hash) ? params.dup : {})
+      retry_params.delete('inputResponses')
+      retry_params.delete(:inputResponses)
+      retry_params.delete('requestState')
+      retry_params.delete(:requestState)
+
+      input_requests = result['inputRequests']
+      retry_params['inputResponses'] = fulfil_input_requests(input_requests, result) unless input_requests.nil?
+      state = result['requestState']
+      retry_params['requestState'] = state unless state.nil?
+      retry_params
+    end
+
+    # Fulfil every input request through the handler registered for its
+    # method. There is no per-key error channel in InputResponses, so any
+    # request this client cannot honour fails the whole round trip.
+    # @param input_requests [Hash] the InputRequests map
+    # @param result [Hash] the InputRequiredResult (for error data)
+    # @return [Hash] the InputResponses map
+    # @raise [MCPClient::Errors::InputRequiredError]
+    def fulfil_input_requests(input_requests, result)
+      unless input_requests.is_a?(Hash)
+        raise MCPClient::Errors::InputRequiredError.new('Malformed InputRequiredResult: inputRequests is not an object',
+                                                        data: result)
+      end
+
+      input_requests.to_h do |key, request|
+        [key, fulfil_input_request(key, request, result)]
+      end
+    end
+
+    # @param key [String] the server-assigned request key
+    # @param request [Hash] the input request ({ 'method' => ..., 'params' => ... })
+    # @param result [Hash] the InputRequiredResult (for error data)
+    # @return [Hash] the handler's result
+    # @raise [MCPClient::Errors::InputRequiredError]
+    def fulfil_input_request(key, request, result)
+      unless request.is_a?(Hash) && request['method'].is_a?(String)
+        raise MCPClient::Errors::InputRequiredError.new("Malformed input request #{key.inspect}", data: result)
+      end
+
+      request_method = request['method']
+      handler_ivar = INPUT_REQUEST_HANDLERS[request_method]
+      unless handler_ivar
+        raise MCPClient::Errors::InputRequiredError.new(
+          "Unsupported input request method #{request_method.inspect} for key #{key.inspect}", data: result
+        )
+      end
+      unless registered_callback?(handler_ivar)
+        raise MCPClient::Errors::InputRequiredError.new(
+          "Server requested #{request_method} (key #{key.inspect}) but no handler is registered for it " \
+          '(the capability was not declared)', data: result
+        )
+      end
+
+      response = instance_variable_get(handler_ivar).call(key, request['params'] || {})
+      unless response.is_a?(Hash)
+        raise MCPClient::Errors::InputRequiredError.new(
+          "Handler for #{request_method} (key #{key.inspect}) returned #{response.class}, expected a result object",
+          data: result
+        )
+      end
+      if (error = response['error'] || response[:error])
+        message = error.is_a?(Hash) ? (error['message'] || error[:message]) : error
+        raise MCPClient::Errors::InputRequiredError.new(
+          "Handler for #{request_method} (key #{key.inspect}) failed: #{message}", data: result
+        )
+      end
+
+      response
+    end
+
     # Notifications the 2026-07-28 revision removed; never written to a
     # modern server (the roots capability has no listChanged there).
     REMOVED_MODERN_NOTIFICATIONS = %w[notifications/roots/list_changed notifications/initialized].freeze
@@ -932,22 +1066,6 @@ module MCPClient
     # @return [Boolean] whether it must be dropped for a modern server
     def suppressed_modern_notification?(method)
       modern? && REMOVED_MODERN_NOTIFICATIONS.include?(method)
-    end
-
-    # An InputRequiredResult asks the client to fulfil server requests and
-    # retry. This client declares no capability a modern server could use
-    # for that yet, so such a result cannot be honoured and must not be
-    # mistaken for the operation's result.
-    # @param result [Object] a JSON-RPC result
-    # @return [void]
-    # @raise [MCPClient::Errors::InputRequiredError]
-    def reject_unfulfillable_input_required!(result)
-      return unless MCPClient::JsonRpcCommon.result_type(result) == 'input_required'
-
-      raise MCPClient::Errors::InputRequiredError.new(
-        'Server returned an input_required result (multi round-trip request) that this client cannot fulfil',
-        data: result
-      )
     end
 
     # Servers SHOULD identify themselves in every result's `_meta`

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -5,11 +5,13 @@ require 'zlib'
 require 'stringio'
 require_relative 'header_params'
 require_relative 'json_rpc_common/error_bodies'
+require_relative 'json_rpc_common/input_waits'
 
 module MCPClient
   # Shared retry/backoff logic for JSON-RPC transports
   module JsonRpcCommon
     include ErrorBodies
+    include InputWaits
 
     # JSON-RPC methods with arbitrary side effects that MUST NOT be re-sent
     # automatically. Even a "transient" failure (5xx, dropped connection,
@@ -931,19 +933,25 @@ module MCPClient
     # with a new id — carrying inputResponses keyed like the requests and
     # the opaque requestState echoed verbatim (omitted when the server sent
     # none). A result without inputRequests asks for nothing this client can
-    # fulfil, so it is retried after a growing pause (INPUT_RETRY_DELAY).
+    # fulfil, so it is retried after a growing pause (INPUT_RETRY_DELAY) that
+    # the host steers through {#on_input_required_wait} and that never runs
+    # past the request timeout: the continuation is handed back instead, on
+    # an error {#resume_input_required} accepts.
     # @param method [String] the JSON-RPC method
     # @param params [Hash] the original params
-    # @param timeout [Numeric, nil] per-request timeout
+    # @param timeout [Numeric, nil] per-request timeout, also bounding the waits
     # @yieldparam params [Hash] params for one attempt (original, or with inputResponses)
     # @yieldreturn [Object] the attempt's result
     # @return [Object] the final (complete) result
     # @raise [MCPClient::Errors::InvalidResultError] input_required on an unsupported method
-    # @raise [MCPClient::Errors::InputRequiredError] when a round trip cannot be fulfilled or too many occur
-    def resolve_input_round_trips(method, params, _timeout = nil)
+    # @raise [MCPClient::Errors::InputRequiredError] when a round trip cannot be fulfilled, is
+    #   cancelled or times out, or too many occur — carrying the continuation
+    def resolve_input_round_trips(method, params, timeout = nil)
       result = yield(params)
       round_trips = 0
       delay = INPUT_RETRY_DELAY
+      started = input_wait_clock
+      deadline = timeout ? started + timeout : nil
       while MCPClient::JsonRpcCommon.result_type(result) == 'input_required'
         # Read on the wire spelling, whatever the transport's JSON middleware
         # did to the keys: a symbolized inputRequests/requestState would
@@ -967,33 +975,22 @@ module MCPClient
         @logger.debug("#{method} requires input (round trip #{round_trips}); fulfilling and retrying")
         retry_params = retry_params_for(params, result)
         unless retry_params.key?('inputResponses')
-          sleep(delay)
-          delay = [delay * 2, INPUT_RETRY_MAX_DELAY].min
+          now = input_wait_clock
+          wait = InputRequiredWait.new(rpc_method: method, round_trip: round_trips, delay: delay,
+                                       request_state: result['requestState'], result: result,
+                                       elapsed: now - started)
+          delay = pace_input_round_trip(wait, deadline, now)
         end
         result = yield(retry_params)
       end
       result
-    end
-
-    # The params for a multi round-trip retry: the original params plus the
-    # fulfilled inputResponses and the server's requestState. Both fields
-    # affect only this retry; the caller's params are not mutated.
-    # @param params [Hash] the original params
-    # @param result [Hash] the InputRequiredResult
-    # @return [Hash]
-    def retry_params_for(params, result)
-      retry_params = (params.is_a?(Hash) ? params.dup : {})
-      retry_params.delete('inputResponses')
-      retry_params.delete(:inputResponses)
-      retry_params.delete('requestState')
-      retry_params.delete(:requestState)
-
-      if result.key?('inputRequests')
-        retry_params['inputResponses'] = fulfil_input_requests(result['inputRequests'], result)
-      end
-      state = result['requestState']
-      retry_params['requestState'] = state unless state.nil?
-      retry_params
+    rescue MCPClient::Errors::InputRequiredError => e
+      # Every failure of the round trip hands the continuation back: the
+      # request it was driving, for #resume_input_required.
+      e.request_method ||= method
+      e.request_params ||= params
+      e.transport ||= self
+      raise
     end
 
     # Fulfil every input request through the handler registered for its

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -929,7 +929,7 @@ module MCPClient
       round_trips = 0
       delay = INPUT_RETRY_DELAY
       started = input_wait_clock
-      deadline = timeout ? started + timeout : nil
+      deadline = input_wait_deadline(started, timeout)
       while MCPClient::JsonRpcCommon.result_type(result) == 'input_required'
         # Read on the wire spelling, whatever the transport's JSON middleware
         # did to the keys: a symbolized inputRequests/requestState would
@@ -957,7 +957,7 @@ module MCPClient
           wait = InputRequiredWait.new(rpc_method: method, round_trip: round_trips, delay: delay,
                                        request_state: result['requestState'], result: result,
                                        elapsed: now - started)
-          delay = pace_input_round_trip(wait, deadline, now)
+          delay = pace_input_round_trip(wait, deadline)
         end
         result = yield(retry_params)
       end

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -521,28 +521,6 @@ module MCPClient
       defined?(@discovery_cache_scope) ? @discovery_cache_scope : nil
     end
 
-    # An InputRequiredResult is defined only for tools/call, resources/read
-    # and prompts/get (MCP 2026-07-28 basic/patterns/mrtr "Supported
-    # Requests"). server/discover is not one of them, so an input_required
-    # discover answer is invalid and MUST NOT be applied or cached: the probe
-    # would otherwise adopt a protocol version out of an unfinished result
-    # and hand that result back as the first heartbeat. The rejection is a
-    # ModernServerError, not an InvalidResultError, because a server
-    # answering server/discover with a 2026-07-28-only discriminator is
-    # modern: the era is settled, so it must never be retried with the
-    # initialize handshake, and MCPClient.connect must not send it on to the
-    # legacy SSE and HTTP+POST transports either.
-    # @param result [Hash] the server/discover result
-    # @return [void]
-    # @raise [MCPClient::Errors::ModernServerError] if the result is an InputRequiredResult
-    def reject_input_required_discover!(result)
-      return unless MCPClient::JsonRpcCommon.result_type(result) == 'input_required'
-
-      raise MCPClient::Errors::ModernServerError,
-            'Server answered server/discover with an input_required result; multi round-trip requests are ' \
-            "only valid for #{MRTR_METHODS.join(', ')}"
-    end
-
     # Check a server/discover answer before anything is read out of it.
     #
     # The input_required rejection has to come first: an InputRequiredResult

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -522,18 +522,39 @@ module MCPClient
     # discover answer is invalid and MUST NOT be applied or cached: the probe
     # would otherwise adopt a protocol version out of an unfinished result
     # and hand that result back as the first heartbeat. The rejection is a
-    # ConnectionError, not an InvalidResultError, because a server answering
-    # server/discover at all is modern — it must never be mistaken for a
-    # legacy server and retried with the initialize handshake.
+    # ModernServerError, not an InvalidResultError, because a server
+    # answering server/discover with a 2026-07-28-only discriminator is
+    # modern: the era is settled, so it must never be retried with the
+    # initialize handshake, and MCPClient.connect must not send it on to the
+    # legacy SSE and HTTP+POST transports either.
     # @param result [Hash] the server/discover result
     # @return [void]
-    # @raise [MCPClient::Errors::ConnectionError] if the result is an InputRequiredResult
+    # @raise [MCPClient::Errors::ModernServerError] if the result is an InputRequiredResult
     def reject_input_required_discover!(result)
       return unless MCPClient::JsonRpcCommon.result_type(result) == 'input_required'
 
-      raise MCPClient::Errors::ConnectionError,
+      raise MCPClient::Errors::ModernServerError,
             'Server answered server/discover with an input_required result; multi round-trip requests are ' \
             "only valid for #{MRTR_METHODS.join(', ')}"
+    end
+
+    # Check a server/discover answer before anything is read out of it.
+    #
+    # The input_required rejection has to come first: an InputRequiredResult
+    # need only carry `requestState` ("At least one of inputRequests or
+    # requestState MUST be present"), so an unfinished discover answer does
+    # not have to look like a DiscoverResult at all. Testing the shape first
+    # would classify that answer as a permissive legacy endpoint answering an
+    # unknown method — and send initialize to a modern server.
+    # @param result [Object] the server/discover result
+    # @return [void]
+    # @raise [MCPClient::Errors::ModernServerError] on an input_required answer
+    # @raise [MCPClient::Errors::ServerError] when the answer is not a DiscoverResult
+    def require_discover_result!(result)
+      reject_input_required_discover!(result)
+      return if discover_result?(result)
+
+      raise MCPClient::Errors::ServerError, 'server/discover was answered without a DiscoverResult'
     end
 
     # Validate a log level name (logging utility levels).
@@ -706,6 +727,27 @@ module MCPClient
       return result[:resultType] if result.key?(:resultType)
 
       'complete'
+    end
+
+    # Restore the wire spelling of a peer's own JSON object. JSON object keys
+    # are always strings, but a host's response middleware may symbolize the
+    # keys of everything it parses (Faraday's :json parser with
+    # symbolize_names) — the middleware ::result_type already tolerates for
+    # the resultType discriminator. Undoing it once, on the protocol object
+    # about to be read, keeps every lookup below (and the params the input
+    # handlers see) on the shape the protocol defines. Values are returned
+    # untouched, so an opaque requestState is still echoed verbatim.
+    # @param value [Object] a parsed JSON value
+    # @return [Object] the same value with Symbol keys spelled as Strings
+    def self.restore_wire_keys(value)
+      case value
+      when Hash
+        value.to_h { |key, member| [key.is_a?(Symbol) ? key.to_s : key, restore_wire_keys(member)] }
+      when Array
+        value.map { |member| restore_wire_keys(member) }
+      else
+        value
+      end
     end
 
     # Result types this transport accepts. Overridden (widened) by transports
@@ -991,6 +1033,11 @@ module MCPClient
       round_trips = 0
       delay = INPUT_RETRY_DELAY
       while MCPClient::JsonRpcCommon.result_type(result) == 'input_required'
+        # Read on the wire spelling, whatever the transport's JSON middleware
+        # did to the keys: a symbolized inputRequests/requestState would
+        # otherwise be invisible here and the retry would go out with neither
+        # the fulfilled answers nor the state the server MUST get back.
+        result = MCPClient::JsonRpcCommon.restore_wire_keys(result)
         unless modern? && MRTR_METHODS.include?(method)
           raise MCPClient::Errors::InvalidResultError,
                 "Invalid result: input_required is only valid for #{MRTR_METHODS.join(', ')} " \

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -760,7 +760,7 @@ module MCPClient
       return result if type == 'complete'
 
       message = "#{method} answered with resultType #{type.to_s[0, 64].inspect}, which this " \
-                'client cannot carry through (multi round-trip requests are not implemented)'
+                'client cannot carry through'
       raise MCPClient::Errors::InputRequiredError.new(message, data: result) if type == 'input_required'
 
       raise MCPClient::Errors::InvalidResultError.new("Invalid result: #{message}", data: result)

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -1039,9 +1039,10 @@ module MCPClient
         # the fulfilled answers nor the state the server MUST get back.
         result = MCPClient::JsonRpcCommon.restore_wire_keys(result)
         unless modern? && MRTR_METHODS.include?(method)
-          raise MCPClient::Errors::InvalidResultError,
-                "Invalid result: input_required is only valid for #{MRTR_METHODS.join(', ')} " \
-                "on an MCP 2026-07-28 server, not #{method} (#{protocol_version})"
+          raise MCPClient::Errors::InvalidResultError.new(
+            "Invalid result: input_required is only valid for #{MRTR_METHODS.join(', ')} " \
+            "on an MCP 2026-07-28 server, not #{method} (#{protocol_version})", data: result
+          )
         end
 
         round_trips += 1

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -4,10 +4,13 @@ require 'json'
 require 'zlib'
 require 'stringio'
 require_relative 'header_params'
+require_relative 'json_rpc_common/error_bodies'
 
 module MCPClient
   # Shared retry/backoff logic for JSON-RPC transports
   module JsonRpcCommon
+    include ErrorBodies
+
     # JSON-RPC methods with arbitrary side effects that MUST NOT be re-sent
     # automatically. Even a "transient" failure (5xx, dropped connection,
     # malformed response) can arrive AFTER the server received the request,
@@ -806,97 +809,6 @@ module MCPClient
       raise MCPClient::Errors::InputRequiredError.new(message, data: result) if type == 'input_required'
 
       raise MCPClient::Errors::InvalidResultError.new("Invalid result: #{message}", data: result)
-    end
-
-    # Build the error for a 4xx response: the typed JSON-RPC error when the
-    # body is a JSON-RPC error response (with the HTTP status prefixed to the
-    # peer's message), otherwise a plain ServerError with the fallback text.
-    # @param response [Faraday::Response] the 4xx response
-    # @param fallback [String] message when the body carries no JSON-RPC error
-    # @return [MCPClient::Errors::ServerError]
-    def jsonrpc_error_from_http_response(response, fallback)
-      status = response.status
-      error = jsonrpc_error_in_body(response)
-      return MCPClient::Errors::ServerError.new(fallback).tap { |e| e.http_status = status } unless error
-
-      typed = MCPClient::Errors::ServerError.from_jsonrpc(error)
-      typed.class.new("#{fallback}: #{typed.message}", code: typed.code, data: typed.data)
-           .tap { |e| e.http_status = status }
-    end
-
-    # Ceiling on the size of an HTTP error body inspected for a JSON-RPC
-    # error. A protocol error response is a few hundred bytes; the body is
-    # peer-controlled, so anything larger is not parsed at all rather than
-    # handed to JSON.parse.
-    MAX_ERROR_BODY_BYTES = 64 * 1024
-
-    # Extract a JSON-RPC error object from an HTTP error body, if there is one.
-    # Only a JSON-RPC 2.0 error response is recognized; anything else is
-    # ignored.
-    # @param response [Faraday::Response] the HTTP response
-    # @return [Hash, nil] the JSON-RPC `error` member, or nil
-    def jsonrpc_error_in_body(response)
-      return nil unless response.respond_to?(:body)
-
-      data = decoded_error_body(response)
-      # Only a JSON-RPC 2.0 error response counts; an arbitrary JSON body
-      # with an "error" member is not a protocol error.
-      return nil unless data.is_a?(Hash) && (data['jsonrpc'] || data[:jsonrpc]) == '2.0'
-
-      error = data['error'] || data[:error]
-      error.is_a?(Hash) ? error : nil
-    end
-
-    # The error body as a decoded object.
-    #
-    # A host may configure the connection (faraday_config) with response
-    # middleware — `conn.response :json` — that decodes the body before it
-    # reaches this transport, on the exception path (`raise_error`) as well
-    # as the response path. That already-parsed body carries the same
-    # protocol error, so it is accepted as-is; only a raw String body is
-    # size-bounded, gunzipped and parsed here (the middleware has already
-    # spent the memory for the ones it decoded).
-    # @param response [Faraday::Response] the HTTP response
-    # @return [Object, nil] the decoded body, or nil when it cannot be read
-    def decoded_error_body(response)
-      body = response.body
-      return body if body.is_a?(Hash)
-      return nil unless body.is_a?(String) && !body.empty?
-      return nil if oversized_error_body?(body)
-
-      headers = response.respond_to?(:headers) ? response.headers || {} : {}
-      encoding = headers['content-encoding'] || headers['Content-Encoding'] || ''
-      body = gunzip_bounded(body) if encoding.include?('gzip')
-      return nil if body.nil?
-
-      JSON.parse(body)
-    rescue JSON::ParserError, Zlib::Error => e
-      @logger.debug("HTTP error body is not a JSON-RPC error: #{e.class}")
-      nil
-    end
-
-    # @param body [String] an HTTP error body
-    # @return [Boolean] whether it exceeds the inspection ceiling (logged)
-    def oversized_error_body?(body)
-      return false if body.bytesize <= MAX_ERROR_BODY_BYTES
-
-      @logger.debug("Ignoring HTTP error body of #{body.bytesize} bytes (over #{MAX_ERROR_BODY_BYTES})")
-      true
-    end
-
-    # Decompress a gzip error body, giving up once the expansion passes the
-    # inspection ceiling (a compressed 4xx body is peer-controlled too).
-    # @param body [String] gzip data
-    # @return [String, nil] the decompressed body, or nil when too large
-    def gunzip_bounded(body)
-      reader = Zlib::GzipReader.new(StringIO.new(body))
-      expanded = reader.read(MAX_ERROR_BODY_BYTES + 1) || ''
-      return expanded if expanded.bytesize <= MAX_ERROR_BODY_BYTES
-
-      @logger.debug("Ignoring gzip HTTP error body expanding past #{MAX_ERROR_BODY_BYTES} bytes")
-      nil
-    ensure
-      reader&.close
     end
 
     # Which request field mirrors into the Mcp-Name header (MCP 2026-07-28

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -4,12 +4,14 @@ require 'json'
 require 'zlib'
 require 'stringio'
 require_relative 'header_params'
+require_relative 'json_rpc_common/envelopes'
 require_relative 'json_rpc_common/error_bodies'
 require_relative 'json_rpc_common/input_waits'
 
 module MCPClient
   # Shared retry/backoff logic for JSON-RPC transports
   module JsonRpcCommon
+    include Envelopes
     include ErrorBodies
     include InputWaits
 
@@ -840,25 +842,6 @@ module MCPClient
       validate_result_type!(result)
       record_server_info(result, method: method)
       result
-    end
-
-    # Read a member of a decoded JSON-RPC envelope.
-    #
-    # The README offers Faraday's JSON middleware for reading a server's error
-    # bodies, and that middleware decodes every response — under
-    # `symbolize_names` the envelope arrives keyed by Symbol. The members are
-    # the peer's, not the host's, so both spellings name the same thing: read
-    # the wire spelling first and fall back to the Symbol one. Anything that
-    # is no Hash is indexed as before, so a malformed envelope fails where it
-    # always did.
-    # @param response [Object] the decoded JSON-RPC envelope
-    # @param name [String] the member's name in its wire spelling
-    # @return [Object, nil] the member, or nil when the envelope carries none
-    def envelope_member(response, name)
-      return response[name] unless response.is_a?(Hash)
-      return response[name] if response.key?(name)
-
-      response[name.to_sym]
     end
 
     # Client requests a server MAY answer with an InputRequiredResult (MCP

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -436,6 +436,7 @@ module MCPClient
         raise MCPClient::Errors::ConnectionError, "Server returned an invalid server/discover result (#{result.class})"
       end
 
+      reject_input_required_discover!(result)
       versions = result['supportedVersions']
       unless versions.is_a?(Array) && versions.all?(String)
         raise MCPClient::Errors::ConnectionError, 'server/discover result has no supportedVersions list'
@@ -513,6 +514,26 @@ module MCPClient
     # @return [String, nil] the cacheScope the last DiscoverResult declared
     def discovery_cache_scope
       defined?(@discovery_cache_scope) ? @discovery_cache_scope : nil
+    end
+
+    # An InputRequiredResult is defined only for tools/call, resources/read
+    # and prompts/get (MCP 2026-07-28 basic/patterns/mrtr "Supported
+    # Requests"). server/discover is not one of them, so an input_required
+    # discover answer is invalid and MUST NOT be applied or cached: the probe
+    # would otherwise adopt a protocol version out of an unfinished result
+    # and hand that result back as the first heartbeat. The rejection is a
+    # ConnectionError, not an InvalidResultError, because a server answering
+    # server/discover at all is modern — it must never be mistaken for a
+    # legacy server and retried with the initialize handshake.
+    # @param result [Hash] the server/discover result
+    # @return [void]
+    # @raise [MCPClient::Errors::ConnectionError] if the result is an InputRequiredResult
+    def reject_input_required_discover!(result)
+      return unless MCPClient::JsonRpcCommon.result_type(result) == 'input_required'
+
+      raise MCPClient::Errors::ConnectionError,
+            'Server answered server/discover with an input_required result; multi round-trip requests are ' \
+            "only valid for #{MRTR_METHODS.join(', ')}"
     end
 
     # Validate a log level name (logging utility levels).
@@ -955,7 +976,8 @@ module MCPClient
     # handlers and retry the original request — as an independent request
     # with a new id — carrying inputResponses keyed like the requests and
     # the opaque requestState echoed verbatim (omitted when the server sent
-    # none). A result without inputRequests is retried immediately.
+    # none). A result without inputRequests asks for nothing this client can
+    # fulfil, so it is retried after a growing pause (INPUT_RETRY_DELAY).
     # @param method [String] the JSON-RPC method
     # @param params [Hash] the original params
     # @param timeout [Numeric, nil] per-request timeout

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -521,25 +521,6 @@ module MCPClient
       defined?(@discovery_cache_scope) ? @discovery_cache_scope : nil
     end
 
-    # Check a server/discover answer before anything is read out of it.
-    #
-    # The input_required rejection has to come first: an InputRequiredResult
-    # need only carry `requestState` ("At least one of inputRequests or
-    # requestState MUST be present"), so an unfinished discover answer does
-    # not have to look like a DiscoverResult at all. Testing the shape first
-    # would classify that answer as a permissive legacy endpoint answering an
-    # unknown method — and send initialize to a modern server.
-    # @param result [Object] the server/discover result
-    # @return [void]
-    # @raise [MCPClient::Errors::ModernServerError] on an input_required answer
-    # @raise [MCPClient::Errors::ServerError] when the answer is not a DiscoverResult
-    def require_discover_result!(result)
-      reject_input_required_discover!(result)
-      return if discover_result?(result)
-
-      raise MCPClient::Errors::ServerError, 'server/discover was answered without a DiscoverResult'
-    end
-
     # Validate a log level name (logging utility levels).
     # @param level [String, Symbol] the level
     # @return [String] the normalized level
@@ -858,7 +839,6 @@ module MCPClient
       result = envelope_member(response, 'result')
       validate_result_type!(result)
       record_server_info(result, method: method)
-      reject_unfulfillable_input_required!(result)
       result
     end
 

--- a/lib/mcp_client/json_rpc_common/envelopes.rb
+++ b/lib/mcp_client/json_rpc_common/envelopes.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module JsonRpcCommon
+    # Reading the members of a decoded JSON-RPC envelope. A host's JSON
+    # middleware may hand the envelope over keyed by Symbol, and its members
+    # are the peer's rather than the host's, so both spellings name the same
+    # thing. Mixed into {MCPClient::JsonRpcCommon}; private there.
+    module Envelopes
+      private
+
+      # Read a member of a decoded JSON-RPC envelope.
+      #
+      # The README offers Faraday's JSON middleware for reading a server's error
+      # bodies, and that middleware decodes every response — under
+      # `symbolize_names` the envelope arrives keyed by Symbol. The members are
+      # the peer's, not the host's, so both spellings name the same thing: read
+      # the wire spelling first and fall back to the Symbol one. Anything that
+      # is no Hash is indexed as before, so a malformed envelope fails where it
+      # always did.
+      # @param response [Object] the decoded JSON-RPC envelope
+      # @param name [String] the member's name in its wire spelling
+      # @return [Object, nil] the member, or nil when the envelope carries none
+      def envelope_member(response, name)
+        return response[name] unless response.is_a?(Hash)
+        return response[name] if response.key?(name)
+
+        response[name.to_sym]
+      end
+    end
+  end
+end

--- a/lib/mcp_client/json_rpc_common/error_bodies.rb
+++ b/lib/mcp_client/json_rpc_common/error_bodies.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'zlib'
+require 'stringio'
+
+module MCPClient
+  module JsonRpcCommon
+    # Reading a JSON-RPC error object out of an HTTP error response body,
+    # bounded in size and inflated only within that bound. Mixed into
+    # {MCPClient::JsonRpcCommon}, so every transport that includes it has
+    # these helpers.
+    module ErrorBodies
+      # Build the error for a 4xx response: the typed JSON-RPC error when the
+      # body is a JSON-RPC error response (with the HTTP status prefixed to the
+      # peer's message), otherwise a plain ServerError with the fallback text.
+      # @param response [Faraday::Response] the 4xx response
+      # @param fallback [String] message when the body carries no JSON-RPC error
+      # @return [MCPClient::Errors::ServerError]
+      def jsonrpc_error_from_http_response(response, fallback)
+        status = response.status
+        error = jsonrpc_error_in_body(response)
+        return MCPClient::Errors::ServerError.new(fallback).tap { |e| e.http_status = status } unless error
+
+        typed = MCPClient::Errors::ServerError.from_jsonrpc(error)
+        typed.class.new("#{fallback}: #{typed.message}", code: typed.code, data: typed.data)
+             .tap { |e| e.http_status = status }
+      end
+
+      # Ceiling on the size of an HTTP error body inspected for a JSON-RPC
+      # error. A protocol error response is a few hundred bytes; the body is
+      # peer-controlled, so anything larger is not parsed at all rather than
+      # handed to JSON.parse.
+      MAX_ERROR_BODY_BYTES = 64 * 1024
+
+      # Extract a JSON-RPC error object from an HTTP error body, if there is one.
+      # Only a JSON-RPC 2.0 error response is recognized; anything else is
+      # ignored.
+      # @param response [Faraday::Response] the HTTP response
+      # @return [Hash, nil] the JSON-RPC `error` member, or nil
+      def jsonrpc_error_in_body(response)
+        return nil unless response.respond_to?(:body)
+
+        data = decoded_error_body(response)
+        # Only a JSON-RPC 2.0 error response counts; an arbitrary JSON body
+        # with an "error" member is not a protocol error.
+        return nil unless data.is_a?(Hash) && (data['jsonrpc'] || data[:jsonrpc]) == '2.0'
+
+        error = data['error'] || data[:error]
+        error.is_a?(Hash) ? error : nil
+      end
+
+      # The error body as a decoded object.
+      #
+      # A host may configure the connection (faraday_config) with response
+      # middleware — `conn.response :json` — that decodes the body before it
+      # reaches this transport, on the exception path (`raise_error`) as well
+      # as the response path. That already-parsed body carries the same
+      # protocol error, so it is accepted as-is; only a raw String body is
+      # size-bounded, gunzipped and parsed here (the middleware has already
+      # spent the memory for the ones it decoded).
+      # @param response [Faraday::Response] the HTTP response
+      # @return [Object, nil] the decoded body, or nil when it cannot be read
+      def decoded_error_body(response)
+        body = response.body
+        return body if body.is_a?(Hash)
+        return nil unless body.is_a?(String) && !body.empty?
+        return nil if oversized_error_body?(body)
+
+        headers = response.respond_to?(:headers) ? response.headers || {} : {}
+        encoding = headers['content-encoding'] || headers['Content-Encoding'] || ''
+        body = gunzip_bounded(body) if encoding.include?('gzip')
+        return nil if body.nil?
+
+        JSON.parse(body)
+      rescue JSON::ParserError, Zlib::Error => e
+        @logger.debug("HTTP error body is not a JSON-RPC error: #{e.class}")
+        nil
+      end
+
+      # @param body [String] an HTTP error body
+      # @return [Boolean] whether it exceeds the inspection ceiling (logged)
+      def oversized_error_body?(body)
+        return false if body.bytesize <= MAX_ERROR_BODY_BYTES
+
+        @logger.debug("Ignoring HTTP error body of #{body.bytesize} bytes (over #{MAX_ERROR_BODY_BYTES})")
+        true
+      end
+
+      # Decompress a gzip error body, giving up once the expansion passes the
+      # inspection ceiling (a compressed 4xx body is peer-controlled too).
+      # @param body [String] gzip data
+      # @return [String, nil] the decompressed body, or nil when too large
+      def gunzip_bounded(body)
+        reader = Zlib::GzipReader.new(StringIO.new(body))
+        expanded = reader.read(MAX_ERROR_BODY_BYTES + 1) || ''
+        return expanded if expanded.bytesize <= MAX_ERROR_BODY_BYTES
+
+        @logger.debug("Ignoring gzip HTTP error body expanding past #{MAX_ERROR_BODY_BYTES} bytes")
+        nil
+      ensure
+        reader&.close
+      end
+    end
+  end
+end

--- a/lib/mcp_client/json_rpc_common/input_waits.rb
+++ b/lib/mcp_client/json_rpc_common/input_waits.rb
@@ -28,6 +28,28 @@ module MCPClient
       # to wait the pace and retry.
       # @param block [Proc] callback that receives an InputRequiredWait
       # @return [void]
+      # An InputRequiredResult is defined only for tools/call, resources/read
+      # and prompts/get (MCP 2026-07-28 basic/patterns/mrtr "Supported
+      # Requests"). server/discover is not one of them, so an input_required
+      # discover answer is invalid and MUST NOT be applied or cached: the probe
+      # would otherwise adopt a protocol version out of an unfinished result
+      # and hand that result back as the first heartbeat. The rejection is a
+      # ModernServerError, not an InvalidResultError, because a server
+      # answering server/discover with a 2026-07-28-only discriminator is
+      # modern: the era is settled, so it must never be retried with the
+      # initialize handshake, and MCPClient.connect must not send it on to the
+      # legacy SSE and HTTP+POST transports either.
+      # @param result [Hash] the server/discover result
+      # @return [void]
+      # @raise [MCPClient::Errors::ModernServerError] if the result is an InputRequiredResult
+      def reject_input_required_discover!(result)
+        return unless MCPClient::JsonRpcCommon.result_type(result) == 'input_required'
+
+        raise MCPClient::Errors::ModernServerError,
+              'Server answered server/discover with an input_required result; multi round-trip requests are ' \
+              "only valid for #{MRTR_METHODS.join(', ')}"
+      end
+
       def on_input_required_wait(&block)
         @input_required_wait_callback = block
       end

--- a/lib/mcp_client/json_rpc_common/input_waits.rb
+++ b/lib/mcp_client/json_rpc_common/input_waits.rb
@@ -102,30 +102,59 @@ module MCPClient
 
       # One pause of a continuation that asked for nothing, as the host steers
       # it. Returns the pace for the next such pause.
+      #
+      # The host's control is host code: it may open a window, ask a person
+      # and come back much later. That time belongs to the request, so the
+      # deadline is read against the clock as it stands when the control
+      # returns, not as it stood when the answer arrived — otherwise a
+      # control that deliberates for most of the timeout still buys itself a
+      # full pause and another request on top of it.
       # @param wait [InputRequiredWait] what the host is told
       # @param deadline [Float, nil] the request timeout on the wait clock
-      # @param now [Float] the wait clock when the answer arrived
       # @return [Numeric] the next delay
-      # @raise [MCPClient::Errors::InputRequiredError] cancelled, or the pause would pass the timeout
-      def pace_input_round_trip(wait, deadline, now)
+      # @raise [MCPClient::Errors::InputRequiredError] cancelled, or out of time for the pause
+      def pace_input_round_trip(wait, deadline)
         decision = @input_required_wait_callback&.call(wait)
-        return wait.delay if decision == :retry
-
+        now = input_wait_clock
         if decision == :cancel
           raise MCPClient::Errors::InputRequiredError.new(
             "#{wait.rpc_method} cancelled by the host while waiting for out-of-band input " \
             "(round trip #{wait.round_trip})", data: wait.result
           )
         end
-        if deadline && now + wait.delay > deadline
+        # "Retry now" skips the pause, so only a deadline that has already
+        # passed stops it: the request it would re-send is over either way.
+        pause = decision == :retry ? 0 : wait.delay
+        if deadline && now + pause > deadline
           raise MCPClient::Errors::InputRequiredError.new(
             "#{wait.rpc_method} is still waiting for out-of-band input at the request timeout " \
             "(round trip #{wait.round_trip}); resume it from the continuation", data: wait.result
           )
         end
+        return wait.delay if decision == :retry
 
         sleep(wait.delay)
         [wait.delay * 2, INPUT_RETRY_MAX_DELAY].min
+      end
+
+      # @param started [Float] the wait clock when the request began
+      # @param timeout [Numeric, nil] the per-request timeout, when the caller gave one
+      # @return [Float, nil] the wait clock reading the waits of this request must not pass
+      def input_wait_deadline(started, timeout)
+        bound = input_wait_timeout(timeout)
+        bound ? started + bound : nil
+      end
+
+      # The bound an out-of-band wait is measured against. A caller that named
+      # no timeout still runs under one — the transport's configured read
+      # timeout — and a wait that outlived it would outlive the request it
+      # belongs to. A transport that bounds nothing (a host adapter that sets
+      # no read timeout) leaves the round-trip ceiling as the only limit.
+      # @param timeout [Numeric, nil] the per-request timeout, when the caller gave one
+      # @return [Numeric, nil] the seconds the waits of this request share
+      def input_wait_timeout(timeout)
+        bound = timeout || (@read_timeout if defined?(@read_timeout))
+        bound if bound.is_a?(Numeric) && bound.positive?
       end
 
       # @return [Float] the monotonic clock, in seconds, the out-of-band waits are bounded by

--- a/lib/mcp_client/json_rpc_common/input_waits.rb
+++ b/lib/mcp_client/json_rpc_common/input_waits.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module JsonRpcCommon
+    # The host's hand on a multi round-trip request that waits on an
+    # interaction happening out of band (MCP 2026-07-28 client/elicitation
+    # "URL Mode": "Clients SHOULD provide manual controls that let the user
+    # retry or cancel the original request"): the pause before each retry of
+    # a requestState-only answer is the host's to steer, it never runs past
+    # the request timeout, and a stopped request resumes from the
+    # continuation its error carries. Mixed into {MCPClient::JsonRpcCommon}.
+    module InputWaits
+      # What the host is told before each paced retry of a continuation that
+      # asked for nothing (an out-of-band interaction still in progress): the
+      # request, how many round trips it has taken, the pause about to be
+      # taken, the server's requestState, the InputRequiredResult itself and
+      # the seconds spent waiting so far.
+      InputRequiredWait = Struct.new(:rpc_method, :round_trip, :delay, :request_state, :result, :elapsed,
+                                     keyword_init: true)
+
+      # Register the host's control over an out-of-band wait (MCP 2026-07-28
+      # client/elicitation "URL Mode": "Clients SHOULD provide manual controls
+      # that let the user retry or cancel the original request"). The block is
+      # called with an {InputRequiredWait} before each paced retry of a
+      # continuation that asked for nothing; it returns `:retry` to retry at
+      # once, `:cancel` to stop with an {MCPClient::Errors::InputRequiredError}
+      # the host can hand to {#resume_input_required} later, or anything else
+      # to wait the pace and retry.
+      # @param block [Proc] callback that receives an InputRequiredWait
+      # @return [void]
+      def on_input_required_wait(&block)
+        @input_required_wait_callback = block
+      end
+
+      # Resume a multi round-trip request from the continuation an
+      # {MCPClient::Errors::InputRequiredError} carries: the original request
+      # goes out again as a new request with the server's requestState echoed
+      # and no inputResponses, and the round trip continues from there.
+      # @param error [MCPClient::Errors::InputRequiredError] a resumable error
+      # @param timeout [Numeric, nil] per-request timeout for the resumed request
+      # @return [Object] the final (complete) result
+      # @raise [ArgumentError] if the error carries no continuation
+      def resume_input_required(error, timeout: nil)
+        unless error.is_a?(MCPClient::Errors::InputRequiredError) && error.resumable?
+          raise ArgumentError, 'the error carries no continuation to resume'
+        end
+
+        params = error.request_params.is_a?(Hash) ? error.request_params.dup : {}
+        %w[inputResponses requestState].each do |key|
+          params.delete(key)
+          params.delete(key.to_sym)
+        end
+        params['requestState'] = error.request_state unless error.request_state.nil?
+        ensure_initialized if respond_to?(:ensure_initialized, true)
+        rpc_request(error.request_method, params, timeout: timeout)
+      end
+
+      private
+
+      # The params for a multi round-trip retry: the original params plus the
+      # fulfilled inputResponses and the server's requestState. Both fields
+      # affect only this retry; the caller's params are not mutated.
+      # @param params [Hash] the original params
+      # @param result [Hash] the InputRequiredResult
+      # @return [Hash]
+      def retry_params_for(params, result)
+        retry_params = (params.is_a?(Hash) ? params.dup : {})
+        retry_params.delete('inputResponses')
+        retry_params.delete(:inputResponses)
+        retry_params.delete('requestState')
+        retry_params.delete(:requestState)
+
+        if result.key?('inputRequests')
+          retry_params['inputResponses'] = fulfil_input_requests(result['inputRequests'], result)
+        end
+        state = result['requestState']
+        retry_params['requestState'] = state unless state.nil?
+        retry_params
+      end
+
+      # One pause of a continuation that asked for nothing, as the host steers
+      # it. Returns the pace for the next such pause.
+      # @param wait [InputRequiredWait] what the host is told
+      # @param deadline [Float, nil] the request timeout on the wait clock
+      # @param now [Float] the wait clock when the answer arrived
+      # @return [Numeric] the next delay
+      # @raise [MCPClient::Errors::InputRequiredError] cancelled, or the pause would pass the timeout
+      def pace_input_round_trip(wait, deadline, now)
+        decision = @input_required_wait_callback&.call(wait)
+        return wait.delay if decision == :retry
+
+        if decision == :cancel
+          raise MCPClient::Errors::InputRequiredError.new(
+            "#{wait.rpc_method} cancelled by the host while waiting for out-of-band input " \
+            "(round trip #{wait.round_trip})", data: wait.result
+          )
+        end
+        if deadline && now + wait.delay > deadline
+          raise MCPClient::Errors::InputRequiredError.new(
+            "#{wait.rpc_method} is still waiting for out-of-band input at the request timeout " \
+            "(round trip #{wait.round_trip}); resume it from the continuation", data: wait.result
+          )
+        end
+
+        sleep(wait.delay)
+        [wait.delay * 2, INPUT_RETRY_MAX_DELAY].min
+      end
+
+      # @return [Float] the monotonic clock, in seconds, the out-of-band waits are bounded by
+      def input_wait_clock
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
+  end
+end

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -116,6 +116,9 @@ module MCPClient
       @http_conn = nil
       @session_id = nil
       @oauth_provider = opts[:oauth_provider]
+      @elicitation_request_callback = nil # MCP 2026-07-28 multi round-trip requests
+      @roots_list_request_callback = nil
+      @sampling_request_callback = nil
     end
 
     # Connect to the MCP server over HTTP
@@ -461,6 +464,29 @@ module MCPClient
       Enumerator.new do |yielder|
         yielder << call_tool(tool_name, parameters)
       end
+    end
+
+    # Register a handler for elicitation input requests (MCP 2026-07-28 multi
+    # round-trip requests; there is no server-initiated request channel on
+    # this transport, so these only serve InputRequiredResult round trips).
+    # @param block [Proc] callback that receives (key, params) and returns an ElicitResult
+    # @return [void]
+    def on_elicitation_request(&block)
+      @elicitation_request_callback = block
+    end
+
+    # Register a handler for roots/list input requests (MCP 2026-07-28).
+    # @param block [Proc] callback that receives (key, params) and returns a ListRootsResult
+    # @return [void]
+    def on_roots_list_request(&block)
+      @roots_list_request_callback = block
+    end
+
+    # Register a handler for sampling input requests (MCP 2026-07-28).
+    # @param block [Proc] callback that receives (key, params) and returns a CreateMessageResult
+    # @return [void]
+    def on_sampling_request(&block)
+      @sampling_request_callback = block
     end
 
     # Terminate the current session (if any)

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -489,6 +489,18 @@ module MCPClient
       @sampling_request_callback = block
     end
 
+    # This transport has no legacy server-request channel (server requests on
+    # a response stream are dropped), so on a legacy session it must not
+    # advertise roots, elicitation or sampling: the handlers above only serve
+    # the modern multi round-trip pattern.
+    # @return [Hash]
+    def client_capabilities
+      capabilities = super
+      return capabilities if modern?
+
+      capabilities.except('roots', 'elicitation', 'sampling')
+    end
+
     # Terminate the current session (if any)
     # @return [Boolean] true if termination was successful or no session exists
     def terminate_session

--- a/lib/mcp_client/server_sse/json_rpc_transport.rb
+++ b/lib/mcp_client/server_sse/json_rpc_transport.rb
@@ -30,18 +30,29 @@ module MCPClient
       def rpc_request(method, params = {}, timeout: nil)
         ensure_initialized
 
-        with_retry(method) do
-          request_id = @mutex.synchronize { @request_id += 1 }
-          request = build_jsonrpc_request(method, params, request_id)
-          begin
-            send_jsonrpc_request(request, timeout: timeout)
-          rescue MCPClient::Errors::RequestTimeoutError
-            # MCP lifecycle: on timeout the sender SHOULD issue a cancellation
-            # notification for the abandoned request and stop waiting.
-            send_cancellation_notification(request_id) if cancellable_request?(method, params)
-            raise
-          end
+        # The multi round-trip resolver sits outside the per-attempt retry, so
+        # a retry carrying inputResponses/requestState keeps them through
+        # transport retries — the same shape as the other transports, so an
+        # input_required answer is validated and fulfilled here as well.
+        resolve_input_round_trips(method, params, timeout) do |attempt_params|
+          with_retry(method) { send_one_request(method, attempt_params, timeout) }
         end
+      end
+
+      # One request on the wire: build it, send it and wait for its answer.
+      # @param method [String] JSON-RPC method
+      # @param params [Hash] the params of this attempt
+      # @param timeout [Numeric, nil] per-request timeout
+      # @return [Object] the result
+      def send_one_request(method, params, timeout)
+        request_id = @mutex.synchronize { @request_id += 1 }
+        request = build_jsonrpc_request(method, params, request_id)
+        send_jsonrpc_request(request, timeout: timeout)
+      rescue MCPClient::Errors::RequestTimeoutError
+        # MCP lifecycle: on timeout the sender SHOULD issue a cancellation
+        # notification for the abandoned request and stop waiting.
+        send_cancellation_notification(request_id) if request_id && cancellable_request?(method, params)
+        raise
       end
 
       # Best-effort notifications/cancelled for a request the client stopped

--- a/lib/mcp_client/server_stdio/json_rpc_transport.rb
+++ b/lib/mcp_client/server_stdio/json_rpc_transport.rb
@@ -250,6 +250,7 @@ module MCPClient
         # not recorded: apply_discover_result records it once the whole
         # result has validated.
         result = process_jsonrpc_response(res, method: 'server/discover')
+        reject_input_required_discover!(result)
         unless discover_result?(result)
           raise invalid_discover_answer(modern_answer, 'answered without a DiscoverResult')
         end
@@ -525,6 +526,14 @@ module MCPClient
         # recovery, so a retry that carries inputResponses/requestState keeps
         # them through transport retries, version renegotiation and the like.
         result = resolve_input_round_trips(method, params, timeout) do |attempt_params|
+          # Every round is its own request, and the subprocess may have exited
+          # between two of them — the host handler that gathers the input
+          # waits for a person. MCP 2026-07-28 basic/transports/stdio
+          # ("Unexpected Termination"): the client SHOULD restart a server
+          # that terminated unexpectedly. The continuation is then re-issued
+          # against the fresh process with the answers and the state it was
+          # gathered for, rather than written to a dead pipe.
+          ensure_initialized
           with_retry(method) do
             sent_version = nil
             begin

--- a/lib/mcp_client/server_stdio/json_rpc_transport.rb
+++ b/lib/mcp_client/server_stdio/json_rpc_transport.rb
@@ -521,25 +521,30 @@ module MCPClient
           method = 'server/discover'
         end
 
-        result = with_retry(method) do
-          sent_version = nil
-          begin
-            send_request_and_wait(method, params, timeout) { |version| sent_version = version }
-          rescue MCPClient::Errors::UnsupportedProtocolVersionError => e
-            # MCP 2026-07-28 basic/versioning: "The client SHOULD select a
-            # mutually supported version from the supported list and retry
-            # the request". The server rejected the request before
-            # processing it, so re-sending cannot duplicate a side effect.
-            # Compared against the version THIS request declared, read back
-            # from the request itself: a concurrent request may have moved
-            # the transport on while this one was being built.
-            version = select_protocol_version(e.supported)
-            raise unless modern? && version && version != sent_version
+        # The multi round-trip resolver sits outside the per-attempt
+        # recovery, so a retry that carries inputResponses/requestState keeps
+        # them through transport retries, version renegotiation and the like.
+        result = resolve_input_round_trips(method, params, timeout) do |attempt_params|
+          with_retry(method) do
+            sent_version = nil
+            begin
+              send_request_and_wait(method, attempt_params, timeout) { |version| sent_version = version }
+            rescue MCPClient::Errors::UnsupportedProtocolVersionError => e
+              # MCP 2026-07-28 basic/versioning: "The client SHOULD select a
+              # mutually supported version from the supported list and retry
+              # the request". The server rejected the request before
+              # processing it, so re-sending cannot duplicate a side effect.
+              # Compared against the version THIS request declared, read back
+              # from the request itself: a concurrent request may have moved
+              # the transport on while this one was being built.
+              version = select_protocol_version(e.supported)
+              raise unless modern? && version && version != sent_version
 
-            @logger.info("Server does not support protocol version #{sent_version}; " \
-                         "retrying #{method} with #{version}")
-            @protocol_version = version
-            send_request_and_wait(method, params, timeout)
+              @logger.info("Server does not support protocol version #{sent_version}; " \
+                           "retrying #{method} with #{version}")
+              @protocol_version = version
+              send_request_and_wait(method, attempt_params, timeout)
+            end
           end
         end
         # Every server/discover answer is validated and applied: a later

--- a/spec/lib/mcp_client/client_roots_spec.rb
+++ b/spec/lib/mcp_client/client_roots_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe MCPClient::Client, 'Roots (MCP 2025-06-18)' do
     allow(mock_server).to receive(:respond_to?).with(:on_sampling_request).and_return(true)
     allow(mock_server).to receive(:respond_to?).with(:protocol_era).and_return(true)
     allow(mock_server).to receive(:protocol_era).and_return(:legacy)
+    # A legacy session that declared roots: only declared capabilities may be
+    # used, so notify_roots_changed asks the transport what it declared.
+    allow(mock_server).to receive(:respond_to?).with(:client_capabilities).and_return(true)
+    allow(mock_server).to receive(:client_capabilities).and_return({ 'roots' => { 'listChanged' => true } })
     allow(mock_server).to receive(:on_elicitation_request)
     allow(mock_server).to receive(:on_roots_list_request)
     allow(mock_server).to receive(:on_sampling_request)

--- a/spec/lib/mcp_client/mrtr_2026_round4_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_round4_spec.rb
@@ -1,0 +1,358 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 multi round-trip requests, review round 4 (codex): the
+# corners a mutated resolver survived — two input requests sharing a method,
+# continuations correlated by id through the real reader with answers
+# arriving out of order, the Client sampling adapter on a two-round tool
+# loop, a continuation's own timeout over a real pipe, the legacy form
+# answer for an action outside the schema, and the malformed shapes of an
+# input request.
+RSpec.describe 'MCP 2026-07-28 multi round-trip requests — round 4' do
+  def discover_result
+    { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'], 'capabilities' => { 'tools' => {} } }
+  end
+
+  def input_required(requests, state: 'st')
+    result = { 'resultType' => 'input_required', 'requestState' => state }
+    result['inputRequests'] = requests unless requests.nil?
+    result
+  end
+
+  def form_elicit_request(message = 'Who?')
+    { 'method' => 'elicitation/create',
+      'params' => { 'mode' => 'form', 'message' => message,
+                    'requestedSchema' => { 'type' => 'object',
+                                           'properties' => { 'name' => { 'type' => 'string' } } } } }
+  end
+
+  def sampling_request(extra = {})
+    { 'method' => 'sampling/createMessage',
+      'params' => { 'messages' => [{ 'role' => 'user',
+                                     'content' => { 'type' => 'text', 'text' => 'Capital of France?' } }],
+                    'maxTokens' => 100 }.merge(extra) }
+  end
+
+  def modern_stdio(**)
+    MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1, **)
+  end
+
+  def script_stdio(server, responses)
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    allow(server).to receive(:sleep)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift or raise 'no scripted response left'
+      responder.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+    sent
+  end
+
+  def client_with(server, **)
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+    MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'x' }], **)
+  end
+
+  # Wire the transport's stdout to a pipe so every response travels the real
+  # reader thread; the responder decides what (if anything) to write back,
+  # and may write more than one line at once.
+  def wire_up(server, &responder)
+    reader, writer = IO.pipe
+    sent = []
+    write_lock = Mutex.new
+    stdin = double('stdin', flush: nil, closed?: false, close: nil)
+    allow(stdin).to receive(:puts) do |line|
+      request = JSON.parse(line)
+      sent << request
+      answers = responder.call(request)
+      answers = [answers] if answers.is_a?(Hash)
+      (answers || []).each { |answer| write_lock.synchronize { writer.puts(JSON.generate(answer)) } }
+    end
+    server.instance_variable_set(:@stdin, stdin)
+    allow(server).to receive(:connect) do
+      server.instance_variable_set(:@stdout, reader)
+      true
+    end
+    allow(server).to receive(:start_stderr_reader)
+    allow(server).to receive(:sleep)
+    [sent, reader, writer]
+  end
+
+  def response_to(request, result)
+    { 'jsonrpc' => '2.0', 'id' => request['id'], 'result' => result }
+  end
+
+  describe 'two input requests that share a method' do
+    it 'fulfils both, each with its own answer, in one round trip' do
+      server = modern_stdio
+      handled = []
+      server.on_elicitation_request do |key, params|
+        handled << key
+        { 'action' => 'accept', 'content' => { 'name' => "#{key}:#{params['message']}" } }
+      end
+      sent = script_stdio(server, [{ 'result' => discover_result },
+                                   { 'result' => input_required({ 'first' => form_elicit_request('one'),
+                                                                  'second' => form_elicit_request('two') }) },
+                                   { 'result' => { 'content' => [] } }])
+
+      server.call_tool('t', {})
+
+      expect(handled).to contain_exactly('first', 'second')
+      expect(sent.last['params']['inputResponses'])
+        .to eq({ 'first' => { 'action' => 'accept', 'content' => { 'name' => 'first:one' } },
+                 'second' => { 'action' => 'accept', 'content' => { 'name' => 'second:two' } } })
+    end
+  end
+
+  describe 'overlapping continuations through the real reader' do
+    it 'delivers each continuation its own answer when the answers arrive in reverse order' do
+      server = modern_stdio(read_timeout: 5)
+      held = Queue.new
+      # The two continuations are held until both are on the wire and then
+      # answered in REVERSE order, so arrival order and request order differ.
+      sent, reader, writer = wire_up(server) do |request|
+        case request['method']
+        when 'server/discover' then response_to(request, discover_result)
+        when 'tools/call'
+          name = request['params']['name']
+          if request['params'].key?('inputResponses')
+            held << request
+            next nil if held.size < 2
+
+            Array.new(2) { held.pop }.reverse.map do |continuation|
+              params = continuation['params']
+              answered_for = params['inputResponses'][params['name']]['content']['for']
+              response_to(continuation, { 'content' => [{ 'type' => 'text',
+                                                          'text' => "#{params['name']}:#{answered_for}" }] })
+            end
+          else
+            response_to(request, input_required({ name => form_elicit_request(name) }, state: "state-#{name}"))
+          end
+        end
+      end
+      inside = Queue.new
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+      server.on_elicitation_request do |key, _params|
+        inside << key
+        sleep(0.001) while inside.size < 2 && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+        { 'action' => 'accept', 'content' => { 'for' => key } }
+      end
+
+      begin
+        alpha = Thread.new { server.call_tool('alpha', {}) }
+        beta = Thread.new { server.call_tool('beta', {}) }
+
+        expect(alpha.value['content'].first['text']).to eq('alpha:alpha')
+        expect(beta.value['content'].first['text']).to eq('beta:beta')
+        continuations = sent.select { |r| r['method'] == 'tools/call' && r['params'].key?('inputResponses') }
+        expect(continuations.map { |r| [r['params']['name'], r['params']['requestState']] })
+          .to contain_exactly(%w[alpha state-alpha], %w[beta state-beta])
+        expect(server.instance_variable_get(:@pending)).to be_empty
+        expect(server.instance_variable_get(:@awaiting)).to be_empty
+      ensure
+        server.cleanup
+        reader.close unless reader.closed?
+        writer.close unless writer.closed?
+      end
+    end
+  end
+
+  describe 'the Client sampling adapter on a two-round tool loop' do
+    it 'passes several tool uses through with the toolUse default and forwards the matching results' do
+      stdio = modern_stdio
+      rounds = []
+      handler = lambda do |messages, _prefs, _system, _max, params|
+        rounds << [messages, params['tools']]
+        if rounds.size == 1
+          # No role, model or stopReason: the adapter supplies them.
+          { 'content' => [{ 'type' => 'tool_use', 'id' => 'call_1', 'name' => 'search', 'input' => { 'q' => 'paris' } },
+                          { 'type' => 'tool_use', 'id' => 'call_2', 'name' => 'fetch', 'input' => {} }] }
+        else
+          { 'content' => 'Paris' }
+        end
+      end
+      client = client_with(stdio, sampling_handler: handler, sampling_supports_tools: true)
+      tools = [{ 'name' => 'search', 'inputSchema' => { 'type' => 'object' } },
+               { 'name' => 'fetch', 'inputSchema' => { 'type' => 'object' } }]
+      tool_results = [{ 'role' => 'user',
+                        'content' => [{ 'type' => 'tool_result', 'toolUseId' => 'call_1',
+                                        'content' => [{ 'type' => 'text', 'text' => 'Paris' }] },
+                                      { 'type' => 'tool_result', 'toolUseId' => 'call_2',
+                                        'content' => [{ 'type' => 'text', 'text' => 'ok' }] }] }]
+      sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                  { 'result' => { 'tools' => [{ 'name' => 'c',
+                                                                'inputSchema' => { 'type' => 'object' } }] } },
+                                  { 'result' => input_required({ 's' => sampling_request('tools' => tools) },
+                                                               state: 'loop') },
+                                  { 'result' => input_required({ 's2' => sampling_request('tools' => tools,
+                                                                                          'messages' => tool_results) },
+                                                               state: 'loop') },
+                                  { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'done' }] } }])
+
+      expect(client.call_tool('c', {})['content'].first['text']).to eq('done')
+
+      calls = sent.select { |r| r['method'] == 'tools/call' }
+      first = calls[1]['params']['inputResponses']['s']
+      expect(first['content'].map { |c| c['id'] }).to eq(%w[call_1 call_2])
+      expect(first['content'].map { |c| c['type'] }).to eq(%w[tool_use tool_use])
+      expect(first).to include('role' => 'assistant', 'stopReason' => 'toolUse', 'model' => 'unknown')
+      expect(rounds.last).to eq([tool_results, tools])
+      expect(calls[2]['params']['inputResponses'])
+        .to eq({ 's2' => { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'Paris' },
+                           'model' => 'unknown', 'stopReason' => 'endTurn' } })
+    end
+  end
+
+  describe 'a continuation that times out over the real wire' do
+    it 'honours the request timeout, cancels by the continuation id and leaves no registration behind' do
+      server = modern_stdio(read_timeout: 5, retries: 0)
+      server.on_elicitation_request { |_key, _params| { 'action' => 'accept', 'content' => { 'name' => 'ada' } } }
+      sent, reader, writer = wire_up(server) do |request|
+        case request['method']
+        when 'server/discover' then response_to(request, discover_result)
+        when 'tools/call'
+          # The continuation is never answered.
+          next nil if request['params'].key?('inputResponses')
+
+          response_to(request, input_required({ 'a' => form_elicit_request }))
+        end
+      end
+
+      begin
+        started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        expect { server.rpc_request('tools/call', { 'name' => 'greet', 'arguments' => {} }, timeout: 0.2) }
+          .to raise_error(MCPClient::Errors::RequestTimeoutError)
+        expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).to be < 2
+
+        calls = sent.select { |r| r['method'] == 'tools/call' }
+        expect(calls.size).to eq(2)
+        expect(calls.last['params']).to include('requestState' => 'st')
+        cancelled = sent.select { |r| r['method'] == 'notifications/cancelled' }
+        expect(cancelled.map { |n| n['params']['requestId'] }).to eq([calls.last['id']])
+        expect(server.instance_variable_get(:@pending)).to be_empty
+        expect(server.instance_variable_get(:@awaiting)).to be_empty
+      ensure
+        server.cleanup
+        reader.close unless reader.closed?
+        writer.close unless writer.closed?
+      end
+    end
+  end
+
+  describe 'a legacy form elicitation answered with an action outside the schema' do
+    it 'answers cancel without the content' do
+      stdio = MCPClient::ServerStdio.new(command: 'echo legacy', protocol: :legacy)
+      written = []
+      stdio.instance_variable_set(:@stdin, double('stdin', flush: nil).tap do |io|
+        allow(io).to receive(:puts) { |line| written << line }
+      end)
+      client_with(stdio, elicitation_handler: ->(_m, _s) { { 'action' => 'submit', 'content' => { 'name' => 'ada' } } })
+
+      stdio.handle_server_request({ 'id' => 7, 'method' => 'elicitation/create',
+                                    'params' => form_elicit_request['params'] })
+
+      answer = JSON.parse(written.last)
+      expect(answer['id']).to eq(7)
+      expect(answer['result']).to eq({ 'action' => 'cancel' })
+      expect(answer).not_to have_key('error')
+    end
+  end
+
+  describe 'malformed input requests' do
+    {
+      'a request without a method' => { 'a' => { 'params' => {} } },
+      'a request whose method is not a string' => { 'a' => { 'method' => 42, 'params' => {} } }
+    }.each do |shape, requests|
+      it "rejects #{shape} as malformed" do
+        server = modern_stdio
+        invoked = false
+        server.on_elicitation_request { |_k, _p| invoked = true }
+        script_stdio(server, [{ 'result' => discover_result }, { 'result' => input_required(requests) }])
+
+        expect { server.call_tool('t', {}) }
+          .to raise_error(MCPClient::Errors::InputRequiredError, /Malformed input request "a"/)
+        expect(invoked).to be(false)
+      end
+    end
+
+    it 'rejects an inputRequests array as malformed' do
+      server = modern_stdio
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'x' } } }
+      script_stdio(server, [{ 'result' => discover_result },
+                            { 'result' => input_required([form_elicit_request]) }])
+
+      expect { server.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /inputRequests is not an object/)
+    end
+  end
+  # Review round 4 (grok): tools/call pins Mcp-Name on its continuation; the
+  # other two MRTR methods build their params with symbol keys and had no
+  # such pin, so a string-only header lookup would drop the header on their
+  # retries without reddening anything.
+  describe 'Mcp-Name on resources/read and prompts/get continuations (Streamable HTTP)' do
+    let(:url) { 'https://example.com/mcp' }
+    let(:server) { MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0) }
+
+    after { server.cleanup }
+
+    def stub_modern_server(answers)
+      requests = []
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        requests << { headers: request.headers, body: body }
+        result = body['method'] == 'server/discover' ? discover_result : answers.call(body)
+        { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'], 'result' => result),
+          headers: { 'Content-Type' => 'application/json' } }
+      end
+      requests
+    end
+
+    it 'mirrors the URI into Mcp-Name on the original resources/read and its continuation' do
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'ada' } } }
+      requests = stub_modern_server(lambda do |body|
+        if body['params'].key?('inputResponses')
+          { 'contents' => [{ 'uri' => 'file:///r', 'text' => 'hello' }] }
+        else
+          input_required({ 'who' => form_elicit_request })
+        end
+      end)
+
+      contents = server.read_resource('file:///r')
+
+      expect(contents.first.text).to eq('hello')
+      reads = requests.select { |r| r[:body]['method'] == 'resources/read' }
+      expect(reads.size).to eq(2)
+      expect(reads.map { |r| r[:headers]['Mcp-Name'] }).to eq(['file:///r', 'file:///r'])
+      expect(reads.map { |r| r[:headers]['Mcp-Method'] }).to eq(%w[resources/read resources/read])
+      expect(reads[1][:body]['params']).to include('uri' => 'file:///r', 'requestState' => 'st')
+      expect(reads[1][:body]['params']['inputResponses']['who']['content']).to eq({ 'name' => 'ada' })
+    end
+
+    it 'mirrors the prompt name into Mcp-Name on the original prompts/get and its continuation' do
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'ada' } } }
+      requests = stub_modern_server(lambda do |body|
+        if body['params'].key?('inputResponses')
+          { 'messages' => [{ 'role' => 'user', 'content' => { 'type' => 'text', 'text' => 'hi' } }] }
+        else
+          input_required({ 'who' => form_elicit_request })
+        end
+      end)
+
+      prompt = server.get_prompt('letter', { 'to' => 'ada' })
+
+      expect(prompt['messages'].first['content']['text']).to eq('hi')
+      gets = requests.select { |r| r[:body]['method'] == 'prompts/get' }
+      expect(gets.size).to eq(2)
+      expect(gets.map { |r| r[:headers]['Mcp-Name'] }).to eq(%w[letter letter])
+      expect(gets[1][:body]['params']).to include('name' => 'letter', 'arguments' => { 'to' => 'ada' },
+                                                  'requestState' => 'st')
+      expect(gets[1][:body]['params']['inputResponses']['who']['content']).to eq({ 'name' => 'ada' })
+    end
+  end
+end

--- a/spec/lib/mcp_client/mrtr_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_round5_spec.rb
@@ -9,7 +9,8 @@ require 'webmock/rspec'
 # way down, the continuation-level recoveries on the HTTP transports (version
 # renegotiation and an ordinary retry), two overlapping HTTP round trips each
 # spending their own HeaderMismatch refresh, and the sampling histories this
-# client hands to the host unvalidated on both eras.
+# client refuses before they reach the host on both eras (round 6 pins the
+# rules; these pin that a modern and a legacy request are refused alike).
 RSpec.describe 'MCP 2026-07-28 multi round-trip requests — round 5' do
   let(:url) { 'https://example.com/mcp' }
 
@@ -340,31 +341,37 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests — round 5' do
        { 'role' => 'user', 'content' => { 'type' => 'text', 'text' => 'never mind' } }]
     end
 
-    it 'hands a mixed or dangling tool history to the modern round-trip sampler unchanged' do
-      stdio = modern_stdio
-      seen = []
-      handler = lambda do |messages, _prefs, _system, _max, params|
-        seen << [messages, params['tools']]
-        { 'content' => 'ok' }
+    # Both parties SHOULD validate message content (client/sampling
+    # "Security Considerations"); a user message mixing tool results with
+    # text, or an assistant tool use no user message answers, is refused
+    # before the host's sampler sees it — locally on the round-trip path,
+    # where inputResponses has no per-request error channel.
+    it 'refuses a mixed or dangling tool history on the modern round-trip path before the sampler runs' do
+      [mixed_history, dangling_history].each do |history|
+        stdio = modern_stdio
+        seen = []
+        handler = lambda do |messages, _prefs, _system, _max, params|
+          seen << [messages, params['tools']]
+          { 'content' => 'ok' }
+        end
+        client = client_with(stdio, sampling_handler: handler, sampling_supports_tools: true)
+        sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                    { 'result' => tool_list },
+                                    { 'result' => input_required({ 's' => sampling_request('tools' => tools,
+                                                                                           'messages' => history) },
+                                                                 state: 'one') },
+                                    { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'done' }] } }])
+
+        expect { client.call_tool('c', {}) }
+          .to raise_error(MCPClient::Errors::InputRequiredError, /sampling.*Invalid params/i) do |e|
+            expect(e.request_state).to eq('one')
+          end
+        expect(seen).to be_empty
+        expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
       end
-      client = client_with(stdio, sampling_handler: handler, sampling_supports_tools: true)
-      mixed = sampling_request('tools' => tools, 'messages' => mixed_history)
-      dangling = sampling_request('tools' => tools, 'messages' => dangling_history)
-      sent = script_stdio(stdio, [{ 'result' => discover_result },
-                                  { 'result' => tool_list },
-                                  { 'result' => input_required({ 's' => mixed }, state: 'one') },
-                                  { 'result' => input_required({ 's' => dangling }, state: 'two') },
-                                  { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'done' }] } }])
-
-      expect(client.call_tool('c', {})['content'].first['text']).to eq('done')
-
-      expect(seen).to eq([[mixed_history, tools], [dangling_history, tools]])
-      answers = sent.select { |r| r['method'] == 'tools/call' }.drop(1).map { |r| r['params']['inputResponses']['s'] }
-      expect(answers).to all(include('role' => 'assistant', 'stopReason' => 'endTurn',
-                                     'content' => { 'type' => 'text', 'text' => 'ok' }))
     end
 
-    it 'hands a mixed or dangling tool history to the legacy sampling handler unchanged' do
+    it 'refuses a mixed or dangling tool history on the legacy path with -32602 before the sampler runs' do
       seen = []
       handler = lambda do |messages, _prefs, _system, _max, params|
         seen << [messages, params['tools']]
@@ -377,9 +384,9 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests — round 5' do
         client.send(:handle_sampling_request, 7, { 'messages' => history, 'tools' => tools, 'maxTokens' => 10 })
       end
 
-      expect(seen).to eq([[mixed_history, tools], [dangling_history, tools]])
-      expect(results).to all(include('role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'ok' }))
-      expect(results.map { |r| r.key?('error') }).to eq([false, false])
+      expect(seen).to be_empty
+      expect(results.map { |r| r.dig('error', 'code') }).to eq([-32_602, -32_602])
+      expect(results.map { |r| r.key?('result') }).to eq([false, false])
     end
   end
 end

--- a/spec/lib/mcp_client/mrtr_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_round5_spec.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 multi round-trip requests, review round 5 (codex): the
+# corners a mutated resolver still survived — a symbolized InputRequiredResult
+# whose arrays (messages, tools) must be restored to the wire spelling all the
+# way down, the continuation-level recoveries on the HTTP transports (version
+# renegotiation and an ordinary retry), two overlapping HTTP round trips each
+# spending their own HeaderMismatch refresh, and the sampling histories this
+# client hands to the host unvalidated on both eras.
+RSpec.describe 'MCP 2026-07-28 multi round-trip requests — round 5' do
+  let(:url) { 'https://example.com/mcp' }
+
+  def discover_result(capabilities: { 'tools' => {} })
+    { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'], 'capabilities' => capabilities }
+  end
+
+  def input_required(requests, state: 'st')
+    result = { 'resultType' => 'input_required', 'requestState' => state }
+    result['inputRequests'] = requests unless requests.nil?
+    result
+  end
+
+  def form_elicit_request(message = 'Who?')
+    { 'method' => 'elicitation/create',
+      'params' => { 'mode' => 'form', 'message' => message,
+                    'requestedSchema' => { 'type' => 'object',
+                                           'properties' => { 'name' => { 'type' => 'string' } } } } }
+  end
+
+  def sampling_request(extra = {})
+    { 'method' => 'sampling/createMessage',
+      'params' => { 'messages' => [{ 'role' => 'user',
+                                     'content' => { 'type' => 'text', 'text' => 'Capital of France?' } }],
+                    'maxTokens' => 100 }.merge(extra) }
+  end
+
+  def modern_stdio(**)
+    MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1, **)
+  end
+
+  def script_stdio(server, responses)
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    allow(server).to receive(:sleep)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift or raise 'no scripted response left'
+      responder = responder.call if responder.respond_to?(:call)
+      responder.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+    sent
+  end
+
+  def client_with(server, **)
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+    MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'x' }], **)
+  end
+
+  def json_response(id, result)
+    { status: 200, headers: { 'Content-Type' => 'application/json' },
+      body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result) }
+  end
+
+  def error_response(id, code, message, data = nil, status: 400)
+    error = { 'code' => code, 'message' => message }
+    error['data'] = data if data
+    { status: status, headers: { 'Content-Type' => 'application/json' },
+      body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'error' => error) }
+  end
+
+  let(:tool_list) { { 'tools' => [{ 'name' => 'c', 'inputSchema' => { 'type' => 'object' } }] } }
+
+  describe 'a symbolized InputRequiredResult restored all the way down' do
+    # A host's JSON middleware that symbolizes names does so inside arrays
+    # too: the sampling messages, the tool definitions. Restoring only the
+    # top-level hashes would hand the sampler symbol-keyed messages it never
+    # asked for — and the Client adapter reads them by their wire names.
+    let(:symbolized_request) do
+      { method: 'sampling/createMessage',
+        params: { messages: [{ role: 'user', content: { type: 'text', text: 'Who?' } },
+                             { role: 'assistant',
+                               content: [{ type: 'tool_use', id: 'call_1', name: 'search', input: { q: 'ada' } }] },
+                             { role: 'user',
+                               content: [{ type: 'tool_result', toolUseId: 'call_1',
+                                           content: [{ type: 'text', text: 'Ada Lovelace' }] }] }],
+                  tools: [{ name: 'search',
+                            inputSchema: { type: 'object', properties: { q: { type: 'string' } } } }],
+                  toolChoice: { mode: 'auto' },
+                  maxTokens: 5 } }
+    end
+
+    let(:wire_messages) do
+      [{ 'role' => 'user', 'content' => { 'type' => 'text', 'text' => 'Who?' } },
+       { 'role' => 'assistant',
+         'content' => [{ 'type' => 'tool_use', 'id' => 'call_1', 'name' => 'search', 'input' => { 'q' => 'ada' } }] },
+       { 'role' => 'user',
+         'content' => [{ 'type' => 'tool_result', 'toolUseId' => 'call_1',
+                         'content' => [{ 'type' => 'text', 'text' => 'Ada Lovelace' }] }] }]
+    end
+
+    let(:wire_tools) do
+      [{ 'name' => 'search',
+         'inputSchema' => { 'type' => 'object', 'properties' => { 'q' => { 'type' => 'string' } } } }]
+    end
+
+    it 'hands the Client sampling adapter string-keyed messages and tools, and answers under the string key' do
+      stdio = modern_stdio
+      seen = []
+      handler = lambda do |messages, _prefs, _system, max_tokens, params|
+        seen << [messages, max_tokens, params]
+        { 'content' => 'Ada' }
+      end
+      client = client_with(stdio, sampling_handler: handler, sampling_supports_tools: true)
+      sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                  { 'result' => tool_list },
+                                  { 'result' => { resultType: 'input_required', requestState: 'sym',
+                                                  inputRequests: { a: symbolized_request } } },
+                                  { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'done' }] } }])
+
+      expect(client.call_tool('c', {})['content'].first['text']).to eq('done')
+
+      messages, max_tokens, params = seen.fetch(0)
+      expect(messages).to eq(wire_messages)
+      expect(max_tokens).to eq(5)
+      expect(params['tools']).to eq(wire_tools)
+      expect(params['toolChoice']).to eq({ 'mode' => 'auto' })
+      expect(params.keys).to all(be_a(String))
+      calls = sent.select { |r| r['method'] == 'tools/call' }
+      expect(calls.size).to eq(2)
+      expect(calls[1]['params']['requestState']).to eq('sym')
+      expect(calls[1]['params']['inputResponses'].keys).to eq(['a'])
+      expect(calls[1]['params']['inputResponses']['a'])
+        .to include('role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'Ada' })
+    end
+
+    it 'hands a transport-level sampling handler the whole request on the wire spelling' do
+      server = modern_stdio
+      server.declare_sampling_tools
+      seen = []
+      server.on_sampling_request do |key, params|
+        seen << [key, params]
+        { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'Ada' }, 'model' => 'm',
+          'stopReason' => 'endTurn' }
+      end
+      script_stdio(server, [{ 'result' => discover_result },
+                            { 'result' => { resultType: 'input_required', requestState: 'sym',
+                                            inputRequests: { a: symbolized_request } } },
+                            { 'result' => { 'content' => [] } }])
+
+      server.call_tool('c', {})
+
+      key, params = seen.fetch(0)
+      expect(key).to eq('a')
+      expect(params).to eq('messages' => wire_messages, 'tools' => wire_tools,
+                           'toolChoice' => { 'mode' => 'auto' }, 'maxTokens' => 5)
+    end
+  end
+
+  describe 'continuation-level recoveries on Streamable HTTP' do
+    def streamable(**)
+      MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0, **)
+    end
+
+    it 'keeps the continuation through a version renegotiation of the retry' do
+      stub_const('MCPClient::MODERN_PROTOCOL_VERSIONS', %w[2026-07-28 2026-06-18])
+      server = streamable
+      fulfilled = 0
+      server.on_elicitation_request do |_key, _params|
+        fulfilled += 1
+        { 'action' => 'accept', 'content' => { 'name' => 'ada' } }
+      end
+      bodies = []
+      versions_seen = []
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        bodies << body
+        calls = bodies.count { |b| b['method'] == 'tools/call' }
+        case body['method']
+        when 'server/discover' then json_response(body['id'], discover_result)
+        when 'tools/call'
+          versions_seen << request.headers['Mcp-Protocol-Version']
+          case calls
+          when 1 then json_response(body['id'], input_required({ 'a' => form_elicit_request }, state: 'st'))
+          when 2
+            error_response(body['id'], -32_022, 'Unsupported protocol version',
+                           { 'supported' => ['2026-06-18'], 'requested' => '2026-07-28' })
+          else json_response(body['id'], { 'content' => [{ 'type' => 'text', 'text' => 'done' }] })
+          end
+        else json_response(body['id'], tool_list)
+        end
+      end
+
+      expect(server.call_tool('c', {})['content'].first['text']).to eq('done')
+
+      calls = bodies.select { |b| b['method'] == 'tools/call' }
+      expect(calls.size).to eq(3)
+      expect(calls.map { |c| c['id'] }.uniq.size).to eq(3)
+      # Everything but the renegotiated version is re-sent verbatim.
+      expect(calls[2]['params'].except('_meta')).to eq(calls[1]['params'].except('_meta'))
+      expect(calls[2]['params']['requestState']).to eq('st')
+      expect(calls[2]['params']['inputResponses']['a']).to eq({ 'action' => 'accept',
+                                                                'content' => { 'name' => 'ada' } })
+      version = MCPClient::JsonRpcCommon::META_PROTOCOL_VERSION
+      expect(calls.map { |c| c['params']['_meta'][version] }).to eq(%w[2026-07-28 2026-07-28 2026-06-18])
+      expect(versions_seen).to eq(%w[2026-07-28 2026-07-28 2026-06-18])
+      expect(fulfilled).to eq(1)
+      server.cleanup
+    end
+
+    it 'keeps the continuation through an ordinary retry of an idempotent request' do
+      server = streamable(retries: 1, retry_backoff: 0.01)
+      fulfilled = 0
+      server.on_elicitation_request do |_key, _params|
+        fulfilled += 1
+        { 'action' => 'accept', 'content' => { 'name' => 'ada' } }
+      end
+      bodies = []
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        bodies << body
+        reads = bodies.count { |b| b['method'] == 'resources/read' }
+        case body['method']
+        when 'server/discover' then json_response(body['id'], discover_result(capabilities: { 'resources' => {} }))
+        when 'resources/read'
+          case reads
+          when 1 then json_response(body['id'], input_required({ 'a' => form_elicit_request }, state: 'st'))
+          when 2 then { status: 503, headers: { 'Content-Type' => 'text/plain' }, body: 'later' }
+          else json_response(body['id'], { 'contents' => [{ 'uri' => 'file:///x', 'text' => 'hello' }] })
+          end
+        end
+      end
+
+      result = server.rpc_request('resources/read', { 'uri' => 'file:///x' })
+
+      expect(result['contents'].first['text']).to eq('hello')
+      reads = bodies.select { |b| b['method'] == 'resources/read' }
+      expect(reads.size).to eq(3)
+      expect(reads.map { |r| r['id'] }.uniq.size).to eq(3)
+      expect(reads[2]['params']).to eq(reads[1]['params'])
+      expect(reads[2]['params']['requestState']).to eq('st')
+      expect(reads[2]['params']['inputResponses']['a']).to eq({ 'action' => 'accept',
+                                                                'content' => { 'name' => 'ada' } })
+      # The round trip was fulfilled once; the retry replays the same attempt.
+      expect(fulfilled).to eq(1)
+      server.cleanup
+    end
+  end
+
+  describe 'overlapping round trips on plain HTTP' do
+    # The one HeaderMismatch refresh belongs to each logical request: two
+    # calls in flight at once that both mismatch each get their own refresh
+    # and retry, and neither's spent allowance is charged to the other.
+    it 'gives each concurrent tools/call its own HeaderMismatch refresh' do
+      http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+      http.on_elicitation_request { |_key, _params| { 'action' => 'accept', 'content' => { 'name' => 'ada' } } }
+      lock = Mutex.new
+      headers = { 'q1' => 'Region', 'q2' => 'Region' }
+      calls = Hash.new { |h, k| h[k] = [] }
+      arrived = []
+      list_count = 0
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'server/discover' then json_response(body['id'], discover_result)
+        when 'tools/list'
+          lock.synchronize { list_count += 1 }
+          tools = %w[q1 q2].map do |name|
+            schema = { 'type' => 'object',
+                       'properties' => { 'region' => { 'type' => 'string',
+                                                       'x-mcp-header' => lock.synchronize { headers[name] } } } }
+            { 'name' => name, 'inputSchema' => schema }
+          end
+          json_response(body['id'], { 'tools' => tools })
+        when 'tools/call'
+          name = body['params']['name']
+          first = lock.synchronize do
+            calls[name] << request.headers
+            calls[name].size == 1
+          end
+          if first
+            # Hold the first rejection until both calls are in flight, so the
+            # two refreshes really do overlap — and hand q2 its rejection only
+            # once q1's refresh has fetched the list, so a budget shared
+            # between the two calls would already be spent when q2 needs it.
+            lock.synchronize { arrived << name }
+            ready = lambda do
+              lock.synchronize { arrived.size >= 2 && (name == 'q1' || list_count >= 2) }
+            end
+            sleep(0.001) while !ready.call && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+            lock.synchronize { headers[name] = 'Zone' }
+            error_response(body['id'], -32_020, 'Header mismatch: Mcp-Param-Zone')
+          else
+            json_response(body['id'], { 'content' => [{ 'type' => 'text', 'text' => name }] })
+          end
+        end
+      end
+
+      http.list_tools
+      results = %w[q1 q2].map { |name| Thread.new { [name, http.call_tool(name, { 'region' => 'eu' })] } }
+                         .to_h(&:value)
+
+      expect(results.transform_values { |r| r['content'].first['text'] }).to eq({ 'q1' => 'q1', 'q2' => 'q2' })
+      expect(arrived.sort).to eq(%w[q1 q2])
+      %w[q1 q2].each do |name|
+        expect(calls[name].size).to eq(2), name
+        expect(calls[name].last['Mcp-Param-Zone']).to eq('eu'), name
+      end
+      # The initial list plus one refresh per logical call.
+      expect(list_count).to eq(3)
+      http.cleanup
+    end
+  end
+
+  describe 'sampling histories this client leaves to the host' do
+    # client/sampling (2026-07-28): both parties SHOULD validate message
+    # content; the 2025-11-25 text recommends -32602 for a malformed history.
+    # This client does not: the history is the host's to judge (it is the one
+    # with a model behind it), so a mixed tool-result/text message and a tool
+    # use without its result reach the handler exactly as sent, on both eras.
+    let(:tools) { [{ 'name' => 'search', 'inputSchema' => { 'type' => 'object' } }] }
+    let(:mixed_history) do
+      [{ 'role' => 'user', 'content' => { 'type' => 'text', 'text' => 'Weather?' } },
+       { 'role' => 'assistant',
+         'content' => [{ 'type' => 'tool_use', 'id' => 'call_1', 'name' => 'search', 'input' => {} }] },
+       { 'role' => 'user',
+         'content' => [{ 'type' => 'tool_result', 'toolUseId' => 'call_1',
+                         'content' => [{ 'type' => 'text', 'text' => 'sunny' }] },
+                       { 'type' => 'text', 'text' => 'and tomorrow?' }] }]
+    end
+    let(:dangling_history) do
+      [{ 'role' => 'assistant',
+         'content' => [{ 'type' => 'tool_use', 'id' => 'call_9', 'name' => 'search', 'input' => {} }] },
+       { 'role' => 'user', 'content' => { 'type' => 'text', 'text' => 'never mind' } }]
+    end
+
+    it 'hands a mixed or dangling tool history to the modern round-trip sampler unchanged' do
+      stdio = modern_stdio
+      seen = []
+      handler = lambda do |messages, _prefs, _system, _max, params|
+        seen << [messages, params['tools']]
+        { 'content' => 'ok' }
+      end
+      client = client_with(stdio, sampling_handler: handler, sampling_supports_tools: true)
+      mixed = sampling_request('tools' => tools, 'messages' => mixed_history)
+      dangling = sampling_request('tools' => tools, 'messages' => dangling_history)
+      sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                  { 'result' => tool_list },
+                                  { 'result' => input_required({ 's' => mixed }, state: 'one') },
+                                  { 'result' => input_required({ 's' => dangling }, state: 'two') },
+                                  { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'done' }] } }])
+
+      expect(client.call_tool('c', {})['content'].first['text']).to eq('done')
+
+      expect(seen).to eq([[mixed_history, tools], [dangling_history, tools]])
+      answers = sent.select { |r| r['method'] == 'tools/call' }.drop(1).map { |r| r['params']['inputResponses']['s'] }
+      expect(answers).to all(include('role' => 'assistant', 'stopReason' => 'endTurn',
+                                     'content' => { 'type' => 'text', 'text' => 'ok' }))
+    end
+
+    it 'hands a mixed or dangling tool history to the legacy sampling handler unchanged' do
+      seen = []
+      handler = lambda do |messages, _prefs, _system, _max, params|
+        seen << [messages, params['tools']]
+        { 'content' => 'ok' }
+      end
+      client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'echo test' }],
+                                     sampling_handler: handler, sampling_supports_tools: true)
+
+      results = [mixed_history, dangling_history].map do |history|
+        client.send(:handle_sampling_request, 7, { 'messages' => history, 'tools' => tools, 'maxTokens' => 10 })
+      end
+
+      expect(seen).to eq([[mixed_history, tools], [dangling_history, tools]])
+      expect(results).to all(include('role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'ok' }))
+      expect(results.map { |r| r.key?('error') }).to eq([false, false])
+    end
+  end
+end

--- a/spec/lib/mcp_client/mrtr_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_round6_spec.rb
@@ -85,8 +85,11 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests — round 6' do
   end
 
   describe 'the out-of-band wait is the host\'s to steer' do
+    # Round 7: the waits are bounded by the transport's read timeout when the
+    # caller names none, and this example paces through 1.5s of them — so the
+    # transport is given room for what the example is about.
     it 'asks the host before each paced retry and waits by default' do
-      stdio = modern_stdio
+      stdio = modern_stdio(read_timeout: 30)
       waits = []
       stdio.on_input_required_wait { |wait| waits << wait }
       sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => state_only('s1') },
@@ -179,8 +182,11 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests — round 6' do
     end
 
     it 'bounds the wait by the request timeout and hands back the continuation' do
-      stdio = modern_stdio
-      clock = [0.0, 0.0, 0.6, 1.3, 2.5]
+      stdio = modern_stdio(read_timeout: 30)
+      # Two readings a round from round 7 on: one for the wait's own elapsed,
+      # one after the host's control returns, which is what the pause is
+      # measured from. Round 1 pauses at 0.0; round 2 is over the 1.0 bound.
+      clock = [0.0, 0.0, 0.0, 0.6, 0.6]
       allow(stdio).to receive(:input_wait_clock) { clock.shift || 9.0 }
       sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => state_only('s1') },
                                   { 'result' => state_only('s2') }, { 'result' => state_only('s3') },

--- a/spec/lib/mcp_client/mrtr_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_round6_spec.rb
@@ -1,0 +1,401 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 multi round-trip requests, review round 6 (codex): the
+# out-of-band wait is the host's to steer ("Clients SHOULD provide manual
+# controls that let the user retry or cancel the original request",
+# client/elicitation "URL Mode"), a cancelled or timed-out wait can be
+# resumed from the continuation it carried, the sampling histories this
+# client hands to the host are checked against the message rules both
+# parties SHOULD validate (client/sampling "Security Considerations"), and
+# the HTTP transports carry a per-request timeout into every continuation.
+RSpec.describe 'MCP 2026-07-28 multi round-trip requests — round 6' do
+  let(:url) { 'https://example.com/mcp' }
+
+  def discover_result(capabilities: { 'tools' => {} })
+    { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'], 'capabilities' => capabilities }
+  end
+
+  def state_only(state)
+    { 'resultType' => 'input_required', 'requestState' => state }
+  end
+
+  def input_required(requests, state: 'st')
+    result = { 'resultType' => 'input_required', 'requestState' => state }
+    result['inputRequests'] = requests unless requests.nil?
+    result
+  end
+
+  def elicit_request(message = 'Who?')
+    { 'method' => 'elicitation/create',
+      'params' => { 'mode' => 'form', 'message' => message,
+                    'requestedSchema' => { 'type' => 'object',
+                                           'properties' => { 'name' => { 'type' => 'string' } } } } }
+  end
+
+  def sampling_request(extra = {})
+    { 'method' => 'sampling/createMessage',
+      'params' => { 'messages' => [{ 'role' => 'user',
+                                     'content' => { 'type' => 'text', 'text' => 'Capital of France?' } }],
+                    'maxTokens' => 100 }.merge(extra) }
+  end
+
+  def done
+    { 'content' => [{ 'type' => 'text', 'text' => 'done' }] }
+  end
+
+  def modern_stdio(**)
+    MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1, **)
+  end
+
+  def script_stdio(server, responses)
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    allow(server).to receive(:sleep)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift or raise 'no scripted response left'
+      responder = responder.call if responder.respond_to?(:call)
+      responder.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+    sent
+  end
+
+  def client_with(server, **)
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+    MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'x' }], **)
+  end
+
+  def calls(sent)
+    sent.select { |r| r['method'] == 'tools/call' }
+  end
+
+  def streamable(**)
+    MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0, **)
+  end
+
+  def json_response(id, result)
+    { status: 200, headers: { 'Content-Type' => 'application/json' },
+      body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result) }
+  end
+
+  describe 'the out-of-band wait is the host\'s to steer' do
+    it 'asks the host before each paced retry and waits by default' do
+      stdio = modern_stdio
+      waits = []
+      stdio.on_input_required_wait { |wait| waits << wait }
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => state_only('s1') },
+                                  { 'result' => state_only('s2') }, { 'result' => done }])
+      expect(stdio).to receive(:sleep).with(0.5).ordered
+      expect(stdio).to receive(:sleep).with(1.0).ordered
+
+      expect(stdio.call_tool('t', {})).to eq(done)
+
+      expect(waits.map(&:round_trip)).to eq([1, 2])
+      expect(waits.map(&:request_state)).to eq(%w[s1 s2])
+      expect(waits.map(&:delay)).to eq([0.5, 1.0])
+      expect(waits.map(&:rpc_method)).to eq(%w[tools/call tools/call])
+      expect(waits.last.result).to eq(state_only('s2'))
+      expect(calls(sent).map { |r| r['params']['requestState'] }).to eq([nil, 's1', 's2'])
+    end
+
+    it 'retries at once when the host says so' do
+      stdio = modern_stdio
+      stdio.on_input_required_wait { |_wait| :retry }
+      expect(stdio).not_to receive(:sleep)
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => state_only('s1') },
+                                  { 'result' => done }])
+
+      expect(stdio.call_tool('t', {})).to eq(done)
+      expect(calls(sent).size).to eq(2)
+    end
+
+    it 'stops on cancel with the continuation the host can resume from, sending nothing more' do
+      stdio = modern_stdio
+      stdio.on_input_required_wait { |_wait| :cancel }
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => state_only('s1') },
+                                  { 'result' => done }])
+
+      expect { stdio.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /cancel/i) do |e|
+        expect(e.request_state).to eq('s1')
+        expect(e.request_method).to eq('tools/call')
+        expect(e.request_params).to eq({ 'name' => 't', 'arguments' => {} })
+        expect(e).to be_resumable
+      end
+      expect(calls(sent).size).to eq(1)
+    end
+
+    it 'resumes a cancelled request from its continuation: the state goes back, the answers do not' do
+      stdio = modern_stdio
+      decisions = [:cancel]
+      stdio.on_input_required_wait { |_wait| decisions.shift || :wait }
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => state_only('s1') },
+                                  { 'result' => state_only('s2') }, { 'result' => done }])
+      error = begin
+        stdio.call_tool('t', { 'city' => 'Paris' })
+      rescue MCPClient::Errors::InputRequiredError => e
+        e
+      end
+
+      expect(stdio.resume_input_required(error)).to eq(done)
+
+      resumed = calls(sent).drop(1)
+      expect(resumed.map { |r| r['params']['requestState'] }).to eq(%w[s1 s2])
+      expect(resumed.map { |r| r['params']['name'] }).to eq(%w[t t])
+      expect(resumed.map { |r| r['params']['arguments'] }).to all(eq({ 'city' => 'Paris' }))
+      expect(resumed.map { |r| r['params'].key?('inputResponses') }).to eq([false, false])
+      expect(resumed.map { |r| r['id'] }.uniq.size).to eq(2)
+    end
+
+    it 'resumes through the Client, which routes to the transport that raised' do
+      stdio = modern_stdio
+      stdio.on_input_required_wait { |_wait| :cancel }
+      tools = { 'tools' => [{ 'name' => 't', 'inputSchema' => { 'type' => 'object' } }] }
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => tools },
+                                  { 'result' => state_only('s1') }, { 'result' => done }])
+      client = client_with(stdio)
+      error = begin
+        client.call_tool('t', {})
+      rescue MCPClient::Errors::InputRequiredError => e
+        e
+      end
+      stdio.on_input_required_wait { |_wait| :wait }
+
+      expect(client.resume_input_required(error)).to eq(done)
+      expect(calls(sent).last['params']['requestState']).to eq('s1')
+    end
+
+    it 'refuses to resume an error that carries no continuation' do
+      stdio = modern_stdio
+      bare = MCPClient::Errors::InputRequiredError.new('x', data: state_only('s1'))
+
+      expect(bare).not_to be_resumable
+      expect { stdio.resume_input_required(bare) }.to raise_error(ArgumentError, /continuation/)
+    end
+
+    it 'bounds the wait by the request timeout and hands back the continuation' do
+      stdio = modern_stdio
+      clock = [0.0, 0.0, 0.6, 1.3, 2.5]
+      allow(stdio).to receive(:input_wait_clock) { clock.shift || 9.0 }
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => state_only('s1') },
+                                  { 'result' => state_only('s2') }, { 'result' => state_only('s3') },
+                                  { 'result' => done }])
+      stdio.send(:ensure_initialized)
+
+      expect { stdio.rpc_request('tools/call', { 'name' => 't', 'arguments' => {} }, timeout: 1.0) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /timeout/i) do |e|
+          expect(e.request_state).to eq('s2')
+          expect(e).to be_resumable
+        end
+      expect(calls(sent).size).to eq(2)
+    end
+  end
+
+  describe 'sampling histories are validated before they reach the host' do
+    let(:tools) { [{ 'name' => 'search', 'inputSchema' => { 'type' => 'object' } }] }
+    let(:tool_use) do
+      { 'role' => 'assistant',
+        'content' => [{ 'type' => 'tool_use', 'id' => 'call_1', 'name' => 'search', 'input' => {} }] }
+    end
+    let(:tool_result) do
+      { 'role' => 'user', 'content' => [{ 'type' => 'tool_result', 'toolUseId' => 'call_1',
+                                          'content' => [{ 'type' => 'text', 'text' => 'ok' }] }] }
+    end
+    let(:valid_loop) do
+      [{ 'role' => 'user', 'content' => { 'type' => 'text', 'text' => 'hi' } }, tool_use, tool_result]
+    end
+    let(:mixed_result) do
+      [tool_use, { 'role' => 'user', 'content' => [tool_result['content'].first,
+                                                   { 'type' => 'text', 'text' => 'and?' }] }]
+    end
+    let(:dangling_use) { [tool_use, { 'role' => 'user', 'content' => { 'type' => 'text', 'text' => 'never mind' } }] }
+    let(:wrong_id) do
+      [tool_use, { 'role' => 'user', 'content' => [tool_result['content'].first.merge('toolUseId' => 'other')] }]
+    end
+    let(:bad_role) { [{ 'role' => 'system', 'content' => { 'type' => 'text', 'text' => 'x' } }] }
+    let(:no_content) { [{ 'role' => 'user' }] }
+
+    def scripted_client(stdio, history, handler)
+      client = client_with(stdio, sampling_handler: handler, sampling_supports_tools: true)
+      tool_list = { 'tools' => [{ 'name' => 'c', 'inputSchema' => { 'type' => 'object' } }] }
+      request = sampling_request('tools' => tools, 'messages' => history)
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => tool_list },
+                                  { 'result' => input_required({ 's' => request }) }, { 'result' => done }])
+      [client, sent]
+    end
+
+    it 'fails the round trip locally for each malformed history, without sending a retry' do
+      [mixed_result, dangling_use, wrong_id, bad_role, no_content].each do |history|
+        stdio = modern_stdio
+        calls_to_host = 0
+        handler = lambda do |*|
+          calls_to_host += 1
+          { 'content' => 'ok' }
+        end
+        client, sent = scripted_client(stdio, history, handler)
+
+        expect { client.call_tool('c', {}) }
+          .to raise_error(MCPClient::Errors::InputRequiredError, /sampling|message/i), history.inspect
+        expect(calls_to_host).to eq(0), history.inspect
+        expect(calls(sent).size).to eq(1), history.inspect
+      end
+    end
+
+    it 'accepts a user message of tool results on its own: the spec forbids the mixing, not the message' do
+      stdio = modern_stdio
+      seen = nil
+      client, = scripted_client(stdio, [tool_result], lambda { |messages, *|
+        seen = messages
+        { 'content' => 'ok' }
+      })
+
+      expect(client.call_tool('c', {})).to eq(done)
+      expect(seen).to eq([tool_result])
+    end
+
+    it 'hands a well-formed tool loop through and answers the round trip' do
+      stdio = modern_stdio
+      seen = nil
+      client, sent = scripted_client(stdio, valid_loop, lambda { |messages, *|
+        seen = messages
+        { 'content' => 'ok' }
+      })
+
+      expect(client.call_tool('c', {})).to eq(done)
+      expect(seen).to eq(valid_loop)
+      expect(calls(sent).last['params']['inputResponses']['s']).to include('role' => 'assistant')
+    end
+
+    it 'answers a legacy sampling request carrying a malformed history with -32602 on the wire' do
+      stdio = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+      stdio.instance_variable_set(:@protocol_version, '2025-11-25')
+      calls_to_host = 0
+      handler = lambda do |*|
+        calls_to_host += 1
+        { 'content' => 'ok' }
+      end
+      client_with(stdio, sampling_handler: handler, sampling_supports_tools: true)
+      written = []
+      allow(stdio).to receive(:send_message) { |msg| written << msg }
+
+      stdio.send(:handle_server_request, { 'jsonrpc' => '2.0', 'id' => 7, 'method' => 'sampling/createMessage',
+                                           'params' => { 'messages' => mixed_result, 'tools' => tools,
+                                                         'maxTokens' => 10 } })
+
+      expect(written.size).to eq(1)
+      expect(written.first['id']).to eq(7)
+      expect(written.first.dig('error', 'code')).to eq(-32_602)
+      expect(written.first).not_to have_key('result')
+      expect(calls_to_host).to eq(0)
+    end
+
+    it 'answers a legacy sampling request carrying a well-formed history with the sampled message' do
+      stdio = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+      stdio.instance_variable_set(:@protocol_version, '2025-11-25')
+      client_with(stdio, sampling_handler: ->(*) { { 'content' => 'ok', 'model' => 'm' } },
+                         sampling_supports_tools: true)
+      written = []
+      allow(stdio).to receive(:send_message) { |msg| written << msg }
+
+      stdio.send(:handle_server_request, { 'jsonrpc' => '2.0', 'id' => 8, 'method' => 'sampling/createMessage',
+                                           'params' => { 'messages' => valid_loop, 'tools' => tools,
+                                                         'maxTokens' => 10 } })
+
+      expect(written.size).to eq(1)
+      expect(written.first['id']).to eq(8)
+      expect(written.first['result']).to include('role' => 'assistant', 'model' => 'm',
+                                                 'content' => { 'type' => 'text', 'text' => 'ok' })
+      expect(written.first).not_to have_key('error')
+    end
+  end
+
+  describe 'the per-request timeout on the HTTP transports' do
+    it 'reaches every continuation attempt of a Streamable HTTP round trip' do
+      server = streamable
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'ada' } } }
+      bodies = []
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        bodies << body
+        case body['method']
+        when 'server/discover' then json_response(body['id'], discover_result)
+        # A modern tools/call reads the definitions first (Mcp-Param-* headers).
+        when 'tools/list'
+          json_response(body['id'], 'tools' => [{ 'name' => 't', 'inputSchema' => { 'type' => 'object' } }],
+                                    'ttlMs' => 60_000)
+        when 'tools/call'
+          if body['params'].key?('inputResponses')
+            json_response(body['id'], done)
+          else
+            json_response(body['id'], input_required({ 'a' => elicit_request }))
+          end
+        end
+      end
+      allow(server).to receive(:attempt_request).and_call_original
+
+      expect(server.rpc_request('tools/call', { 'name' => 't', 'arguments' => {} }, timeout: 0.25)).to eq(done)
+
+      expect(server).to have_received(:attempt_request).with('tools/call', anything, 0.25, anything).twice
+      expect(bodies.count { |b| b['method'] == 'tools/call' }).to eq(2)
+    end
+
+    it 'times out a stalled continuation without a further retry' do
+      server = streamable
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'ada' } } }
+      bodies = []
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        bodies << body
+        case body['method']
+        when 'server/discover' then json_response(body['id'], discover_result)
+        # A modern tools/call reads the definitions first (Mcp-Param-* headers).
+        when 'tools/list'
+          json_response(body['id'], 'tools' => [{ 'name' => 't', 'inputSchema' => { 'type' => 'object' } }],
+                                    'ttlMs' => 60_000)
+        when 'tools/call'
+          # The continuation's read stalls past the request timeout.
+          raise Faraday::TimeoutError, 'execution expired' if body['params'].key?('inputResponses')
+
+          json_response(body['id'], input_required({ 'a' => elicit_request }))
+        end
+      end
+
+      expect { server.rpc_request('tools/call', { 'name' => 't', 'arguments' => {} }, timeout: 0.2) }
+        .to raise_error(MCPClient::Errors::RequestTimeoutError)
+      expect(bodies.count { |b| b['method'] == 'tools/call' }).to eq(2)
+    end
+  end
+
+  describe 'a handler that starts another round trip on the same transport' do
+    it 'completes the nested request first, each with its own state and answers' do
+      stdio = modern_stdio
+      inner_results = []
+      stdio.on_elicitation_request do |key, params|
+        inner_results << stdio.call_tool('inner', {}) if params['message'] == 'outer?'
+        { 'action' => 'accept', 'content' => { 'name' => "#{key}-answer" } }
+      end
+      sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                  { 'result' => input_required({ 'o' => elicit_request('outer?') }, state: 'outer') },
+                                  { 'result' => input_required({ 'i' => elicit_request('inner?') }, state: 'inner') },
+                                  { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'inner done' }] } },
+                                  { 'result' => done }])
+
+      result = Timeout.timeout(5) { stdio.call_tool('outer', {}) }
+
+      expect(result).to eq(done)
+      expect(inner_results).to eq([{ 'content' => [{ 'type' => 'text', 'text' => 'inner done' }] }])
+      wire = calls(sent).map do |r|
+        [r['params']['name'], r['params']['requestState'], r['params']['inputResponses']&.keys]
+      end
+      expect(wire).to eq([['outer', nil, nil], ['inner', nil, nil],
+                          ['inner', 'inner', ['i']], ['outer', 'outer', ['o']]])
+      expect(calls(sent).last['params']['inputResponses']['o']['content']).to eq({ 'name' => 'o-answer' })
+      expect(calls(sent)[2]['params']['inputResponses']['i']['content']).to eq({ 'name' => 'i-answer' })
+    end
+  end
+end

--- a/spec/lib/mcp_client/mrtr_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_round7_spec.rb
@@ -1,0 +1,432 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+require 'socket'
+
+# MCP 2026-07-28 multi round-trip requests, review round 7 (codex): an
+# out-of-band wait is bounded by the timeout the request actually runs under
+# — the caller's own, or the transport's configured read timeout when the
+# caller named none — and the time the host's own control spends deciding
+# counts against it. The sampling histories handed to the host are checked
+# for the fields the message rules give meaning to, so a tool use and a tool
+# result do not correlate by a pair of missing identifiers
+# (client/sampling "Security Considerations").
+# A server that answers the discovery, the tool list and the first
+# tools/call, then accepts the continuation and never answers it.
+class StallingContinuationServer
+  attr_reader :received
+
+  def initialize
+    @received = []
+    @socket = TCPServer.new('127.0.0.1', 0)
+    @stop = false
+    @thread = Thread.new { serve }
+  end
+
+  def base_url = "http://127.0.0.1:#{@socket.addr[1]}"
+
+  def close
+    @stop = true
+    @socket.close unless @socket.closed?
+    @thread&.kill
+  end
+
+  private
+
+  def serve
+    until @stop
+      client = accept_one
+      break if client.nil?
+
+      Thread.new { handle(client) }
+    end
+  end
+
+  def accept_one
+    @socket.accept
+  rescue StandardError
+    nil
+  end
+
+  def handle(client)
+    body = read_request(client)
+    return if body.nil?
+
+    message = JSON.parse(body)
+    @received << message
+    answer = answer_for(message)
+    # The continuation is accepted and left hanging: its own timeout is
+    # the only thing that can end it.
+    return sleep(30) if answer.nil?
+
+    write(client, JSON.generate('jsonrpc' => '2.0', 'id' => message['id'], 'result' => answer))
+  rescue StandardError
+    nil
+  ensure
+    client.close unless client.closed?
+  end
+
+  def answer_for(message)
+    case message['method']
+    when 'server/discover'
+      { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'], 'capabilities' => { 'tools' => {} } }
+    when 'tools/list'
+      { 'tools' => [{ 'name' => 't', 'inputSchema' => { 'type' => 'object' } }], 'ttlMs' => 60_000 }
+    when 'tools/call'
+      return nil if message['params'].key?('inputResponses')
+
+      { 'resultType' => 'input_required', 'requestState' => 'st',
+        'inputRequests' => { 'a' => { 'method' => 'elicitation/create',
+                                      'params' => { 'mode' => 'form', 'message' => 'Who?',
+                                                    'requestedSchema' => { 'type' => 'object' } } } } }
+    end
+  end
+
+  def read_request(client)
+    headers = +''
+    headers << client.readline until headers.end_with?("\r\n\r\n")
+    length = headers[/Content-Length:\s*(\d+)/i, 1].to_i
+    client.read(length)
+  rescue StandardError
+    nil
+  end
+
+  def write(client, payload)
+    client.write("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" \
+                 "Content-Length: #{payload.bytesize}\r\n\r\n#{payload}")
+  end
+end
+
+RSpec.describe 'MCP 2026-07-28 multi round-trip requests — round 7' do
+  def discover_result
+    { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'], 'capabilities' => { 'tools' => {} } }
+  end
+
+  def state_only(state)
+    { 'resultType' => 'input_required', 'requestState' => state }
+  end
+
+  def input_required(requests, state: 'st')
+    { 'resultType' => 'input_required', 'requestState' => state, 'inputRequests' => requests }
+  end
+
+  def sampling_request(history, tools)
+    { 'method' => 'sampling/createMessage',
+      'params' => { 'messages' => history, 'maxTokens' => 100, 'tools' => tools } }
+  end
+
+  def done
+    { 'content' => [{ 'type' => 'text', 'text' => 'done' }] }
+  end
+
+  def modern_stdio(**)
+    MCPClient::ServerStdio.new(command: 'echo test', **)
+  end
+
+  def script_stdio(server, responses)
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    allow(server).to receive(:sleep)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift or raise 'no scripted response left'
+      responder.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+    sent
+  end
+
+  def calls(sent)
+    sent.select { |r| r['method'] == 'tools/call' }
+  end
+
+  # ---------------------------------------------------------------------------
+  describe 'the wait is bounded by the timeout the request runs under' do
+    # A caller that names no timeout still runs under one: the transport's
+    # configured read timeout. Before, the bound existed only for an explicit
+    # `timeout:`, so a state-only answer paced its way past a read timeout of
+    # a hundredth of a second.
+    it 'bounds a wait by the transport read timeout when the caller named none' do
+      stdio = modern_stdio(read_timeout: 0.05)
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => state_only('s1') },
+                                  { 'result' => done }])
+      stdio.send(:ensure_initialized)
+
+      expect { stdio.rpc_request('tools/call', { 'name' => 't', 'arguments' => {} }) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /timeout/i) do |e|
+          expect(e.request_state).to eq('s1')
+          expect(e).to be_resumable
+        end
+      expect(calls(sent).size).to eq(1)
+      expect(stdio).not_to have_received(:sleep)
+    end
+
+    # The host's control is host code: it may open a window, ask a person and
+    # come back a minute later. That minute belongs to the request, so the
+    # pause that follows is measured from when the control returned.
+    it 'counts the time the host control itself spent against the timeout' do
+      stdio = modern_stdio(read_timeout: 30)
+      now = 0.0
+      allow(stdio).to receive(:input_wait_clock) { now }
+      stdio.on_input_required_wait do |_wait|
+        now += 0.5
+        :wait
+      end
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => state_only('s1') },
+                                  { 'result' => done }])
+      stdio.send(:ensure_initialized)
+
+      expect { stdio.rpc_request('tools/call', { 'name' => 't', 'arguments' => {} }, timeout: 0.6) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /timeout/i) do |e|
+          expect(e.request_state).to eq('s1')
+        end
+      expect(calls(sent).size).to eq(1)
+      expect(stdio).not_to have_received(:sleep)
+    end
+
+    # The bound is the caller's when it named one, even where the transport's
+    # own read timeout is longer: a request cannot outlast what it was given.
+    it 'still prefers the caller\'s own timeout over the transport default' do
+      stdio = modern_stdio(read_timeout: 30)
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => state_only('s1') },
+                                  { 'result' => done }])
+      stdio.send(:ensure_initialized)
+
+      expect { stdio.rpc_request('tools/call', { 'name' => 't', 'arguments' => {} }, timeout: 0.01) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /timeout/i)
+      expect(calls(sent).size).to eq(1)
+    end
+
+    # A transport with no bound of its own (a host adapter that never sets
+    # one) keeps the documented behaviour: the round-trip ceiling is what
+    # stops it, not a timeout nobody set.
+    it 'paces on when neither the caller nor the transport bounds the request' do
+      stdio = modern_stdio(read_timeout: nil)
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => state_only('s1') },
+                                  { 'result' => done }])
+      stdio.send(:ensure_initialized)
+
+      expect(stdio.rpc_request('tools/call', { 'name' => 't', 'arguments' => {} })).to eq(done)
+      expect(calls(sent).size).to eq(2)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe 'sampling histories are checked on the fields that carry meaning' do
+    let(:tools) { [{ 'name' => 'search', 'inputSchema' => { 'type' => 'object' } }] }
+
+    def use_block(id, name: 'search')
+      { 'type' => 'tool_use', 'id' => id, 'name' => name, 'input' => {} }
+    end
+
+    def result_block(id)
+      { 'type' => 'tool_result', 'toolUseId' => id, 'content' => [{ 'type' => 'text', 'text' => 'ok' }] }
+    end
+
+    def ask
+      { 'role' => 'user', 'content' => { 'type' => 'text', 'text' => 'hi' } }
+    end
+
+    def run(history)
+      stdio = modern_stdio(read_timeout: 1)
+      invoked = 0
+      handler = lambda do |*|
+        invoked += 1
+        { 'content' => 'ok' }
+      end
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(stdio)
+      client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'x' }],
+                                     sampling_handler: handler, sampling_supports_tools: true)
+      tool_list = { 'tools' => [{ 'name' => 'c', 'inputSchema' => { 'type' => 'object' } }] }
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => tool_list },
+                                  { 'result' => input_required({ 's' => sampling_request(history, tools) }) },
+                                  { 'result' => done }])
+      [client, sent, -> { invoked }]
+    end
+
+    def expect_refused(history)
+      client, sent, invoked = run(history)
+
+      expect { client.call_tool('c', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /message/)
+      expect(invoked.call).to eq(0)
+      expect(calls(sent).size).to eq(1)
+    end
+
+    def expect_accepted(history)
+      client, sent, invoked = run(history)
+
+      expect(client.call_tool('c', {})).to eq(done)
+      expect(invoked.call).to eq(1)
+      expect(calls(sent).size).to eq(2)
+    end
+
+    it 'refuses a text block that carries no text' do
+      expect_refused([{ 'role' => 'user', 'content' => [{ 'type' => 'text' }] }])
+    end
+
+    # The refusal names what to look at: the block and its type, never the
+    # content itself (a malformed history is exactly where a server would
+    # hide something it wants echoed into the host's logs).
+    it 'names the block type in the refusal, and not the block' do
+      client, = run([{ 'role' => 'user', 'content' => [{ 'type' => 'text', 'secret' => 'sssh' }] }])
+
+      expect { client.call_tool('c', {}) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /"text" content block without the fields/) do |e|
+          expect(e.message).not_to include('sssh')
+        end
+    end
+
+    it 'refuses a tool use with no id answered by a tool result with no toolUseId' do
+      use = { 'type' => 'tool_use', 'name' => 'search', 'input' => {} }
+      answer = { 'type' => 'tool_result', 'content' => [{ 'type' => 'text', 'text' => 'ok' }] }
+      expect_refused([ask,
+                      { 'role' => 'assistant', 'content' => [use] },
+                      { 'role' => 'user', 'content' => [answer] }])
+    end
+
+    it 'refuses a history that ends on an unanswered tool use' do
+      expect_refused([ask, { 'role' => 'assistant', 'content' => [use_block('call_1')] }])
+    end
+
+    it 'refuses a tool result whose toolUseId is not a string' do
+      expect_refused([ask,
+                      { 'role' => 'assistant', 'content' => [use_block('call_1')] },
+                      { 'role' => 'user', 'content' => [result_block(1)] }])
+    end
+
+    # Nothing in the message rules orders the answers: two uses answered by
+    # their two results, whichever way round, is a valid history.
+    it 'accepts two tool uses answered in the other order' do
+      expect_accepted([ask,
+                       { 'role' => 'assistant', 'content' => [use_block('call_1'), use_block('call_2')] },
+                       { 'role' => 'user', 'content' => [result_block('call_2'), result_block('call_1')] }])
+    end
+
+    # The content types are an open set: a block this client does not know is
+    # the host's to read, not this client's to refuse — refusing it would
+    # break a session with a server using a type added after this release.
+    it 'accepts a content block of a type it does not know' do
+      expect_accepted([{ 'role' => 'user', 'content' => [{ 'type' => 'flowchart', 'nodes' => [] }] }])
+    end
+
+    it 'accepts an image block that carries its data and mimeType' do
+      expect_accepted([{ 'role' => 'user',
+                         'content' => [{ 'type' => 'image', 'data' => 'AAAA', 'mimeType' => 'image/png' }] }])
+    end
+
+    it 'refuses an image block with no data' do
+      expect_refused([{ 'role' => 'user', 'content' => [{ 'type' => 'image', 'mimeType' => 'image/png' }] }])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe 'the host controls reach the server that raised' do
+    # One server cannot tell "the transport that raised" from "the first
+    # transport": the continuation is resumed on its own server, and the
+    # other one is never asked.
+    it 'resumes a continuation on its own server, not on the first' do
+      first = modern_stdio(read_timeout: 1)
+      second = modern_stdio(read_timeout: 1)
+      second.on_input_required_wait { |_wait| :cancel }
+      tools = { 'tools' => [{ 'name' => 'only-on-second', 'inputSchema' => { 'type' => 'object' } }] }
+      first_sent = script_stdio(first, [{ 'result' => discover_result }, { 'result' => { 'tools' => [] } }])
+      second_sent = script_stdio(second, [{ 'result' => discover_result }, { 'result' => tools },
+                                          { 'result' => state_only('s1') }, { 'result' => done }])
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(first, second)
+      client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'a' },
+                                                          { type: 'stdio', command: 'b' }])
+      error = begin
+        client.call_tool('only-on-second', {})
+      rescue MCPClient::Errors::InputRequiredError => e
+        e
+      end
+      second.on_input_required_wait { |_wait| :wait }
+
+      expect(client.resume_input_required(error)).to eq(done)
+      expect(calls(second_sent).size).to eq(2)
+      expect(calls(second_sent).last['params']['requestState']).to eq('s1')
+      expect(calls(first_sent)).to be_empty
+    end
+
+    # Registered on the Client, the control covers every server it holds.
+    it 'registers a wait control through the Client for each of its servers' do
+      first = modern_stdio(read_timeout: 1)
+      second = modern_stdio(read_timeout: 1)
+      script_stdio(first, [{ 'result' => discover_result }, { 'result' => { 'tools' => [] } }])
+      tools = { 'tools' => [{ 'name' => 't', 'inputSchema' => { 'type' => 'object' } }] }
+      sent = script_stdio(second, [{ 'result' => discover_result }, { 'result' => tools },
+                                   { 'result' => state_only('s1') }, { 'result' => done }])
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(first, second)
+      client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'a' },
+                                                          { type: 'stdio', command: 'b' }])
+      seen = []
+      client.on_input_required_wait do |wait|
+        seen << wait.rpc_method
+        :cancel
+      end
+
+      expect { client.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /cancelled by the host/)
+      expect(seen).to eq(['tools/call'])
+      expect(calls(sent).size).to eq(1)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe 'an elicitation mode this client does not implement' do
+    # form and url are the two modes the Client serves; any other is refused
+    # before the host's handler sees it, and the round trip fails with the
+    # continuation rather than sending an answer the server cannot use.
+    it 'fails the round trip without asking the host' do
+      stdio = modern_stdio(read_timeout: 1)
+      invoked = false
+      handler = lambda do |_message, _details|
+        invoked = true
+        { 'name' => 'ada' }
+      end
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(stdio)
+      client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'x' }],
+                                     elicitation_handler: handler)
+      tool_list = { 'tools' => [{ 'name' => 'c', 'inputSchema' => { 'type' => 'object' } }] }
+      request = { 'method' => 'elicitation/create',
+                  'params' => { 'mode' => 'dialog', 'message' => 'Who?' } }
+      sent = script_stdio(stdio, [{ 'result' => discover_result }, { 'result' => tool_list },
+                                  { 'result' => input_required({ 'a' => request }) }, { 'result' => done }])
+
+      expect { client.call_tool('c', {}) }.to raise_error(MCPClient::Errors::InputRequiredError)
+      expect(invoked).to be(false)
+      expect(calls(sent).size).to eq(1)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # The continuation is a request like any other: the timeout the call was
+  # made with bounds it on the wire, not just in the argument the recovery
+  # wrapper is handed.
+  describe 'an HTTP continuation runs under the call\'s own timeout' do
+    around do |example|
+      WebMock.disable!
+      @fixture = StallingContinuationServer.new
+      example.run
+    ensure
+      @fixture&.close
+      WebMock.enable!
+    end
+
+    it 'ends a stalled continuation at the call timeout, not at the transport default' do
+      server = MCPClient::ServerStreamableHTTP.new(base_url: @fixture.base_url, endpoint: '/mcp',
+                                                   retries: 0, read_timeout: 30)
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'ada' } } }
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      expect { server.rpc_request('tools/call', { 'name' => 't', 'arguments' => {} }, timeout: 0.4) }
+        .to raise_error(MCPClient::Errors::RequestTimeoutError)
+
+      expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).to be < 10
+      expect(@fixture.received.count { |m| m['method'] == 'tools/call' }).to eq(2)
+    end
+  end
+end

--- a/spec/lib/mcp_client/mrtr_2026_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_spec.rb
@@ -105,10 +105,14 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests' do
       expect(responses['r']).to eq({ 'roots' => [{ 'uri' => 'file:///p', 'name' => 'p' }] })
     end
 
-    it 'retries immediately when only requestState is present' do
+    # The retry is paced (INPUT_RETRY_DELAY), not immediate; what this pins is
+    # that a requestState-only answer is retried at all, carrying the state
+    # and no inputResponses. The pacing itself is covered further down.
+    it 'retries a requestState-only answer with the state and no inputResponses' do
       sent = script_stdio(server, [{ 'result' => discover_result },
                                    { 'result' => input_required(nil, state: 'wait-for-oob') },
                                    { 'result' => { 'content' => [] } }])
+      allow(server).to receive(:sleep)
 
       server.call_tool('t', {})
 
@@ -158,14 +162,23 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests' do
                                    { 'result' => { 'messages' => [] } }])
 
       contents = server.read_resource('file:///r')
-      prompt = server.get_prompt('p', {})
+      prompt = server.get_prompt('p', { 'topic' => 'ruby' })
 
       expect(contents.first.text).to eq('ok')
       expect(prompt).to eq({ 'messages' => [] })
       expect(sent.map { |r| r['method'] })
         .to eq(%w[server/discover resources/read resources/read prompts/get prompts/get])
       expect(sent[2]['params']['uri']).to eq('file:///r')
-      expect(sent[4]['params']['name']).to eq('p')
+      expect(sent[2]['params']['inputResponses'])
+        .to eq({ 'a' => { 'action' => 'accept', 'content' => { 'name' => 'x' } } })
+      expect(sent[2]['params']['requestState']).to eq('opaque-state')
+      # The prompts/get retry is a continuation, not the original request sent
+      # again: it keeps the name and arguments AND carries the round trip.
+      expect(sent[4]['params']).to include('name' => 'p', 'arguments' => { 'topic' => 'ruby' },
+                                           'requestState' => 'opaque-state')
+      expect(sent[4]['params']['inputResponses'])
+        .to eq({ 'b' => { 'action' => 'accept', 'content' => { 'name' => 'x' } } })
+      expect(sent[3]['params']).not_to have_key('inputResponses')
     end
 
     it 'rejects an input_required result on a method that does not support it' do
@@ -175,16 +188,30 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests' do
       expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
     end
 
-    it 'bounds the number of round trips' do
+    it 'documents ten as the round-trip ceiling' do
+      expect(MCPClient::JsonRpcCommon::MAX_INPUT_ROUND_TRIPS).to eq(10)
+    end
+
+    it 'completes on the tenth round trip' do
       server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'x' } } }
       responses = [{ 'result' => discover_result }] +
-                  Array.new(MCPClient::JsonRpcCommon::MAX_INPUT_ROUND_TRIPS + 2) do
-                    { 'result' => input_required({ 'a' => elicit_request }) }
-                  end
+                  Array.new(10) { { 'result' => input_required({ 'a' => elicit_request }) } } +
+                  [{ 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'finally' }] } }]
+      sent = script_stdio(server, responses)
+
+      expect(server.call_tool('t', {})['content'].first['text']).to eq('finally')
+      expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(11)
+    end
+
+    it 'gives up on the eleventh round trip' do
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'x' } } }
+      responses = [{ 'result' => discover_result }] +
+                  Array.new(12) { { 'result' => input_required({ 'a' => elicit_request }) } }
       sent = script_stdio(server, responses)
 
       expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /round trips/)
-      expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(MCPClient::JsonRpcCommon::MAX_INPUT_ROUND_TRIPS + 1)
+      # Eleven requests: the original plus the ten permitted continuations.
+      expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(11)
     end
 
     it 'raises InputRequiredError without retrying when an input request cannot be fulfilled' do

--- a/spec/lib/mcp_client/mrtr_2026_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_spec.rb
@@ -558,3 +558,150 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests — plain HTTP on a leg
     http.cleanup
   end
 end
+
+# Review round 2 (grok): a URL-mode elicitation only reports consent when
+# the handler explicitly accepted; non-object input request params are
+# malformed; peer text in the client's elicitation logs is sanitized;
+# sampling through the Client and resources/read over HTTP are covered.
+RSpec.describe 'MCP 2026-07-28 multi round-trip requests — round 2' do
+  def discover_result
+    { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'], 'capabilities' => { 'tools' => {} } }
+  end
+
+  def script_stdio(server, responses)
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift or raise 'no scripted response left'
+      responder.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+    allow(server).to receive(:sleep)
+    sent
+  end
+
+  def url_request
+    { 'method' => 'elicitation/create',
+      'params' => { 'mode' => 'url', 'url' => 'https://mcp.example.com/connect', 'message' => 'Authorize' } }
+  end
+
+  def client_with(stdio, **options)
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(stdio)
+    MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'x' }], **options)
+  end
+
+  it 'answers a URL-mode elicitation with cancel unless the handler explicitly accepts' do
+    [{ 'name' => 'x' }, 'ok', nil, false, { 'action' => 'decline' }].each do |handler_result|
+      stdio = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+      client = client_with(stdio, elicitation_handler: ->(_m, _d) { handler_result })
+      sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                  { 'result' => { 'tools' => [{ 'name' => 'c', 'inputSchema' => {} }] } },
+                                  { 'result' => { 'resultType' => 'input_required', 'requestState' => 'oob',
+                                                  'inputRequests' => { 'auth' => url_request } } },
+                                  { 'result' => { 'content' => [] } }])
+
+      client.call_tool('c', {})
+
+      answer = sent.last['params']['inputResponses']['auth']
+      expected = handler_result == { 'action' => 'decline' } ? 'decline' : 'cancel'
+      expect(answer).to eq({ 'action' => expected }), "handler result #{handler_result.inspect}"
+    end
+  end
+
+  it 'accepts a URL-mode elicitation on an explicit accept or a literal true' do
+    [{ 'action' => 'accept' }, true].each do |handler_result|
+      stdio = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+      client = client_with(stdio, elicitation_handler: ->(_m, _d) { handler_result })
+      sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                  { 'result' => { 'tools' => [{ 'name' => 'c', 'inputSchema' => {} }] } },
+                                  { 'result' => { 'resultType' => 'input_required', 'requestState' => 'oob',
+                                                  'inputRequests' => { 'auth' => url_request } } },
+                                  { 'result' => { 'content' => [] } }])
+
+      client.call_tool('c', {})
+
+      expect(sent.last['params']['inputResponses']['auth']).to eq({ 'action' => 'accept' })
+    end
+  end
+
+  it 'treats non-object input request params as malformed' do
+    server = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+    server.on_elicitation_request { |_k, _p| { 'action' => 'accept' } }
+    script_stdio(server, [{ 'result' => discover_result },
+                          { 'result' => { 'resultType' => 'input_required',
+                                          'inputRequests' => { 'a' => { 'method' => 'elicitation/create',
+                                                                        'params' => 'not-an-object' } } } }])
+
+    expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /params/)
+  end
+
+  it 'sanitizes the peer-controlled mode and schema text in the client elicitation logs' do
+    output = StringIO.new
+    stdio = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+    client = client_with(stdio, logger: Logger.new(output), elicitation_handler: ->(_m, _d) { { 'name' => 'x' } })
+    bad_mode = { 'method' => 'elicitation/create', 'params' => { 'mode' => "form\nWARN forged", 'message' => 'm' } }
+    script_stdio(stdio, [{ 'result' => discover_result },
+                         { 'result' => { 'tools' => [{ 'name' => 'c', 'inputSchema' => {} }] } },
+                         { 'result' => { 'resultType' => 'input_required',
+                                         'inputRequests' => { 'a' => bad_mode } } }])
+
+    expect { client.call_tool('c', {}) }.to raise_error(MCPClient::Errors::InputRequiredError)
+    expect(output.string).not_to include("\nWARN forged")
+  end
+
+  it 'fulfils a sampling input request through the Client sampling handler' do
+    stdio = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+    client = client_with(stdio, sampling_handler: lambda { |messages, _prefs, _system, _max|
+      { 'role' => 'assistant',
+        'content' => { 'type' => 'text', 'text' => "echo: #{messages.first['content']['text']}" },
+        'model' => 'm', 'stopReason' => 'endTurn' }
+    })
+    sampling = { 'method' => 'sampling/createMessage',
+                 'params' => { 'messages' => [{ 'role' => 'user', 'content' => { 'type' => 'text', 'text' => 'hi' } }],
+                               'maxTokens' => 10 } }
+    sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                { 'result' => { 'tools' => [{ 'name' => 'c', 'inputSchema' => {} }] } },
+                                { 'result' => { 'resultType' => 'input_required',
+                                                'inputRequests' => { 's' => sampling } } },
+                                { 'result' => { 'content' => [] } }])
+
+    client.call_tool('c', {})
+
+    expect(sent.last['params']['inputResponses']['s']['content']['text']).to eq('echo: hi')
+    expect(sent.last['params']['_meta']['io.modelcontextprotocol/clientCapabilities']).to include('sampling' => {})
+  end
+
+  it 'runs resources/read round trips over Streamable HTTP' do
+    server = MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'x' } } }
+    requests = []
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      body = JSON.parse(request.body)
+      requests << body
+      result = case body['method']
+               when 'server/discover' then discover_result
+               when 'resources/read'
+                 if body['params'].key?('inputResponses')
+                   { 'contents' => [{ 'uri' => 'file:///r', 'text' => 'ok' }] }
+                 else
+                   { 'resultType' => 'input_required', 'requestState' => 's',
+                     'inputRequests' => { 'a' => { 'method' => 'elicitation/create',
+                                                   'params' => { 'message' => 'm',
+                                                                 'requestedSchema' => { 'type' => 'object' } } } } }
+                 end
+               end
+      { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'], 'result' => result),
+        headers: { 'Content-Type' => 'application/json' } }
+    end
+
+    expect(server.read_resource('file:///r').first.text).to eq('ok')
+    reads = requests.select { |r| r['method'] == 'resources/read' }
+    expect(reads.size).to eq(2)
+    expect(reads.last['params']['uri']).to eq('file:///r')
+    expect(reads.last['params']['requestState']).to eq('s')
+    server.cleanup
+  end
+end

--- a/spec/lib/mcp_client/mrtr_2026_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_spec.rb
@@ -333,3 +333,200 @@ end
 RSpec::Matchers.define :equal_string do |expected|
   match { |actual| actual.is_a?(String) && actual == expected && actual.encoding == expected.encoding }
 end
+
+# Review (codex): round-trip params survive transport-level recovery of an
+# attempt; handler exceptions become InputRequiredError; an explicit null
+# inputRequests is malformed; input_required from a legacy session is
+# rejected; the plain HTTP transport exposes the handlers.
+RSpec.describe 'MCP 2026-07-28 multi round-trip requests — review follow-ups' do
+  def discover_result
+    { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'], 'capabilities' => { 'tools' => {} } }
+  end
+
+  def elicit_request
+    { 'method' => 'elicitation/create',
+      'params' => { 'mode' => 'form', 'message' => 'name?',
+                    'requestedSchema' => { 'type' => 'object', 'properties' => {} } } }
+  end
+
+  def script_stdio(server, responses)
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift
+      raise 'no scripted response left' unless responder
+
+      response = responder.respond_to?(:call) ? responder.call(sent.last) : responder
+      raise response if response.is_a?(Exception)
+
+      response.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+    sent
+  end
+
+  let(:server) { MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1, retries: 1, retry_backoff: 0) }
+
+  it 'wraps a handler exception as InputRequiredError' do
+    server.on_elicitation_request { |_k, _p| raise 'boom' }
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => { 'resultType' => 'input_required',
+                                                 'inputRequests' => { 'a' => elicit_request } } }])
+
+    expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, %r{elicitation/create})
+    expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
+  end
+
+  it 'treats an explicit null inputRequests as malformed' do
+    script_stdio(server, [{ 'result' => discover_result },
+                          { 'result' => { 'resultType' => 'input_required', 'inputRequests' => nil,
+                                          'requestState' => 's' } }])
+
+    expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /inputRequests/)
+  end
+
+  it 'keeps the round-trip params when a retry attempt is recovered at the transport level' do
+    server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => {} } }
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => { 'resultType' => 'input_required', 'requestState' => 'st',
+                                                 'inputRequests' => { 'a' => elicit_request } } },
+                                 MCPClient::Errors::TransportError.new('flaky pipe'),
+                                 { 'result' => { 'tools' => [] } }])
+
+    server.rpc_request('resources/read', { 'uri' => 'file:///x' })
+
+    reads = sent.select { |r| r['method'] == 'resources/read' }
+    expect(reads.size).to eq(3)
+    expect(reads[1]['params']['requestState']).to eq('st')
+    expect(reads[2]['params']['requestState']).to eq('st')
+    expect(reads[2]['params']['inputResponses']).to eq({ 'a' => { 'action' => 'accept', 'content' => {} } })
+  end
+
+  it 'rejects input_required from a legacy session' do
+    legacy = MCPClient::ServerStdio.new(command: 'echo test', protocol: :legacy)
+    sent = script_stdio(legacy, [{ 'result' => { 'protocolVersion' => '2025-11-25', 'capabilities' => {} } },
+                                 { 'result' => { 'resultType' => 'input_required', 'requestState' => 's' } }])
+
+    expect { legacy.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
+    expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
+  end
+
+  it 'exposes the handlers on the plain HTTP transport and declares the capabilities' do
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    expect(http).to respond_to(:on_elicitation_request, :on_roots_list_request, :on_sampling_request)
+    http.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'x' } } }
+    http.on_roots_list_request { |_k, _p| { 'roots' => [] } }
+    requests = []
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      body = JSON.parse(request.body)
+      requests << body
+      result = case body['method']
+               when 'server/discover' then discover_result
+               when 'tools/list' then { 'tools' => [] }
+               when 'tools/call'
+                 if body['params'].key?('inputResponses')
+                   { 'content' => [] }
+                 else
+                   { 'resultType' => 'input_required', 'inputRequests' => { 'a' => elicit_request } }
+                 end
+               end
+      { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'], 'result' => result),
+        headers: { 'Content-Type' => 'application/json' } }
+    end
+
+    expect(http.call_tool('t', {})).to eq({ 'content' => [] })
+    caps = requests.last['params']['_meta']['io.modelcontextprotocol/clientCapabilities']
+    expect(caps).to include('elicitation' => { 'form' => {}, 'url' => {} }, 'roots' => {})
+    expect(requests.last['params']['inputResponses']).to eq({ 'a' => { 'action' => 'accept',
+                                                                       'content' => { 'name' => 'x' } } })
+    http.cleanup
+  end
+
+  it 'lets MCPClient::Client wire its handlers to a plain HTTP server' do
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(http)
+    client = MCPClient::Client.new(mcp_server_configs: [{ type: 'http', base_url: 'x' }],
+                                   elicitation_handler: ->(_m, _s) { { 'name' => 'x' } })
+    expect(http.instance_variable_get(:@elicitation_request_callback)).not_to be_nil
+    expect(http.instance_variable_get(:@roots_list_request_callback)).not_to be_nil
+    client.cleanup
+  end
+end
+
+RSpec.describe 'MCP 2026-07-28 multi round-trip requests — pacing and URL mode' do
+  def discover_result
+    { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'], 'capabilities' => { 'tools' => {} } }
+  end
+
+  def script_stdio(server, responses)
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift or raise 'no scripted response left'
+      responder.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+    sent
+  end
+
+  it 'paces retries of requestState-only answers with a growing delay' do
+    server = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+    delays = []
+    allow(server).to receive(:sleep) { |d| delays << d }
+    script_stdio(server, [{ 'result' => discover_result },
+                          { 'result' => { 'resultType' => 'input_required', 'requestState' => 's1' } },
+                          { 'result' => { 'resultType' => 'input_required', 'requestState' => 's2' } },
+                          { 'result' => { 'resultType' => 'input_required', 'requestState' => 's3' } },
+                          { 'result' => { 'content' => [] } }])
+
+    server.call_tool('t', {})
+
+    expect(delays).to eq([0.5, 1.0, 2.0])
+  end
+
+  it 'does not pace retries that carry fulfilled input responses' do
+    server = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+    server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => {} } }
+    expect(server).not_to receive(:sleep)
+    request = { 'method' => 'elicitation/create',
+                'params' => { 'message' => 'x', 'requestedSchema' => { 'type' => 'object' } } }
+    script_stdio(server, [{ 'result' => discover_result },
+                          { 'result' => { 'resultType' => 'input_required', 'inputRequests' => { 'a' => request } } },
+                          { 'result' => { 'content' => [] } }])
+
+    server.call_tool('t', {})
+  end
+
+  it 'routes a URL-mode elicitation through the Client handler and answers with a bare accept' do
+    stdio = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(stdio)
+    seen = nil
+    client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'x' }],
+                                   elicitation_handler: lambda { |message, details|
+                                     seen = [message, details]
+                                     { 'action' => 'accept' }
+                                   })
+    url_request = { 'method' => 'elicitation/create',
+                    'params' => { 'mode' => 'url', 'url' => 'https://mcp.example.com/connect', 'message' => 'Authorize' } }
+    sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                { 'result' => { 'tools' => [{ 'name' => 'connect',
+                                                              'inputSchema' => { 'type' => 'object' } }] } },
+                                { 'result' => { 'resultType' => 'input_required', 'requestState' => 'oob',
+                                                'inputRequests' => { 'auth' => url_request } } },
+                                { 'result' => { 'content' => [] } }])
+    allow(stdio).to receive(:sleep)
+
+    client.call_tool('connect', {})
+
+    expect(seen.first).to eq('Authorize')
+    expect(seen.last).to include('mode' => 'url', 'url' => 'https://mcp.example.com/connect')
+    expect(sent.last['params']['inputResponses']).to eq({ 'auth' => { 'action' => 'accept' } })
+    expect(sent.last['params']['requestState']).to eq('oob')
+  end
+end

--- a/spec/lib/mcp_client/mrtr_2026_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_spec.rb
@@ -1,0 +1,335 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 Multi Round-Trip Requests (basic/patterns/mrtr, SEP-2322):
+# servers no longer send roots/list, sampling/createMessage or
+# elicitation/create as their own JSON-RPC requests. Instead tools/call,
+# resources/read and prompts/get may answer with an InputRequiredResult
+# (resultType "input_required") whose inputRequests the client fulfils
+# before retrying the original request — with a new id, the same params,
+# `inputResponses` keyed like the requests, and `requestState` echoed
+# verbatim (or omitted when the server sent none).
+MRTR_META_CAPS = 'io.modelcontextprotocol/clientCapabilities'
+
+RSpec.describe 'MCP 2026-07-28 multi round-trip requests' do
+  def discover_result(capabilities: { 'tools' => {}, 'resources' => {}, 'prompts' => {} })
+    { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'], 'capabilities' => capabilities }
+  end
+
+  def input_required(requests, state: 'opaque-state')
+    result = { 'resultType' => 'input_required' }
+    result['inputRequests'] = requests if requests
+    result['requestState'] = state if state
+    result
+  end
+
+  def elicit_request(message = 'Please provide your GitHub username')
+    { 'method' => 'elicitation/create',
+      'params' => { 'mode' => 'form', 'message' => message,
+                    'requestedSchema' => { 'type' => 'object', 'properties' => { 'name' => { 'type' => 'string' } },
+                                           'required' => ['name'] } } }
+  end
+
+  def sampling_request
+    { 'method' => 'sampling/createMessage',
+      'params' => { 'messages' => [{ 'role' => 'user',
+                                     'content' => { 'type' => 'text', 'text' => 'Capital of France?' } }],
+                    'maxTokens' => 100 } }
+  end
+
+  # A stdio server driven by scripted responses (no subprocess).
+  def script_stdio(server, responses)
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift
+      raise 'no scripted response left' unless responder
+
+      response = responder.respond_to?(:call) ? responder.call(sent.last) : responder
+      response.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+    sent
+  end
+
+  describe 'on stdio' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1) }
+
+    it 'fulfils an elicitation input request and retries with inputResponses and requestState' do
+      handled = []
+      server.on_elicitation_request do |key, params|
+        handled << [key, params]
+        { 'action' => 'accept', 'content' => { 'name' => 'octocat' } }
+      end
+      sent = script_stdio(server, [{ 'result' => discover_result },
+                                   { 'result' => input_required({ 'github_login' => elicit_request }) },
+                                   { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'hi octocat' }] } }])
+
+      result = server.call_tool('greet', { 'loud' => true })
+
+      expect(result['content'].first['text']).to eq('hi octocat')
+      expect(handled).to eq([['github_login', elicit_request['params']]])
+      calls = sent.select { |r| r['method'] == 'tools/call' }
+      expect(calls.size).to eq(2)
+      expect(calls[0]['id']).not_to eq(calls[1]['id'])
+      expect(calls[0]['params']).not_to have_key('inputResponses')
+      expect(calls[1]['params']['name']).to eq('greet')
+      expect(calls[1]['params']['arguments']).to eq({ 'loud' => true })
+      expect(calls[1]['params']['inputResponses'])
+        .to eq({ 'github_login' => { 'action' => 'accept', 'content' => { 'name' => 'octocat' } } })
+      expect(calls[1]['params']['requestState']).to eq('opaque-state')
+    end
+
+    it 'fulfils sampling and roots input requests alongside elicitation in one round trip' do
+      server.on_elicitation_request { |_k, _p| { 'action' => 'decline' } }
+      server.on_sampling_request do |_k, _p|
+        { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'Paris' }, 'model' => 'm',
+          'stopReason' => 'endTurn' }
+      end
+      server.on_roots_list_request { |_k, _p| { 'roots' => [{ 'uri' => 'file:///p', 'name' => 'p' }] } }
+      sent = script_stdio(server, [{ 'result' => discover_result },
+                                   { 'result' => input_required({ 'q' => elicit_request, 'c' => sampling_request,
+                                                                  'r' => { 'method' => 'roots/list' } }) },
+                                   { 'result' => { 'content' => [] } }])
+
+      server.call_tool('t', {})
+
+      responses = sent.last['params']['inputResponses']
+      expect(responses['q']).to eq({ 'action' => 'decline' })
+      expect(responses['c']['content']['text']).to eq('Paris')
+      expect(responses['r']).to eq({ 'roots' => [{ 'uri' => 'file:///p', 'name' => 'p' }] })
+    end
+
+    it 'retries immediately when only requestState is present' do
+      sent = script_stdio(server, [{ 'result' => discover_result },
+                                   { 'result' => input_required(nil, state: 'wait-for-oob') },
+                                   { 'result' => { 'content' => [] } }])
+
+      server.call_tool('t', {})
+
+      retry_params = sent.last['params']
+      expect(retry_params['requestState']).to eq('wait-for-oob')
+      expect(retry_params).not_to have_key('inputResponses')
+    end
+
+    it 'omits requestState on the retry when the server sent none, and echoes it verbatim otherwise' do
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'x' } } }
+      weird = ' é {"not":"parsed"} =?base64?x?= '
+      sent = script_stdio(server, [{ 'result' => discover_result },
+                                   { 'result' => input_required({ 'a' => elicit_request }, state: nil) },
+                                   { 'result' => input_required({ 'b' => elicit_request }, state: weird) },
+                                   { 'result' => { 'content' => [] } }])
+
+      server.call_tool('t', {})
+
+      calls = sent.select { |r| r['method'] == 'tools/call' }
+      expect(calls.size).to eq(3)
+      expect(calls[1]['params']).not_to have_key('requestState')
+      expect(calls[2]['params']['requestState']).to equal_string(weird)
+      expect(calls[2]['params']['inputResponses'].keys).to eq(['b'])
+    end
+
+    it 'keeps the round trip scoped to its own request' do
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'x' } } }
+      sent = script_stdio(server, [{ 'result' => discover_result },
+                                   { 'result' => input_required({ 'a' => elicit_request }) },
+                                   { 'result' => { 'content' => [] } },
+                                   { 'result' => { 'tools' => [] } }])
+
+      server.call_tool('t', {})
+      server.list_tools
+
+      expect(sent.last['method']).to eq('tools/list')
+      expect(sent.last['params']).not_to have_key('inputResponses')
+      expect(sent.last['params']).not_to have_key('requestState')
+    end
+
+    it 'supports resources/read and prompts/get' do
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'x' } } }
+      sent = script_stdio(server, [{ 'result' => discover_result },
+                                   { 'result' => input_required({ 'a' => elicit_request }) },
+                                   { 'result' => { 'contents' => [{ 'uri' => 'file:///r', 'text' => 'ok' }] } },
+                                   { 'result' => input_required({ 'b' => elicit_request }) },
+                                   { 'result' => { 'messages' => [] } }])
+
+      contents = server.read_resource('file:///r')
+      prompt = server.get_prompt('p', {})
+
+      expect(contents.first.text).to eq('ok')
+      expect(prompt).to eq({ 'messages' => [] })
+      expect(sent.map { |r| r['method'] })
+        .to eq(%w[server/discover resources/read resources/read prompts/get prompts/get])
+      expect(sent[2]['params']['uri']).to eq('file:///r')
+      expect(sent[4]['params']['name']).to eq('p')
+    end
+
+    it 'rejects an input_required result on a method that does not support it' do
+      script_stdio(server, [{ 'result' => discover_result },
+                            { 'result' => input_required({ 'a' => elicit_request }) }])
+
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
+    end
+
+    it 'bounds the number of round trips' do
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'x' } } }
+      responses = [{ 'result' => discover_result }] +
+                  Array.new(MCPClient::JsonRpcCommon::MAX_INPUT_ROUND_TRIPS + 2) do
+                    { 'result' => input_required({ 'a' => elicit_request }) }
+                  end
+      sent = script_stdio(server, responses)
+
+      expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /round trips/)
+      expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(MCPClient::JsonRpcCommon::MAX_INPUT_ROUND_TRIPS + 1)
+    end
+
+    it 'raises InputRequiredError without retrying when an input request cannot be fulfilled' do
+      sent = script_stdio(server, [{ 'result' => discover_result },
+                                   { 'result' => input_required({ 'a' => elicit_request }) }])
+
+      expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError) do |e|
+        expect(e.input_requests).to eq({ 'a' => elicit_request })
+        expect(e.request_state).to eq('opaque-state')
+        expect(e.message).to match(/elicitation/)
+      end
+      expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
+    end
+
+    it 'raises InputRequiredError for an unknown input request method' do
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept' } }
+      script_stdio(server, [{ 'result' => discover_result },
+                            { 'result' => input_required({ 'a' => { 'method' => 'ping', 'params' => {} } }) }])
+
+      expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /ping/)
+    end
+
+    it 'raises InputRequiredError when a handler answers with an error' do
+      server.on_sampling_request { |_k, _p| { 'error' => { 'code' => -1, 'message' => 'Sampling rejected' } } }
+      script_stdio(server, [{ 'result' => discover_result },
+                            { 'result' => input_required({ 'c' => sampling_request }) }])
+
+      expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /Sampling rejected/)
+    end
+
+    it 'raises InputRequiredError for malformed inputRequests' do
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept' } }
+      script_stdio(server, [{ 'result' => discover_result },
+                            { 'result' => input_required({ 'a' => 'not-an-object' }) }])
+
+      expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError)
+    end
+
+    it 'declares roots, elicitation and sampling in modern requests once handlers are registered' do
+      server.on_elicitation_request { |_k, _p| nil }
+      server.on_roots_list_request { |_k, _p| nil }
+      server.on_sampling_request { |_k, _p| nil }
+      server.declare_sampling_tools
+      sent = script_stdio(server, [{ 'result' => discover_result }, { 'result' => { 'tools' => [] } }])
+
+      server.list_tools
+
+      caps = sent.last['params']['_meta'][MRTR_META_CAPS]
+      expect(caps['roots']).to eq({})
+      expect(caps['elicitation']).to eq({ 'form' => {}, 'url' => {} })
+      expect(caps['sampling']).to eq({ 'tools' => {} })
+    end
+
+    it 'declares nothing a modern server could ask for when no handler is registered' do
+      sent = script_stdio(server, [{ 'result' => discover_result }, { 'result' => { 'tools' => [] } }])
+
+      server.list_tools
+
+      expect(sent.last['params']['_meta'][MRTR_META_CAPS]).to eq({})
+    end
+  end
+
+  describe 'on Streamable HTTP' do
+    let(:url) { 'https://example.com/mcp' }
+    let(:server) { MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0) }
+
+    after { server.cleanup }
+
+    it 'retries the POST with a new id, inputResponses, requestState and the Mcp-Name header' do
+      server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'octocat' } } }
+      requests = []
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        requests << { headers: request.headers, body: body }
+        result = case body['method']
+                 when 'server/discover' then discover_result
+                 when 'tools/list' then { 'tools' => [] }
+                 when 'tools/call'
+                   if body['params'].key?('inputResponses')
+                     { 'content' => [{ 'type' => 'text', 'text' => 'done' }] }
+                   else
+                     input_required({ 'login' => elicit_request })
+                   end
+                 end
+        { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'], 'result' => result),
+          headers: { 'Content-Type' => 'application/json' } }
+      end
+
+      result = server.call_tool('greet', {})
+
+      expect(result['content'].first['text']).to eq('done')
+      calls = requests.select { |r| r[:body]['method'] == 'tools/call' }
+      expect(calls.size).to eq(2)
+      expect(calls[1][:body]['id']).not_to eq(calls[0][:body]['id'])
+      expect(calls[1][:body]['params']['inputResponses']['login']['content']).to eq({ 'name' => 'octocat' })
+      expect(calls[1][:body]['params']['requestState']).to eq('opaque-state')
+      expect(calls[1][:headers]['Mcp-Name']).to eq('greet')
+    end
+  end
+
+  describe 'through MCPClient::Client' do
+    def greet_tool
+      { 'name' => 'greet', 'inputSchema' => { 'type' => 'object' } }
+    end
+
+    it 'routes elicitation input requests to the configured handler and roots to the client roots' do
+      stdio = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(stdio)
+      seen = []
+      client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'x' }],
+                                     roots: [{ 'uri' => 'file:///home', 'name' => 'home' }],
+                                     elicitation_handler: lambda { |message, schema|
+                                       seen << [message, schema['required']]
+                                       { 'name' => 'octocat' }
+                                     })
+      sent = script_stdio(stdio, [
+                            { 'result' => discover_result },
+                            { 'result' => { 'tools' => [greet_tool] } },
+                            { 'result' => input_required({ 'login' => elicit_request,
+                                                           'r' => { 'method' => 'roots/list' } }) },
+                            { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'hi' }] } }
+                          ])
+
+      result = client.call_tool('greet', {})
+
+      expect(result['content'].first['text']).to eq('hi')
+      expect(seen).to eq([['Please provide your GitHub username', ['name']]])
+      responses = sent.last['params']['inputResponses']
+      expect(responses['login']).to eq({ 'action' => 'accept', 'content' => { 'name' => 'octocat' } })
+      expect(responses['r']).to eq({ 'roots' => [{ 'uri' => 'file:///home', 'name' => 'home' }] })
+    end
+
+    it 'surfaces an unfulfillable round trip as InputRequiredError from call_tool' do
+      stdio = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(stdio)
+      client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'x' }])
+      script_stdio(stdio, [{ 'result' => discover_result },
+                           { 'result' => { 'tools' => [greet_tool] } },
+                           { 'result' => input_required({ 'login' => elicit_request }) }])
+
+      expect { client.call_tool('greet', {}) }.to raise_error(MCPClient::Errors::InputRequiredError)
+    end
+  end
+end
+
+RSpec::Matchers.define :equal_string do |expected|
+  match { |actual| actual.is_a?(String) && actual == expected && actual.encoding == expected.encoding }
+end

--- a/spec/lib/mcp_client/mrtr_2026_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_spec.rb
@@ -530,3 +530,31 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests — pacing and URL mode
     expect(sent.last['params']['requestState']).to eq('oob')
   end
 end
+
+RSpec.describe 'MCP 2026-07-28 multi round-trip requests — plain HTTP on a legacy session' do
+  it 'does not advertise roots, elicitation or sampling to a legacy server it cannot serve them on' do
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    http.on_elicitation_request { |_k, _p| { 'action' => 'accept' } }
+    http.on_roots_list_request { |_k, _p| { 'roots' => [] } }
+    http.on_sampling_request { |_k, _p| {} }
+    init_params = nil
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      body = JSON.parse(request.body)
+      case body['method']
+      when 'server/discover' then { status: 400, body: '' }
+      when 'initialize'
+        init_params = body['params']
+        { status: 200, headers: { 'Content-Type' => 'application/json' },
+          body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'],
+                              'result' => { 'protocolVersion' => '2025-11-25', 'capabilities' => {},
+                                            'serverInfo' => { 'name' => 'l', 'version' => '1' } }) }
+      else { status: 202, body: '' }
+      end
+    end
+
+    http.connect
+
+    expect(init_params['capabilities']).to eq({})
+    http.cleanup
+  end
+end

--- a/spec/lib/mcp_client/mrtr_2026_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_spec.rb
@@ -188,10 +188,6 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests' do
       expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
     end
 
-    it 'documents ten as the round-trip ceiling' do
-      expect(MCPClient::JsonRpcCommon::MAX_INPUT_ROUND_TRIPS).to eq(10)
-    end
-
     it 'completes on the tenth round trip' do
       server.on_elicitation_request { |_k, _p| { 'action' => 'accept', 'content' => { 'name' => 'x' } } }
       responses = [{ 'result' => discover_result }] +
@@ -472,13 +468,45 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests — review follow-ups' 
     http.cleanup
   end
 
-  it 'lets MCPClient::Client wire its handlers to a plain HTTP server' do
+  it 'drives a MCPClient::Client sampling round trip against a plain HTTP server' do
     http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
     allow(MCPClient::ServerFactory).to receive(:create).and_return(http)
+    asked = []
     client = MCPClient::Client.new(mcp_server_configs: [{ type: 'http', base_url: 'x' }],
-                                   elicitation_handler: ->(_m, _s) { { 'name' => 'x' } })
-    expect(http.instance_variable_get(:@elicitation_request_callback)).not_to be_nil
-    expect(http.instance_variable_get(:@roots_list_request_callback)).not_to be_nil
+                                   sampling_handler: lambda { |messages, _prefs, _system, max_tokens|
+                                     asked << [messages, max_tokens]
+                                     { 'role' => 'assistant', 'model' => 'm', 'stopReason' => 'endTurn',
+                                       'content' => { 'type' => 'text', 'text' => 'Paris' } }
+                                   })
+    sampling = { 'method' => 'sampling/createMessage',
+                 'params' => { 'messages' => [{ 'role' => 'user',
+                                                'content' => { 'type' => 'text', 'text' => 'Capital?' } }],
+                               'maxTokens' => 100 } }
+    bodies = []
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      body = JSON.parse(request.body)
+      bodies << body
+      result = case body['method']
+               when 'server/discover' then discover_result
+               when 'tools/list' then { 'tools' => [{ 'name' => 'ask', 'inputSchema' => { 'type' => 'object' } }] }
+               when 'tools/call'
+                 if body['params'].key?('inputResponses')
+                   { 'content' => [{ 'type' => 'text', 'text' => 'answered' }] }
+                 else
+                   { 'resultType' => 'input_required', 'requestState' => 'st',
+                     'inputRequests' => { 's' => sampling } }
+                 end
+               end
+      { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'], 'result' => result),
+        headers: { 'Content-Type' => 'application/json' } }
+    end
+
+    expect(client.call_tool('ask', {})['content'].first['text']).to eq('answered')
+    expect(asked.size).to eq(1)
+    expect(asked.first.last).to eq(100)
+    expect(bodies.last['params']['inputResponses']['s'])
+      .to include('role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'Paris' })
+    expect(bodies.last['params']['requestState']).to eq('st')
     client.cleanup
   end
 end
@@ -665,7 +693,7 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests — round 2' do
     expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /params/)
   end
 
-  it 'sanitizes the peer-controlled mode and schema text in the client elicitation logs' do
+  it 'escapes the peer-controlled elicitation mode in the client logs' do
     output = StringIO.new
     stdio = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
     client = client_with(stdio, logger: Logger.new(output), elicitation_handler: ->(_m, _d) { { 'name' => 'x' } })
@@ -676,6 +704,10 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests — round 2' do
                                          'inputRequests' => { 'a' => bad_mode } } }])
 
     expect { client.call_tool('c', {}) }.to raise_error(MCPClient::Errors::InputRequiredError)
+    # The mode is rejected, and the forged log line it carries is written as
+    # one escaped line rather than becoming a second entry of its own.
+    expect(output.string).to include('Rejecting elicitation request with unsupported mode')
+    expect(output.string).to include('\x0AWARN forged')
     expect(output.string).not_to include("\nWARN forged")
   end
 

--- a/spec/lib/mcp_client/mrtr_2026_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_spec.rb
@@ -196,7 +196,13 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests' do
       sent = script_stdio(server, responses)
 
       expect(server.call_tool('t', {})['content'].first['text']).to eq('finally')
-      expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(11)
+      calls = sent.select { |r| r['method'] == 'tools/call' }
+      expect(calls.size).to eq(11)
+      # Every continuation carries the fulfilled answer and the state; the
+      # scripted queue would otherwise be satisfied by state-only retries.
+      expect(calls.drop(1).map { |r| r['params']['inputResponses'] })
+        .to all(eq({ 'a' => { 'action' => 'accept', 'content' => { 'name' => 'x' } } }))
+      expect(calls.drop(1).map { |r| r['params']['requestState'] }).to all(eq('opaque-state'))
     end
 
     it 'gives up on the eleventh round trip' do
@@ -206,8 +212,12 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests' do
       sent = script_stdio(server, responses)
 
       expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /round trips/)
-      # Eleven requests: the original plus the ten permitted continuations.
-      expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(11)
+      # Eleven requests: the original plus the ten permitted continuations,
+      # each of them carrying the fulfilled answer.
+      calls = sent.select { |r| r['method'] == 'tools/call' }
+      expect(calls.size).to eq(11)
+      expect(calls.drop(1).map { |r| r['params']['inputResponses'] })
+        .to all(eq({ 'a' => { 'action' => 'accept', 'content' => { 'name' => 'x' } } }))
     end
 
     it 'raises InputRequiredError without retrying when an input request cannot be fulfilled' do

--- a/spec/lib/mcp_client/mrtr_2026_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_spec.rb
@@ -540,8 +540,11 @@ RSpec.describe 'MCP 2026-07-28 multi round-trip requests — pacing and URL mode
     sent
   end
 
+  # Round 7: an unbounded wait is bounded by the transport's read timeout when
+  # the caller names none; the growth curve is what this example pins, so its
+  # transport is given room for the 3.5s of pauses it walks through.
   it 'paces retries of requestState-only answers with a growing delay' do
-    server = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1)
+    server = MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 60)
     delays = []
     allow(server).to receive(:sleep) { |d| delays << d }
     script_stdio(server, [{ 'result' => discover_result },

--- a/spec/lib/mcp_client/mrtr_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_verify_spec.rb
@@ -1,0 +1,508 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# Verification pass over the MCP 2026-07-28 multi round-trip work:
+#
+#   * SEP-1577: a sampling request carrying `tools` or `toolChoice` is only
+#     valid when the client declared `sampling.tools`. The check must live on
+#     the transport's own round-trip path, not only in MCPClient::Client.
+#   * `notifications/roots/list_changed` may only be sent on a session that
+#     declared the roots capability — registering the plain HTTP handlers
+#     (which serve the modern round trips) must not make a legacy plain HTTP
+#     session a recipient.
+#   * A URL-mode ElicitResult keeps the handler's `_meta` (the schema carries
+#     it) while `content` is still stripped.
+#
+# Plus the coverage the same pass found missing: the retry-pacing ceiling, the
+# sanitized schema warning, a real Client round trip on plain HTTP, concurrent
+# round trips, a continuation surviving transport-level recovery, and the
+# legacy paths none of this may disturb.
+MRTR_VERIFY_CAPS_META = 'io.modelcontextprotocol/clientCapabilities'
+
+# Scripted transports and the request shapes the round trips use.
+module MrtrVerifyHelpers
+  def discover_result(capabilities: { 'tools' => {} })
+    { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'], 'capabilities' => capabilities }
+  end
+
+  def input_required(requests, state: nil)
+    result = { 'resultType' => 'input_required' }
+    result['inputRequests'] = requests if requests
+    result['requestState'] = state if state
+    result
+  end
+
+  def sampling_request(extra = {})
+    { 'method' => 'sampling/createMessage',
+      'params' => { 'messages' => [{ 'role' => 'user',
+                                     'content' => { 'type' => 'text', 'text' => 'Capital of France?' } }],
+                    'maxTokens' => 100 }.merge(extra) }
+  end
+
+  def sampling_result
+    { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'Paris' },
+      'model' => 'test-model', 'stopReason' => 'endTurn' }
+  end
+
+  def form_elicit_request(message = 'Who?')
+    { 'method' => 'elicitation/create',
+      'params' => { 'mode' => 'form', 'message' => message,
+                    'requestedSchema' => { 'type' => 'object',
+                                           'properties' => { 'name' => { 'type' => 'string' } } } } }
+  end
+
+  def url_elicit_request
+    { 'method' => 'elicitation/create',
+      'params' => { 'mode' => 'url', 'url' => 'https://mcp.example.com/connect', 'message' => 'Authorize' } }
+  end
+
+  def modern_stdio(**)
+    MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1, **)
+  end
+
+  # Answer a stdio transport's requests from a scripted list, in order, with
+  # no subprocess behind it.
+  def script_stdio(server, responses)
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    allow(server).to receive(:sleep)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift or raise 'no scripted response left'
+      responder.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+    sent
+  end
+
+  def client_with(server, **)
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+    MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'x' }], **)
+  end
+
+  def json_response(id, result)
+    { status: 200, headers: { 'Content-Type' => 'application/json' },
+      body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result) }
+  end
+end
+
+RSpec.describe 'MCP 2026-07-28 MRTR verification — sampling.tools on the round-trip path' do
+  include MrtrVerifyHelpers
+
+  {
+    'tools' => { 'tools' => [{ 'name' => 'search', 'inputSchema' => { 'type' => 'object' } }] },
+    'toolChoice' => { 'toolChoice' => { 'mode' => 'auto' } }
+  }.each do |field, extra|
+    it "refuses a sampling input request carrying #{field} when sampling.tools is undeclared" do
+      server = modern_stdio
+      invoked = false
+      server.on_sampling_request do |_key, _params|
+        invoked = true
+        sampling_result
+      end
+      sent = script_stdio(server, [{ 'result' => discover_result },
+                                   { 'result' => input_required({ 's' => sampling_request(extra) }) }])
+
+      expect { server.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /sampling\.tools/)
+      expect(invoked).to be(false)
+      expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
+    end
+  end
+
+  it 'declares plain sampling and fulfils a request without tool fields' do
+    server = modern_stdio
+    server.on_sampling_request { |_key, _params| sampling_result }
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => input_required({ 's' => sampling_request }) },
+                                 { 'result' => { 'content' => [] } }])
+
+    server.call_tool('t', {})
+
+    expect(sent.last['params']['inputResponses']['s']).to eq(sampling_result)
+    expect(sent.last['params']['_meta'][MRTR_VERIFY_CAPS_META]['sampling']).to eq({})
+  end
+
+  it 'fulfils a tool-enabled sampling request once declare_sampling_tools was called' do
+    server = modern_stdio
+    server.declare_sampling_tools
+    seen = nil
+    server.on_sampling_request do |_key, params|
+      seen = params
+      sampling_result
+    end
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => input_required(
+                                   { 's' => sampling_request('toolChoice' => { 'mode' => 'auto' }) }
+                                 ) },
+                                 { 'result' => { 'content' => [] } }])
+
+    server.call_tool('t', {})
+
+    expect(seen['toolChoice']).to eq({ 'mode' => 'auto' })
+    expect(sent.last['params']['inputResponses']['s']).to eq(sampling_result)
+    expect(sent.last['params']['_meta'][MRTR_VERIFY_CAPS_META]['sampling']).to eq({ 'tools' => {} })
+  end
+
+  it 'refuses the same request through MCPClient::Client without the opt-in' do
+    stdio = modern_stdio
+    invoked = false
+    client = client_with(stdio, sampling_handler: lambda { |_messages, _prefs, _system, _max|
+      invoked = true
+      sampling_result
+    })
+    sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                { 'result' => { 'tools' => [{ 'name' => 'c', 'inputSchema' => {} }] } },
+                                { 'result' => input_required(
+                                  { 's' => sampling_request('toolChoice' => { 'mode' => 'auto' }) }
+                                ) }])
+
+    expect { client.call_tool('c', {}) }
+      .to raise_error(MCPClient::Errors::InputRequiredError, /sampling\.tools/)
+    expect(invoked).to be(false)
+    expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
+  end
+
+  it 'fulfils it through MCPClient::Client when sampling_supports_tools is set' do
+    stdio = modern_stdio
+    client = client_with(stdio, sampling_supports_tools: true,
+                                sampling_handler: lambda { |_messages, _prefs, _system, _max, params = nil|
+                                  { 'role' => 'assistant', 'model' => 'm', 'stopReason' => 'endTurn',
+                                    'content' => { 'type' => 'text',
+                                                   'text' => "choice:#{params['toolChoice']['mode']}" } }
+                                })
+    sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                { 'result' => { 'tools' => [{ 'name' => 'c', 'inputSchema' => {} }] } },
+                                { 'result' => input_required(
+                                  { 's' => sampling_request('toolChoice' => { 'mode' => 'auto' }) }
+                                ) },
+                                { 'result' => { 'content' => [] } }])
+
+    client.call_tool('c', {})
+
+    expect(sent.last['params']['inputResponses']['s']['content']['text']).to eq('choice:auto')
+    expect(sent.last['params']['_meta'][MRTR_VERIFY_CAPS_META]['sampling']).to eq({ 'tools' => {} })
+  end
+end
+
+RSpec.describe 'MCP 2026-07-28 MRTR verification — roots/list_changed stays on declared capabilities' do
+  include MrtrVerifyHelpers
+
+  def stub_legacy_http(posted)
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      body = JSON.parse(request.body)
+      posted << body
+      case body['method']
+      when 'server/discover' then { status: 400, body: '' }
+      when 'initialize'
+        json_response(body['id'], { 'protocolVersion' => '2025-11-25', 'capabilities' => {},
+                                    'serverInfo' => { 'name' => 'legacy', 'version' => '1' } })
+      else { status: 202, body: '' }
+      end
+    end
+  end
+
+  it 'does not notify a plain HTTP server on a legacy session' do
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    posted = []
+    stub_legacy_http(posted)
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(http)
+    client = MCPClient::Client.new(mcp_server_configs: [{ type: 'http', base_url: 'https://example.com' }])
+    http.connect
+
+    client.roots = [{ 'uri' => 'file:///workspace', 'name' => 'ws' }]
+
+    expect(http.client_capabilities).not_to have_key('roots')
+    expect(posted.map { |b| b['method'] }).not_to include('notifications/roots/list_changed')
+    http.cleanup
+  end
+
+  it 'still notifies a legacy session that declared roots' do
+    legacy = MCPClient::ServerStdio.new(command: 'echo legacy', protocol: :legacy)
+    legacy.instance_variable_set(:@protocol_version, '2025-11-25')
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(legacy)
+    client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'a' }])
+
+    expect(legacy).to receive(:rpc_notify).with('notifications/roots/list_changed', {})
+
+    client.roots = [{ 'uri' => 'file:///tmp', 'name' => 'tmp' }]
+  end
+
+  it 'never notifies a modern session, where the notification no longer exists' do
+    modern = MCPClient::ServerStdio.new(command: 'echo modern')
+    modern.instance_variable_set(:@protocol_version, '2026-07-28')
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(modern)
+    client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'a' }])
+
+    expect(modern).not_to receive(:rpc_notify)
+
+    client.roots = [{ 'uri' => 'file:///tmp', 'name' => 'tmp' }]
+  end
+end
+
+RSpec.describe 'MCP 2026-07-28 MRTR verification — URL-mode elicitation _meta' do
+  include MrtrVerifyHelpers
+
+  let(:receipt) { { 'com.example/receipt' => 'receipt-17' } }
+
+  it 'keeps the handler _meta on the round-trip answer and still strips content' do
+    stdio = modern_stdio
+    client = client_with(stdio, elicitation_handler: lambda { |_message, _details|
+      { 'action' => 'accept', '_meta' => { 'com.example/receipt' => 'receipt-17' },
+        'content' => { 'ignored' => true } }
+    })
+    sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                { 'result' => { 'tools' => [{ 'name' => 'c', 'inputSchema' => {} }] } },
+                                { 'result' => input_required({ 'auth' => url_elicit_request }, state: 'oob') },
+                                { 'result' => { 'content' => [] } }])
+
+    client.call_tool('c', {})
+
+    expect(sent.last['params']['inputResponses']['auth']).to eq({ 'action' => 'accept', '_meta' => receipt })
+  end
+
+  it 'keeps _meta on a decline too, and adds none when the handler sent none' do
+    [%w[decline decline], %w[cancel cancel]].each do |action, expected|
+      stdio = modern_stdio
+      client = client_with(stdio, elicitation_handler: ->(_m, _d) { { 'action' => action, '_meta' => receipt } })
+      sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                  { 'result' => { 'tools' => [{ 'name' => 'c', 'inputSchema' => {} }] } },
+                                  { 'result' => input_required({ 'auth' => url_elicit_request }, state: 'oob') },
+                                  { 'result' => { 'content' => [] } }])
+
+      client.call_tool('c', {})
+
+      expect(sent.last['params']['inputResponses']['auth'])
+        .to eq({ 'action' => expected, '_meta' => receipt })
+    end
+  end
+
+  it 'sends a bare action when the handler returned no _meta' do
+    stdio = modern_stdio
+    client = client_with(stdio, elicitation_handler: ->(_m, _d) { { 'action' => 'accept' } })
+    sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                { 'result' => { 'tools' => [{ 'name' => 'c', 'inputSchema' => {} }] } },
+                                { 'result' => input_required({ 'auth' => url_elicit_request }, state: 'oob') },
+                                { 'result' => { 'content' => [] } }])
+
+    client.call_tool('c', {})
+
+    expect(sent.last['params']['inputResponses']['auth']).to eq({ 'action' => 'accept' })
+  end
+
+  it 'keeps _meta on a legacy server-initiated URL elicitation as well' do
+    stdio = MCPClient::ServerStdio.new(command: 'echo legacy', protocol: :legacy)
+    written = []
+    stdio.instance_variable_set(:@stdin, double('stdin', flush: nil).tap do |io|
+      allow(io).to receive(:puts) { |line| written << line }
+    end)
+    client_with(stdio, elicitation_handler: ->(_m, _d) { { 'action' => 'accept', '_meta' => receipt } })
+
+    stdio.handle_server_request({ 'id' => 7, 'method' => 'elicitation/create',
+                                  'params' => { 'mode' => 'url', 'url' => 'https://mcp.example.com/c',
+                                                'message' => 'Authorize' } })
+
+    expect(JSON.parse(written.last)['result']).to eq({ 'action' => 'accept', '_meta' => receipt })
+  end
+end
+
+RSpec.describe 'MCP 2026-07-28 MRTR verification — pacing, logs and plain HTTP' do
+  include MrtrVerifyHelpers
+
+  it 'caps the growing retry delay instead of doubling without bound' do
+    server = modern_stdio
+    responses = [{ 'result' => discover_result }]
+    7.times { |i| responses << { 'result' => input_required(nil, state: "s#{i}") } }
+    responses << { 'result' => { 'content' => [] } }
+    script_stdio(server, responses)
+    delays = []
+    allow(server).to receive(:sleep) { |seconds| delays << seconds }
+
+    server.call_tool('t', {})
+
+    expect(delays).to eq([0.5, 1, 2, 4, 5, 5, 5])
+    expect(delays.max).to eq(MCPClient::JsonRpcCommon::INPUT_RETRY_MAX_DELAY)
+  end
+
+  it 'escapes peer-controlled schema text in the elicitation schema warning' do
+    output = StringIO.new
+    stdio = modern_stdio
+    client = client_with(stdio, logger: Logger.new(output),
+                                elicitation_handler: ->(_m, _s) { { 'action' => 'decline' } })
+    forged = "victim\nWARN  -- : forged log line"
+    request = { 'method' => 'elicitation/create',
+                'params' => { 'mode' => 'form', 'message' => 'm',
+                              'requestedSchema' => { 'type' => 'object',
+                                                     'properties' => { forged => { 'type' => 'sneaky' } } } } }
+    script_stdio(stdio, [{ 'result' => discover_result },
+                         { 'result' => { 'tools' => [{ 'name' => 'c', 'inputSchema' => {} }] } },
+                         { 'result' => input_required({ 'a' => request }) },
+                         { 'result' => { 'content' => [] } }])
+
+    client.call_tool('c', {})
+
+    expect(output.string).to include('Elicitation schema validation warnings')
+    expect(output.string).to include('\x0AWARN  -- : forged log line')
+    expect(output.string).not_to include("\nWARN  -- : forged log line")
+  end
+
+  it 'serves a full MCPClient::Client round trip over plain HTTP' do
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(http)
+    client = MCPClient::Client.new(
+      mcp_server_configs: [{ type: 'http', base_url: 'https://example.com' }],
+      roots: [{ 'uri' => 'file:///workspace', 'name' => 'ws' }],
+      elicitation_handler: ->(_message, _schema) { { 'name' => 'ada' } }
+    )
+    bodies = []
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      body = JSON.parse(request.body)
+      bodies << body
+      result = case body['method']
+               when 'server/discover' then discover_result
+               when 'tools/list'
+                 { 'tools' => [{ 'name' => 'greet', 'inputSchema' => { 'type' => 'object' } }] }
+               when 'tools/call'
+                 if body['params'].key?('inputResponses')
+                   { 'content' => [{ 'type' => 'text', 'text' => 'hi ada' }] }
+                 else
+                   input_required({ 'who' => form_elicit_request,
+                                    'where' => { 'method' => 'roots/list', 'params' => {} } }, state: 'st')
+                 end
+               end
+      json_response(body['id'], result)
+    end
+
+    result = client.call_tool('greet', {})
+
+    expect(result['content'].first['text']).to eq('hi ada')
+    retry_params = bodies.last['params']
+    expect(retry_params['requestState']).to eq('st')
+    expect(retry_params['inputResponses']['who']).to eq({ 'action' => 'accept', 'content' => { 'name' => 'ada' } })
+    expect(retry_params['inputResponses']['where'])
+      .to eq({ 'roots' => [{ 'uri' => 'file:///workspace', 'name' => 'ws' }] })
+    client.cleanup
+  end
+
+  it 'keeps the continuation through a HeaderMismatch refresh on plain HTTP' do
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    http.on_elicitation_request { |_key, _params| { 'action' => 'accept', 'content' => { 'name' => 'ada' } } }
+    header = 'Region'
+    bodies = []
+    headers_seen = []
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      body = JSON.parse(request.body)
+      bodies << body
+      calls = bodies.count { |b| b['method'] == 'tools/call' }
+      case body['method']
+      when 'server/discover' then json_response(body['id'], discover_result)
+      when 'tools/list'
+        schema = { 'type' => 'object',
+                   'properties' => { 'region' => { 'type' => 'string', 'x-mcp-header' => header } } }
+        json_response(body['id'], { 'tools' => [{ 'name' => 'q', 'inputSchema' => schema }] })
+      when 'tools/call'
+        headers_seen << request.headers
+        if calls == 1
+          json_response(body['id'], input_required({ 'a' => form_elicit_request }, state: 'st'))
+        elsif calls == 2
+          header = 'Zone'
+          { status: 400, headers: { 'Content-Type' => 'application/json' },
+            body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'],
+                                'error' => { 'code' => -32_020, 'message' => 'Header mismatch: Mcp-Param-Zone' }) }
+        else
+          json_response(body['id'], { 'content' => [] })
+        end
+      end
+    end
+
+    http.list_tools
+    http.call_tool('q', { 'region' => 'eu' })
+
+    calls = bodies.select { |b| b['method'] == 'tools/call' }
+    expect(calls.size).to eq(3)
+    expect(calls.last['params']['requestState']).to eq('st')
+    expect(calls.last['params']['inputResponses']['a'])
+      .to eq({ 'action' => 'accept', 'content' => { 'name' => 'ada' } })
+    expect(headers_seen.last['Mcp-Param-Zone']).to eq('eu')
+    http.cleanup
+  end
+end
+
+# A stdio transport whose wire is a Ruby block: each response is computed from
+# the request it answers, so concurrent round trips cannot cross-talk through
+# a shared script.
+class MrtrScriptedStdio < MCPClient::ServerStdio
+  attr_reader :sent
+
+  def initialize(responder:, **)
+    super(**)
+    @responder = responder
+    @sent = []
+    @sent_lock = Mutex.new
+  end
+
+  # ServerStdio#connect answers true after spawning the process; this
+  # override keeps that contract, so it cannot be renamed to a predicate.
+  def connect # rubocop:disable Naming/PredicateMethod
+    true
+  end
+
+  def start_reader; end
+
+  def start_stderr_reader; end
+
+  def send_request(request)
+    @sent_lock.synchronize { @sent << request }
+  end
+
+  def wait_response(id, **_opts)
+    request = @sent_lock.synchronize { @sent.find { |r| r['id'] == id } }
+    @responder.call(request).merge('jsonrpc' => '2.0', 'id' => id)
+  end
+end
+
+RSpec.describe 'MCP 2026-07-28 MRTR verification — concurrent round trips' do
+  include MrtrVerifyHelpers
+
+  it 'keeps each concurrent round trip scoped to its own request' do
+    responder = lambda do |request|
+      case request['method']
+      when 'server/discover' then { 'result' => discover_result }
+      when 'tools/call'
+        name = request['params']['name']
+        if request['params'].key?('inputResponses')
+          { 'result' => { 'content' => [{ 'type' => 'text', 'text' => name }] } }
+        else
+          { 'result' => input_required({ name => form_elicit_request(name) }, state: "state-#{name}") }
+        end
+      end
+    end
+    server = MrtrScriptedStdio.new(command: 'echo test', read_timeout: 5, responder: responder)
+    # Handlers are host code and may block (a real user prompt does), so hold
+    # every thread inside its own round trip until all four are there: the
+    # answers must still be routed per request, never through the transport.
+    inside = Queue.new
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+    server.on_elicitation_request do |key, _params|
+      inside << key
+      sleep(0.001) while inside.size < 4 && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+      { 'action' => 'accept', 'content' => { 'key' => key } }
+    end
+
+    %w[alpha beta gamma delta].map { |name| Thread.new { server.call_tool(name, {}) } }.each(&:join)
+
+    expect(inside.size).to eq(4)
+    retries = server.sent.select { |r| r['method'] == 'tools/call' && r['params'].key?('inputResponses') }
+    expect(retries.size).to eq(4)
+    retries.each do |request|
+      name = request['params']['name']
+      expect(request['params']['requestState']).to eq("state-#{name}")
+      expect(request['params']['inputResponses'].keys).to eq([name])
+      expect(request['params']['inputResponses'][name]['content']).to eq({ 'key' => name })
+    end
+  end
+end

--- a/spec/lib/mcp_client/mrtr_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_verify_spec.rb
@@ -493,9 +493,14 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — concurrent round trips' do
       { 'action' => 'accept', 'content' => { 'key' => key } }
     end
 
-    %w[alpha beta gamma delta].map { |name| Thread.new { server.call_tool(name, {}) } }.each(&:join)
+    results = %w[alpha beta gamma delta]
+              .map { |name| Thread.new { [name, server.call_tool(name, {})] } }
+              .to_h(&:value)
 
     expect(inside.size).to eq(4)
+    # Each thread's own final result came back to it, not another thread's.
+    expect(results.transform_values { |r| r['content'].first['text'] })
+      .to eq({ 'alpha' => 'alpha', 'beta' => 'beta', 'gamma' => 'gamma', 'delta' => 'delta' })
     retries = server.sent.select { |r| r['method'] == 'tools/call' && r['params'].key?('inputResponses') }
     expect(retries.size).to eq(4)
     retries.each do |request|
@@ -504,5 +509,713 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — concurrent round trips' do
       expect(request['params']['inputResponses'].keys).to eq([name])
       expect(request['params']['inputResponses'][name]['content']).to eq({ 'key' => name })
     end
+  end
+end
+
+# Review round 3 (codex): MRTR is defined only for tools/call, resources/read
+# and prompts/get (basic/patterns/mrtr "Supported Requests"). server/discover
+# is not one of them, so an input_required discover answer must be rejected
+# before the version and capabilities it carries are applied or cached —
+# otherwise the probe records a modern version from an unfinished result and
+# the first heartbeat hands that result straight back to the caller.
+RSpec.describe 'MCP 2026-07-28 MRTR verification — server/discover never answers input_required' do
+  include MrtrVerifyHelpers
+
+  def input_required_discover
+    { 'resultType' => 'input_required', 'supportedVersions' => ['2026-07-28'],
+      'capabilities' => {}, 'requestState' => 'pending-discovery' }
+  end
+
+  it 'rejects an input_required server/discover on stdio without recording the version' do
+    server = modern_stdio(protocol: :modern)
+    sent = script_stdio(server, [{ 'result' => input_required_discover },
+                                 { 'result' => { 'tools' => [] } }])
+
+    expect { server.list_tools }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect(sent.map { |r| r['method'] }).to eq(['server/discover'])
+    expect(server.instance_variable_get(:@protocol_version)).to be_nil
+    expect(server.instance_variable_get(:@last_discover_result)).to be_nil
+  end
+
+  it 'does not hand the unfinished discover result back from the first ping on stdio' do
+    server = modern_stdio(protocol: :modern)
+    script_stdio(server, [{ 'result' => input_required_discover }, { 'result' => input_required_discover }])
+
+    expect { server.ping }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+  end
+
+  it 'rejects an input_required server/discover on plain HTTP' do
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0,
+                                     protocol: :modern)
+    stub_request(:post, 'https://example.com/mcp')
+      .to_return { |request| json_response(JSON.parse(request.body)['id'], input_required_discover) }
+
+    expect { http.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect(http.instance_variable_get(:@last_discover_result)).to be_nil
+    http.cleanup
+  end
+
+  it 'rejects an input_required server/discover on Streamable HTTP' do
+    server = MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0,
+                                                 protocol: :modern)
+    stub_request(:post, 'https://example.com/mcp')
+      .to_return { |request| json_response(JSON.parse(request.body)['id'], input_required_discover) }
+
+    expect { server.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect(server.instance_variable_get(:@last_discover_result)).to be_nil
+    server.cleanup
+  end
+
+  it 'still rejects it when a later heartbeat answers input_required' do
+    server = modern_stdio(protocol: :modern)
+    # The probe succeeds, so the session is no longer freshly probed and the
+    # next ping is a real server/discover round trip on the wire.
+    script_stdio(server, [{ 'result' => discover_result }, { 'result' => { 'tools' => [] } },
+                          { 'result' => input_required_discover }])
+    server.list_tools
+
+    expect { server.ping }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect(server.instance_variable_get(:@last_discover_result)).to eq(discover_result)
+  end
+end
+
+# Review round 3 (codex): every attempt is derived from the CALLER's params,
+# never from the previous attempt's. "The client MUST omit fields the server
+# did not send in the latest InputRequiredResult" applies to every retry, and
+# the caller's own hash must survive the round trip untouched.
+RSpec.describe 'MCP 2026-07-28 MRTR verification — continuation fields are rebuilt every attempt' do
+  include MrtrVerifyHelpers
+
+  let(:server) { modern_stdio }
+
+  before { server.on_elicitation_request { |_key, _params| { 'action' => 'accept', 'content' => { 'n' => 1 } } } }
+
+  it 'drops both continuation fields once the server stops sending them' do
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => input_required({ 'a' => form_elicit_request }, state: 'st1') },
+                                 { 'result' => input_required(nil, state: nil) },
+                                 { 'result' => { 'content' => [] } }])
+
+    server.call_tool('greet', { 'x' => 1 })
+
+    calls = sent.select { |r| r['method'] == 'tools/call' }
+    expect(calls.size).to eq(3)
+    expect(calls[1]['params']).to include('inputResponses', 'requestState')
+    expect(calls[2]['params']).not_to have_key('inputResponses')
+    expect(calls[2]['params']).not_to have_key('requestState')
+    expect(calls[2]['params']).to include('name' => 'greet', 'arguments' => { 'x' => 1 })
+  end
+
+  it 'drops fulfilled inputResponses when the next round asks only for state' do
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => input_required({ 'a' => form_elicit_request }, state: 'st1') },
+                                 { 'result' => input_required(nil, state: 'st2') },
+                                 { 'result' => { 'content' => [] } }])
+
+    server.call_tool('greet', {})
+
+    calls = sent.select { |r| r['method'] == 'tools/call' }
+    expect(calls[1]['params']['requestState']).to eq('st1')
+    expect(calls[2]['params']['requestState']).to eq('st2')
+    expect(calls[2]['params']).not_to have_key('inputResponses')
+  end
+
+  it 'never carries a previous round key into the next inputResponses map' do
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => input_required({ 'first' => form_elicit_request }, state: 's1') },
+                                 { 'result' => input_required({ 'second' => form_elicit_request }, state: 's2') },
+                                 { 'result' => { 'content' => [] } }])
+
+    server.call_tool('greet', {})
+
+    calls = sent.select { |r| r['method'] == 'tools/call' }
+    expect(calls[1]['params']['inputResponses'].keys).to eq(['first'])
+    expect(calls[2]['params']['inputResponses'].keys).to eq(['second'])
+  end
+
+  it 'ignores continuation fields the caller supplied, in either key spelling' do
+    caller_params = { 'uri' => 'file:///r', 'inputResponses' => { 'stale' => { 'action' => 'accept' } },
+                      requestState: 'stale-state' }
+    untouched = { 'uri' => 'file:///r', 'inputResponses' => { 'stale' => { 'action' => 'accept' } },
+                  requestState: 'stale-state' }
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => input_required({ 'a' => form_elicit_request }, state: 'fresh') },
+                                 { 'result' => { 'contents' => [] } }])
+
+    server.rpc_request('resources/read', caller_params)
+
+    retry_params = sent.last['params']
+    expect(retry_params['inputResponses'].keys).to eq(['a'])
+    expect(retry_params['requestState']).to eq('fresh')
+    expect(retry_params).not_to have_key(:requestState)
+    expect(retry_params).not_to have_key(:inputResponses)
+    expect(caller_params).to eq(untouched)
+  end
+
+  it 'leaves the caller params object unmodified across several round trips' do
+    caller_params = { 'uri' => 'file:///r' }
+    script_stdio(server, [{ 'result' => discover_result },
+                          { 'result' => input_required({ 'a' => form_elicit_request }, state: 's1') },
+                          { 'result' => input_required({ 'b' => form_elicit_request }, state: 's2') },
+                          { 'result' => { 'contents' => [] } }])
+
+    server.rpc_request('resources/read', caller_params)
+
+    expect(caller_params).to eq({ 'uri' => 'file:///r' })
+  end
+end
+
+# Review round 3 (codex): SEP-1577 tool-enabled sampling on the round-trip
+# path must actually deliver the tool definitions — and the tool_use /
+# tool_result loop they exist for — to the host's sampler.
+RSpec.describe 'MCP 2026-07-28 MRTR verification — sampling tool definitions reach the handler' do
+  include MrtrVerifyHelpers
+
+  def search_tools
+    [{ 'name' => 'search', 'description' => 'Search the web',
+       'inputSchema' => { 'type' => 'object', 'properties' => { 'q' => { 'type' => 'string' } } } },
+     { 'name' => 'fetch', 'inputSchema' => { 'type' => 'object' } }]
+  end
+
+  it 'hands the declared tools, toolChoice, messages and maxTokens to the sampler' do
+    server = modern_stdio
+    server.declare_sampling_tools
+    seen = nil
+    server.on_sampling_request do |_key, params|
+      seen = params
+      sampling_result
+    end
+    request = sampling_request('tools' => search_tools, 'toolChoice' => { 'mode' => 'required' })
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => input_required({ 's' => request }) },
+                                 { 'result' => { 'content' => [] } }])
+
+    server.call_tool('t', {})
+
+    expect(seen['tools']).to eq(search_tools)
+    expect(seen['toolChoice']).to eq({ 'mode' => 'required' })
+    expect(seen['maxTokens']).to eq(100)
+    expect(seen['messages'].first['content']['text']).to eq('Capital of France?')
+    expect(sent.last['params']['inputResponses']['s']).to eq(sampling_result)
+  end
+
+  it 'carries a multi tool_use answer back and the matching tool_result messages forward' do
+    server = modern_stdio
+    server.declare_sampling_tools
+    seen = []
+    tool_use = { 'role' => 'assistant', 'model' => 'test-model', 'stopReason' => 'toolUse',
+                 'content' => [{ 'type' => 'tool_use', 'id' => 'call_1', 'name' => 'search',
+                                 'input' => { 'q' => 'paris' } },
+                               { 'type' => 'tool_use', 'id' => 'call_2', 'name' => 'fetch', 'input' => {} }] }
+    server.on_sampling_request do |_key, params|
+      seen << params['messages']
+      seen.size == 1 ? tool_use : sampling_result
+    end
+    tool_results = [{ 'role' => 'user',
+                      'content' => [{ 'type' => 'tool_result', 'toolUseId' => 'call_1',
+                                      'content' => [{ 'type' => 'text', 'text' => 'Paris' }] },
+                                    { 'type' => 'tool_result', 'toolUseId' => 'call_2',
+                                      'content' => [{ 'type' => 'text', 'text' => 'ok' }] }] }]
+    second = sampling_request('tools' => search_tools, 'messages' => tool_results)
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => input_required(
+                                   { 's' => sampling_request('tools' => search_tools) }, state: 'loop'
+                                 ) },
+                                 { 'result' => input_required({ 's2' => second }, state: 'loop') },
+                                 { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'done' }] } }])
+
+    expect(server.call_tool('t', {})['content'].first['text']).to eq('done')
+
+    calls = sent.select { |r| r['method'] == 'tools/call' }
+    expect(calls[1]['params']['inputResponses']['s']).to eq(tool_use)
+    expect(calls[1]['params']['inputResponses']['s']['content'].map { |c| c['id'] }).to eq(%w[call_1 call_2])
+    expect(seen.last).to eq(tool_results)
+    expect(calls[2]['params']['inputResponses'].keys).to eq(['s2'])
+  end
+
+  it 'rejects an empty tools array as tool-enabled sampling without the declaration' do
+    server = modern_stdio
+    invoked = false
+    server.on_sampling_request do |_key, _params|
+      invoked = true
+      sampling_result
+    end
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => input_required({ 's' => sampling_request('tools' => []) }) }])
+
+    expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /sampling\.tools/)
+    expect(invoked).to be(false)
+    expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
+  end
+
+  it 'passes every sampling argument through MCPClient::Client to the host handler' do
+    stdio = modern_stdio
+    seen = nil
+    client = client_with(stdio, sampling_supports_tools: true,
+                                sampling_handler: lambda { |messages, prefs, system, max, params = nil|
+                                  seen = { messages: messages, prefs: prefs, system: system, max: max,
+                                           params: params }
+                                  sampling_result
+                                })
+    request = sampling_request('tools' => search_tools, 'toolChoice' => { 'mode' => 'auto' },
+                               'systemPrompt' => 'Be terse',
+                               'modelPreferences' => { 'hints' => [{ 'name' => 'claude' }] })
+    sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                { 'result' => { 'tools' => [{ 'name' => 'c', 'inputSchema' => {} }] } },
+                                { 'result' => input_required({ 's' => request }) },
+                                { 'result' => { 'content' => [] } }])
+
+    client.call_tool('c', {})
+
+    expect(seen[:max]).to eq(100)
+    expect(seen[:system]).to eq('Be terse')
+    expect(seen[:prefs]).to eq({ 'hints' => [{ 'name' => 'claude' }] })
+    expect(seen[:params]['tools']).to eq(search_tools)
+    expect(sent.last['params']['inputResponses']['s']).to eq(sampling_result)
+  end
+end
+
+# Review round 3 (codex): an input handler that answers with anything but a
+# result object fails the round trip — InputResponses has no per-key error
+# channel, so a partial map must never reach the wire.
+RSpec.describe 'MCP 2026-07-28 MRTR verification — handler results that are not result objects' do
+  include MrtrVerifyHelpers
+
+  [nil, 'accepted', 42, [{ 'action' => 'accept' }]].each do |bad|
+    it "raises InputRequiredError when a handler returns #{bad.class}" do
+      server = modern_stdio
+      server.on_elicitation_request { |_key, _params| bad }
+      sent = script_stdio(server, [{ 'result' => discover_result },
+                                   { 'result' => input_required({ 'a' => form_elicit_request }, state: 'st') }])
+
+      expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError) do |e|
+        expect(e.message).to match(/expected a result object/)
+        expect(e.request_state).to eq('st')
+        expect(e.input_requests).to eq({ 'a' => form_elicit_request })
+      end
+      expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
+    end
+  end
+
+  it 'raises InputRequiredError for a symbol-keyed handler error' do
+    server = modern_stdio
+    server.on_sampling_request { |_key, _params| { error: { message: 'model unavailable' } } }
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => input_required({ 's' => sampling_request }, state: 'st') }])
+
+    expect { server.call_tool('t', {}) }
+      .to raise_error(MCPClient::Errors::InputRequiredError, /model unavailable/)
+    expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
+  end
+
+  it 'fails the whole round trip when one entry of a multi-entry map fails' do
+    server = modern_stdio
+    fulfilled = []
+    server.on_elicitation_request do |key, _params|
+      fulfilled << key
+      { 'action' => 'accept', 'content' => {} }
+    end
+    server.on_sampling_request { |_key, _params| { 'error' => { 'code' => -1, 'message' => 'no model' } } }
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => input_required({ 'a' => form_elicit_request,
+                                                                's' => sampling_request }, state: 'st') }])
+
+    expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /no model/)
+    expect(fulfilled).to eq(['a'])
+    expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
+  end
+end
+
+# Review round 3 (codex): the remaining attempt-level recoveries. The resolver
+# sits outside them, so a broken response stream or a version renegotiation
+# re-sends the SAME continuation under a new request id — and never asks the
+# host to fulfil the round trip a second time.
+RSpec.describe 'MCP 2026-07-28 MRTR verification — a continuation survives the remaining recoveries' do
+  include MrtrVerifyHelpers
+
+  let(:url) { 'https://example.com/mcp' }
+
+  def sse_event(message)
+    "event: message\ndata: #{JSON.generate(message)}\n\n"
+  end
+
+  # A response stream that ends without ever carrying the response.
+  def truncated_stream
+    sse_event('jsonrpc' => '2.0', 'method' => 'notifications/progress', 'params' => { 'progress' => 1 })
+  end
+
+  it 're-issues a continuation whose Streamable HTTP response stream closed empty' do
+    server = MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    fulfilled = 0
+    server.on_elicitation_request do |_key, _params|
+      fulfilled += 1
+      { 'action' => 'accept', 'content' => { 'name' => 'ada' } }
+    end
+    bodies = []
+    stub_request(:post, url).to_return do |request|
+      body = JSON.parse(request.body)
+      bodies << body
+      calls = bodies.count { |b| b['method'] == 'tools/call' }
+      case body['method']
+      when 'server/discover' then json_response(body['id'], discover_result)
+      when 'tools/call'
+        case calls
+        when 1 then json_response(body['id'], input_required({ 'a' => form_elicit_request }, state: 'st'))
+        when 2 then { status: 200, body: truncated_stream, headers: { 'Content-Type' => 'text/event-stream' } }
+        else json_response(body['id'], { 'content' => [{ 'type' => 'text', 'text' => 'done' }] })
+        end
+      else json_response(body['id'], { 'tools' => [] })
+      end
+    end
+
+    expect(server.call_tool('t', {})['content'].first['text']).to eq('done')
+
+    calls = bodies.select { |b| b['method'] == 'tools/call' }
+    expect(calls.size).to eq(3)
+    expect(calls[1]['id']).not_to eq(calls[2]['id'])
+    expect(calls[2]['params']).to eq(calls[1]['params'])
+    expect(calls[2]['params']['requestState']).to eq('st')
+    expect(calls[2]['params']['inputResponses']['a']).to eq({ 'action' => 'accept', 'content' => { 'name' => 'ada' } })
+    # The round trip was fulfilled once; the re-issue is a transport-level
+    # replay of the same attempt, not a new round trip.
+    expect(fulfilled).to eq(1)
+    server.cleanup
+  end
+
+  it 'keeps the continuation through a version renegotiation of the retry' do
+    # This client speaks exactly one modern revision, so a second one has to
+    # exist for the server to negotiate down to.
+    stub_const('MCPClient::MODERN_PROTOCOL_VERSIONS', %w[2026-07-28 2026-06-18])
+    server = modern_stdio
+    fulfilled = 0
+    server.on_elicitation_request do |_key, _params|
+      fulfilled += 1
+      { 'action' => 'accept', 'content' => { 'name' => 'ada' } }
+    end
+    rejected = false
+    responses = [{ 'result' => discover_result },
+                 { 'result' => input_required({ 'a' => form_elicit_request }, state: 'st') },
+                 lambda do
+                   rejected = true
+                   { 'error' => { 'code' => -32_022, 'message' => 'Unsupported protocol version',
+                                  'data' => { 'supported' => ['2026-06-18'], 'requested' => '2026-07-28' } } }
+                 end,
+                 { 'result' => { 'content' => [] } }]
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    allow(server).to receive(:sleep)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift or raise 'no scripted response left'
+      responder = responder.call if responder.respond_to?(:call)
+      responder.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+
+    server.call_tool('t', {})
+
+    expect(rejected).to be(true)
+    calls = sent.select { |r| r['method'] == 'tools/call' }
+    expect(calls.size).to eq(3)
+    expect(calls[1]['id']).not_to eq(calls[2]['id'])
+    # Everything but the renegotiated version is re-sent verbatim.
+    expect(calls[2]['params'].except('_meta')).to eq(calls[1]['params'].except('_meta'))
+    expect(calls[2]['params']['requestState']).to eq('st')
+    expect(calls[1]['params']['_meta'][MCPClient::JsonRpcCommon::META_PROTOCOL_VERSION]).to eq('2026-07-28')
+    expect(calls[2]['params']['_meta'][MCPClient::JsonRpcCommon::META_PROTOCOL_VERSION]).to eq('2026-06-18')
+    expect(fulfilled).to eq(1)
+  end
+
+  it 'runs a prompts/get round trip over plain HTTP' do
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    http.on_elicitation_request { |_key, _params| { 'action' => 'accept', 'content' => { 'tone' => 'formal' } } }
+    bodies = []
+    stub_request(:post, url).to_return do |request|
+      body = JSON.parse(request.body)
+      bodies << body
+      result = case body['method']
+               when 'server/discover' then discover_result(capabilities: { 'prompts' => {} })
+               when 'prompts/get'
+                 if body['params'].key?('inputResponses')
+                   { 'messages' => [{ 'role' => 'user',
+                                      'content' => { 'type' => 'text', 'text' => 'Dear Sir' } }] }
+                 else
+                   input_required({ 'tone' => form_elicit_request('Tone?') }, state: 'ps')
+                 end
+               end
+      json_response(body['id'], result)
+    end
+
+    prompt = http.get_prompt('letter', { 'to' => 'ada' })
+
+    expect(prompt['messages'].first['content']['text']).to eq('Dear Sir')
+    gets = bodies.select { |b| b['method'] == 'prompts/get' }
+    expect(gets.size).to eq(2)
+    expect(gets[1]['params']).to include('name' => 'letter', 'arguments' => { 'to' => 'ada' },
+                                         'requestState' => 'ps')
+    expect(gets[1]['params']['inputResponses']['tone'])
+      .to eq({ 'action' => 'accept', 'content' => { 'tone' => 'formal' } })
+    http.cleanup
+  end
+end
+
+# Review round 3 (codex): two overlapping round trips that use the SAME input
+# key, one of which cannot be fulfilled. Nothing may leak between them: the
+# failing request raises, the other completes with its own answer.
+RSpec.describe 'MCP 2026-07-28 MRTR verification — overlapping round trips with identical input keys' do
+  include MrtrVerifyHelpers
+
+  it 'fails only the request whose input could not be fulfilled' do
+    responder = lambda do |request|
+      case request['method']
+      when 'server/discover' then { 'result' => discover_result }
+      when 'tools/call'
+        answers = request['params']['inputResponses']
+        if answers
+          { 'result' => { 'content' => [{ 'type' => 'text', 'text' => answers['k']['content']['for'] }] } }
+        else
+          { 'result' => input_required({ 'k' => form_elicit_request(request['params']['name']) },
+                                       state: "state-#{request['params']['name']}") }
+        end
+      end
+    end
+    server = MrtrScriptedStdio.new(command: 'echo test', read_timeout: 5, responder: responder)
+    inside = Queue.new
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+    server.on_elicitation_request do |key, params|
+      raise "unexpected key #{key}" unless key == 'k'
+
+      inside << params['message']
+      sleep(0.001) while inside.size < 2 && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+      raise 'the user closed the dialog' if params['message'] == 'doomed'
+
+      { 'action' => 'accept', 'content' => { 'for' => params['message'] } }
+    end
+
+    fine = Thread.new { server.call_tool('fine', {}) }
+    doomed = Thread.new do
+      server.call_tool('doomed', {})
+    rescue MCPClient::Errors::MCPError => e
+      e
+    end
+
+    expect(fine.value['content'].first['text']).to eq('fine')
+    expect(doomed.value).to be_a(MCPClient::Errors::InputRequiredError)
+    expect(doomed.value.request_state).to eq('state-doomed')
+    retries = server.sent.select { |r| r['method'] == 'tools/call' && r['params'].key?('inputResponses') }
+    expect(retries.map { |r| r['params']['name'] }).to eq(['fine'])
+    expect(retries.first['params']['inputResponses']['k']['content']).to eq({ 'for' => 'fine' })
+  end
+end
+
+# Review round 3 (codex): the roots/list_changed recipients across a mixed
+# fleet, asserting what each session declared and what actually went out.
+RSpec.describe 'MCP 2026-07-28 MRTR verification — roots/list_changed across a mixed fleet' do
+  include MrtrVerifyHelpers
+
+  it 'writes the notification only on the legacy stdio session that declared roots' do
+    legacy = MCPClient::ServerStdio.new(command: 'echo legacy', protocol: :legacy)
+    written = []
+    legacy.instance_variable_set(:@stdin, double('stdin', flush: nil).tap do |io|
+      allow(io).to receive(:puts) { |line| written << line }
+    end)
+    legacy.instance_variable_set(:@initialized, true)
+    legacy.instance_variable_set(:@protocol_version, '2025-11-25')
+    modern = modern_stdio
+    modern.instance_variable_set(:@initialized, true)
+    modern.instance_variable_set(:@protocol_version, '2026-07-28')
+    allow(modern).to receive(:rpc_notify).and_call_original
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    http.instance_variable_set(:@protocol_version, '2025-11-25')
+    allow(http).to receive(:rpc_notify)
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(legacy, modern, http)
+    client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'a' },
+                                                        { type: 'stdio', command: 'b' },
+                                                        { type: 'http', base_url: 'https://example.com' }])
+
+    client.roots = [{ 'uri' => 'file:///workspace', 'name' => 'ws' }]
+
+    expect(legacy.client_capabilities['roots']).to eq({ 'listChanged' => true })
+    expect(modern.client_capabilities['roots']).to eq({})
+    expect(http.client_capabilities).not_to have_key('roots')
+    notification = JSON.parse(written.last)
+    expect(notification).to include('method' => 'notifications/roots/list_changed')
+    expect(notification).not_to have_key('id')
+    expect(modern).not_to have_received(:rpc_notify)
+    expect(http).not_to have_received(:rpc_notify)
+    http.cleanup
+  end
+end
+
+# Review round 3 (codex): the URL-mode consent normalization this PR added is
+# shared by the legacy server-initiated path; symbol-keyed handler results
+# must travel it the same way.
+RSpec.describe 'MCP 2026-07-28 MRTR verification — URL-mode consent on the legacy path' do
+  include MrtrVerifyHelpers
+
+  def legacy_stdio_with(handler)
+    stdio = MCPClient::ServerStdio.new(command: 'echo legacy', protocol: :legacy)
+    written = []
+    stdio.instance_variable_set(:@stdin, double('stdin', flush: nil).tap do |io|
+      allow(io).to receive(:puts) { |line| written << line }
+    end)
+    client_with(stdio, elicitation_handler: handler)
+    [stdio, written]
+  end
+
+  def url_request_message
+    { 'id' => 7, 'method' => 'elicitation/create',
+      'params' => { 'mode' => 'url', 'url' => 'https://mcp.example.com/c', 'message' => 'Authorize' } }
+  end
+
+  it 'answers cancel when a legacy URL elicitation handler returns form-shaped content' do
+    stdio, written = legacy_stdio_with(->(_m, _d) { { 'name' => 'ada' } })
+
+    stdio.handle_server_request(url_request_message)
+
+    expect(JSON.parse(written.last)['result']).to eq({ 'action' => 'cancel' })
+  end
+
+  it 'accepts a symbol-keyed legacy URL answer and keeps its symbol-keyed _meta' do
+    stdio, written = legacy_stdio_with(->(_m, _d) { { action: 'accept', _meta: { 'com.example/r' => 'r-1' } } })
+
+    stdio.handle_server_request(url_request_message)
+
+    expect(JSON.parse(written.last)['result'])
+      .to eq({ 'action' => 'accept', '_meta' => { 'com.example/r' => 'r-1' } })
+  end
+
+  it 'keeps a symbol-keyed _meta on the modern round-trip answer too' do
+    stdio = modern_stdio
+    client = client_with(stdio, elicitation_handler: lambda { |_m, _d|
+      { action: 'decline', _meta: { 'com.example/r' => 'r-2' } }
+    })
+    sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                { 'result' => { 'tools' => [{ 'name' => 'c', 'inputSchema' => {} }] } },
+                                { 'result' => input_required({ 'auth' => url_elicit_request }, state: 'oob') },
+                                { 'result' => { 'content' => [] } }])
+
+    client.call_tool('c', {})
+
+    expect(sent.last['params']['inputResponses']['auth'])
+      .to eq({ 'action' => 'decline', '_meta' => { 'com.example/r' => 'r-2' } })
+  end
+end
+
+# Review round 3 (codex): the round trips above answer a stubbed
+# #wait_response. This one runs over a real pipe, so the reader thread,
+# handle_line and the id correlation in @pending are the ones under test —
+# and the request that follows a continuation must be an ordinary one again.
+RSpec.describe 'MCP 2026-07-28 MRTR verification — round trips over real stdio response handling' do
+  include MrtrVerifyHelpers
+
+  # Wire the transport's stdout to a pipe that a fake stdin answers into, so
+  # every response travels the real reader thread.
+  def wire_up(server, &responder)
+    reader, writer = IO.pipe
+    sent = []
+    stdin = double('stdin', flush: nil, closed?: false, close: nil)
+    allow(stdin).to receive(:puts) do |line|
+      request = JSON.parse(line)
+      sent << request
+      answer = responder.call(request)
+      writer.puts(JSON.generate(answer.merge('jsonrpc' => '2.0', 'id' => request['id']))) if answer
+    end
+    server.instance_variable_set(:@stdin, stdin)
+    allow(server).to receive(:connect) do
+      server.instance_variable_set(:@stdout, reader)
+      true
+    end
+    allow(server).to receive(:start_stderr_reader)
+    allow(server).to receive(:sleep)
+    [sent, reader, writer]
+  end
+
+  it 'correlates a continuation and the ordinary request that follows it' do
+    server = modern_stdio(read_timeout: 5)
+    server.on_elicitation_request { |_key, _params| { 'action' => 'accept', 'content' => { 'name' => 'ada' } } }
+    sent, reader, writer = wire_up(server) do |request|
+      case request['method']
+      when 'server/discover' then { 'result' => discover_result }
+      when 'tools/call'
+        if request['params'].key?('inputResponses')
+          { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'hi ada' }] } }
+        else
+          { 'result' => input_required({ 'a' => form_elicit_request }, state: 'st') }
+        end
+      when 'tools/list' then { 'result' => { 'tools' => [] } }
+      end
+    end
+
+    begin
+      expect(server.call_tool('greet', {})['content'].first['text']).to eq('hi ada')
+      expect(server.list_tools).to eq([])
+
+      calls = sent.select { |r| r['method'] == 'tools/call' }
+      expect(calls.size).to eq(2)
+      expect(calls[0]['id']).not_to eq(calls[1]['id'])
+      expect(calls[1]['params']['requestState']).to eq('st')
+      expect(sent.last['method']).to eq('tools/list')
+      expect(sent.last['params']).not_to have_key('inputResponses')
+      expect(sent.last['params']).not_to have_key('requestState')
+      expect(server.instance_variable_get(:@pending)).to be_empty
+      expect(server.instance_variable_get(:@awaiting)).to be_empty
+    ensure
+      server.cleanup
+      reader.close unless reader.closed?
+      writer.close unless writer.closed?
+    end
+  end
+
+  it 'rejects an input_required answer to server/discover over the real wire' do
+    server = modern_stdio(read_timeout: 5, protocol: :modern)
+    sent, reader, writer = wire_up(server) do |_request|
+      { 'result' => { 'resultType' => 'input_required', 'supportedVersions' => ['2026-07-28'],
+                      'capabilities' => {}, 'requestState' => 'pending-discovery' } }
+    end
+
+    begin
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+      expect(sent.map { |r| r['method'] }).to eq(['server/discover'])
+    ensure
+      reader.close unless reader.closed?
+      writer.close unless writer.closed?
+    end
+  end
+end
+
+# Review round 3 (codex): the discover rejection must not read as a legacy
+# rejection either. A server that answered server/discover at all is modern,
+# so protocol: :auto must surface the failure rather than fall back to the
+# initialize handshake with an unfinished result behind it.
+RSpec.describe 'MCP 2026-07-28 MRTR verification — an input_required discover is not a legacy verdict' do
+  include MrtrVerifyHelpers
+
+  it 'does not fall back to initialize on an auto-negotiating stdio transport' do
+    server = modern_stdio
+    sent = script_stdio(server, [{ 'result' => { 'resultType' => 'input_required',
+                                                 'supportedVersions' => ['2026-07-28'],
+                                                 'capabilities' => {}, 'requestState' => 'pending' } },
+                                 { 'result' => { 'protocolVersion' => '2025-11-25', 'capabilities' => {} } }])
+
+    expect { server.list_tools }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect(sent.map { |r| r['method'] }).to eq(['server/discover'])
+  end
+
+  it 'does not fall back to initialize on an auto-negotiating plain HTTP transport' do
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    bodies = []
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      body = JSON.parse(request.body)
+      bodies << body['method']
+      json_response(body['id'], { 'resultType' => 'input_required', 'supportedVersions' => ['2026-07-28'],
+                                  'capabilities' => {}, 'requestState' => 'pending' })
+    end
+
+    expect { http.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect(bodies).to eq(['server/discover'])
+    http.cleanup
   end
 end

--- a/spec/lib/mcp_client/mrtr_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_verify_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'tmpdir'
 require 'webmock/rspec'
 
 # Verification pass over the MCP 2026-07-28 multi round-trip work:
@@ -430,6 +431,52 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — pacing, logs and plain HTTP
     expect(headers_seen.last['Mcp-Param-Zone']).to eq('eu')
     http.cleanup
   end
+
+  # The one HeaderMismatch refresh belongs to the logical request, not to each
+  # attempt: the round trips are one tools/call as far as the caller is
+  # concerned. A continuation that mismatches again is not going to be fixed
+  # by a second tools/list, so the error surfaces instead of looping.
+  it 'spends the single HeaderMismatch refresh across the whole round trip' do
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    http.on_elicitation_request { |_key, _params| { 'action' => 'accept', 'content' => { 'name' => 'ada' } } }
+    header = 'Region'
+    bodies = []
+    mismatch = lambda do |id, name|
+      { status: 400, headers: { 'Content-Type' => 'application/json' },
+        body: JSON.generate('jsonrpc' => '2.0', 'id' => id,
+                            'error' => { 'code' => -32_020, 'message' => "Header mismatch: Mcp-Param-#{name}" }) }
+    end
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      body = JSON.parse(request.body)
+      bodies << body
+      calls = bodies.count { |b| b['method'] == 'tools/call' }
+      case body['method']
+      when 'server/discover' then json_response(body['id'], discover_result)
+      when 'tools/list'
+        schema = { 'type' => 'object',
+                   'properties' => { 'region' => { 'type' => 'string', 'x-mcp-header' => header } } }
+        json_response(body['id'], { 'tools' => [{ 'name' => 'q', 'inputSchema' => schema }] })
+      when 'tools/call'
+        case calls
+        when 1
+          header = 'Zone'
+          mismatch.call(body['id'], 'Zone')
+        when 2 then json_response(body['id'], input_required({ 'a' => form_elicit_request }, state: 'st'))
+        else mismatch.call(body['id'], 'District')
+        end
+      end
+    end
+
+    http.list_tools
+    expect { http.call_tool('q', { 'region' => 'eu' }) }.to raise_error(MCPClient::Errors::HeaderMismatchError)
+
+    # Three tools/call requests: the mismatched original, the refreshed one
+    # that answered input_required, and the continuation that mismatched
+    # again — with no second refresh behind it.
+    expect(bodies.count { |b| b['method'] == 'tools/call' }).to eq(3)
+    expect(bodies.count { |b| b['method'] == 'tools/list' }).to eq(2)
+    http.cleanup
+  end
 end
 
 # A stdio transport whose wire is a Ruby block: each response is computed from
@@ -486,10 +533,15 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — concurrent round trips' do
     # every thread inside its own round trip until all four are there: the
     # answers must still be routed per request, never through the transport.
     inside = Queue.new
-    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+    seen = Queue.new
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
     server.on_elicitation_request do |key, _params|
       inside << key
       sleep(0.001) while inside.size < 4 && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+      # What this thread saw when it gave up waiting. Four means every round
+      # trip really was in flight at once; a resolver that serialized them
+      # would let each thread through on its own with fewer.
+      seen << inside.size
       { 'action' => 'accept', 'content' => { 'key' => key } }
     end
 
@@ -497,7 +549,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — concurrent round trips' do
               .map { |name| Thread.new { [name, server.call_tool(name, {})] } }
               .to_h(&:value)
 
-    expect(inside.size).to eq(4)
+    expect(Array.new(4) { seen.pop }).to all(eq(4))
     # Each thread's own final result came back to it, not another thread's.
     expect(results.transform_values { |r| r['content'].first['text'] })
       .to eq({ 'alpha' => 'alpha', 'beta' => 'beta', 'gamma' => 'gamma', 'delta' => 'delta' })
@@ -590,6 +642,10 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — continuation fields are reb
 
   before { server.on_elicitation_request { |_key, _params| { 'action' => 'accept', 'content' => { 'n' => 1 } } } }
 
+  # A result carrying neither field is more than the server is allowed to send
+  # ("At least one of inputRequests or requestState MUST be present"); the
+  # client tolerates it, and drops everything the previous round left behind.
+  # The valid one-field-at-a-time shapes are covered further down.
   it 'drops both continuation fields once the server stops sending them' do
     sent = script_stdio(server, [{ 'result' => discover_result },
                                  { 'result' => input_required({ 'a' => form_elicit_request }, state: 'st1') },
@@ -633,22 +689,37 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — continuation fields are reb
     expect(calls[2]['params']['inputResponses'].keys).to eq(['second'])
   end
 
+  # Each attempt keeps exactly what the LATEST result asked for, so every
+  # spelling of a stale continuation field has to go — including the ones the
+  # fresh values would not have overwritten. The two rounds are the shapes the
+  # server may send: inputs without state, then state without inputs.
   it 'ignores continuation fields the caller supplied, in either key spelling' do
     caller_params = { 'uri' => 'file:///r', 'inputResponses' => { 'stale' => { 'action' => 'accept' } },
-                      requestState: 'stale-state' }
+                      inputResponses: { 'stale' => { 'action' => 'accept' } },
+                      'requestState' => 'stale-string', requestState: 'stale-symbol' }
     untouched = { 'uri' => 'file:///r', 'inputResponses' => { 'stale' => { 'action' => 'accept' } },
-                  requestState: 'stale-state' }
+                  inputResponses: { 'stale' => { 'action' => 'accept' } },
+                  'requestState' => 'stale-string', requestState: 'stale-symbol' }
     sent = script_stdio(server, [{ 'result' => discover_result },
-                                 { 'result' => input_required({ 'a' => form_elicit_request }, state: 'fresh') },
+                                 { 'result' => input_required({ 'a' => form_elicit_request }, state: nil) },
+                                 { 'result' => input_required(nil, state: 'fresh') },
                                  { 'result' => { 'contents' => [] } }])
 
     server.rpc_request('resources/read', caller_params)
 
-    retry_params = sent.last['params']
-    expect(retry_params['inputResponses'].keys).to eq(['a'])
-    expect(retry_params['requestState']).to eq('fresh')
-    expect(retry_params).not_to have_key(:requestState)
-    expect(retry_params).not_to have_key(:inputResponses)
+    reads = sent.select { |r| r['method'] == 'resources/read' }
+    expect(reads.size).to eq(3)
+    # The server sent inputRequests and no state: neither spelling of the
+    # caller's requestState may be presented as one.
+    expect(reads[1]['params']['inputResponses'].keys).to eq(['a'])
+    expect(reads[1]['params']).not_to have_key(:inputResponses)
+    expect(reads[1]['params']).not_to have_key('requestState')
+    expect(reads[1]['params']).not_to have_key(:requestState)
+    # And now state without inputRequests: no answers ride along.
+    expect(reads[2]['params']['requestState']).to eq('fresh')
+    expect(reads[2]['params']).not_to have_key(:requestState)
+    expect(reads[2]['params']).not_to have_key('inputResponses')
+    expect(reads[2]['params']).not_to have_key(:inputResponses)
     expect(caller_params).to eq(untouched)
   end
 
@@ -882,6 +953,40 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — a continuation survives the
     server.cleanup
   end
 
+  # Every other Streamable HTTP round trip here is answered with application/
+  # json. The unfinished result and the completion can equally arrive as SSE
+  # events, behind a notification on the same stream.
+  it 'drives a round trip whose answers arrive as SSE events' do
+    server = MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    server.on_elicitation_request { |_key, _params| { 'action' => 'accept', 'content' => { 'name' => 'ada' } } }
+    bodies = []
+    stub_request(:post, url).to_return do |request|
+      body = JSON.parse(request.body)
+      bodies << body
+      calls = bodies.count { |b| b['method'] == 'tools/call' }
+      next json_response(body['id'], discover_result) if body['method'] == 'server/discover'
+
+      result = if calls == 1
+                 input_required({ 'a' => form_elicit_request }, state: 'st')
+               else
+                 { 'content' => [{ 'type' => 'text', 'text' => 'done' }] }
+               end
+      stream = sse_event('jsonrpc' => '2.0', 'method' => 'notifications/progress',
+                         'params' => { 'progressToken' => 'p', 'progress' => calls }) +
+               sse_event('jsonrpc' => '2.0', 'id' => body['id'], 'result' => result)
+      { status: 200, body: stream, headers: { 'Content-Type' => 'text/event-stream' } }
+    end
+
+    expect(server.call_tool('t', {})['content'].first['text']).to eq('done')
+
+    calls = bodies.select { |b| b['method'] == 'tools/call' }
+    expect(calls.size).to eq(2)
+    expect(calls[0]['id']).not_to eq(calls[1]['id'])
+    expect(calls[1]['params']['requestState']).to eq('st')
+    expect(calls[1]['params']['inputResponses']['a']).to eq({ 'action' => 'accept', 'content' => { 'name' => 'ada' } })
+    server.cleanup
+  end
+
   it 'keeps the continuation through a version renegotiation of the retry' do
     # This client speaks exactly one modern revision, so a second one has to
     # exist for the server to negotiate down to.
@@ -983,12 +1088,15 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — overlapping round trips wit
     end
     server = MrtrScriptedStdio.new(command: 'echo test', read_timeout: 5, responder: responder)
     inside = Queue.new
-    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+    seen = Queue.new
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
     server.on_elicitation_request do |key, params|
       raise "unexpected key #{key}" unless key == 'k'
 
       inside << params['message']
       sleep(0.001) while inside.size < 2 && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+      # Both round trips have to be in flight for this to prove anything.
+      seen << inside.size
       raise 'the user closed the dialog' if params['message'] == 'doomed'
 
       { 'action' => 'accept', 'content' => { 'for' => params['message'] } }
@@ -1002,6 +1110,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — overlapping round trips wit
     end
 
     expect(fine.value['content'].first['text']).to eq('fine')
+    expect(Array.new(2) { seen.pop }).to all(eq(2))
     expect(doomed.value).to be_a(MCPClient::Errors::InputRequiredError)
     expect(doomed.value.request_state).to eq('state-doomed')
     retries = server.sent.select { |r| r['method'] == 'tools/call' && r['params'].key?('inputResponses') }
@@ -1217,5 +1326,433 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — an input_required discover 
     expect { http.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
     expect(bodies).to eq(['server/discover'])
     http.cleanup
+  end
+end
+
+# Review round 5 (grok): an InputRequiredResult is allowed to carry only
+# `requestState` — "At least one of inputRequests or requestState MUST be
+# present" (basic/patterns/mrtr) — so an unfinished discover answer need not
+# have the DiscoverResult shape at all. The shape test must therefore not be
+# what decides the era: `resultType: "input_required"` exists only in
+# 2026-07-28, so a peer that sent it is modern and must never be retried with
+# the legacy initialize handshake.
+RSpec.describe 'MCP 2026-07-28 MRTR verification — an unfinished discover without supportedVersions' do
+  include MrtrVerifyHelpers
+
+  let(:state_only_discover) { { 'resultType' => 'input_required', 'requestState' => 'pending-discovery' } }
+
+  it 'does not fall back to initialize on an auto-negotiating stdio transport' do
+    server = modern_stdio
+    sent = script_stdio(server, [{ 'result' => state_only_discover },
+                                 { 'result' => { 'protocolVersion' => '2025-11-25', 'capabilities' => {} } },
+                                 { 'result' => { 'tools' => [] } }])
+
+    expect { server.list_tools }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect(sent.map { |r| r['method'] }).to eq(['server/discover'])
+    expect(server.instance_variable_get(:@protocol_version)).to be_nil
+  end
+
+  it 'does not fall back to initialize on an auto-negotiating plain HTTP transport' do
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    bodies = []
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      body = JSON.parse(request.body)
+      bodies << body['method']
+      json_response(body['id'], state_only_discover)
+    end
+
+    expect { http.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect(bodies).to eq(['server/discover'])
+    http.cleanup
+  end
+
+  it 'does not fall back to initialize on an auto-negotiating Streamable HTTP transport' do
+    server = MCPClient::ServerStreamableHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    bodies = []
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      body = JSON.parse(request.body)
+      bodies << body['method']
+      json_response(body['id'], state_only_discover)
+    end
+
+    expect { server.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect(bodies).to eq(['server/discover'])
+    server.cleanup
+  end
+
+  # The era the rejection settles is cached like any other modern verdict, so
+  # a second attempt on the same transport does not reopen the question.
+  it 'keeps the modern verdict for a later connect on the same transport' do
+    http = MCPClient::ServerHTTP.new(base_url: 'https://example.com', endpoint: '/mcp', retries: 0)
+    bodies = []
+    stub_request(:post, 'https://example.com/mcp').to_return do |request|
+      body = JSON.parse(request.body)
+      bodies << body['method']
+      json_response(body['id'], state_only_discover)
+    end
+
+    2.times { expect { http.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/) }
+
+    expect(bodies).to eq(%w[server/discover server/discover])
+    expect(http.instance_variable_get(:@confirmed_era)).to eq(:modern)
+    http.cleanup
+  end
+end
+
+# Review round 5 (codex): the rejection has to survive MCPClient.connect's
+# transport detector too. A server that answered server/discover is modern,
+# so the legacy SSE and HTTP+POST fallbacks cannot do better — and trying
+# them buries the actionable message in a "tried all transports" list.
+RSpec.describe 'MCP 2026-07-28 MRTR verification — an unfinished discover through MCPClient.connect' do
+  include MrtrVerifyHelpers
+
+  let(:ambiguous_url) { 'https://example.com/api' }
+
+  it 'stops at the modern verdict instead of trying the legacy SSE transport' do
+    post_stub = stub_request(:post, ambiguous_url).to_return do |request|
+      json_response(JSON.parse(request.body)['id'],
+                    { 'resultType' => 'input_required', 'supportedVersions' => ['2026-07-28'],
+                      'capabilities' => { 'tools' => {} }, 'requestState' => 'pending-discovery' })
+    end
+    get_stub = stub_request(:get, ambiguous_url).to_return(status: 200, body: '')
+
+    expect { MCPClient.connect(ambiguous_url, retries: 0) }
+      .to raise_error(MCPClient::Errors::ModernServerError, /input_required/)
+
+    expect(post_stub).to have_been_requested.once
+    expect(get_stub).not_to have_been_requested
+  end
+
+  it 'stops there for the requestState-only shape as well' do
+    post_stub = stub_request(:post, ambiguous_url).to_return do |request|
+      json_response(JSON.parse(request.body)['id'],
+                    { 'resultType' => 'input_required', 'requestState' => 'pending-discovery' })
+    end
+    get_stub = stub_request(:get, ambiguous_url).to_return(status: 200, body: '')
+
+    expect { MCPClient.connect(ambiguous_url, retries: 0) }
+      .to raise_error(MCPClient::Errors::ModernServerError, /input_required/)
+
+    expect(post_stub).to have_been_requested.once
+    expect(get_stub).not_to have_been_requested
+  end
+end
+
+# Review round 5 (grok): ::result_type accepts a symbol-keyed `resultType`
+# because a host's response middleware may symbolize the keys of everything
+# it parses (Faraday's :json parser with symbolize_names). The rest of the
+# InputRequiredResult has to survive that middleware too: reading only the
+# String spelling would enter the round-trip loop and then retry WITHOUT
+# fulfilling inputRequests and WITHOUT echoing requestState — both client
+# MUSTs (basic/patterns/mrtr "Client Requirements").
+RSpec.describe 'MCP 2026-07-28 MRTR verification — a symbolized InputRequiredResult' do
+  include MrtrVerifyHelpers
+
+  let(:server) { modern_stdio }
+
+  it 'fulfils a symbol-keyed inputRequests map and echoes its symbol-keyed requestState' do
+    seen = []
+    server.on_elicitation_request do |key, params|
+      seen << [key, params]
+      { 'action' => 'accept', 'content' => { 'name' => 'ada' } }
+    end
+    symbolized = { resultType: 'input_required',
+                   inputRequests: { 'a' => { method: 'elicitation/create',
+                                             params: { mode: 'form', message: 'Who?',
+                                                       requestedSchema: { type: 'object' } } } },
+                   requestState: 'symbol-state' }
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => symbolized },
+                                 { 'result' => { 'content' => [] } }])
+
+    server.call_tool('greet', {})
+
+    calls = sent.select { |r| r['method'] == 'tools/call' }
+    expect(calls.size).to eq(2)
+    expect(calls[1]['params']['requestState']).to eq('symbol-state')
+    expect(calls[1]['params']['inputResponses'])
+      .to eq({ 'a' => { 'action' => 'accept', 'content' => { 'name' => 'ada' } } })
+    # The handler is host code written against the wire shape, so it sees the
+    # protocol's own spelling however the transport parsed it.
+    expect(seen.map(&:first)).to eq(['a'])
+    expect(seen.first.last).to include('mode' => 'form', 'message' => 'Who?')
+  end
+
+  it 'refuses a symbol-keyed tool-enabled sampling request without the declaration' do
+    sampled = false
+    server.on_sampling_request { |_key, _params| sampled = true }
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => { resultType: 'input_required',
+                                                 inputRequests: {
+                                                   'c' => { method: 'sampling/createMessage',
+                                                            params: { messages: [], tools: [{ name: 't' }] } }
+                                                 },
+                                                 requestState: 'st' } }])
+
+    expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError, /sampling.tools/)
+    expect(sampled).to be(false)
+    expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
+  end
+
+  it 'reports a symbol-keyed unfulfillable round trip with its requests and state' do
+    script_stdio(server, [{ 'result' => discover_result },
+                          { 'result' => { resultType: 'input_required',
+                                          inputRequests: { 'a' => { method: 'elicitation/create', params: {} } },
+                                          requestState: 'sym' } }])
+
+    expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError) do |error|
+      expect(error.request_state).to eq('sym')
+      expect(error.input_requests).to eq({ 'a' => { 'method' => 'elicitation/create', 'params' => {} } })
+    end
+  end
+end
+
+# Review round 5 (codex): ensure_initialized runs once, before the resolver;
+# every continuation round after that goes straight to the wire. On stdio the
+# subprocess can exit while the host is gathering the input — a real prompt
+# waits for a person — and MCP 2026-07-28 basic/transports/stdio ("Unexpected
+# Termination") says a client SHOULD restart a server that terminated
+# unexpectedly. Writing the continuation to the dead process's pipe instead
+# loses the whole call to a broken pipe, with the gathered answers in it.
+MRTR_STDIO_FIXTURE = File.expand_path('../../support/protocol_era_stdio_server.rb', __dir__)
+
+RSpec.describe 'MCP 2026-07-28 MRTR verification — a continuation against a retired stdio process', :slow do
+  around do |example|
+    Dir.mktmpdir('mcp-mrtr') do |dir|
+      @transcript = File.join(dir, 'transcript.log')
+      example.run
+    end
+  end
+
+  attr_reader :transcript
+
+  after do
+    transcript_pids.each do |pid|
+      Process.kill('KILL', pid)
+    rescue Errno::ESRCH, Errno::EPERM
+      nil
+    end
+  end
+
+  # @param path [String] transcript path
+  # @return [Array<String>] the lines the fixture has flushed so far
+  def transcript_lines
+    File.exist?(transcript) ? File.readlines(transcript).map(&:strip).reject(&:empty?) : []
+  rescue Errno::ENOENT
+    []
+  end
+
+  # @return [Array<Integer>] pids of every fixture process spawned
+  def transcript_pids
+    transcript_lines.grep(/\Apid /).map { |line| Integer(line.split.last) }
+  end
+
+  # @return [Array<String>] the JSON-RPC methods the fixture processes received
+  def transcript_methods
+    transcript_lines.grep_v(/\Apid /)
+  end
+
+  # @param pid [Integer]
+  # @return [Boolean] whether the process still exists (a reaped child does not)
+  def process_alive?(pid)
+    Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH, Errno::EPERM
+    false
+  end
+
+  # @param what [String] what is being waited for, for the failure message
+  # @return [void]
+  def wait_for(what, timeout: 5)
+    deadline = Time.now + timeout
+    sleep 0.02 until yield || Time.now > deadline
+    raise "timed out after #{timeout}s waiting for #{what}" unless yield
+  end
+
+  it 'restarts the server and completes the continuation it was gathering answers for' do
+    server = MCPClient::ServerStdio.new(command: [RbConfig.ruby, MRTR_STDIO_FIXTURE, 'mrtr-one-shot', transcript],
+                                        read_timeout: 5, discover_timeout: 3)
+    server.on_elicitation_request do |_key, _params|
+      # The fixture exits as soon as it has asked for input; a host handler is
+      # exactly where that wait happens, so the transport retires under it.
+      wait_for('the first subprocess to exit') { transcript_pids.first && !process_alive?(transcript_pids.first) }
+      wait_for('the transport to be retired') { server.transport_retired? }
+      { 'action' => 'accept', 'content' => { 'name' => 'ada' } }
+    end
+
+    result = server.call_tool('greet', {})
+
+    # The continuation reached a fresh process with the gathered answer and
+    # the state it was issued against, both intact.
+    expect(result['content'].first['text']).to eq('ada/st')
+    expect(transcript_pids.uniq.size).to eq(2)
+    expect(transcript_methods).to eq(%w[server/discover tools/call server/discover tools/call])
+  ensure
+    server&.cleanup
+  end
+end
+
+# Review round 5 (grok, codex): the boundaries of the round-trip loop that had
+# no example — an inputRequests map that is present but empty, and the three
+# ways a registered handler can still fail the round trip (schema-invalid
+# content, a rejected sampling request, an unknown action).
+RSpec.describe 'MCP 2026-07-28 MRTR verification — round-trip boundaries' do
+  include MrtrVerifyHelpers
+
+  def greet_tool
+    { 'name' => 'c', 'inputSchema' => { 'type' => 'object' } }
+  end
+
+  it 'retries an empty inputRequests map at once, with an empty inputResponses map' do
+    server = modern_stdio
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => { 'resultType' => 'input_required', 'inputRequests' => {},
+                                                 'requestState' => 'st' } },
+                                 { 'result' => { 'content' => [] } }])
+
+    server.call_tool('t', {})
+
+    calls = sent.select { |r| r['method'] == 'tools/call' }
+    expect(calls.size).to eq(2)
+    # Present-but-empty is not the same as omitted: the server asked for
+    # nothing rather than for something out of band, so the answer is an empty
+    # map and the retry is not paced.
+    expect(calls[1]['params']['inputResponses']).to eq({})
+    expect(calls[1]['params']['requestState']).to eq('st')
+    expect(server).not_to have_received(:sleep)
+  end
+
+  # requestState is opaque: "" is a value the server chose, not an absence, so
+  # it is echoed. Only an omitted state is omitted from the retry.
+  it 'echoes an empty requestState rather than omitting it' do
+    server = modern_stdio
+    server.on_elicitation_request { |_key, _params| { 'action' => 'accept', 'content' => {} } }
+    sent = script_stdio(server, [{ 'result' => discover_result },
+                                 { 'result' => input_required({ 'a' => form_elicit_request }, state: '') },
+                                 { 'result' => { 'content' => [] } }])
+
+    server.call_tool('t', {})
+
+    expect(sent.last['params']).to have_key('requestState')
+    expect(sent.last['params']['requestState']).to eq('')
+  end
+
+  # A continuation is an independent request with an id of its own, so the
+  # cancellation a timeout owes the server has to name that id — the original
+  # request's was answered a round ago.
+  it 'cancels a timed-out continuation by the continuation own request id' do
+    server = modern_stdio
+    server.on_elicitation_request { |_key, _params| { 'action' => 'accept', 'content' => {} } }
+    sent = []
+    written = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    stdin = double('stdin', flush: nil, closed?: false, close: nil)
+    allow(stdin).to receive(:puts) { |line| written << line }
+    server.instance_variable_set(:@stdin, stdin)
+    allow(server).to receive(:send_request) { |request| sent << request }
+    answers = [{ 'result' => discover_result },
+               { 'result' => input_required({ 'a' => form_elicit_request }, state: 'st') },
+               :timeout]
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      answer = answers.shift or raise 'no scripted response left'
+      raise MCPClient::Errors::RequestTimeoutError, 'Timeout waiting for response' if answer == :timeout
+
+      answer.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+
+    expect { server.rpc_request('resources/read', { 'uri' => 'file:///r' }) }
+      .to raise_error(MCPClient::Errors::RequestTimeoutError)
+
+    reads = sent.select { |request| request['method'] == 'resources/read' }
+    expect(reads.size).to eq(2)
+    expect(reads.last['params']).to include('requestState' => 'st')
+    cancelled = written.map { |line| JSON.parse(line) }.select { |m| m['method'] == 'notifications/cancelled' }
+    expect(cancelled.size).to eq(1)
+    expect(cancelled.first['params']['requestId']).to eq(reads.last['id'])
+    expect(reads.last['id']).not_to eq(reads.first['id'])
+  end
+
+  # Spec SHOULD (client/elicitation): the client validates the content against
+  # requestedSchema and does not transmit content that violates it. There is
+  # no per-key error channel in InputResponses, so the round trip fails.
+  it 'fails the round trip when the handler content violates the requestedSchema' do
+    stdio = modern_stdio
+    client = client_with(stdio, elicitation_handler: ->(_message, _schema) { { 'name' => 42 } })
+    request = { 'method' => 'elicitation/create',
+                'params' => { 'mode' => 'form', 'message' => 'Who?',
+                              'requestedSchema' => { 'type' => 'object',
+                                                     'properties' => { 'name' => { 'type' => 'string' } },
+                                                     'required' => ['name'] } } }
+    sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                { 'result' => { 'tools' => [greet_tool] } },
+                                { 'result' => input_required({ 'a' => request }, state: 'st') }])
+
+    expect { client.call_tool('c', {}) }
+      .to raise_error(MCPClient::Errors::InputRequiredError, /schema validation/)
+    expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
+  end
+
+  # A nil sampling result is the host's rejection signal (-1 "User rejected
+  # sampling request" on the legacy back-channel). On the round-trip path
+  # there is nowhere to write that error, so the original call fails.
+  it 'fails the round trip when the Client sampling handler rejects with nil' do
+    stdio = modern_stdio
+    # An empty handler returns nil, which is the host's rejection signal.
+    client = client_with(stdio, sampling_handler: ->(_messages, _prefs, _system, _max) {})
+    sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                { 'result' => { 'tools' => [greet_tool] } },
+                                { 'result' => input_required({ 's' => sampling_request }, state: 'st') }])
+
+    expect { client.call_tool('c', {}) }
+      .to raise_error(MCPClient::Errors::InputRequiredError, /Sampling rejected/)
+    expect(sent.count { |r| r['method'] == 'tools/call' }).to eq(1)
+  end
+
+  # ElicitResult.action is exactly accept | decline | cancel. An action
+  # outside that set is not consent the user gave, so it is answered as cancel
+  # — the same verdict URL mode reaches for the same handler result — rather
+  # than rewritten into an accept and transmitted with the content attached.
+  it 'answers cancel when the form handler returns an action outside the schema' do
+    stdio = modern_stdio
+    client = client_with(stdio, elicitation_handler: lambda { |_message, _schema|
+      { 'action' => 'submit', 'content' => { 'name' => 'ada' } }
+    })
+    sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                { 'result' => { 'tools' => [greet_tool] } },
+                                { 'result' => input_required({ 'a' => form_elicit_request }, state: 'st') },
+                                { 'result' => { 'content' => [] } }])
+
+    client.call_tool('c', {})
+
+    expect(sent.last['params']['inputResponses']['a']).to eq({ 'action' => 'cancel' })
+  end
+
+  # "If mode is not specified, form mode is assumed" (client/elicitation).
+  it 'treats an elicitation request without a mode as form mode' do
+    stdio = modern_stdio
+    seen = nil
+    client = client_with(stdio, elicitation_handler: lambda { |message, schema|
+      seen = [message, schema]
+      { 'name' => 'ada' }
+    })
+    request = { 'method' => 'elicitation/create',
+                'params' => { 'message' => 'Who?',
+                              'requestedSchema' => { 'type' => 'object',
+                                                     'properties' => { 'name' => { 'type' => 'string' } } } } }
+    sent = script_stdio(stdio, [{ 'result' => discover_result },
+                                { 'result' => { 'tools' => [greet_tool] } },
+                                { 'result' => input_required({ 'a' => request }, state: 'st') },
+                                { 'result' => { 'content' => [] } }])
+
+    client.call_tool('c', {})
+
+    # The handler was given the requestedSchema (form mode), not a URL-mode
+    # payload, and its content was transmitted with the accept action form
+    # mode carries. URL mode would have stripped the content.
+    expect(seen).to eq(['Who?', { 'type' => 'object', 'properties' => { 'name' => { 'type' => 'string' } } }])
+    expect(sent.last['params']['inputResponses']['a'])
+      .to eq({ 'action' => 'accept', 'content' => { 'name' => 'ada' } })
   end
 end

--- a/spec/lib/mcp_client/mrtr_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_verify_spec.rb
@@ -502,7 +502,7 @@ class MrtrScriptedStdio < MCPClient::ServerStdio
 
   def start_stderr_reader; end
 
-  def send_request(request)
+  def send_request(request, _generation = nil)
     @sent_lock.synchronize { @sent << request }
   end
 

--- a/spec/lib/mcp_client/mrtr_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_verify_spec.rb
@@ -314,8 +314,11 @@ end
 RSpec.describe 'MCP 2026-07-28 MRTR verification — pacing, logs and plain HTTP' do
   include MrtrVerifyHelpers
 
+  # Round 7: waits are bounded by the transport's read timeout when the caller
+  # names none, and the curve this example pins runs to 22.5s of them — so the
+  # transport is given the room, and the bound is pinned in round 7's own file.
   it 'caps the growing retry delay instead of doubling without bound' do
-    server = modern_stdio
+    server = modern_stdio(read_timeout: 120)
     responses = [{ 'result' => discover_result }]
     7.times { |i| responses << { 'result' => input_required(nil, state: "s#{i}") } }
     responses << { 'result' => { 'content' => [] } }

--- a/spec/lib/mcp_client/mrtr_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/mrtr_2026_verify_spec.rb
@@ -583,7 +583,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — server/discover never answe
     sent = script_stdio(server, [{ 'result' => input_required_discover },
                                  { 'result' => { 'tools' => [] } }])
 
-    expect { server.list_tools }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect { server.list_tools }.to raise_error(MCPClient::Errors::ToolCallError, /input_required/)
     expect(sent.map { |r| r['method'] }).to eq(['server/discover'])
     expect(server.instance_variable_get(:@protocol_version)).to be_nil
     expect(server.instance_variable_get(:@last_discover_result)).to be_nil
@@ -593,7 +593,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — server/discover never answe
     server = modern_stdio(protocol: :modern)
     script_stdio(server, [{ 'result' => input_required_discover }, { 'result' => input_required_discover }])
 
-    expect { server.ping }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect { server.ping }.to raise_error(MCPClient::Errors::ModernServerError, /input_required/)
   end
 
   it 'rejects an input_required server/discover on plain HTTP' do
@@ -602,7 +602,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — server/discover never answe
     stub_request(:post, 'https://example.com/mcp')
       .to_return { |request| json_response(JSON.parse(request.body)['id'], input_required_discover) }
 
-    expect { http.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect { http.connect }.to raise_error(MCPClient::Errors::ModernServerError, /input_required/)
     expect(http.instance_variable_get(:@last_discover_result)).to be_nil
     http.cleanup
   end
@@ -613,7 +613,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — server/discover never answe
     stub_request(:post, 'https://example.com/mcp')
       .to_return { |request| json_response(JSON.parse(request.body)['id'], input_required_discover) }
 
-    expect { server.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect { server.connect }.to raise_error(MCPClient::Errors::ModernServerError, /input_required/)
     expect(server.instance_variable_get(:@last_discover_result)).to be_nil
     server.cleanup
   end
@@ -626,7 +626,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — server/discover never answe
                           { 'result' => input_required_discover }])
     server.list_tools
 
-    expect { server.ping }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect { server.ping }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
     expect(server.instance_variable_get(:@last_discover_result)).to eq(discover_result)
   end
 end
@@ -1286,7 +1286,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — round trips over real stdio
     end
 
     begin
-      expect { server.list_tools }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::ToolCallError, /input_required/)
       expect(sent.map { |r| r['method'] }).to eq(['server/discover'])
     ensure
       reader.close unless reader.closed?
@@ -1309,7 +1309,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — an input_required discover 
                                                  'capabilities' => {}, 'requestState' => 'pending' } },
                                  { 'result' => { 'protocolVersion' => '2025-11-25', 'capabilities' => {} } }])
 
-    expect { server.list_tools }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect { server.list_tools }.to raise_error(MCPClient::Errors::ToolCallError, /input_required/)
     expect(sent.map { |r| r['method'] }).to eq(['server/discover'])
   end
 
@@ -1323,7 +1323,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — an input_required discover 
                                   'capabilities' => {}, 'requestState' => 'pending' })
     end
 
-    expect { http.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect { http.connect }.to raise_error(MCPClient::Errors::ModernServerError, /input_required/)
     expect(bodies).to eq(['server/discover'])
     http.cleanup
   end
@@ -1347,7 +1347,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — an unfinished discover with
                                  { 'result' => { 'protocolVersion' => '2025-11-25', 'capabilities' => {} } },
                                  { 'result' => { 'tools' => [] } }])
 
-    expect { server.list_tools }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect { server.list_tools }.to raise_error(MCPClient::Errors::ToolCallError, /input_required/)
     expect(sent.map { |r| r['method'] }).to eq(['server/discover'])
     expect(server.instance_variable_get(:@protocol_version)).to be_nil
   end
@@ -1361,7 +1361,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — an unfinished discover with
       json_response(body['id'], state_only_discover)
     end
 
-    expect { http.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect { http.connect }.to raise_error(MCPClient::Errors::ModernServerError, /input_required/)
     expect(bodies).to eq(['server/discover'])
     http.cleanup
   end
@@ -1375,7 +1375,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — an unfinished discover with
       json_response(body['id'], state_only_discover)
     end
 
-    expect { server.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/)
+    expect { server.connect }.to raise_error(MCPClient::Errors::ModernServerError, /input_required/)
     expect(bodies).to eq(['server/discover'])
     server.cleanup
   end
@@ -1391,7 +1391,7 @@ RSpec.describe 'MCP 2026-07-28 MRTR verification — an unfinished discover with
       json_response(body['id'], state_only_discover)
     end
 
-    2.times { expect { http.connect }.to raise_error(MCPClient::Errors::MCPError, /input_required/) }
+    2.times { expect { http.connect }.to raise_error(MCPClient::Errors::ModernServerError, /input_required/) }
 
     expect(bodies).to eq(%w[server/discover server/discover])
     expect(http.instance_variable_get(:@confirmed_era)).to eq(:modern)

--- a/spec/lib/mcp_client/protocol_foundations_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_round5_spec.rb
@@ -124,6 +124,10 @@ end
 # Round 4 pinned "no wrapper flattens an unfinished result" on stdio and
 # ServerHTTP only; the SSE and Streamable HTTP wrappers duplicate that code
 # and their guards could be removed without a failure.
+# From the multi round-trip branch on, input_required is only a valid answer
+# to the request types the pattern is defined for (tools/call, resources/read,
+# prompts/get); on a list or a completion it is an invalid result, and the
+# whole answer still rides on the error.
 RSpec.describe 'ServerSSE and ServerStreamableHTTP surface an unfinished list or completion' do
   let(:incomplete) { { 'resultType' => 'input_required', 'requestState' => 'continue-later' } }
   let(:tool) { { 'name' => 't', 'description' => 'd', 'inputSchema' => {} } }
@@ -132,7 +136,8 @@ RSpec.describe 'ServerSSE and ServerStreamableHTTP surface an unfinished list or
     it 'raises instead of returning an empty tool list' do
       answer_with([incomplete])
 
-      expect { server.list_tools }.to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+      expect { server.list_tools }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /input_required is only valid/) do |e|
         expect(e.data).to eq(incomplete)
         expect(e).not_to be_a(MCPClient::Errors::ToolCallError)
       end
@@ -141,7 +146,8 @@ RSpec.describe 'ServerSSE and ServerStreamableHTTP surface an unfinished list or
     it 'raises instead of returning an empty prompt list' do
       answer_with([incomplete])
 
-      expect { server.list_prompts }.to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+      expect { server.list_prompts }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /input_required is only valid/) do |e|
         expect(e.data).to eq(incomplete)
       end
     end
@@ -149,7 +155,8 @@ RSpec.describe 'ServerSSE and ServerStreamableHTTP surface an unfinished list or
     it 'raises instead of returning an empty resource list' do
       answer_with([incomplete])
 
-      expect { server.list_resources }.to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+      expect { server.list_resources }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /input_required is only valid/) do |e|
         expect(e.data).to eq(incomplete)
       end
     end
@@ -158,7 +165,7 @@ RSpec.describe 'ServerSSE and ServerStreamableHTTP surface an unfinished list or
       answer_with([incomplete])
 
       expect { server.list_resource_templates }
-        .to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+        .to raise_error(MCPClient::Errors::InvalidResultError, /input_required is only valid/) do |e|
         expect(e.data).to eq(incomplete)
       end
     end
@@ -169,7 +176,7 @@ RSpec.describe 'ServerSSE and ServerStreamableHTTP surface an unfinished list or
         server.complete(ref: { 'type' => 'ref/prompt', 'name' => 'p' }, argument: { 'name' => 'a', 'value' => '' })
       end
 
-      expect(&request).to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+      expect(&request).to raise_error(MCPClient::Errors::InvalidResultError, /input_required is only valid/) do |e|
         expect(e.data).to eq(incomplete)
       end
     end
@@ -177,7 +184,8 @@ RSpec.describe 'ServerSSE and ServerStreamableHTTP surface an unfinished list or
     it 'raises instead of silently dropping an unfinished second page' do
       answer_with([{ 'resultType' => 'complete', 'tools' => [tool], 'nextCursor' => 'p2' }, incomplete])
 
-      expect { server.list_tools }.to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+      expect { server.list_tools }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /input_required is only valid/) do |e|
         expect(e.data).to eq(incomplete)
       end
     end
@@ -248,45 +256,35 @@ RSpec.describe 'an unfinished tool or prompt result survives stdio and SSE off t
   end
 
   shared_examples 'accepts and preserves a continuation' do
-    # Whatever a transport does with a continuation it cannot fulfil —
-    # surface it as the typed error (a transport that drives multi round-trip
-    # requests) or hand it back whole (one that does not yet) — nothing of it
-    # may be lost on the way. Each context says which of the two it pins.
-    def continuation_of
-      yield
-    rescue MCPClient::Errors::InputRequiredError => e
-      expect(continuation_raises).to be(true), 'the continuation was raised where a raw result was pinned'
-      e.data
-    else
-      expect(continuation_raises).to be(false), 'the continuation was returned where the typed error was pinned'
-      # `else` cannot reach the block's value, so the caller re-runs it below.
-      nil
-    end
-
-    def continuation_from(&request)
-      result = continuation_of(&request)
-      result.nil? ? request.call : result
-    end
-
+    # Both transports drive multi round-trip requests, and with no handler
+    # registered for the request they raise the typed error carrying the
+    # whole continuation: nothing of it may be lost on the way.
     it 'surfaces the whole continuation from call_tool' do
       answer_with('result' => unfinished)
 
-      expect(continuation_from { server.call_tool('t', {}) }).to eq(unfinished)
+      expect { server.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /no handler is registered/) do |e|
+          expect(e.data).to eq(unfinished)
+        end
     end
 
     it 'surfaces the whole continuation from get_prompt' do
       answer_with('result' => unfinished)
 
-      expect(continuation_from { server.get_prompt('p', {}) }).to eq(unfinished)
+      expect { server.get_prompt('p', {}) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /no handler is registered/) do |e|
+          expect(e.data).to eq(unfinished)
+        end
     end
 
     it 'keeps the InputRequests map intact' do
       answer_with('result' => unfinished)
 
-      continuation = continuation_from { server.call_tool('t', {}) }
-      expect(continuation['inputRequests'].keys).to eq(['city'])
-      expect(continuation.dig('inputRequests', 'city', 'method')).to eq('elicitation/create')
-      expect(continuation['requestState']).to eq('continue-later')
+      expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError) do |e|
+        expect(e.input_requests.keys).to eq(['city'])
+        expect(e.input_requests.dig('city', 'method')).to eq('elicitation/create')
+        expect(e.request_state).to eq('continue-later')
+      end
     end
 
     # "At least one of inputRequests or requestState MUST be present": a
@@ -295,14 +293,18 @@ RSpec.describe 'an unfinished tool or prompt result survives stdio and SSE off t
       stateless = unfinished.except('requestState')
       answer_with('result' => stateless)
 
-      expect(continuation_from { server.call_tool('t', {}) }).to eq(stateless)
+      expect { server.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /no handler is registered/) do |e|
+          expect(e.data).to eq(stateless)
+          expect(e.request_state).to be_nil
+        end
     end
 
     it 'surfaces it from read_resource with the continuation on the error data' do
       answer_with('result' => unfinished)
 
       expect { server.read_resource('file:///x') }
-        .to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+        .to raise_error(MCPClient::Errors::InputRequiredError, /no handler is registered/) do |e|
           expect(e.data).to eq(unfinished)
         end
     end
@@ -318,9 +320,6 @@ RSpec.describe 'an unfinished tool or prompt result survives stdio and SSE off t
 
   context 'with ServerStdio (line -> reader dispatch -> waiter)' do
     let(:server) { MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 5) }
-    # The stateless stdio transport drives multi round-trip requests: with
-    # nothing to fulfil this one it raises the typed error.
-    let(:continuation_raises) { true }
 
     before do
       server.instance_variable_set(:@initialized, true)
@@ -339,9 +338,6 @@ RSpec.describe 'an unfinished tool or prompt result survives stdio and SSE off t
 
   context 'with ServerSSE (POST -> SSE event -> result store -> waiter)' do
     let(:server) { MCPClient::ServerSSE.new(base_url: 'https://example.com/sse', read_timeout: 5, retries: 0) }
-    # The SSE transport hands the continuation back whole until the HTTP
-    # branches teach it the round trip.
-    let(:continuation_raises) { false }
 
     before do
       server.instance_variable_set(:@connection_established, true)

--- a/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
@@ -191,14 +191,22 @@ RSpec.describe 'MCP 2026-07-28 protocol foundations' do
       expect(MCPClient::JsonRpcCommon.result_type(result)).to eq('complete')
     end
 
-    it 'passes an "input_required" result through for the multi round-trip resolver' do
+    it 'passes an "input_required" result through for the multi round-trip resolver on a modern session' do
       # Only a modern session has the multi round-trip pattern; a legacy one
       # answering with it is malformed (see the era examples in the
       # verification spec).
       transport.instance_variable_set(:@protocol_version, '2026-07-28')
       result = { 'resultType' => 'input_required', 'requestState' => 'blob' }
       expect(MCPClient::JsonRpcCommon.result_type(result)).to eq('input_required')
+      transport.instance_variable_set(:@protocol_version, '2026-07-28')
       expect(transport.process_jsonrpc_response({ 'id' => 1, 'result' => result })).to eq(result)
+    end
+
+    it 'rejects an "input_required" result from a legacy session' do
+      result = { 'resultType' => 'input_required', 'requestState' => 'blob' }
+      transport.instance_variable_set(:@protocol_version, '2025-11-25')
+      expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => result }) }
+        .to raise_error(MCPClient::Errors::InvalidResultError)
     end
 
     it 'rejects an unrecognized resultType as an invalid response' do

--- a/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_spec.rb
@@ -191,15 +191,14 @@ RSpec.describe 'MCP 2026-07-28 protocol foundations' do
       expect(MCPClient::JsonRpcCommon.result_type(result)).to eq('complete')
     end
 
-    it 'recognizes an "input_required" result and surfaces it as InputRequiredError' do
+    it 'passes an "input_required" result through for the multi round-trip resolver' do
       # Only a modern session has the multi round-trip pattern; a legacy one
       # answering with it is malformed (see the era examples in the
       # verification spec).
       transport.instance_variable_set(:@protocol_version, '2026-07-28')
       result = { 'resultType' => 'input_required', 'requestState' => 'blob' }
       expect(MCPClient::JsonRpcCommon.result_type(result)).to eq('input_required')
-      expect { transport.process_jsonrpc_response({ 'id' => 1, 'result' => result }) }
-        .to raise_error(MCPClient::Errors::InputRequiredError) { |e| expect(e.request_state).to eq('blob') }
+      expect(transport.process_jsonrpc_response({ 'id' => 1, 'result' => result })).to eq(result)
     end
 
     it 'rejects an unrecognized resultType as an invalid response' do

--- a/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
@@ -755,12 +755,15 @@ end
 
 # --- Round 3, finding B: a read must never be flattened while incomplete ----
 #
-# read_resource projects `contents` out of the result. This client does not
-# drive multi round-trip requests yet, so an InputRequiredResult reaching the
-# wrapper must surface — presenting a continuation as an empty successful
-# read loses the requestState and lies about the outcome.
+# read_resource projects `contents` out of the result, so an unfinished result
+# reaching the wrapper must surface: presenting a continuation as an empty
+# successful read loses the requestState and lies about the outcome. The
+# transports below stub the request layer, which pins the wrapper's own guard
+# (require_complete_result!) whatever the round-trip resolver does; the stdio
+# context drives the real resolver with a round trip it cannot fulfil.
 RSpec.describe 'read_resource never presents an unfinished read as an empty one' do
   let(:incomplete) { { 'resultType' => 'input_required', 'requestState' => 'continue-later' } }
+  let(:unfinished_message) { /input/ }
 
   shared_examples 'surfaces an incomplete resources/read result' do
     it 'raises instead of returning an empty content list on a modern session' do
@@ -768,7 +771,7 @@ RSpec.describe 'read_resource never presents an unfinished read as an empty one'
       stub_read_result(incomplete)
 
       expect { server.read_resource('file:///x.txt') }
-        .to raise_error(MCPClient::Errors::InputRequiredError, /input/) do |e|
+        .to raise_error(MCPClient::Errors::InputRequiredError, unfinished_message) do |e|
           expect(e).not_to be_a(MCPClient::Errors::ResourceReadError)
           expect(e.protocol_error?).to be(true)
           # The continuation is preserved, not discarded: a host can drive
@@ -789,11 +792,25 @@ RSpec.describe 'read_resource never presents an unfinished read as an empty one'
 
   context 'with ServerStdio' do
     let(:server) { MCPClient::ServerStdio.new(command: 'echo test') }
+    # The only context that reaches the round-trip resolver, so its unfinished
+    # answer asks for something no handler is registered for: the round trip
+    # ends on the first answer instead of being retried ten times.
+    let(:incomplete) do
+      { 'resultType' => 'input_required', 'requestState' => 'continue-later',
+        'inputRequests' => { 'a' => { 'method' => 'elicitation/create', 'params' => { 'message' => 'Who?' } } } }
+    end
+    let(:unfinished_message) { /no handler is registered/ }
 
+    # Answers exactly one resources/read; a retry finds nothing left, so an
+    # unfinished read that is quietly retried fails the example rather than
+    # sleeping its way to the round-trip ceiling.
     def stub_read_result(result)
       server.instance_variable_set(:@initialized, true)
       allow(server).to receive(:send_request)
-      allow(server).to receive(:wait_response).and_return({ 'jsonrpc' => '2.0', 'id' => 1, 'result' => result })
+      answers = [{ 'jsonrpc' => '2.0', 'id' => 1, 'result' => result }]
+      allow(server).to receive(:wait_response) do
+        answers.shift or raise 'resources/read was sent twice'
+      end
     end
 
     include_examples 'surfaces an incomplete resources/read result'

--- a/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
@@ -1760,9 +1760,7 @@ RSpec.describe 'an unfinished result survives the HTTP transports off the wire' 
     # inputRequests is a MAP of server-assigned key => request object, not a
     # list: the resolver keys its inputResponses by the same names.
     { 'resultType' => 'input_required', 'requestState' => 'continue-later',
-      'inputRequests' => { 'city' => { 'method' => 'elicitation/create',
-                                       'params' => { 'mode' => 'form', 'message' => 'which city?',
-                                                     'requestedSchema' => { 'type' => 'object' } } } } }
+      'inputRequests' => { 'city' => city_request } }
   end
 
   # Anything the operation under test needs on the way (a modern call_tool
@@ -1931,11 +1929,15 @@ RSpec.describe 'ServerSSE resource errors and unfinished reads off the stream' d
 
   it 'surfaces an unfinished read with the continuation on the error data' do
     server.instance_variable_set(:@protocol_version, '2026-07-28')
-    unfinished = { 'resultType' => 'input_required', 'requestState' => 'continue-later' }
+    unfinished = { 'resultType' => 'input_required', 'requestState' => 'continue-later',
+                   'inputRequests' => { 'city' => { 'method' => 'elicitation/create',
+                                                    'params' => { 'mode' => 'form', 'message' => 'which city?' } } } }
     answer_with('result' => unfinished)
 
+    # The transport drives the round trip; with no handler for the request
+    # it raises the typed error carrying the whole continuation.
     expect { server.read_resource('file:///x') }
-      .to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+      .to raise_error(MCPClient::Errors::InputRequiredError, /no handler is registered/) do |e|
         expect(e.data).to eq(unfinished)
       end
   end

--- a/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
@@ -1705,6 +1705,10 @@ RSpec.describe 'Client#call_tool does not run output validation on an unfinished
       server: mock_server
     )
   end
+  # The built-in transports resolve a continuation themselves (the multi
+  # round-trip branch) and never hand one up; a transport of the host's own
+  # that does is what this pins, so the Client's output validation gate is
+  # exercised directly on the published InputRequests wire shape.
   let(:unfinished) do
     { 'resultType' => 'input_required', 'requestState' => 'continue-later',
       'inputRequests' => { 'city' => { 'method' => 'elicitation/create',

--- a/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
@@ -723,17 +723,14 @@ RSpec.describe 'input_required is a modern-era result type' do
     transport.process_jsonrpc_response({ 'jsonrpc' => '2.0', 'id' => 1, 'result' => result })
   end
 
-  it 'recognizes it once a modern revision is established' do
+  it 'accepts it once a modern revision is established' do
     transport.protocol_version = '2026-07-28'
     result = { 'resultType' => 'input_required', 'requestState' => 'continue-later' }
 
-    # Recognized, not accepted: this client cannot fulfil the round trip, so
-    # the result surfaces as the InputRequired condition with the whole
-    # answer on `data` — never as an invalid result, and never flattened.
-    expect { process(result) }.to raise_error(MCPClient::Errors::InputRequiredError) do |e|
-      expect(e.data).to eq(result)
-      expect(e.request_state).to eq('continue-later')
-    end
+    # The parser hands it on: the multi round-trip resolver that wraps every
+    # request is what drives it to a finished answer, and what reports the
+    # condition when it cannot.
+    expect(process(result)).to eq(result)
     expect(transport.accepted_result_types).to include('input_required')
   end
 
@@ -771,7 +768,7 @@ RSpec.describe 'read_resource never presents an unfinished read as an empty one'
       stub_read_result(incomplete)
 
       expect { server.read_resource('file:///x.txt') }
-        .to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+        .to raise_error(MCPClient::Errors::InputRequiredError, /input/) do |e|
           expect(e).not_to be_a(MCPClient::Errors::ResourceReadError)
           expect(e.protocol_error?).to be(true)
           # The continuation is preserved, not discarded: a host can drive

--- a/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/protocol_foundations_2026_verify_spec.rb
@@ -1583,9 +1583,9 @@ end
 # resources/read. read_resource was pinned in round 3; every other wrapper
 # that projects a field out of the result still turned an unfinished answer
 # into a successful empty one -- an empty tool list, a dropped second page,
-# The condition is reported as InputRequired wherever it is caught: the
-# response parser refuses a round trip this client cannot drive, and the
-# projector guard below it reports the same answer the same way.
+# On a method the round-trip pattern does not cover, an unfinished answer
+# is malformed rather than a continuation to drive: the resolver names the
+# three methods it is valid for and carries the whole answer on the error.
 # or an empty completion -- discarding the requestState with it.
 RSpec.describe 'no list or completion wrapper flattens an unfinished result' do
   let(:incomplete) { { 'resultType' => 'input_required', 'requestState' => 'continue-later' } }
@@ -1594,7 +1594,7 @@ RSpec.describe 'no list or completion wrapper flattens an unfinished result' do
     it 'raises instead of returning an empty tool list' do
       answer_with(incomplete)
 
-      expect { server.list_tools }.to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
         expect(e.data).to eq(incomplete)
         expect(e).not_to be_a(MCPClient::Errors::ToolCallError)
       end
@@ -1603,7 +1603,7 @@ RSpec.describe 'no list or completion wrapper flattens an unfinished result' do
     it 'raises instead of returning an empty prompt list' do
       answer_with(incomplete)
 
-      expect { server.list_prompts }.to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+      expect { server.list_prompts }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
         expect(e.data).to eq(incomplete)
         expect(e).not_to be_a(MCPClient::Errors::PromptGetError)
       end
@@ -1612,14 +1612,14 @@ RSpec.describe 'no list or completion wrapper flattens an unfinished result' do
     it 'raises instead of returning an empty resource list' do
       answer_with(incomplete)
 
-      expect { server.list_resources }.to raise_error(MCPClient::Errors::InputRequiredError, /input_required/)
+      expect { server.list_resources }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
     end
 
     it 'raises instead of returning an empty resource template list' do
       answer_with(incomplete)
 
       expect { server.list_resource_templates }
-        .to raise_error(MCPClient::Errors::InputRequiredError, /input_required/)
+        .to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
     end
 
     it 'raises instead of returning an empty completion' do
@@ -1628,7 +1628,7 @@ RSpec.describe 'no list or completion wrapper flattens an unfinished result' do
         server.complete(ref: { 'type' => 'ref/prompt', 'name' => 'p' }, argument: { 'name' => 'a', 'value' => '' })
       end
 
-      expect(&request).to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+      expect(&request).to raise_error(MCPClient::Errors::InvalidResultError, /input_required/) do |e|
         expect(e.data).to eq(incomplete)
       end
     end
@@ -1680,7 +1680,7 @@ RSpec.describe 'no list or completion wrapper flattens an unfinished result' do
           headers: { 'Content-Type' => 'application/json' } }
       end
 
-      expect { server.list_tools }.to raise_error(MCPClient::Errors::InputRequiredError, /input_required/)
+      expect { server.list_tools }.to raise_error(MCPClient::Errors::InvalidResultError, /input_required/)
     end
   end
 end
@@ -1757,9 +1757,18 @@ RSpec.describe 'an unfinished result survives the HTTP transports off the wire' 
       'params' => { 'mode' => 'form', 'message' => 'which city?', 'requestedSchema' => { 'type' => 'object' } } }
   end
   let(:unfinished) do
+    # inputRequests is a MAP of server-assigned key => request object, not a
+    # list: the resolver keys its inputResponses by the same names.
     { 'resultType' => 'input_required', 'requestState' => 'continue-later',
-      'inputRequests' => { 'city' => city_request } }
+      'inputRequests' => { 'city' => { 'method' => 'elicitation/create',
+                                       'params' => { 'mode' => 'form', 'message' => 'which city?',
+                                                     'requestedSchema' => { 'type' => 'object' } } } } }
   end
+
+  # Anything the operation under test needs on the way (a modern call_tool
+  # reads tools/list first) answers complete, so only the call itself is
+  # unfinished.
+  let(:complete_list) { { 'result' => { 'resultType' => 'complete', 'tools' => [], 'prompts' => [] } } }
 
   shared_examples 'accepts and preserves a continuation' do
     before do
@@ -1777,7 +1786,7 @@ RSpec.describe 'an unfinished result survives the HTTP transports off the wire' 
         respond_with('result' => unfinished)
 
         expect { server.public_send(operation, 'x', {}) }
-          .to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+          .to raise_error(MCPClient::Errors::InputRequiredError, /no handler is registered/) do |e|
             expect(e.data).to eq(unfinished)
             expect(e.request_state).to eq('continue-later')
             expect(e.input_requests).to eq({ 'city' => city_request })
@@ -1789,9 +1798,9 @@ RSpec.describe 'an unfinished result survives the HTTP transports off the wire' 
       respond_with('result' => unfinished)
 
       expect { server.read_resource('file:///x') }
-        .to raise_error(MCPClient::Errors::InputRequiredError, /input_required/) do |e|
+        .to raise_error(MCPClient::Errors::InputRequiredError, /no handler is registered/) do |e|
           expect(e.data).to eq(unfinished)
-          expect(e.input_requests).to eq({ 'city' => city_request })
+          expect(e.data['inputRequests'].keys).to eq(['city'])
         end
     end
 
@@ -1828,8 +1837,12 @@ RSpec.describe 'an unfinished result survives the HTTP transports off the wire' 
 
     def respond_with(response)
       stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
-        id = JSON.parse(request.body)['id']
-        { status: 200, body: JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(response)),
+        body = JSON.parse(request.body)
+        # Only the operation under test answers unfinished: a modern call_tool
+        # reads tools/list first, to derive its Mcp-Param-* headers, and a list
+        # answering this way would fail before the call ever went out.
+        answer = MCPClient::JsonRpcCommon::MRTR_METHODS.include?(body['method']) ? response : complete_list
+        { status: 200, body: JSON.generate({ 'jsonrpc' => '2.0', 'id' => body['id'] }.merge(answer)),
           headers: { 'Content-Type' => 'application/json' } }
       end
     end
@@ -1842,8 +1855,9 @@ RSpec.describe 'an unfinished result survives the HTTP transports off the wire' 
 
     def respond_with(response)
       stub_request(:post, "#{base_url}#{endpoint}").to_return do |request|
-        id = JSON.parse(request.body)['id']
-        payload = JSON.generate({ 'jsonrpc' => '2.0', 'id' => id }.merge(response))
+        body = JSON.parse(request.body)
+        answer = MCPClient::JsonRpcCommon::MRTR_METHODS.include?(body['method']) ? response : complete_list
+        payload = JSON.generate({ 'jsonrpc' => '2.0', 'id' => body['id'] }.merge(answer))
         { status: 200, body: "event: message\ndata: #{payload}\n\n",
           headers: { 'Content-Type' => 'text/event-stream' } }
       end

--- a/spec/lib/mcp_client/stateless_stdio_2026_round4_spec.rb
+++ b/spec/lib/mcp_client/stateless_stdio_2026_round4_spec.rb
@@ -545,7 +545,10 @@ RSpec.describe 'MCP 2026-07-28 stateless protocol (stdio) — round 4' do
       expect(sent.first['params']['_meta'][R4_META::META_PROTOCOL_VERSION]).to eq(MCPClient::LATEST_PROTOCOL_VERSION)
     end
 
-    it 'declares no capabilities even with roots, elicitation and sampling callbacks registered' do
+    # The multi round-trip branch declares, on the probe as on every other
+    # request, the input requests the registered handlers can serve: the
+    # server MUST NOT ask for what the client did not declare.
+    it 'declares the input requests it can serve, on the probe as on every request' do
       sent, = script_stdio(server, [{ 'result' => discover_result }, { 'result' => tool_list_result }])
       server.on_roots_list_request { |_id, _params| { 'roots' => [] } }
       server.on_elicitation_request { |_id, _params| { 'action' => 'accept' } }
@@ -553,7 +556,8 @@ RSpec.describe 'MCP 2026-07-28 stateless protocol (stdio) — round 4' do
 
       server.list_tools
 
-      expect(sent.map { |req| req['params']['_meta'][R4_META::META_CLIENT_CAPABILITIES] }).to eq([{}, {}])
+      declared = { 'elicitation' => { 'form' => {}, 'url' => {} }, 'roots' => {}, 'sampling' => {} }
+      expect(sent.map { |req| req['params']['_meta'][R4_META::META_CLIENT_CAPABILITIES] }).to eq([declared, declared])
     end
   end
 

--- a/spec/lib/mcp_client/stateless_stdio_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/stateless_stdio_2026_round6_spec.rb
@@ -541,12 +541,16 @@ RSpec.describe 'MCP 2026-07-28 stateless protocol (stdio) — round 6' do
       end
     end
 
+    # From the multi round-trip branch on, input_required is only valid on
+    # tools/call, resources/read and prompts/get: an unfinished list is an
+    # invalid result, still carrying the whole answer, never an empty list.
     it 'never flattens an unfinished tools/list page into an empty list' do
       wire_stdio(server, [{ 'result' => discover_result }, { 'result' => unfinished }])
 
-      expect { server.list_tools }.to raise_error(MCPClient::Errors::InputRequiredError) do |e|
-        expect(e.data).to eq(unfinished)
-      end
+      expect { server.list_tools }
+        .to raise_error(MCPClient::Errors::InvalidResultError, /input_required is only valid/) do |e|
+          expect(e.data).to eq(unfinished)
+        end
     end
   end
 

--- a/spec/lib/mcp_client/stateless_stdio_2026_spec.rb
+++ b/spec/lib/mcp_client/stateless_stdio_2026_spec.rb
@@ -618,7 +618,8 @@ RSpec.describe 'MCP 2026-07-28 stateless protocol (stdio)' do
       sent = script_stdio(server, [{ 'result' => { 'resultType' => 'input_required',
                                                    'requestState' => 'opaque-state' } }])
 
-      expect { server.list_tools }.to raise_error(MCPClient::Errors::ToolCallError, /modern but incompatible/i)
+      expect { server.list_tools }
+        .to raise_error(MCPClient::Errors::ToolCallError, /input_required result; multi round-trip requests/i)
       expect(sent.map { |r| r['method'] }).to eq(['server/discover'])
     end
 
@@ -955,29 +956,32 @@ RSpec.describe 'MCP 2026-07-28 stateless protocol (stdio) — review follow-ups'
       expect(sent.size).to eq(2)
     end
 
-    # An unfinished answer that asks for nothing is still unfinished. This
-    # client MAY retry such a result immediately, and if it ever does it MUST
-    # echo requestState unchanged — until then it surfaces the state rather
-    # than re-sending the call or presenting an empty result as the answer.
-    it 'surfaces an unfinished result that carries only requestState, without re-sending' do
+    # An unfinished answer that asks for nothing is still unfinished: the
+    # round-trip resolver re-sends the call with requestState echoed back
+    # unchanged, under a new id, rather than presenting an empty result as
+    # the answer.
+    it 'retries an unfinished result that carries only requestState, echoing the state' do
+      allow(server).to receive(:sleep)
       sent = script_stdio(server, [{ 'result' => discover_result },
                                    { 'result' => { 'resultType' => 'input_required',
-                                                   'requestState' => 'opaque-blob' } }])
+                                                   'requestState' => 'opaque-blob' } },
+                                   { 'result' => { 'resultType' => 'complete', 'content' => [] } }])
 
-      expect { server.call_tool('t', {}) }.to raise_error(MCPClient::Errors::InputRequiredError) do |e|
-        expect(e.request_state).to eq('opaque-blob')
-        expect(e.input_requests).to eq({})
-      end
-      expect(sent.map { |r| r['method'] }).to eq(%w[server/discover tools/call])
+      expect(server.call_tool('t', {})['content']).to eq([])
+      expect(sent.map { |r| r['method'] }).to eq(%w[server/discover tools/call tools/call])
+      expect(sent.last['params']['requestState']).to eq('opaque-blob')
+      expect(sent.last['id']).not_to eq(sent[1]['id'])
     end
 
-    it 'surfaces an unfinished prompts/get answer the same way' do
-      script_stdio(server, [{ 'result' => discover_result },
-                            { 'result' => { 'resultType' => 'input_required', 'requestState' => 'blob' } }])
+    it 'retries an unfinished prompts/get answer the same way' do
+      allow(server).to receive(:sleep)
+      sent = script_stdio(server, [{ 'result' => discover_result },
+                                   { 'result' => { 'resultType' => 'input_required',
+                                                   'requestState' => 'blob' } },
+                                   { 'result' => { 'resultType' => 'complete', 'messages' => [] } }])
 
-      expect { server.get_prompt('greet', {}) }.to raise_error(MCPClient::Errors::InputRequiredError) do |e|
-        expect(e.request_state).to eq('blob')
-      end
+      expect(server.get_prompt('greet', {})['messages']).to eq([])
+      expect(sent.last['params']['requestState']).to eq('blob')
     end
   end
 end

--- a/spec/lib/mcp_client/stateless_stdio_2026_spec.rb
+++ b/spec/lib/mcp_client/stateless_stdio_2026_spec.rb
@@ -175,12 +175,12 @@ RSpec.describe 'MCP 2026-07-28 stateless protocol (stdio)' do
       expect(first[META_VERSION]).to eq('2026-07-28')
     end
 
-    it 'declares roots with listChanged only to legacy servers (removed in 2026-07-28)' do
+    it 'declares roots without listChanged in modern mode (the notification was removed)' do
       transport.instance_variable_set(:@roots_list_request_callback, proc {})
       transport.protocol_version = '2025-11-25'
       expect(transport.client_capabilities['roots']).to eq({ 'listChanged' => true })
       transport.protocol_version = '2026-07-28'
-      expect(transport.client_capabilities).not_to have_key('roots')
+      expect(transport.client_capabilities['roots']).to eq({})
     end
 
     it 'declares negotiated extensions under clientCapabilities.extensions' do
@@ -942,29 +942,7 @@ RSpec.describe 'MCP 2026-07-28 stateless protocol (stdio) — review follow-ups'
     expect(server.protocol_era).to eq(:modern)
   end
 
-  describe 'modern client capabilities before multi round-trip support' do
-    let(:transport) do
-      Class.new do
-        include MCPClient::JsonRpcCommon
-
-        attr_accessor :protocol_version
-
-        def initialize
-          @logger = Logger.new(StringIO.new)
-        end
-      end.new
-    end
-
-    it 'omits roots, elicitation and sampling from modern requests' do
-      transport.instance_variable_set(:@roots_list_request_callback, proc {})
-      transport.instance_variable_set(:@elicitation_request_callback, proc {})
-      transport.instance_variable_set(:@sampling_request_callback, proc {})
-      transport.protocol_version = '2025-11-25'
-      expect(transport.client_capabilities.keys).to include('roots', 'elicitation', 'sampling')
-      transport.protocol_version = '2026-07-28'
-      expect(transport.client_capabilities).to eq({})
-    end
-
+  describe 'input_required results' do
     it 'surfaces an input_required result as InputRequiredError instead of a tool result' do
       sent = script_stdio(server, [{ 'result' => discover_result },
                                    { 'result' => { 'resultType' => 'input_required', 'requestState' => 'blob',

--- a/spec/lib/mcp_client/streamable_http_modern_2026_spec.rb
+++ b/spec/lib/mcp_client/streamable_http_modern_2026_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'MCP 2026-07-28 Streamable HTTP modern mode' do
 
     describe 'era detection' do
       it 'goes modern on a DiscoverResult and never opens a GET stream, initializes or terminates a session' do
-        get_stub = stub_request(:get, url).to_return(status: 405, body: '')
+        stub_request(:get, url).to_return(status: 405, body: '')
         delete_stub = stub_request(:delete, url).to_return(status: 200, body: '')
         requests = stub_modern_server('server/discover' => discover_result, 'tools/list' => { 'tools' => [] })
 
@@ -118,7 +118,12 @@ RSpec.describe 'MCP 2026-07-28 Streamable HTTP modern mode' do
         expect(server.protocol_era).to eq(:modern)
         expect(server.capabilities).to eq({ 'tools' => {}, 'logging' => {} })
         expect(server.server_info).to eq({ 'name' => 'modern', 'version' => '1' })
-        expect(get_stub).not_to have_been_requested
+        # This server's own traffic: a modern session sends its protocol
+        # version on every request and never a session id. A GET from another
+        # example's events thread would otherwise fail this one.
+        expect(a_request(:get, url).with(headers: { 'Mcp-Protocol-Version' => '2026-07-28' }))
+          .not_to have_been_made
+        expect(server.instance_variable_get(:@events_thread)).to be_nil
         expect(delete_stub).not_to have_been_requested
       end
 
@@ -243,6 +248,9 @@ RSpec.describe 'MCP 2026-07-28 Streamable HTTP modern mode' do
           fresh.connect
           expect(requests).to eq(%w[server/discover initialize notifications/initialized])
           expect(fresh.protocol_era).to eq(:legacy)
+          # A legacy session runs an events thread; without this it outlives
+          # the example and its GETs land in whichever example is running next.
+          fresh.cleanup
           fresh.cleanup
         end
       end

--- a/spec/support/protocol_era_stdio_server.rb
+++ b/spec/support/protocol_era_stdio_server.rb
@@ -235,7 +235,8 @@ end
 # @return [Boolean] whether the mode answered the request itself
 def answered_by_mode?(msg)
   case MODE
-  when 'modern', 'modern-one-shot', 'modern-exit-on-call', 'mrtr-one-shot', 'future-only' then answered_by_modern_mode?(msg)
+  when 'modern', 'modern-one-shot', 'modern-exit-on-call', 'mrtr-one-shot', 'future-only'
+    answered_by_modern_mode?(msg)
   when 'modern-mute-list' then answered_by_modern_mute_list?(msg)
   when 'legacy-one-shot', 'legacy-broken-init', 'late-discover' then answered_by_legacy_mode?(msg)
   when 'modern-then-ping' then answered_by_modern_then_ping?(msg)
@@ -265,7 +266,10 @@ def answered_by_modern_mode?(msg)
     # and not replay it on the replacement process.
     exit 0 if msg['method'] == 'tools/call'
   when 'mrtr-one-shot'
-    return mrtr_one_shot(msg) if msg['method'] == 'tools/call'
+    return false unless msg['method'] == 'tools/call'
+
+    mrtr_one_shot(msg)
+    return true
   end
   false
 end

--- a/spec/support/protocol_era_stdio_server.rb
+++ b/spec/support/protocol_era_stdio_server.rb
@@ -14,6 +14,11 @@
 #   modern-one-shot   like modern, but exit as soon as one tools/list has
 #                     been answered, so an unexpected termination after a
 #                     successful handshake is observable
+#   mrtr-one-shot     like modern, but answer the first tools/call with an
+#                     InputRequiredResult and exit, so the continuation the
+#                     client sends next meets a retired transport; a
+#                     tools/call that carries inputResponses is completed,
+#                     echoing the answers and the state it arrived with
 #   legacy            reject server/discover, then run the initialize handshake
 #   legacy-one-shot   like legacy, but exit as soon as one tools/list has
 #                     been answered, so a restart of a legacy process has to
@@ -154,7 +159,7 @@ def modern_request?(msg)
   # 2025-11-25 server, and the same mode name covers both.
   return !REPLACEMENT if MODE == 'modern-then-ping'
 
-  %w[modern modern-one-shot modern-exit-on-call future-only].include?(MODE)
+  %w[modern modern-one-shot modern-exit-on-call mrtr-one-shot future-only].include?(MODE)
 end
 
 # @param msg [Hash] the request
@@ -188,6 +193,29 @@ def meta_violation(msg)
   nil
 end
 
+# Answer one tools/call for the mrtr-one-shot mode: an unfinished result the
+# first time, the completion afterwards. Between the two the process exits,
+# so the continuation only completes if the client restarted the server and
+# kept the answers it had already gathered.
+# @param msg [Hash] the tools/call request
+# @return [void]
+def mrtr_one_shot(msg)
+  params = msg['params'] || {}
+  answers = params['inputResponses']
+  if answers
+    text = "#{answers.dig('a', 'content', 'name')}/#{params['requestState']}"
+    return respond(msg['id'], { 'content' => [{ 'type' => 'text', 'text' => text }] })
+  end
+
+  elicitation = { 'method' => 'elicitation/create',
+                  'params' => { 'mode' => 'form', 'message' => 'Who?',
+                                'requestedSchema' => { 'type' => 'object' } } }
+  respond(msg['id'], { 'resultType' => 'input_required', 'inputRequests' => { 'a' => elicitation },
+                       'requestState' => 'st' })
+  # Terminate unexpectedly while the client is gathering that input.
+  exit 0
+end
+
 # @param msg [Hash] the request
 # @return [void]
 def handle_request(msg)
@@ -207,7 +235,7 @@ end
 # @return [Boolean] whether the mode answered the request itself
 def answered_by_mode?(msg)
   case MODE
-  when 'modern', 'modern-one-shot', 'modern-exit-on-call', 'future-only' then answered_by_modern_mode?(msg)
+  when 'modern', 'modern-one-shot', 'modern-exit-on-call', 'mrtr-one-shot', 'future-only' then answered_by_modern_mode?(msg)
   when 'modern-mute-list' then answered_by_modern_mute_list?(msg)
   when 'legacy-one-shot', 'legacy-broken-init', 'late-discover' then answered_by_legacy_mode?(msg)
   when 'modern-then-ping' then answered_by_modern_then_ping?(msg)
@@ -236,6 +264,8 @@ def answered_by_modern_mode?(msg)
     # Terminate with the call unanswered: the client must fail it promptly
     # and not replay it on the replacement process.
     exit 0 if msg['method'] == 'tools/call'
+  when 'mrtr-one-shot'
+    return mrtr_one_shot(msg) if msg['method'] == 'tools/call'
   end
   false
 end


### PR DESCRIPTION
## Summary

Fifth PR of the MCP 2026-07-28 series (stacked on #227). Implements [Multi Round-Trip Requests](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr) (SEP-2322), which replaces server-initiated `roots/list`, `sampling/createMessage` and `elicitation/create` requests on modern servers.

- **Resolver** (`JsonRpcCommon#resolve_input_round_trips`) — while `tools/call`, `resources/read` or `prompts/get` answers with `resultType: "input_required"`, fulfil every `inputRequests` entry through the transport's registered handler (`on_elicitation_request`, `on_sampling_request`, `on_roots_list_request` — the same callbacks `MCPClient::Client` already wires for its elicitation handler, sampling handler and roots) and retry the original request as an independent request: new JSON-RPC id, same params, `inputResponses` keyed like the requests, `requestState` echoed verbatim or omitted when the server sent none. A result without `inputRequests` is retried immediately. Wired into both the stdio and HTTP transports' request path (so version renegotiation, HeaderMismatch refresh and stream re-issue all go through it).
- **Client requirements enforced** — ids differ between attempts; `inputResponses`/`requestState` affect only the retry; `input_required` on any other method is an `InvalidResultError` (servers MUST NOT send it there); more than 10 consecutive round trips, an unknown input request method, a missing handler, a handler error or a malformed `inputRequests` raise `InputRequiredError` (with `input_requests`/`request_state`) without retrying.
- **Capabilities** — modern requests declare `elicitation` (`form`+`url`), `roots` (`{}`, no `listChanged`) and `sampling` (`tools` when opted in) again once a handler is registered; PR 2's placeholder that withheld them is removed.

## Test plan

- [x] `bundle exec rspec` — 1949 examples, 0 failures (17 new in `mrtr_2026_spec.rb`, incl. an end-to-end `MCPClient::Client` elicitation + roots round trip and a Streamable HTTP retry)
- [x] `bundle exec rubocop` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoErzDypnq7hhuFBtueML7