### PR TITLE
MCP 2026-07-28: JSON Schema handling (dialects, local $ref, composition bounds, any structuredContent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,77 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **The standard assertions are evaluated, patterns are ECMAScript, and
+  unsupported dialects are refused wherever they appear (second verification
+  round).** MCP 2026-07-28 basic "Implementation Requirements" makes JSON
+  Schema 2020-12 support mandatory, and a standard assertion left unevaluated
+  is not a smaller report but a wrong verdict. Eight fixes:
+
+  - *Every decidable standard keyword is now applied.* `multipleOf`,
+    `uniqueItems`, `contains` (item by item, with `minContains` /
+    `maxContains`), `minProperties` / `maxProperties`, `patternProperties`,
+    `additionalProperties`, `propertyNames`, `dependentRequired` /
+    `dependentSchemas` (and both halves of draft-07 `dependencies`) and
+    `additionalItems` were reported as "unsupported" and skipped. Skipping
+    them left a composition branch *undecided*, and an undecided branch is
+    accepted wherever the composition is monotonic — so
+    `{"allOf": [{"multipleOf": 3}]}` admitted `4`, `{"not": {"multipleOf":
+    2}}` admitted `4`, `{"uniqueItems": true}` admitted `[1, 1]`, and
+    `{"contains": {"type": "string"}}` admitted `[1, 2]`. All of them are
+    evaluated now (`uniqueItems` under JSON equality, so `[1, 1.0]` is not
+    unique, and `multipleOf` by exact division, so `0.0075` is a multiple of
+    `0.0001`), and the partial-coverage report is left with only what
+    genuinely cannot be decided: the two keywords read off the annotations a
+    whole composition produces (`unevaluatedItems`, `unevaluatedProperties`),
+    the dynamic references, and the two keywords that only annotate (`format`,
+    `contentSchema`). A node whose own `type` already rejected the value no
+    longer evaluates the keywords for the type it does not have.
+  - *A `pattern` is an ECMA-262 regular expression.* Ruby's `^` and `$` match
+    at every line boundary, ECMAScript's only at the ends of the subject
+    (JSON Schema 2020-12 Core Section 4.3), so `"a\nb"` satisfied `"^a$"`
+    here and not there — and through `not` was *rejected* although the schema
+    accepts it. The anchors are rewritten before matching (an escaped one, and
+    one inside a character class, stays literal); `patternProperties` keys are
+    matched the same way.
+  - *An unsupported output dialect is an error in both modes.* It was routed
+    through the structured-content violation path, so the default `:warn` mode
+    logged it and returned the result. The client cannot read the schema at
+    all, which the spec's "MUST ... return an appropriate error indicating the
+    dialect is not supported" does not leave to the host's mode.
+  - *A refreshed input dialect is refused too.* The check covered the
+    definition a call was prepared from, not the one it was answered under: a
+    transport's `HeaderMismatch` recovery re-derives the call's `Mcp-Param-*`
+    headers from a refreshed `tools/list`, and a refreshed `inputSchema`
+    declaring an unsupported dialect passed unnoticed. The result of a call is
+    now checked against the answering definition's dialect as well as its
+    output schema, on `call_tool`, on the streaming path and on a task's
+    result.
+  - *`structuredContent: null` is structured content only from 2026-07-28 on.*
+    MCP 2025-11-25 knows object structured content only, so on a session
+    negotiated to that revision a present null is again what it was there: no
+    structured content at all. A transport that cannot say which revision it
+    negotiated is not assumed legacy.
+  - *Two schema resources may not answer to one URI.* Colliding `$id`s were
+    resolved by luck — whichever the walk met first — while colliding anchor
+    names were already reported. A duplicate resource URI now makes the
+    document unusable (JSON Schema 2020-12 Core Section 9.1.2).
+  - *The preflight reads the remaining keyword shapes.* `{"required":
+    ["a","a"]}`, `{"$id": "urn:root#bad"}`, `{"$anchor": "not a name"}`,
+    `{"minContains": -1}`, `{"multipleOf": 0}`, `{"uniqueItems": "yes"}`,
+    `{"minProperties": -1}`, a malformed `dependentRequired` and a
+    `$dynamicRef` that is not a string were all accepted as usable schemas.
+    Each is now reported: the elements of `required` must be unique, a modern
+    `$id` carries no non-empty fragment, an anchor holds a plain name, and the
+    numeric bounds hold the numbers their keywords are defined to hold.
+  - *An absolute reference into the bundled document is accounted for like the
+    bare pointer it addresses.* Only a bare fragment was recognised as a
+    pointer, so booleans reached through `urn:root#/x-bools/bN` were not
+    charged toward the subschema bound while the identical `#/x-bools/bN`
+    were: 1,100 references to 1,100 booleans passed the preflight under one
+    spelling and were rejected under the other. A reference is retargeted to
+    its bundled resource before its pointer is read, so both spellings count
+    the same.
+
 - **The preflight runs off the call stack, an unsupported input dialect is an
   error, bundled references resolve, and `definitions` is the modern `$defs`
   (verification round).** Seven fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,12 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   per-validation time budget; hitting a bound aborts the validation with
   a single error, never with a pass, even under `not` or `oneOf`. Values
   quoted in messages are clipped, and the client sanitizes and bounds the
-  violation text it logs or raises.
+  violation text it logs or raises. Errors inside `anyOf` / `oneOf` /
+  `not` / `if` candidates are only a verdict and do not count toward the
+  error bound; positional keywords follow the dialect (`prefixItems` in
+  2020-12, where an `items` array is invalid; an `items` array in draft-07
+  and 2019-09); a present but malformed `$schema` makes the schema
+  unusable; an `outputSchema` of `false` is preserved by `Tool.from_json`.
 - **structuredContent.** Any JSON value is accepted, including `null`:
   presence is decided by the `structuredContent` key, and the value —
   object, array, scalar or null — is validated against the output schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   2020-12, where an `items` array is invalid; an `items` array in draft-07
   and 2019-09); a present but malformed `$schema` makes the schema
   unusable; an `outputSchema` of `false` is preserved by `Tool.from_json`.
+  The keyword grammar follows the dialect (`DIALECT_KEYWORDS`): a keyword
+  the dialect does not define (`prefixItems` or `$dynamicRef` in draft-07,
+  `dependencies` or `additionalItems` in 2020-12, ...) is ignored rather
+  than shape-checked or reported, draft-07 `dependencies` accepts property
+  name arrays, draft-07 boolean `exclusiveMinimum` / `exclusiveMaximum`
+  make `minimum` / `maximum` exclusive (the other dialect's form is a
+  schema problem), a draft-07 `$ref` hides its sibling applicators at
+  preflight too, plain-name fragments (`#name`) resolve to `$anchor` /
+  `$dynamicAnchor` (2019-09, 2020-12) or `$id: "#name"` (draft-07), and an
+  external `$recursiveRef` (2019-09) makes the schema unusable like an
+  external `$dynamicRef`. `Tool#structured_output?` is true for any
+  provided `outputSchema`, the empty schema `{}` included, so such a tool's
+  successful result must carry `structuredContent`.
 - **structuredContent.** Any JSON value is accepted, including `null`:
   presence is decided by the `structuredContent` key, and the value —
   object, array, scalar or null — is validated against the output schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,13 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   bounded by its own lexical depth, not the referring location, a boolean
   target is not charged per reference, and boolean subschemas obey the
   depth bound.
+- **Positions and assertions (round 15).** Lexical depths follow each
+  resource's own dialect, so the bounds verdict cannot depend on key
+  order; the unsupported-keyword scan reads a referenced target at its
+  own lexical depth; a boolean a pointer reaches obeys the depth bound at
+  its own position; a tautological `additionalItems` beside a tuple
+  decides nothing; an input schema the validator cannot interpret asserts
+  nothing (the call goes out without the `required` check).
 
 ### Authorization (RFC 9207 issuer validation, client registration)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **Inert assertions and unvisited positions (round 20).** Under `not` /
+  `oneOf` / `if`, `contains` of `true` / `{}` on an array that already
+  holds the items `minContains` requires, `unevaluatedItems` once such a
+  `contains` (or an `items` schema) evaluated every item, `patternProperties`
+  matching nothing or only tautologies, and a dependency whose present
+  trigger cannot fail (an empty required list, `true`, `{}`) decide
+  nothing; a boolean in a position the preflight walk never visits — beside
+  a draft-07 `$ref`, or behind an opaque keyword — is charged toward
+  `MAX_SUBSCHEMAS` when a reference reaches it; the unsupported-keyword
+  scan follows a pointer into a data keyword at the target's own position;
+  a symbol-keyed target adopted from a data keyword is copied within the
+  structural budget.
+
 - **Definition identity (round 19).** `Tool#schema_identity` names a tool
   definition: every copy the client cache hands out carries the same
   token and a definition fetched again carries a new one, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,12 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   the dialect does not define (`prefixItems` or `$dynamicRef` in draft-07,
   `dependencies` or `additionalItems` in 2020-12, ...) is ignored rather
   than shape-checked or reported, draft-07 `dependencies` accepts property
-  name arrays, draft-07 boolean `exclusiveMinimum` / `exclusiveMaximum`
-  make `minimum` / `maximum` exclusive (the other dialect's form is a
-  schema problem), a draft-07 `$ref` hides its sibling applicators at
+  name arrays, `exclusiveMinimum` / `exclusiveMaximum` are numbers in
+  every supported dialect (draft-07 included; the draft-04 boolean form is
+  a schema problem) and are applied independently of `minimum` /
+  `maximum`, each validation error counts once toward `MAX_ERRORS`,
+  percent-encoded plain-name fragments are decoded before the anchor
+  lookup, a draft-07 `$ref` hides its sibling applicators at
   preflight too, plain-name fragments (`#name`) resolve to `$anchor` /
   `$dynamicAnchor` (2019-09, 2020-12) or `$id: "#name"` (draft-07), and an
   external `$recursiveRef` (2019-09) makes the schema unusable like an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,19 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   its bound before reaching every object makes the schema unusable; a JSON
   Pointer token with `~` not followed by `0` or `1` is unresolvable (RFC
   6901).
+- **Decided compositions and effective assertions (round 14).** `anyOf`,
+  `oneOf` and `allOf` stop evaluating branches once the outcome is
+  definite (any pass, two passes, the first failure), so a later branch
+  can no longer abort a decided validation (`{"anyOf": [true, {"$ref":
+  "#"}]}` accepts everything); an unevaluated assertion counts as
+  uncertainty under `not` / `oneOf` / `if` only when it can still change
+  the result (`minContains` / `maxContains` need `contains`,
+  `additionalItems` a tuple `items`, and tautological values such as
+  `additionalProperties: true`, `uniqueItems: false`, `minProperties: 0`
+  or an empty dependency map decide nothing); a referenced target is
+  bounded by its own lexical depth, not the referring location, a boolean
+  target is not charged per reference, and boolean subschemas obey the
+  depth bound.
 
 ### Authorization (RFC 9207 issuer validation, client registration)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@
 Groundwork for the 2026-07-28 protocol revision (stateless, per-request
 metadata). Each feature lands in its own PR; this section accumulates them.
 
+### JSON Schema handling
+
+- **Dialects.** `MCPClient::SchemaValidator` treats a schema without
+  `$schema` as JSON Schema 2020-12, accepts 2020-12, 2019-09 and draft-07
+  (`SUPPORTED_DIALECTS`), and reports any other declared dialect as an
+  error ("dialect ... is not supported") instead of validating permissively.
+  `SchemaValidator.check_schema` reports why a schema is unusable; an
+  unusable `outputSchema` is a structured-content violation (warning or
+  `ValidationError` in `:strict` mode) and an unusable `inputSchema` is
+  logged once per tool.
+- **`$ref`.** References inside the schema document (`#`, `#/$defs/...`,
+  `#/definitions/...`, any JSON pointer, with `~0`/`~1` and percent
+  escapes) are resolved, recursively, with a hop limit. A `$ref` to a
+  network URI, another document, a `urn:` or `file:` is never dereferenced
+  and makes the schema unusable rather than permissive; an unresolvable
+  local `$ref` is an error too.
+- **Composition.** `allOf`, `anyOf`, `oneOf`, `not`, `if`/`then`/`else`
+  and boolean schemas are evaluated (they are no longer reported as
+  unsupported keywords). Resource bounds apply: nesting depth
+  (`MAX_SCHEMA_DEPTH`), total subschemas (`MAX_SUBSCHEMAS`), `$ref` chain
+  length (`MAX_REF_DEPTH`) and the per-validation time budget now covers
+  the whole walk.
+- **structuredContent.** Any JSON value is accepted, including `null`:
+  presence is decided by the `structuredContent` key, and the value —
+  object, array, scalar or null — is validated against the output schema.
+  The `x-mcp-header` annotation is ignored by the validator.
+
 ### Authorization (RFC 9207 issuer validation, client registration)
 
 - **Issuer validation.** `OAuthProvider#start_authorization_flow` records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **The pointer to an empty-named member, decided `contains` and satisfied
+  dependencies (round 23).** The JSON pointer `/` (`#/`, `#%2F`) addresses
+  the member named `""` (RFC 6901 Section 5) instead of the whole document,
+  so a `$ref` to it resolves rather than being reported as a cyclic chain,
+  and `#/` without such a member is unresolvable. A `contains` whose schema
+  matches every item (`true` / `{}`) is decided against the array's own
+  length — the default `minContains` of 1 rejects the empty array, and
+  `maxContains` bounds it — instead of only leaving a branch undecided, so
+  `not` / `if` / `oneOf` / `anyOf` no longer fail open on it. A
+  `dependentRequired` (or draft-07 `dependencies`) list whose names the
+  instance already carries cannot fail, so those branches are decided too.
+
 - **Adopted subtrees, data-keyword identifiers and readable fragments
   (round 22).** A subtree a pointer enters through a data keyword
   (`default`, `enum`, `const`, `examples`) is normalized and indexed once,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,13 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   draft-07 (the other bag is unknown to the dialect and not walked, though
   JSON pointers into it still resolve and what a `$ref` reaches is
   preflighted), and the unsupported-keyword scan stops at the subschema
-  bound and runs once per tool output schema.
+  bound and runs once per tool output schema. Pointer fragments are
+  relative to the schema resource the `$ref` sits in (`#` and `#/$defs/x`
+  inside an embedded resource are that resource's), the unsupported-keyword
+  scan follows local `$ref`s (a target in a definition bag the dialect does
+  not walk is scanned too), an `if` without `then` or `else` is not
+  evaluated, and a document with more than `MAX_STRUCTURAL_OBJECTS` objects
+  is rejected while it is being normalized rather than copied whole.
   The keyword grammar follows the dialect (`DIALECT_KEYWORDS`): a keyword
   the dialect does not define (`prefixItems` or `$dynamicRef` in draft-07,
   `dependencies` or `additionalItems` in 2020-12, ...) is ignored rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **Bounded coverage matching and adopted targets (round 21).** The pattern
+  matching behind the `patternProperties` / `additionalProperties` /
+  `unevaluatedProperties` coverage checks runs under the validation
+  deadline and the same regexp timeout as `pattern`, so a backtracking
+  expression cannot hold the calling thread. Every schema a pointer adopts
+  from a data or vendor keyword is charged against
+  `MAX_STRUCTURAL_OBJECTS` — string keys included, which is what arrives
+  over the wire — and its reachable positions are indexed within the
+  existing bounds, so a nested `$ref` such as `#/default/$defs/i` resolves
+  and the schemas inside an adopted resource keep its dialect. Dependency
+  triggers are looked up in both key forms. An explicit
+  `"outputSchema": null` in `tools/list` is a declaration, not an absent
+  field: the client still requires `structuredContent` and reports the null
+  schema as unusable, like any other invalid schema root.
+
 - **Inert assertions and unvisited positions (round 20).** Under `not` /
   `oneOf` / `if`, `contains` of `true` / `{}` on an array that already
   holds the items `minContains` requires, `unevaluatedItems` once such a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,18 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   network URI, another document, a `urn:` or `file:` is never dereferenced
   and makes the schema unusable rather than permissive; an unresolvable
   local `$ref` is an error too.
-- **Composition.** `allOf`, `anyOf`, `oneOf`, `not`, `if`/`then`/`else`
-  and boolean schemas are evaluated (they are no longer reported as
-  unsupported keywords). Resource bounds apply: nesting depth
-  (`MAX_SCHEMA_DEPTH`), total subschemas (`MAX_SUBSCHEMAS`), `$ref` chain
-  length (`MAX_REF_DEPTH`) and the per-validation time budget now covers
-  the whole walk.
+- **Composition.** `allOf`, `anyOf`, `oneOf`, `not`, `if`/`then`/`else`,
+  `prefixItems` (2020-12) / tuple-form `items` (draft-07, 2019-09) and
+  boolean schemas (root or nested) are evaluated (they are no longer
+  reported as unsupported keywords); under draft-07 a `$ref` replaces its
+  siblings. Resource bounds apply: nesting depth (`MAX_SCHEMA_DEPTH`),
+  total subschemas (`MAX_SUBSCHEMAS`, boolean subschemas included), `$ref`
+  chain length (`MAX_REF_DEPTH`, checked at preflight too), nodes visited
+  (`MAX_NODE_VISITS`), errors produced (`MAX_ERRORS`) and the
+  per-validation time budget; hitting a bound aborts the validation with
+  a single error, never with a pass, even under `not` or `oneOf`. Values
+  quoted in messages are clipped, and the client sanitizes and bounds the
+  violation text it logs or raises.
 - **structuredContent.** Any JSON value is accepted, including `null`:
   presence is decided by the `structuredContent` key, and the value —
   object, array, scalar or null — is validated against the output schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **Round 12.** A `$id` resource the anchor index could not reach (beyond
+  the depth bound) counts as truncation and a reference from a schema the
+  index does not know is unresolvable, never resolved against the document
+  root; a branch of `not` / `oneOf` / `if` is undecided only while an
+  unevaluated assertion that applies to the instance remains — annotations
+  (`format`, `contentSchema`) and assertions of another instance type
+  decide nothing, so a branch settled by its evaluated keywords is a full
+  verdict (`ANNOTATION_KEYWORDS`, `UNSUPPORTED_ASSERTIONS_BY_TYPE`).
+
 - **Dialects.** `MCPClient::SchemaValidator` treats a schema without
   `$schema` as JSON Schema 2020-12, accepts 2020-12, 2019-09 and draft-07
   (`SUPPORTED_DIALECTS`), and reports any other declared dialect as an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **Schemas applied to one value no longer consume the call stack, and a
+  draft-07 `$id` fragment is percent-decoded (round 27).** Round 26 stopped
+  *counting* the schemas a node applies to the same instance value against
+  the depth bound, but each of them still cost a Ruby stack frame: a
+  recursive schema composed through N `$defs` mixins applied N of them per
+  instance level, so the stack grew with the product of the instance depth
+  and the mixin count. Eight `allOf` mixins aborted a 90-level instance with
+  `validation aborted: schema too deeply recursive for this stack` on the
+  main thread, and four of them aborted a 99-level one on a `Thread` — the
+  stack a transport's reader actually runs on — so a conforming
+  `structuredContent` failed the validation the MCP tools spec says a client
+  SHOULD perform. The same-instance applications — a `$ref` hop, an `allOf`
+  / `anyOf` / `oneOf` / `not` / `if` branch, a `then` / `else` — are now
+  applied iteratively on an explicit stack, so a frame is spent only on a
+  step into a child value and `MAX_NODE_DEPTH` genuinely bounds the stack:
+  every mixin count reaches the full 256 levels the bound names, on a thread
+  as on the main stack, and an instance nested past it aborts as
+  `instance nested deeper than 256` rather than on the stack. The
+  `SystemStackError` rescue stays as a backstop. Separately, a draft-07 `$id`
+  is a URI reference, so the plain name it declares is now percent-decoded
+  (RFC 3986 Section 2.1) exactly as a `$ref`'s fragment already was:
+  `$id: "#foo%2Dbar"` declares the anchor `foo-bar`, and the matching
+  `$ref: "#foo%2Dbar"` resolves instead of being reported unresolvable.
+
 - **The instance-depth bound counts descents into the instance (round 26).**
   The depth budget the walk applies (round 25) counted every frame of the
   walk, `$ref` hops and `allOf` / `anyOf` / `oneOf` / `if` branches applied to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,11 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   is); an `$anchor` / `$dynamicAnchor` (or draft-07 fragment `$id`)
   declared more than once within one schema resource makes the schema
   unusable instead of binding references to whichever declaration was met
-  first.
+  first. A resource (`$id` URI) reached through a definition bag the
+  dialect does not walk names its own anchors (nothing outside it sees
+  them); the structural bound counts object entries too, so a wide map of
+  leaf values is rejected before it is copied, and the copy runs under the
+  validation deadline.
 
 ### Authorization (RFC 9207 issuer validation, client registration)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,18 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   presence is decided by the `structuredContent` key, and the value —
   object, array, scalar or null — is validated against the output schema.
   The `x-mcp-header` annotation is ignored by the validator.
+- **Resources and anchors (round 9).** Plain-name anchors come only from
+  schema positions the dialect walks: a definition bag the dialect does
+  not define (`definitions` under 2020-12, `$defs` under draft-07) stays
+  pointer-addressable but is never a source of names, and nothing beside a
+  draft-07 `$ref` but its `definitions` is. An embedded resource root (a
+  subschema whose `$id` is a URI) may declare its own `$schema`, which is
+  the dialect for that resource at preflight, in the anchor index, in the
+  keyword scan and during validation (a malformed or unsupported embedded
+  `$schema` makes the schema unusable like at the root; a `$schema` that is
+  not at a resource root is ignored). The structural bound counts array
+  members too, so a wide array of boolean schemas is rejected before it is
+  copied, and numeric bound errors clip the values they quote.
 
 ### Authorization (RFC 9207 issuer validation, client registration)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   not at a resource root is ignored). The structural bound counts array
   members too, so a wide array of boolean schemas is rejected before it is
   copied, and numeric bound errors clip the values they quote.
+- **Reference chains and anchors (round 10).** A `$ref` chain is
+  followed by where each hop lands, not by the text of its fragment, so a
+  reference entering an embedded resource whose own `$ref` reuses the same
+  fragment is not a cycle (a chain returning to a schema it reached still
+  is); an `$anchor` / `$dynamicAnchor` (or draft-07 fragment `$id`)
+  declared more than once within one schema resource makes the schema
+  unusable instead of binding references to whichever declaration was met
+  first.
 
 ### Authorization (RFC 9207 issuer validation, client registration)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **Malformed percent escapes, contains bounds the length settles and the
+  `$ref` hop budget (round 24).** A `$ref` fragment holding a malformed
+  percent escape (`#/$defs/a%ZZ`, `#/$defs/a%`) decodes to nothing and is
+  unresolvable (RFC 3986 Section 2.1), instead of falling back to the
+  undecoded text and resolving onto a member literally spelled that way, so
+  such a schema is reported unusable. The number of items a `contains` can
+  match is between none and the array's length whatever its item schema
+  says, so every bound that range settles is now decided rather than left
+  open: any `contains` rejects an array shorter than `minContains` (the
+  empty array by default), and a `contains` of `false` matches nothing — so
+  `not` / `if` / `oneOf` / `anyOf` no longer fail open on them. The
+  validation-time `$ref` hop budget counts the references applied to one
+  instance value and starts over below each property and item, so a
+  recursive schema (`{"items": {"$ref": "#"}}`) describes data nested deeper
+  than 32 levels instead of aborting on it.
+
 - **The pointer to an empty-named member, decided `contains` and satisfied
   dependencies (round 23).** The JSON pointer `/` (`#/`, `#%2F`) addresses
   the member named `""` (RFC 6901 Section 5) instead of the whole document,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,25 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   2020-12 keep it an annotation; a companion keyword the dialect does not
   define (`minContains` under draft-07) changes nothing.
 
+- **Pointer depth by the dialect in force, ineffective assertions
+  (round 18).** The depth of what a pointer `$ref` reaches is classified by
+  the dialect in force at each node — an embedded resource's own `$schema`
+  takes over when the pointer enters it — and once the pointer crossed a
+  keyword that dialect does not define, every token counts, a lexical depth
+  recorded under another grammar never overriding it (a 2020-12
+  `prefixItems` boolean inside a draft-07 document is legal at the bound; a
+  draft-07 `prefixItems` nest reached by pointer is out of bounds). A
+  boolean the preflight walk already admitted is not charged a second time
+  when a reference reaches it. A schema a pointer reaches under a data or
+  vendor keyword is indexed on arrival (a `$ref` written in it resolves in
+  its resource) and normalized when given with symbol keys. Under `not`,
+  `oneOf` and `if`, an unevaluated assertion that cannot change this
+  instance decides nothing: `unevaluatedItems` when the tuple or an `items`
+  schema covers every item, `additionalProperties` / `unevaluatedProperties`
+  when every property is covered, `uniqueItems` below two items,
+  `maxContains` / `maxProperties` the instance cannot exceed,
+  `minProperties` it already satisfies, a dependency none of whose
+  triggers is present.
 - **Round 12.** A `$id` resource the anchor index could not reach (beyond
   the depth bound) counts as truncation and a reference from a schema the
   index does not know is unresolvable, never resolved against the document

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **The instance-depth bound counts descents into the instance (round 26).**
+  The depth budget the walk applies (round 25) counted every frame of the
+  walk, `$ref` hops and `allOf` / `anyOf` / `oneOf` / `if` branches applied to
+  the *same* instance value included. A recursive schema composed through a
+  handful of `$defs` mixins spends several such frames per instance level, so
+  the count ran up at a multiple of the data's depth and JSON a peer can
+  legitimately send — nesting under `JSON.parse`'s default `max_nesting` of
+  100 — aborted with `validation aborted: instance or schema nesting deeper
+  than 512`: a `SchemaValidationError` under `:strict`, a false mismatch
+  under `:warn`. Only a step into a child value — an array item or a property
+  value — is counted now, the way the validate-time `$ref` hop budget already
+  works, and same-instance recursion stays bounded by `MAX_REF_DEPTH` and
+  `MAX_NODE_VISITS` as before. The bound is 256 levels of instance nesting,
+  and because it cannot bound what a single level costs on the stack,
+  `SchemaValidator.validate` also catches `SystemStackError` and reports it as
+  one aborted validation: an instance nested past what the stack can carry
+  still ends as a validation error rather than an exception escaping a tool
+  call, on a transport's reader thread as much as on the main one.
+
 - **A `$ref` to a non-schema member, unsatisfiable `contains` bounds and a
   depth-bounded walk (round 25).** The keyword scan no longer raises
   `ArgumentError` when a local `$ref` points at a member that is not a schema
@@ -24,7 +43,8 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   the interpreter's stack allows — reachable through the public
   `SchemaValidator.validate`, which unlike the wire path is not gated by
   `JSON.parse`'s `max_nesting` — aborts with a single validation error
-  instead of a `SystemStackError` that escapes the validator.
+  instead of a `SystemStackError` that escapes the validator. (What that
+  bound counts, and its value, are corrected in round 26 above.)
 
 - **Malformed percent escapes, contains bounds the length settles and the
   `$ref` hop budget (round 24).** A `$ref` fragment holding a malformed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   (`format`, `contentSchema`) and assertions of another instance type
   decide nothing, so a branch settled by its evaluated keywords is a full
   verdict (`ANNOTATION_KEYWORDS`, `UNSUPPORTED_ASSERTIONS_BY_TYPE`).
+- **Definite verdicts (round 13).** A branch that fails on an evaluated
+  assertion leaves no uncertainty behind, `anyOf` passes as soon as any
+  branch definitely passes (whatever the order of an undecided one), and
+  `oneOf` fails as soon as two branches definitely pass; uncertainty only
+  counts where it could still change the outcome.
 
 - **Dialects.** `MCPClient::SchemaValidator` treats a schema without
   `$schema` as JSON Schema 2020-12, accepts 2020-12, 2019-09 and draft-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **Definition identity (round 19).** `Tool#schema_identity` names a tool
+  definition: every copy the client cache hands out carries the same
+  token and a definition fetched again carries a new one, so the
+  once-per-definition checks of a tool's schemas (unusable input schema,
+  partial output-schema coverage) run once across cache hits and again
+  after a refresh, without hashing a peer-supplied document.
+  `MCPClient::DeepCopy.copy` is iterative, so copying a document nested
+  deeper than the Ruby stack allows cannot overflow it.
+
 - **Dialect-opaque pointers and charged booleans (round 17).** A pointer
   step through a keyword the dialect in force does not define
   (`prefixItems` under draft-07) is opaque data, so it cannot undercount a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **A `$ref` to a non-schema member, unsatisfiable `contains` bounds and a
+  depth-bounded walk (round 25).** The keyword scan no longer raises
+  `ArgumentError` when a local `$ref` points at a member that is not a schema
+  object (`{"$ref": "#/x", "x": true}`, `{"definitions": {}, "x": 1.5,
+  "$ref": "#/x"}`): such a target has no lexical depth at all, so the depth
+  the scan compares stays a number and an accepted schema can no longer turn
+  a successful call into an exception. `contains` bounds that no count can
+  satisfy — `minContains` above `maxContains`, the default `minContains` of 1
+  beside `maxContains: 0` — now fail on the bounds alone, before any appeal
+  to an item schema this validator cannot decide, so `anyOf` / `if` /
+  `oneOf` / `not` no longer fail open on them; bounds the array's length
+  genuinely cannot settle (`minContains: 0, maxContains: 0` over an
+  undecidable item schema) stay unevaluated as before. The walk over an
+  instance is bounded at 512 levels of nesting, so data nested deeper than
+  the interpreter's stack allows — reachable through the public
+  `SchemaValidator.validate`, which unlike the wire path is not gated by
+  `JSON.parse`'s `max_nesting` — aborts with a single validation error
+  instead of a `SystemStackError` that escapes the validator.
+
 - **Malformed percent escapes, contains bounds the length settles and the
   `$ref` hop budget (round 24).** A `$ref` fragment holding a malformed
   percent escape (`#/$defs/a%ZZ`, `#/$defs/a%`) decodes to nothing and is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,20 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   them); the structural bound counts object entries too, so a wide map of
   leaf values is rejected before it is copied, and the copy runs under the
   validation deadline.
+- **Undecided branches and bounds (round 11).** A branch the validator
+  can only partly evaluate (it carries an unsupported assertion such as
+  `multipleOf`) is no verdict for `not`, `oneOf` or `if`: it is neither a
+  match nor a mismatch, so `{"not": {"multipleOf": 2}}` never rejects a
+  value (anyOf / allOf keep treating a partial pass as a pass, the
+  permissive direction). A document nested deeper than
+  `MAX_SCHEMA_DEPTH` schema levels can hold is rejected while it is
+  copied instead of keeping the rest raw; the client keys its once-per
+  schema checks by the schema object, never by hashing a peer document
+  whole. Under draft-07 a URI `$id` beside a `$ref` is ignored with the
+  other siblings (it starts no resource); an anchor index that stopped at
+  its bound before reaching every object makes the schema unusable; a JSON
+  Pointer token with `~` not followed by `0` or `1` is unresolvable (RFC
+  6901).
 
 ### Authorization (RFC 9207 issuer validation, client registration)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **Dialect-opaque pointers and charged booleans (round 17).** A pointer
+  step through a keyword the dialect in force does not define
+  (`prefixItems` under draft-07) is opaque data, so it cannot undercount a
+  target's depth; every distinct boolean a `$ref` reaches counts once
+  toward `MAX_SUBSCHEMAS`; under draft-07 `format` is an unevaluated
+  assertion (a string branch carrying one is undecided) while 2019-09 and
+  2020-12 keep it an annotation; a companion keyword the dialect does not
+  define (`minContains` under draft-07) changes nothing.
+
 - **Round 12.** A `$id` resource the anchor index could not reach (beyond
   the depth bound) counts as truncation and a reference from a schema the
   index does not know is unresolvable, never resolved against the document

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,76 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **The preflight runs off the call stack, an unsupported input dialect is an
+  error, bundled references resolve, and `definitions` is the modern `$defs`
+  (verification round).** Seven fixes:
+
+  - *The preflight and the coverage scan no longer recurse.* Round 27 made
+    validation iterative, but `check_schema` and `unsupported_keywords` — both
+    of which the client runs *before* `validate`, so its `SystemStackError`
+    rescue could not cover them — still spent an interpreter frame per `$ref`
+    hop. A shallow document below every structural bound whose references
+    chain through 400 schemas (`{"$ref": "#/$defs/0", "$defs": {"0": {"allOf":
+    [{"$ref": "#/$defs/1"}]}, ...}}`) raised `SystemStackError` out of
+    `Client#call_tool` on a transport's reader thread, as its input or its
+    output schema. Both now read the document from an explicit stack, in the
+    same depth-first document order, so only the resource bounds decide.
+  - *An unsupported input dialect is an error the caller sees.* A tool whose
+    `inputSchema` declared, say, `{"$schema": "urn:unknown-dialect"}` had its
+    parameter check silently skipped: the request went out and its result came
+    back successfully, in `:strict` mode as much as in `:warn`. MCP 2026-07-28
+    basic "Implementation Requirements" says a client "MUST handle unsupported
+    dialects gracefully by returning an appropriate error indicating the
+    dialect is not supported", so `call_tool` now raises
+    `MCPClient::Errors::ValidationError` naming the dialect and refuses to
+    send the call. SEP-2106 assigns no JSON-RPC code to this, so it is a
+    library error rather than an invented wire one. An input schema that is
+    unusable for any *other* reason is still only warned about, and the call
+    still goes out.
+  - *A reference to a resource the document bundles resolves inside it.*
+    `{"$defs": {"s": {"$id": "urn:example:s", "type": "string"}}, "$ref":
+    "urn:example:s"}` was rejected as an external reference although its
+    target is right there; so were relative references resolving against the
+    base an enclosing `$id` establishes, and the empty reference `""`, which
+    names the current resource. References are now resolved as URI references
+    (RFC 3986 Section 5.2) against the base of the resource holding them, and
+    only one naming a resource the document does not carry is external —
+    which is what bundling (JSON Schema 2020-12 Core Section 9.3.1) needs.
+    Nothing is fetched, as before.
+  - *`definitions` is the deprecated `$defs` of the modern dialects.* Under
+    2020-12 and 2019-09 it was treated as an unknown container: an `$anchor`
+    declared in it named nothing (`{"definitions": {"x": {"$anchor": "x",
+    "type": "integer"}}, "$ref": "#x"}` rejected `1` as unresolvable), and
+    what it held was neither preflighted nor scanned for unsupported
+    keywords. The meta-schema of both dialects retains `definitions`, and
+    2020-12 Validation Appendix A asks implementations to give it the
+    behaviour of `$defs`; it now has it. `$defs` remains unknown to draft-07,
+    which does not define it.
+  - *2019-09 and draft-07 anchor names admit a colon.* Both spell a plain
+    name `[A-Za-z][-A-Za-z0-9.:_]*`, where 2020-12 spells it
+    `[A-Za-z_][-A-Za-z0-9._]*`. The 2020-12 syntax was applied to every
+    dialect, so a legal `{"$anchor": "a:b"}` under 2019-09 named nothing and
+    `"#a:b"` was reported unresolvable. Each dialect's own syntax now
+    applies, at the resource the reference resolves in.
+  - *Malformed keyword values are rejected at preflight.* `{"allOf": []}` and
+    `{"prefixItems": []}` were accepted and then read as permissive, though
+    both keywords are defined to hold a non-empty array; a `$defs` entry that
+    is not a schema was exempted unless a reference reached it; and the
+    assertion keywords the validator evaluates (`type`, `enum`, `required`,
+    `pattern`, `minLength` / `maxLength`, `minItems` / `maxItems`, `minimum` /
+    `maximum`) were read whatever they held. All of them now make the schema
+    unusable, naming the keyword at fault, rather than passing data off as
+    checked.
+  - *An undecidable condition still reports a failure both branches agree
+    on.* `validate(3, {"if" => {"multipleOf" => 2}, "then" => false, "else"
+    => false})` returned no errors, and so did validating `4`: the `if` uses a
+    keyword this validator does not evaluate, so neither branch was applied.
+    Exactly one of `then` and `else` is applied whichever way the condition
+    goes (JSON Schema 2020-12 Section 10.2.2), so a value both of them reject
+    is invalid — and is now reported, under `:strict` as a raised violation.
+    A conditional whose branches genuinely disagree, or that writes only one
+    of them, stays undecided as before.
+
 - **Schemas applied to one value no longer consume the call stack, and a
   draft-07 `$id` fragment is percent-decoded (round 27).** Round 26 stopped
   *counting* the schemas a node applies to the same instance value against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,17 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### Authorization (RFC 9207 issuer validation, client registration)
 
+- **Pointer depth and instance-aware assertions (round 16).** The depth
+  of what a pointer `$ref` reaches is counted in schema steps along the
+  percent-decoded pointer (`#/properties/b` and `#/allOf/0` are one below
+  the enclosing schema), so a boolean legal at the bound is not rejected
+  when referenced; every token under a data or unknown keyword
+  (`default`, `enum`, `const`, `examples`, vendor keys) is a step, so a
+  document hidden there obeys `MAX_SCHEMA_DEPTH` too (and an object
+  reached that way is walked at its own position). An unevaluated
+  assertion is uncertainty only when it can still change this instance:
+  `additionalItems: false` decides nothing when the tuple covers every
+  item, and `contains` decides nothing when `minContains` is 0.
 - **Issuer validation.** `OAuthProvider#start_authorization_flow` records
   the selected authorization server's `issuer` with the PKCE record;
   `complete_authorization_flow(code, state, iss:)` (and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   2020-12, where an `items` array is invalid; an `items` array in draft-07
   and 2019-09); a present but malformed `$schema` makes the schema
   unusable; an `outputSchema` of `false` is preserved by `Tool.from_json`.
+  Plain-name fragments are scoped to their schema resource (a subschema
+  whose `$id` is a URI starts a new resource; `#name` never crosses into or
+  out of an embedded resource), a draft-07 `$id` is a plain name only when
+  it is a pure fragment, keywords beside a draft-07 `$ref` contribute no
+  anchors, `$defs` belongs to 2019-09 / 2020-12 and `definitions` to
+  draft-07 (the other bag is unknown to the dialect and not walked, though
+  JSON pointers into it still resolve and what a `$ref` reaches is
+  preflighted), and the unsupported-keyword scan stops at the subschema
+  bound and runs once per tool output schema.
   The keyword grammar follows the dialect (`DIALECT_KEYWORDS`): a keyword
   the dialect does not define (`prefixItems` or `$dynamicRef` in draft-07,
   `dependencies` or `additionalItems` in 2020-12, ...) is ignored rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **Adopted subtrees, data-keyword identifiers and readable fragments
+  (round 22).** A subtree a pointer enters through a data keyword
+  (`default`, `enum`, `const`, `examples`) is normalized and indexed once,
+  memoized by the identity of what the document holds, and the rest of the
+  pointer is walked through that copy: a nested pointer such as
+  `#/default/$defs/i` lands on the object the index already knows, with the
+  resource, dialect and subschema charge it gave it, instead of a second
+  copy attributed to the referrer. Such a subtree declares no anchors of
+  its own unless an `$id` really starts a resource there, so an `$anchor`
+  written inside a data keyword no longer collides with the document's
+  names or makes `#name` resolvable depending on member order; `validate`
+  reuses the index the preflight built, so an accepted schema validates the
+  way it was checked. A `$ref` fragment whose percent-escapes are not valid
+  UTF-8 resolves to nothing instead of raising. A property, definition or
+  pattern named `enum`, `const`, `default` or `examples` is a schema
+  position like any other. A composition branch its supported assertions
+  already rejected is not measured for the keywords the validator does not
+  evaluate. The once-per-definition input-schema and coverage checks are
+  forgotten with the tool-cache entries they name.
+
 - **Bounded coverage matching and adopted targets (round 21).** The pattern
   matching behind the `patternProperties` / `additionalProperties` /
   `unevaluatedProperties` coverage checks runs under the validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **The annotation-driven keywords are evaluated, the dynamic references
+  narrowed to the dynamic ones, and the checks that ran outside the rules
+  brought under them (fifth verification round).**
+
+  - *`unevaluatedProperties` and `unevaluatedItems` beside a composition.*
+    The previous round refused, in `:strict`, every result whose schema used
+    one of the two beside an in-place applicator — including a conforming
+    `{"id": "1"}` against the canonical closed composition `{"$ref": ...,
+    "unevaluatedProperties": false}` SEP-2106 made legal on a tool schema —
+    and let `{"id": "1", "secret": "leak"}` through in `:warn`. Both
+    verdicts were wrong. The annotations a whole composition produces (JSON
+    Schema 2020-12 Core Sections 11.2 and 11.3: what `properties`,
+    `patternProperties`, `additionalProperties`, `prefixItems`, `items`,
+    `contains` and the two keywords themselves evaluated) are now collected
+    through every `$ref`, `allOf`, `anyOf`, `oneOf`, `if`/`then`/`else` and
+    `dependentSchemas` that passed — never from a failed branch, never from
+    a cousin — and the keyword is applied to what is left, wherever it
+    appears. `{"id": "1"}` conforms, `secret` is rejected in `:strict` and
+    warned about in `:warn`, on the synchronous, streaming and task paths
+    alike, and neither keyword is reported as unsupported any more.
+  - *The dynamic references are dynamic only where they are.* A
+    `$dynamicRef` naming a pointer or a plain `$anchor`, and a
+    `$recursiveRef` whose target carries no `$recursiveAnchor: true`, are
+    the plain references the specification says they are (2020-12 Core
+    Section 8.2.3.2, 2019-09 Core Section 8.2.4.2.1): they are applied as a
+    `$ref` — `{"$dynamicRef": "#/$defs/n"}` accepted `"bad"` against an
+    integer definition — and checked as one at preflight. Only a reference
+    the dynamic scope could re-bind stays unevaluated, reported, and refused
+    in `:strict`.
+  - *ECMA-262 word boundaries and group numbering.* Ruby's `\b` knows
+    every Unicode letter, so `"é"` satisfied `"\b"` and `not` reversed the
+    verdict; ECMA-262 defines the assertion over `[A-Za-z0-9_]`, and the
+    translation now spells it that way. ECMA-262 numbers named and unnamed
+    groups alike while Ruby stops capturing unnamed groups once a named one
+    exists, so `^(?<a>x)(y)\2$` — a valid pattern matching `"xyy"` — was
+    refused at preflight; every group is now written as a named one and a
+    numeric back-reference names the group it numbers.
+  - *The preflight under the deadline.* Checking a schema translated and
+    compiled every pattern it holds without consulting the validation-wide
+    deadline (700 patterns of 9,999 characters cost seconds past a 20 ms
+    budget before the late error). The check reads the deadline before
+    every position and every pattern, reports the exhausted budget where it
+    stops, and `check_schema` gets a budget of its own when the caller
+    names none.
+  - *Malformed core declarations.* A `$schema` on a subschema that is no
+    resource root was ignored; it is read at a resource root only (2020-12
+    Core Section 8.1.1) and is refused elsewhere. A `$vocabulary` keyed by a
+    relative reference was accepted; a vocabulary is identified by a URI.
+  - *An embedded resource's dialect governs what it requires of the
+    arguments.* The local check of a call's required arguments read every
+    position under the document root's dialect, so a draft-07 resource
+    embedded in a 2020-12 document had the `required` beside its `$ref`
+    counted (draft-07 ignores the sibling) and the call refused. Each
+    position is read under its own resource's dialect.
+  - *An output dialect this client cannot read stops the call before it is
+    sent*, as an input one already did, rather than after the tool has run;
+    and an error result under such a schema is refused too — the dialect
+    error is not limited to successful results.
+  - *A streamed chunk without `resultType` that is no CallToolResult* (a
+    progress object) was read as a complete result and checked against the
+    tool's output schema; only a chunk shaped as a result is.
+
 - **A bounded pattern translation, the rest of ECMA-262, malformed core
   keywords, a strict gate over what is not evaluated, and the retry's own
   definition (fourth verification round).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,77 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **JSON equality, ECMA-262 patterns, the annotation-driven keywords, and a
+  budget the instance cannot outrun (third verification round).** The
+  assertions the previous round started applying reached some wrong verdicts,
+  and the checks ran in places the resource bounds did not reach. Eight
+  fixes:
+
+  - *`uniqueItems` compares JSON values.* An object was canonicalized into an
+    array of its member pairs with nothing recording its type, so `[{}, []]`
+    and `[{"a": 1}, [["a", 1]]]` — pairs of distinct JSON values — were
+    reported as duplicates and `:strict` rejected a conforming result (and,
+    through `not`, accepted one the schema rejects). JSON equality begins
+    with the type (JSON Schema 2020-12 Core Section 4.2.2), and the canonical
+    form now carries it.
+  - *A `pattern` is read as ECMA-262, not only anchored like one.* The
+    previous round rewrote `^` and `$`; the rest was still Ruby, and the two
+    dialects disagree in both directions. `\A` anchors in Ruby and is a
+    literal `"A"` in ECMA-262 (Annex B identity escape), `.` excludes only
+    `"\n"` in Ruby against ECMA-262's four line terminators, Ruby's `\s`
+    knows none of the Unicode spaces ECMA-262 counts, and `[]` — an empty
+    class matching nothing there — is no expression at all in Ruby, so the
+    keyword was skipped and every string passed it. A pattern is now
+    translated to the Ruby expression that means the same thing, inside
+    character classes included (where Ruby's nested classes and `&&`
+    intersection are ECMA-262 literals).
+  - *`unevaluatedItems` and `unevaluatedProperties` are evaluated where a
+    node produces the annotations they read.* They were skipped outright, so
+    `{"prefixItems": [{"type": "number"}], "unevaluatedItems": false}`
+    admitted `[1, "x"]` and `{"unevaluatedProperties": false}` admitted
+    `{"extra": 1}` — instances a 2020-12 validator rejects. At a node with no
+    in-place applicator they are exactly `additionalItems` /
+    `additionalProperties` over what the node did not name, and they are
+    applied there (and no longer reported as partial coverage). Beside an
+    `allOf` / `anyOf` / `oneOf` / `if` / `$ref` / `dependentSchemas` — or, for
+    items, a `contains`, whose matches annotate — the annotations come from a
+    whole composition, and the keyword stays unevaluated and reported. The
+    dynamic references (`$dynamicRef`, `$recursiveRef`) need the dynamic
+    scope a validation was entered through, which this validator does not
+    track: they remain unevaluated, reported, and never a match for `not`,
+    `oneOf` or `if`.
+  - *The loops over the instance consult the budget.* How wide an object or
+    an array is, is the peer's choice, and a member decided without
+    descending into it visited no node — so the deadline was only consulted
+    between the nodes such a sweep happened to visit. A 100k-property object
+    under `{"not": {"additionalProperties": false}}` ran ~8x past a 20ms
+    budget and reported the work as a pass. The property sweep, the tuple
+    tail and the recursive `uniqueItems` canonicalization now reach a
+    checkpoint per member.
+  - *The metadata keywords must be written as their type.* `{"readOnly":
+    "no"}`, `{"title": 5}`, `{"format": 3}` and their kind preflighted clean,
+    so `:strict` checked results against a schema no validator could read.
+    Annotating rather than asserting does not exempt a keyword from JSON
+    Schema 2020-12 Validation Section 9; a malformed one makes the document
+    unusable, as a malformed assertion does.
+  - *An ordinary streamed result is validated.* `call_tool_streaming` handed
+    the transport's chunks back unchecked unless the tasks extension was on
+    and the chunk was a task, so the very payload `call_tool` refuses came
+    through it silently — the unsupported output dialect included. A chunk
+    that is a complete `CallToolResult` now gets the same check as a
+    synchronous answer; anything else is progress and is passed through.
+  - *A `HeaderMismatch` retry is not sent under a schema nothing can read.*
+    The rejection means the server did not execute the attempt, and the
+    retry is the send that would — so a refreshed `inputSchema` declaring an
+    unsupported dialect now stops the call before it goes out, rather than
+    after the tool has run.
+  - *2025-11-25 structured content is an object.* Only a present `null` was
+    read as "no structured content" on a legacy session; an array, a string,
+    a number or a boolean was taken for structured content and checked
+    against the output schema. The widening to any JSON value is a 2026-07-28
+    rule and does not reach back over a session negotiated to the older
+    revision.
+
 - **The standard assertions are evaluated, patterns are ECMAScript, and
   unsupported dialects are refused wherever they appear (second verification
   round).** MCP 2026-07-28 basic "Implementation Requirements" makes JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **A bounded pattern translation, the rest of ECMA-262, malformed core
+  keywords, a strict gate over what is not evaluated, and the retry's own
+  definition (fourth verification round).**
+
+  - *Pattern translation runs under the budget.* The ECMA-262 rewrite walked
+    the pattern by index — quadratic on a multibyte pattern — and never
+    consulted the deadline, so a 100,000-character `pattern` held the
+    calling thread for seconds past the one-second budget and, under `not`,
+    reported a pass. The translation is one linear pass that checks the
+    deadline as it goes, and a `pattern` (or `patternProperties` key) longer
+    than 10,000 characters makes the schema unusable at preflight.
+  - *The rest of ECMA-262.* A back-reference to a group that did not
+    participate matches the empty string in ECMA-262 and failed in Ruby
+    (`^(a)?\1$` rejected `""`); a numeric escape past the group count is
+    the legacy octal escape; a surrogate-pair escape (`\uD83D\uDE00`) is
+    the character it encodes and a lone surrogate matches nothing (Ruby
+    could not compile either, and the pattern was dropped — every string
+    passed it); Ruby-only syntax ECMA-262 refuses — inline flags (`(?i)`),
+    possessive quantifiers (`a++`), atomic groups, comments, `(?'n')`
+    groups — now makes the schema unusable instead of being read as Ruby.
+    An unreadable pattern is a malformed keyword, never an absent one.
+  - *Malformed core keywords.* An `$id` that is no URI reference, a
+    `$vocabulary` that is not an object of booleans keyed by URI and a
+    2019-09 `$recursiveAnchor` that is not a boolean were read as usable
+    schemas; each is refused at preflight.
+  - *`:strict` refuses what cannot be shown to conform.* A schema using an
+    assertion this validator does not evaluate (the dynamic references,
+    `unevaluatedItems` / `unevaluatedProperties` beside a composition)
+    logged "validation is partial" and returned the result: `:strict`
+    accepted `{"id": "1", "secret": "leak"}` against the canonical closed
+    composition `{"$ref": ..., "unevaluatedProperties": false}`. In
+    `:strict` such a result is refused with a `ValidationError` naming the
+    keywords, on every call; the annotation-only keywords still pass, and
+    `:warn` keeps its once-per-definition warning. The full dynamic-scope
+    and annotation-collecting evaluation stays deferred and documented.
+  - *The HeaderMismatch retry goes out under the definition it was checked
+    against.* The dialect check before the retry and the retry's header
+    derivation each looked the tool up, and on a list bounded with
+    `ttlMs: 0` each lookup fetched: the check read one definition and the
+    call went out under the next, whose dialect nothing here could read.
+    The checked definition is pinned for the send.
+  - *Required arguments through the applicators.* The local check of a
+    call's required arguments read the root only; it now follows the root's
+    `$ref` chain and `allOf` members (the tools spec: clients SHOULD follow
+    `$ref` resolution when validating tool inputs), leaving conditional
+    branches to the server.
+
 - **JSON equality, ECMA-262 patterns, the annotation-driven keywords, and a
   budget the instance cannot outrun (third verification round).** The
   assertions the previous round started applying reached some wrong verdicts,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **Dynamic references bind to the outermost scope, a branchless `if` keeps
+  its annotations, and the checks around a result close their last gaps
+  (sixth verification round).**
+
+  - *`$dynamicRef` and `$recursiveRef` are evaluated.* The dynamic scope a
+    reference is met in always starts at the root resource of the schema
+    being applied, so a `$dynamicRef` whose anchor the root declares binds to
+    the root wherever it is met (JSON Schema 2020-12 Core Section 8.2.3.2:
+    the recursive-node shape `{"$dynamicAnchor": "node", "properties":
+    {"child": {"$dynamicRef": "#node"}}}` now rejects `{"child": 1}`, and the
+    strict tree re-binds the open tree's items to the closed root), a
+    `$recursiveRef` to a root whose `$recursiveAnchor` is true likewise
+    (2019-09 Core Section 8.2.4.2.2), and where exactly one resource declares
+    the anchor it is the target the reference named. Only a document in which
+    several non-root resources declare the same dynamic anchor would need the
+    evaluation path to choose: that one reference stays unevaluated,
+    reported, and refused in `:strict`; the previous round refused every
+    dynamic-anchor reference in `:strict` and let an invalid instance through
+    in `:warn`.
+  - *A branchless `if` still annotates.* An `if` without `then` or `else`
+    was skipped, so `{"if": {"properties": {"foo": true}},
+    "unevaluatedProperties": false}` rejected the conforming `{"foo": 1}`
+    (and, under `not`, accepted the non-conforming one). The condition is
+    evaluated whether or not a branch follows, and the annotations of one
+    that passed are what the `unevaluated*` beside it reads (Section
+    10.2.2.1).
+  - *Generated capture-group names cannot collide.* An unnamed group beside
+    a named one is written as a named group, and a pattern naming its own
+    group `__mcp_g1` made `^(a)(?<__mcp_g1>b)\1$` accept `"abb"`. The
+    generated prefix is now one none of the pattern's names begins with.
+  - *The HeaderMismatch retry is refused under an unreadable output dialect
+    too.* The refreshed definition was checked for its input dialect only,
+    so a tool whose refreshed `outputSchema` declared a dialect this client
+    cannot read was run and its result refused afterwards; both schemas are
+    checked before the retry goes out (the unsupported-dialect MUST binds
+    before the call, as on the first send).
+  - *The structuredContent an error result carries is checked.* An error
+    result may omit `structuredContent`; one that carries it is bound by the
+    output schema like any other (the tools specification exempts nothing
+    about error results), so `:warn` logs and `:strict` refuses a
+    non-conforming one instead of skipping it. An `outputSchema` of `false`
+    refuses every structured result in `:strict`.
+
 - **The annotation-driven keywords are evaluated, the dynamic references
   narrowed to the dynamic ones, and the checks that ran outside the rules
   brought under them (fifth verification round).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 
 ### JSON Schema handling
 
+- **Dynamic references bind against the evaluation path, `contains`
+  annotations follow their dialect, and a pattern Ruby cannot reproduce is
+  refused rather than answered (seventh verification round).**
+
+  - *The dynamic scope is tracked.* A `$dynamicRef` binds to the outermost
+    resource of the dynamic scope — the schema resources the evaluation
+    entered on its way to the reference — declaring its anchor (JSON Schema
+    2020-12 Core Section 8.2.3.2), and a `$recursiveRef` likewise (2019-09
+    Core Section 8.2.4.2.2). A resource the instance never enters is not in
+    that scope and declares nothing for the reference, so a document holding
+    a second, unvisited declaration of the anchor no longer leaves the
+    reference unevaluated: `{"$ref": "https://example.com/a", "$defs": {"a":
+    {"$id": "...a", "$dynamicAnchor": "node", "type": "object", "properties":
+    {"child": {"$dynamicRef": "#node"}}}, "b": {"$id": "...b",
+    "$dynamicAnchor": "node", "type": "string"}}}` now rejects
+    `{"child": 1}`. Nothing about the dynamic references is deferred any
+    more: they are gone from the partial-coverage report, and `:strict` gates
+    on the verdict instead of refusing the schema.
+  - *`contains` annotates in 2020-12, not in 2019-09.* `unevaluatedItems`
+    reads the annotations of `items`/`additionalItems` alone in 2019-09
+    (Core Section 9.3.1.3), so `{"$schema": ".../2019-09/schema", "contains":
+    {"type": "integer"}, "unevaluatedItems": false}` now rejects `[1]`, which
+    it accepted while the 2020-12 rule (Section 10.3.1.3) was applied to
+    every dialect.
+  - *A pattern whose ECMA-262 meaning Ruby cannot reproduce is refused.* A
+    back-reference to a group a quantifier repeats reads one way in ECMA-262
+    (the capture is cleared at each iteration) and the other in Ruby (it is
+    kept), and Ruby's lookbehind is fixed-length where ECMA-262's has been
+    variable-length since ES2018. Both used to produce verdicts under the
+    wrong rules — `^(a|(b))*\2$` accepted "abab", which ECMA-262 rejects, and
+    refused "aba", which it accepts — and both are now reported as patterns
+    that cannot be evaluated faithfully. A variable-length lookbehind is no
+    longer reported as "not an ECMA-262 regular expression", which it is.
+  - *The initial send is held to the dialect guard the retry already was.*
+    The header extraction that decides what a `tools/call` carries may read a
+    newer definition than the caller preflighted; that definition is now
+    checked before the request goes out, so a tool whose refreshed schema
+    declares an unreadable dialect is refused instead of running first.
+  - *An error result carrying a non-object `structuredContent` on a
+    2025-11-25 session stays an error result.* The value is dropped there (the
+    revision types the field as an object), and the result was then reported
+    as a successful one missing its structured content — raising in `:strict`
+    on a result the tools specification permits.
+
 - **Dynamic references bind to the outermost scope, a branchless `if` keeps
   its annotations, and the checks around a result close their last gaps
   (sixth verification round).**

--- a/README.md
+++ b/README.md
@@ -362,17 +362,22 @@ data = result['structuredContent']  # Type-safe structured data
 
 # Per MCP 2025-11-25, clients SHOULD validate structured results against the
 # tool's output schema, and a tool that declares an outputSchema must return
-# structuredContent in successful results. call_tool checks both automatically
-# for the common JSON Schema keywords (type, properties, required, items, enum,
-# numeric/string bounds). The full 2020-12 vocabulary ($ref/$dynamicRef/$defs,
-# allOf/anyOf/oneOf/not, if/then/else, additionalProperties, patternProperties,
-# propertyNames, prefixItems, contains/minContains/maxContains, uniqueItems,
-# multipleOf, format, dependentRequired/dependentSchemas, minProperties/
-# maxProperties, unevaluated*) is NOT evaluated: when a schema uses any of
-# those keywords, call_tool logs a "validation is partial" warning naming them
-# (in both modes), since data may pass this check that a full validator would
-# reject. By default a violation (mismatch, or missing structuredContent on a
-# successful result) logs a warning; opt in to strict mode to raise instead:
+# structuredContent in successful results. call_tool checks both automatically,
+# against the JSON Schema vocabulary this client evaluates: type, enum/const,
+# properties/required, patternProperties, additionalProperties, propertyNames,
+# minProperties/maxProperties, dependentRequired/dependentSchemas (draft-07
+# dependencies), items/prefixItems/additionalItems, minItems/maxItems,
+# uniqueItems, contains with minContains/maxContains, string bounds and
+# pattern (ECMAScript anchoring), numeric bounds and multipleOf,
+# allOf/anyOf/oneOf/not, if/then/else, and $ref/$defs/definitions inside the
+# document. What is NOT evaluated is what needs annotations collected across a
+# whole composition (unevaluatedItems, unevaluatedProperties) or a dynamic
+# scope ($dynamicRef, $recursiveRef), plus the two keywords that only annotate
+# (format, contentSchema). When a schema uses one of those, call_tool logs a
+# "validation is partial" warning naming them (in both modes), since data may
+# pass this check that a full validator would reject. By default a violation
+# (mismatch, or missing structuredContent on a successful result) logs a
+# warning; opt in to strict mode to raise instead:
 client = MCPClient::Client.new(
   mcp_server_configs: [...],
   validate_structured_content: :strict # raises MCPClient::Errors::ValidationError on violation
@@ -408,12 +413,20 @@ client.call_tool('t', {})
 #     that dialect is not supported (supported: ...)"
 ```
 
-An unsupported dialect in an `outputSchema` is reported the way every other
-structured-content violation is: a warning by default, a `ValidationError`
-under `validate_structured_content: :strict`. An input schema that is merely
-unusable for another reason (a `$ref` that would need a network fetch, a
-document past the resource bounds, a malformed keyword value) is warned about
-and the call still goes out, since the server owns argument validation.
+The same applies to an `outputSchema`: an unsupported dialect there raises a
+`ValidationError` in both modes, since the client cannot read the schema at
+all — unlike a structured-content mismatch, which the
+`validate_structured_content` mode decides. The definition checked is the one
+the answered request actually went out under, so a `HeaderMismatch` retry
+under a refreshed schema is covered too. A schema that is merely unusable for
+another reason (a `$ref` that would need a network fetch, a document past the
+resource bounds, a malformed keyword value) is warned about, and for an input
+schema the call still goes out, since the server owns argument validation.
+
+Two schema resources may not answer to one URI: a document whose `$id`s (or
+whose `$anchor` names within one resource) collide is unusable, since which
+declaration a reference lands on would otherwise depend on the order the
+document was read in.
 
 References are resolved inside the document only — nothing is ever fetched —
 but a document that bundles the resources it uses is resolved in full: a

--- a/README.md
+++ b/README.md
@@ -380,20 +380,20 @@ data = result['structuredContent']  # Type-safe structured data
 # if-then-else/dependentSchemas that passed — never from a cousin). A
 # $dynamicRef or $recursiveRef that names no dynamic anchor is the plain
 # reference it resolves to and is applied as one; one that does binds to the
-# outermost dynamic scope declaring the anchor — the root resource where it
-# declares it (the recursive-tree shape), else the one resource that does.
-# What is NOT evaluated is a dynamic reference several non-root resources
-# could bind (only the evaluation path could choose, which this client does
-# not track), and the two keywords that only annotate
+# outermost resource of the DYNAMIC SCOPE declaring that anchor — the
+# resources the evaluation actually entered, tracked as it enters them, so a
+# duplicate anchor in a resource the instance never enters decides nothing.
+# What is NOT evaluated is the two keywords that only annotate
 # (format, contentSchema). When a schema uses one of those, call_tool logs a
 # "validation is partial" warning naming them (in both modes), since data may
 # pass this check that a full validator would reject; an unevaluated keyword
-# is never read as a match for not/oneOf/if either. In strict mode a schema
-# using such a dynamic reference refuses the result with a ValidationError,
-# since it cannot be shown to conform; the two annotation-only keywords do
-# not. A pattern is bounded to 10,000 characters
-# and must be an ECMA-262 expression (Ruby-only syntax such as inline flags
-# or possessive quantifiers makes the schema unusable). By default a
+# is never read as a match for not/oneOf/if either. A pattern is bounded to
+# 10,000 characters and must be an ECMA-262 expression (Ruby-only syntax such
+# as inline flags or possessive quantifiers makes the schema unusable). Two
+# ECMA-262 constructs Ruby's engine cannot reproduce — a back-reference to a
+# group a quantifier repeats (ECMA-262 clears it at each iteration, Ruby
+# keeps it) and a variable-length lookbehind — make the schema unusable too,
+# rather than being answered under the other engine's rules. By default a
 # violation (mismatch, or missing structuredContent on a successful result)
 # logs a warning; opt in to strict mode to raise instead:
 client = MCPClient::Client.new(

--- a/README.md
+++ b/README.md
@@ -393,6 +393,37 @@ that is the one it is validated against. A `tools/list_changed` that merely
 arrives while the call is in flight never changes the definition the result is
 checked against — the server never saw the replacement.
 
+#### JSON Schema dialects and references
+
+The built-in validator reads JSON Schema 2020-12 (the MCP default), 2019-09
+and draft-07. Per MCP 2026-07-28 an unsupported dialect must be reported as
+an error, so a tool whose `inputSchema` declares one this client does not
+implement is refused before the request is sent:
+
+```ruby
+# inputSchema: {"$schema": "urn:unknown-dialect", ...}
+client.call_tool('t', {})
+# => raises MCPClient::Errors::ValidationError:
+#    "...input schema declares the JSON Schema dialect \"urn:unknown-dialect\":
+#     that dialect is not supported (supported: ...)"
+```
+
+An unsupported dialect in an `outputSchema` is reported the way every other
+structured-content violation is: a warning by default, a `ValidationError`
+under `validate_structured_content: :strict`. An input schema that is merely
+unusable for another reason (a `$ref` that would need a network fetch, a
+document past the resource bounds, a malformed keyword value) is warned about
+and the call still goes out, since the server owns argument validation.
+
+References are resolved inside the document only — nothing is ever fetched —
+but a document that bundles the resources it uses is resolved in full: a
+`$ref` naming an embedded `$id` (`"urn:example:s"`, a relative URI against the
+base an enclosing `$id` established, or the empty reference `""`) resolves to
+that resource, and only a reference to a resource the document does not carry
+is reported as external. Under 2020-12 and 2019-09 `definitions` behaves as
+the `$defs` it was renamed from, as the meta-schema of both dialects retains
+it.
+
 ### Roots
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -373,20 +373,23 @@ data = result['structuredContent']  # Type-safe structured data
 # minContains/maxContains, string bounds and pattern (an ECMA-262 regular
 # expression, translated before it is matched), numeric bounds and multipleOf,
 # allOf/anyOf/oneOf/not, if/then/else, $ref/$defs/definitions inside the
-# document, and unevaluatedItems/unevaluatedProperties at a node that produces
-# every annotation they read (no allOf/anyOf/oneOf/if/$ref/dependentSchemas
-# beside them, and no contains beside unevaluatedItems). What is NOT evaluated
-# is unevaluatedItems/unevaluatedProperties where a composition produces those
-# annotations, the dynamic references ($dynamicRef, $recursiveRef), which need
-# a dynamic scope this client does not track, and the two keywords that only
-# annotate (format, contentSchema). When a schema uses one of those, call_tool
-# logs a "validation is partial" warning naming them (in both modes), since
-# data may pass this check that a full validator would reject; an unevaluated
-# keyword is never read as a match for not/oneOf/if either. In strict mode a
-# schema using one of the unevaluated ASSERTIONS (the dynamic references, or
-# unevaluatedItems/unevaluatedProperties beside a composition) refuses the
-# result with a ValidationError, since it cannot be shown to conform; the two
-# annotation-only keywords do not. A pattern is bounded to 10,000 characters
+# document, and unevaluatedItems/unevaluatedProperties from the annotations
+# the whole composition produces (what properties/patternProperties/
+# additionalProperties, prefixItems/items/contains and the two keywords
+# themselves evaluated, collected through every $ref/allOf/anyOf/oneOf/
+# if-then-else/dependentSchemas that passed — never from a cousin). A
+# $dynamicRef or $recursiveRef that names no dynamic anchor is the plain
+# reference it resolves to and is applied as one. What is NOT evaluated is a
+# dynamic reference the dynamic scope could re-bind (a $dynamicRef to a
+# $dynamicAnchor, a $recursiveRef to a $recursiveAnchor: true), which needs a
+# scope this client does not track, and the two keywords that only annotate
+# (format, contentSchema). When a schema uses one of those, call_tool logs a
+# "validation is partial" warning naming them (in both modes), since data may
+# pass this check that a full validator would reject; an unevaluated keyword
+# is never read as a match for not/oneOf/if either. In strict mode a schema
+# using such a dynamic reference refuses the result with a ValidationError,
+# since it cannot be shown to conform; the two annotation-only keywords do
+# not. A pattern is bounded to 10,000 characters
 # and must be an ECMA-262 expression (Ruby-only syntax such as inline flags
 # or possessive quantifiers makes the schema unusable). By default a
 # violation (mismatch, or missing structuredContent on a successful result)

--- a/README.md
+++ b/README.md
@@ -382,7 +382,13 @@ data = result['structuredContent']  # Type-safe structured data
 # annotate (format, contentSchema). When a schema uses one of those, call_tool
 # logs a "validation is partial" warning naming them (in both modes), since
 # data may pass this check that a full validator would reject; an unevaluated
-# keyword is never read as a match for not/oneOf/if either. By default a
+# keyword is never read as a match for not/oneOf/if either. In strict mode a
+# schema using one of the unevaluated ASSERTIONS (the dynamic references, or
+# unevaluatedItems/unevaluatedProperties beside a composition) refuses the
+# result with a ValidationError, since it cannot be shown to conform; the two
+# annotation-only keywords do not. A pattern is bounded to 10,000 characters
+# and must be an ECMA-262 expression (Ruby-only syntax such as inline flags
+# or possessive quantifiers makes the schema unusable). By default a
 # violation (mismatch, or missing structuredContent on a successful result)
 # logs a warning; opt in to strict mode to raise instead:
 client = MCPClient::Client.new(

--- a/README.md
+++ b/README.md
@@ -379,10 +379,12 @@ data = result['structuredContent']  # Type-safe structured data
 # themselves evaluated, collected through every $ref/allOf/anyOf/oneOf/
 # if-then-else/dependentSchemas that passed — never from a cousin). A
 # $dynamicRef or $recursiveRef that names no dynamic anchor is the plain
-# reference it resolves to and is applied as one. What is NOT evaluated is a
-# dynamic reference the dynamic scope could re-bind (a $dynamicRef to a
-# $dynamicAnchor, a $recursiveRef to a $recursiveAnchor: true), which needs a
-# scope this client does not track, and the two keywords that only annotate
+# reference it resolves to and is applied as one; one that does binds to the
+# outermost dynamic scope declaring the anchor — the root resource where it
+# declares it (the recursive-tree shape), else the one resource that does.
+# What is NOT evaluated is a dynamic reference several non-root resources
+# could bind (only the evaluation path could choose, which this client does
+# not track), and the two keywords that only annotate
 # (format, contentSchema). When a schema uses one of those, call_tool logs a
 # "validation is partial" warning naming them (in both modes), since data may
 # pass this check that a full validator would reject; an unevaluated keyword

--- a/README.md
+++ b/README.md
@@ -362,22 +362,29 @@ data = result['structuredContent']  # Type-safe structured data
 
 # Per MCP 2025-11-25, clients SHOULD validate structured results against the
 # tool's output schema, and a tool that declares an outputSchema must return
-# structuredContent in successful results. call_tool checks both automatically,
-# against the JSON Schema vocabulary this client evaluates: type, enum/const,
-# properties/required, patternProperties, additionalProperties, propertyNames,
-# minProperties/maxProperties, dependentRequired/dependentSchemas (draft-07
-# dependencies), items/prefixItems/additionalItems, minItems/maxItems,
-# uniqueItems, contains with minContains/maxContains, string bounds and
-# pattern (ECMAScript anchoring), numeric bounds and multipleOf,
-# allOf/anyOf/oneOf/not, if/then/else, and $ref/$defs/definitions inside the
-# document. What is NOT evaluated is what needs annotations collected across a
-# whole composition (unevaluatedItems, unevaluatedProperties) or a dynamic
-# scope ($dynamicRef, $recursiveRef), plus the two keywords that only annotate
-# (format, contentSchema). When a schema uses one of those, call_tool logs a
-# "validation is partial" warning naming them (in both modes), since data may
-# pass this check that a full validator would reject. By default a violation
-# (mismatch, or missing structuredContent on a successful result) logs a
-# warning; opt in to strict mode to raise instead:
+# structuredContent in successful results. call_tool checks both automatically
+# (so does call_tool_streaming, for a chunk that is a complete result, and so
+# does a task's result), against the JSON Schema vocabulary this client
+# evaluates: type, enum/const, properties/required, patternProperties,
+# additionalProperties, propertyNames, minProperties/maxProperties,
+# dependentRequired/dependentSchemas (draft-07 dependencies),
+# items/prefixItems/additionalItems, minItems/maxItems, uniqueItems (JSON
+# equality, so an object is never equal to an array), contains with
+# minContains/maxContains, string bounds and pattern (an ECMA-262 regular
+# expression, translated before it is matched), numeric bounds and multipleOf,
+# allOf/anyOf/oneOf/not, if/then/else, $ref/$defs/definitions inside the
+# document, and unevaluatedItems/unevaluatedProperties at a node that produces
+# every annotation they read (no allOf/anyOf/oneOf/if/$ref/dependentSchemas
+# beside them, and no contains beside unevaluatedItems). What is NOT evaluated
+# is unevaluatedItems/unevaluatedProperties where a composition produces those
+# annotations, the dynamic references ($dynamicRef, $recursiveRef), which need
+# a dynamic scope this client does not track, and the two keywords that only
+# annotate (format, contentSchema). When a schema uses one of those, call_tool
+# logs a "validation is partial" warning naming them (in both modes), since
+# data may pass this check that a full validator would reject; an unevaluated
+# keyword is never read as a match for not/oneOf/if either. By default a
+# violation (mismatch, or missing structuredContent on a successful result)
+# logs a warning; opt in to strict mode to raise instead:
 client = MCPClient::Client.new(
   mcp_server_configs: [...],
   validate_structured_content: :strict # raises MCPClient::Errors::ValidationError on violation
@@ -397,6 +404,15 @@ rejection makes the client refresh `tools/list` and retry with recomputed
 that is the one it is validated against. A `tools/list_changed` that merely
 arrives while the call is in flight never changes the definition the result is
 checked against — the server never saw the replacement.
+
+What counts as structured content follows the revision the session was
+negotiated to. MCP 2026-07-28 widened `structuredContent` to any JSON value,
+so a present `null`, array, string, number or boolean is structured content
+and is validated against the output schema. MCP 2025-11-25 types it as an
+object: on a session negotiated to that revision anything else is no
+structured content at all, and a tool that declares an `outputSchema` and
+sends one is reported as having returned none. A transport that cannot say
+which revision it negotiated is not assumed legacy.
 
 #### JSON Schema dialects and references
 
@@ -418,9 +434,13 @@ The same applies to an `outputSchema`: an unsupported dialect there raises a
 all — unlike a structured-content mismatch, which the
 `validate_structured_content` mode decides. The definition checked is the one
 the answered request actually went out under, so a `HeaderMismatch` retry
-under a refreshed schema is covered too. A schema that is merely unusable for
-another reason (a `$ref` that would need a network fetch, a document past the
-resource bounds, a malformed keyword value) is warned about, and for an input
+under a refreshed schema is covered too — and since the rejection means the
+server did not execute the attempt, a refreshed `inputSchema` whose dialect
+this client cannot read stops the retry before it is sent rather than after
+the tool has run. A schema that is merely unusable for another reason (a
+`$ref` that would need a network fetch, a document past the resource bounds,
+a malformed keyword value — the metadata keywords included, which must be
+written as the type JSON Schema gives them) is warned about, and for an input
 schema the call still goes out, since the server owns argument validation.
 
 Two schema resources may not answer to one URI: a document whose `$id`s (or

--- a/lib/mcp_client/called_tool_definition.rb
+++ b/lib/mcp_client/called_tool_definition.rb
@@ -97,5 +97,42 @@ module MCPClient
     def called_tool_definition_key
       :"mcp_client_called_tool_definition_#{object_id}"
     end
+
+    # Pin the definition the HeaderMismatch retry was checked against, so
+    # the retry's headers are derived from that very definition. Between
+    # the check and the send the list would otherwise be looked up again,
+    # and on a list the server bounds with `ttlMs: 0` another lookup is
+    # another fetch — possibly of a definition the check never read.
+    # @param name [String] the tool named in the retried request
+    # @param tool [MCPClient::Tool, nil] the definition the check read (nil
+    #   when the refreshed list no longer carries the tool)
+    # @return [void]
+    def pin_retry_definition(name, tool)
+      Thread.current[pinned_retry_definition_key] = [name.to_s, tool]
+    end
+
+    # Take the pinned definition for a request, if the retry of that very
+    # tool pinned one. Taken rather than read: it describes one send.
+    # @param name [String] the tool named in the request being sent
+    # @return [Array(MCPClient::Tool, nil), nil] a one-element array holding
+    #   the definition, or nil when nothing is pinned for the tool
+    def take_pinned_retry_definition(name)
+      pinned = Thread.current[pinned_retry_definition_key]
+      return nil unless pinned.is_a?(Array) && pinned.first == name.to_s
+
+      Thread.current[pinned_retry_definition_key] = nil
+      [pinned.last]
+    end
+
+    # Drop a pin the retry never consumed (it raised before sending).
+    # @return [void]
+    def clear_pinned_retry_definition
+      Thread.current[pinned_retry_definition_key] = nil
+    end
+
+    # @return [Symbol] this transport's thread-local key for the pin
+    def pinned_retry_definition_key
+      :"mcp_client_pinned_retry_definition_#{object_id}"
+    end
   end
 end

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1079,8 +1079,9 @@ module MCPClient
       end
     end
 
-    # Validate parameters against tool JSON schema (checks required properties).
-    # A schema declaring a dialect this client does not implement is refused
+    # Validate parameters against tool JSON schema (checks required
+    # properties, through the root's `$ref` chain and `allOf` members). A
+    # schema declaring a dialect this client does not implement is refused
     # outright, so the call is never sent under a schema nothing could read.
     # @param tool [MCPClient::Tool] tool definition with schema
     # @param parameters [Hash] parameters to validate
@@ -1095,18 +1096,20 @@ module MCPClient
       return if state[:unusable]
       return unless schema.is_a?(Hash)
 
-      required = schema['required'] || schema[:required]
-      return unless required.is_a?(Array)
+      # What the schema requires through every applicator that applies
+      # unconditionally: the root, its `$ref` chain, its `allOf` members (the
+      # tools spec: clients SHOULD follow `$ref` resolution when validating
+      # tool inputs). A conditional branch is the server's to judge.
+      required, properties = MCPClient::SchemaValidator.input_requirements(schema)
+      return if required.empty?
 
-      properties = schema['properties'] || schema[:properties] || {}
-
-      missing = required.map(&:to_s) - parameters.keys.map(&:to_s)
+      missing = required - parameters.keys.map(&:to_s)
 
       # Exclude required params that have a default value in the schema,
       # since the server will apply the default.
       missing = missing.reject do |param|
-        prop = properties[param] || properties[param.to_sym]
-        prop.is_a?(Hash) && (prop.key?('default') || prop.key?(:default))
+        prop = properties[param]
+        prop.is_a?(Hash) && prop.key?('default')
       end
 
       return unless missing.any?
@@ -1142,8 +1145,9 @@ module MCPClient
       # the continuation away with it.
       return result unless MCPClient::JsonRpcCommon.result_type(result) == 'complete'
 
-      warn_partial_schema_coverage(tool)
+      unsupported = warn_partial_schema_coverage(tool)
       reject_unsupported_dialect!(tool, output_schema_state(tool), 'output')
+      reject_partial_schema_coverage!(tool, unsupported)
 
       # MCP 2026-07-28: structuredContent "can be any JSON value (object,
       # array, string, number, boolean, or null)", so presence is decided by
@@ -1297,15 +1301,16 @@ module MCPClient
     # coverage is never silent. The schema is scanned once per definition
     # (keyed like {#warn_unusable_input_schema}), not on every result.
     # @param tool [MCPClient::Tool] the tool whose output schema is being used
-    # @return [void]
+    # @return [Array<String>] the unsupported keywords the schema uses
     def warn_partial_schema_coverage(tool)
       @output_schema_coverage ||= {}
       key = [tool.server&.object_id, tool.name]
-      return if @output_schema_coverage[key].equal?(tool_definition_identity(tool))
+      known = @output_schema_coverage[key]
+      return known[:unsupported] if known && known[:identity].equal?(tool_definition_identity(tool))
 
       unsupported = MCPClient::SchemaValidator.unsupported_keywords(tool.output_schema)
-      @output_schema_coverage[key] = tool_definition_identity(tool)
-      return if unsupported.empty?
+      @output_schema_coverage[key] = { identity: tool_definition_identity(tool), unsupported: unsupported }
+      return unsupported if unsupported.empty?
 
       @logger.warn(
         "Structured content check for tool '#{sanitize_peer_log_text(tool.name.to_s)}': validation is partial: " \
@@ -1313,6 +1318,30 @@ module MCPClient
         "keywords: #{unsupported.join(', ')} (full JSON Schema 2020-12 evaluation is not implemented, so " \
         'conforming-looking data may still violate the schema)'
       )
+      unsupported
+    end
+
+    # :strict is a gate. A schema using an assertion this validator does not
+    # evaluate (the dynamic references, `unevaluatedItems` /
+    # `unevaluatedProperties` where a composition produces the annotations
+    # they read) cannot be shown to accept the result, and a result not shown
+    # to conform is refused there — a warning beside a returned value was a
+    # silent pass in everything but the log. A keyword that only annotates
+    # (`format`, `contentSchema`) decides nothing and does not refuse.
+    # @param tool [MCPClient::Tool] the tool whose output schema is being used
+    # @param unsupported [Array<String>] what {#warn_partial_schema_coverage} found
+    # @return [void]
+    # @raise [MCPClient::Errors::ValidationError] in :strict mode
+    def reject_partial_schema_coverage!(tool, unsupported)
+      return unless @validate_structured_content == :strict
+
+      assertions = unsupported - MCPClient::SchemaValidator::ANNOTATION_KEYWORDS
+      return if assertions.empty?
+
+      raise MCPClient::Errors::ValidationError,
+            "Structured content for tool '#{sanitize_peer_log_text(tool.name.to_s)}' cannot be checked against " \
+            'its output schema: the schema uses keywords this validator does not evaluate ' \
+            "(#{assertions.join(', ')}), so the result is not shown to conform"
     end
 
     # Log a structured-content conformance violation and, in :strict mode,

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1170,11 +1170,18 @@ module MCPClient
 
     # Warn (in both :warn and :strict modes) when a tool's output schema uses
     # JSON Schema keywords the built-in validator cannot evaluate, so partial
-    # coverage is never silent.
+    # coverage is never silent. The schema is scanned once per definition
+    # (keyed like {#warn_unusable_input_schema}), not on every result.
     # @param tool [MCPClient::Tool] the tool whose output schema is being used
     # @return [void]
     def warn_partial_schema_coverage(tool)
+      @output_schema_coverage ||= {}
+      key = [tool.server&.object_id, tool.name]
+      identity = tool.output_schema.hash
+      return if @output_schema_coverage[key] == identity
+
       unsupported = MCPClient::SchemaValidator.unsupported_keywords(tool.output_schema)
+      @output_schema_coverage[key] = identity
       return if unsupported.empty?
 
       @logger.warn(

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1465,6 +1465,7 @@ module MCPClient
         end
       end
     end
+
     # Generate a cache key for server-specific items
     # @param server [MCPClient::ServerBase] the server
     # @param item_id [String] the item identifier (name or URI)

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1065,7 +1065,9 @@ module MCPClient
     # @raise [MCPClient::Errors::ValidationError] when required params are missing
     def validate_params!(tool, parameters)
       schema = tool.schema
-      warn_unusable_input_schema(tool)
+      # An input schema the validator cannot interpret asserts nothing: the
+      # call goes out and the server judges its arguments.
+      return if warn_unusable_input_schema(tool)
       return unless schema.is_a?(Hash)
 
       required = schema['required'] || schema[:required]
@@ -1150,8 +1152,9 @@ module MCPClient
     # host learns that local parameter checks are incomplete.
     # @param tool [MCPClient::Tool]
     # @return [void]
+    # @return [Boolean] whether the input schema is unusable for validation
     def warn_unusable_input_schema(tool)
-      return if tool.schema.nil?
+      return false if tool.schema.nil?
 
       # Keyed by the schema object itself as well, so a refreshed tool
       # definition (list_changed, cache expiry, HeaderMismatch recovery) is
@@ -1160,14 +1163,16 @@ module MCPClient
       # check could reject it.
       @input_schema_warnings ||= {}
       key = [tool.server&.object_id, tool.name]
-      return if @input_schema_warnings[key].equal?(tool.schema)
+      known = @input_schema_warnings[key]
+      return known[:unusable] if known && known[:schema].equal?(tool.schema)
 
       problems = MCPClient::SchemaValidator.check_schema(tool.schema)
-      @input_schema_warnings[key] = tool.schema
-      return if problems.empty?
+      @input_schema_warnings[key] = { schema: tool.schema, unusable: !problems.empty? }
+      return false if problems.empty?
 
       @logger.warn("Tool '#{sanitize_peer_log_text(tool.name.to_s)}' input schema is not usable for validation: " \
                    "#{sanitize_peer_log_text(problems.join('; '))}")
+      true
     end
 
     # Warn (in both :warn and :strict modes) when a tool's output schema uses

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -364,7 +364,7 @@ module MCPClient
         # method does not change.
         result = complete_task_result(tool_name, server, result, task_epoch)
 
-        validate_structured_content!(called || tool, result)
+        validate_called_result!(called || tool, result)
       end
     end
 
@@ -714,7 +714,7 @@ module MCPClient
                 read_called = true
               end
               result = complete_task_result(tool_name, server, chunk, epoch)
-              yielder << validate_structured_content!(called || tool, result)
+              yielder << validate_called_result!(called || tool, result)
             end
           end
         end
@@ -1073,7 +1073,7 @@ module MCPClient
     def validate_params!(tool, parameters)
       schema = tool.schema
       state = input_schema_state(tool)
-      reject_unsupported_input_dialect!(tool, state)
+      reject_unsupported_dialect!(tool, state, 'input')
       # An input schema the validator cannot interpret asserts nothing: the
       # call goes out and the server judges its arguments.
       return if state[:unusable]
@@ -1127,11 +1127,15 @@ module MCPClient
       return result unless MCPClient::JsonRpcCommon.result_type(result) == 'complete'
 
       warn_partial_schema_coverage(tool)
+      reject_unsupported_dialect!(tool, output_schema_state(tool), 'output')
 
       # MCP 2026-07-28: structuredContent "can be any JSON value (object,
       # array, string, number, boolean, or null)", so presence is decided by
-      # the key, not by the value.
+      # the key, not by the value. MCP 2025-11-25 knows only object structured
+      # content, so on a session negotiated to that revision a null is what it
+      # was there: no structured content at all.
       key = [:structuredContent, 'structuredContent'].find { |k| result.key?(k) }
+      key = nil if key && result[key].nil? && legacy_server?(tool.server)
       unless key
         handle_structured_content_violation(
           "Tool '#{sanitize_peer_log_text(tool.name.to_s)}' declares an output schema but its successful result " \
@@ -1202,17 +1206,64 @@ module MCPClient
     # know what the arguments must look like, and the caller must be able to
     # see that — so the call is refused before it is sent. SEP-2106 assigns
     # no JSON-RPC code to this, so it is a library error, not a wire one.
+    # The requirement is not conditional on the structured-content mode: a
+    # dialect the client cannot read is not a result it may choose to only
+    # log, on an input schema or on an output one.
     # @param state [Hash] the memoized preflight state
+    # @param kind [String] which schema the dialect was declared on
     # @return [void]
     # @raise [MCPClient::Errors::ValidationError] when the dialect is unsupported
-    def reject_unsupported_input_dialect!(tool, state)
+    def reject_unsupported_dialect!(tool, state, kind)
       dialect = state[:dialect]
       return unless dialect
 
       raise MCPClient::Errors::ValidationError,
-            "Tool '#{sanitize_peer_log_text(tool.name.to_s)}' input schema declares the JSON Schema dialect " \
+            "Tool '#{sanitize_peer_log_text(tool.name.to_s)}' #{kind} schema declares the JSON Schema dialect " \
             "#{sanitize_peer_log_text(dialect.inspect)[0, MAX_VIOLATION_TEXT]}: that dialect is not supported " \
             "(supported: #{MCPClient::SchemaValidator::SUPPORTED_DIALECTS.join(', ')})"
+    end
+
+    # What the preflight made of a tool's outputSchema, checked once per
+    # definition (keyed like {#input_schema_state}). Only the dialect is kept:
+    # every other reason the schema is unusable is reported through
+    # {#handle_structured_content_violation}, which the host's mode decides.
+    # @param tool [MCPClient::Tool]
+    # @return [Hash] the :dialect that is not supported, if any
+    def output_schema_state(tool)
+      return {} if tool.output_schema.nil?
+
+      @output_schema_dialects ||= {}
+      key = [tool.server&.object_id, tool.name]
+      known = @output_schema_dialects[key]
+      return known if known && known[:identity].equal?(tool_definition_identity(tool))
+
+      preflight = {}
+      MCPClient::SchemaValidator.check_schema(tool.output_schema, preflight)
+      @output_schema_dialects[key] = { identity: tool_definition_identity(tool),
+                                       dialect: preflight[:unsupported_dialect] }
+    end
+
+    # Validate the result of a call against the definition the request that
+    # was answered actually went out under. A transport's HeaderMismatch
+    # recovery re-derives a call's Mcp-Param-* headers from a refreshed
+    # tools/list, so the attempt that came back may carry an input schema
+    # this client never resolved — and {#validate_params!} refused the
+    # dialect of the definition the call was prepared from, not of the one it
+    # was sent under.
+    # @param tool [MCPClient::Tool] the answering definition
+    # @param result [Object] the raw tools/call result
+    # @return [Object] the result, unchanged
+    # @raise [MCPClient::Errors::ValidationError]
+    def validate_called_result!(tool, result)
+      reject_unsupported_dialect!(tool, input_schema_state(tool), 'input')
+      validate_structured_content!(tool, result)
+    end
+
+    # @param srv [MCPClient::ServerBase] the transport
+    # @return [Boolean] whether the session was negotiated to a revision
+    #   before 2026-07-28 (a transport that cannot say is not assumed legacy)
+    def legacy_server?(srv)
+      !srv.nil? && srv.respond_to?(:modern?) && srv.modern? == false
     end
 
     # The token naming a tool definition ({MCPClient::Tool#schema_identity});
@@ -1334,7 +1385,7 @@ module MCPClient
     #   or nil for every server
     # @return [void]
     def forget_schema_checks(server = nil)
-      [@input_schema_warnings, @output_schema_coverage].each do |memo|
+      [@input_schema_warnings, @output_schema_coverage, @output_schema_dialects].each do |memo|
         next unless memo
 
         if server

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1061,6 +1061,7 @@ module MCPClient
     # @raise [MCPClient::Errors::ValidationError] when required params are missing
     def validate_params!(tool, parameters)
       schema = tool.schema
+      warn_unusable_input_schema(tool)
       return unless schema.is_a?(Hash)
 
       required = schema['required'] || schema[:required]
@@ -1112,22 +1113,49 @@ module MCPClient
 
       warn_partial_schema_coverage(tool)
 
-      structured = result.key?('structuredContent') ? result['structuredContent'] : result[:structuredContent]
-      if structured.nil?
+      # MCP 2026-07-28: structuredContent "can be any JSON value (object,
+      # array, string, number, boolean, or null)", so presence is decided by
+      # the key, not by the value.
+      key = [:structuredContent, 'structuredContent'].find { |k| result.key?(k) }
+      unless key
         handle_structured_content_violation(
           "Tool '#{tool.name}' declares an output schema but its successful result carries no structuredContent " \
-          '(required by the MCP 2025-11-25 tools spec)'
+          '(required by the MCP tools spec)'
         )
         return result
       end
 
-      errors = MCPClient::SchemaValidator.validate(structured, tool.output_schema)
+      # An unusable output schema (unsupported dialect, external $ref, out of
+      # bounds) is a violation too, never a permissive pass.
+      errors = MCPClient::SchemaValidator.validate(result[key], tool.output_schema)
       unless errors.empty?
         handle_structured_content_violation(
           "Structured content for tool '#{tool.name}' does not match its output schema: #{errors.join('; ')}"
         )
       end
       result
+    end
+
+    # Warn once per tool when its inputSchema cannot be used as a JSON
+    # Schema (MCP 2026-07-28: an unsupported dialect, a network `$ref` that
+    # is never dereferenced, or a schema beyond the resource bounds). The
+    # call still goes out — the server owns argument validation — but the
+    # host learns that local parameter checks are incomplete.
+    # @param tool [MCPClient::Tool]
+    # @return [void]
+    def warn_unusable_input_schema(tool)
+      return if tool.schema.nil?
+
+      @input_schema_warnings ||= {}
+      key = [tool.server&.object_id, tool.name]
+      return if @input_schema_warnings.key?(key)
+
+      problems = MCPClient::SchemaValidator.check_schema(tool.schema)
+      @input_schema_warnings[key] = true
+      return if problems.empty?
+
+      @logger.warn("Tool '#{sanitize_peer_log_text(tool.name.to_s)}' input schema is not usable for validation: " \
+                   "#{sanitize_peer_log_text(problems.join('; '))}")
     end
 
     # Warn (in both :warn and :strict modes) when a tool's output schema uses

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1153,15 +1153,17 @@ module MCPClient
     def warn_unusable_input_schema(tool)
       return if tool.schema.nil?
 
-      # Keyed by the schema itself as well, so a refreshed tool definition
-      # (list_changed, cache expiry, HeaderMismatch recovery) is re-checked.
+      # Keyed by the schema object itself as well, so a refreshed tool
+      # definition (list_changed, cache expiry, HeaderMismatch recovery) is
+      # re-checked. The object, not its hash: hashing a peer-supplied
+      # document walks it whole (or overflows the stack) before the bounded
+      # check could reject it.
       @input_schema_warnings ||= {}
       key = [tool.server&.object_id, tool.name]
-      identity = tool.schema.hash
-      return if @input_schema_warnings[key] == identity
+      return if @input_schema_warnings[key].equal?(tool.schema)
 
       problems = MCPClient::SchemaValidator.check_schema(tool.schema)
-      @input_schema_warnings[key] = identity
+      @input_schema_warnings[key] = tool.schema
       return if problems.empty?
 
       @logger.warn("Tool '#{sanitize_peer_log_text(tool.name.to_s)}' input schema is not usable for validation: " \
@@ -1177,11 +1179,10 @@ module MCPClient
     def warn_partial_schema_coverage(tool)
       @output_schema_coverage ||= {}
       key = [tool.server&.object_id, tool.name]
-      identity = tool.output_schema.hash
-      return if @output_schema_coverage[key] == identity
+      return if @output_schema_coverage[key].equal?(tool.output_schema)
 
       unsupported = MCPClient::SchemaValidator.unsupported_keywords(tool.output_schema)
-      @output_schema_coverage[key] = identity
+      @output_schema_coverage[key] = tool.output_schema
       return if unsupported.empty?
 
       @logger.warn(

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -541,8 +541,10 @@ module MCPClient
         # pin the enumeration takes (see #streamed_call_chunks) — this one
         # covers a transport that sends while building it.
         stream = pinned_to_session(server, task_epoch) { server.call_tool_streaming(tool_name, parameters) }
-        return stream unless task_epoch || (tasks_extension? && modern_server?(server))
-
+        # Every stream goes through the wrapper, whether or not tasks are in
+        # play: "Clients SHOULD validate structured results against this
+        # schema" is about a result, not about the method that fetched it, and
+        # so is the dialect a result's schema declares.
         streamed_call_chunks(stream, tool, tool_name, server, epoch: task_epoch)
       rescue MCPClient::Errors::ConnectionError => e
         # Add server identity information to the error for better context
@@ -703,7 +705,11 @@ module MCPClient
               # it to the call's result, validated as #call_tool does — against
               # the definition a mid-stream refresh (HeaderMismatch recovery)
               # may have replaced.
-              next yielder << chunk unless resolve && task_result?(chunk)
+              task = resolve && task_result?(chunk)
+              # A chunk that is neither a task nor a complete CallToolResult is
+              # progress, not an answer: only a result is checked against the
+              # tool's outputSchema.
+              next yielder << chunk unless task || complete_call_result?(chunk)
 
               # The definition the stream's one request went out under, read
               # before a task is waited for (see #call_tool) and read once:
@@ -713,12 +719,22 @@ module MCPClient
                 called = called_tool_definition(server, tool_name)
                 read_called = true
               end
-              result = complete_task_result(tool_name, server, chunk, epoch)
+              result = task ? complete_task_result(tool_name, server, chunk, epoch) : chunk
               yielder << validate_called_result!(called || tool, result)
             end
           end
         end
       end
+    end
+
+    # Whether a streamed chunk is the call's answer rather than an update on
+    # its way. MCP 2026-07-28 makes `resultType` required and has clients
+    # treat an absent one as "complete", which is what every pre-2026 server
+    # sends.
+    # @param chunk [Object] one chunk of a streaming tools/call
+    # @return [Boolean]
+    def complete_call_result?(chunk)
+      chunk.is_a?(Hash) && MCPClient::JsonRpcCommon.result_type(chunk) == 'complete'
     end
 
     # Hand the host's identity and request metadata to a transport.
@@ -1131,11 +1147,13 @@ module MCPClient
 
       # MCP 2026-07-28: structuredContent "can be any JSON value (object,
       # array, string, number, boolean, or null)", so presence is decided by
-      # the key, not by the value. MCP 2025-11-25 knows only object structured
-      # content, so on a session negotiated to that revision a null is what it
-      # was there: no structured content at all.
+      # the key, not by the value. MCP 2025-11-25 types it as an object, so on
+      # a session negotiated to that revision anything else — a null, an
+      # array, a string, a number, a boolean — is what it was there: no
+      # structured content at all. The widening is a 2026-07-28 rule and does
+      # not reach back over a legacy session.
       key = [:structuredContent, 'structuredContent'].find { |k| result.key?(k) }
-      key = nil if key && result[key].nil? && legacy_server?(tool.server)
+      key = nil if key && !result[key].is_a?(Hash) && legacy_server?(tool.server)
       unless key
         handle_structured_content_violation(
           "Tool '#{sanitize_peer_log_text(tool.name.to_s)}' declares an output schema but its successful result " \

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -303,6 +303,9 @@ module MCPClient
     # @param parameters [Hash] the parameters to pass to the tool
     # @param server [String, Symbol, Integer, MCPClient::ServerBase, nil] optional server to use
     # @return [Object] the result of the tool invocation
+    # @raise [MCPClient::Errors::ValidationError] when the parameters miss a
+    #   required property, or the tool's inputSchema declares a JSON Schema
+    #   dialect this client does not support (MCP 2026-07-28)
     def call_tool(tool_name, parameters, server: nil, progress: nil)
       tool = resolve_tool(tool_name, server: server)
 
@@ -1060,15 +1063,20 @@ module MCPClient
       end
     end
 
-    # Validate parameters against tool JSON schema (checks required properties)
+    # Validate parameters against tool JSON schema (checks required properties).
+    # A schema declaring a dialect this client does not implement is refused
+    # outright, so the call is never sent under a schema nothing could read.
     # @param tool [MCPClient::Tool] tool definition with schema
     # @param parameters [Hash] parameters to validate
-    # @raise [MCPClient::Errors::ValidationError] when required params are missing
+    # @raise [MCPClient::Errors::ValidationError] when required params are
+    #   missing, or the schema's dialect is not supported
     def validate_params!(tool, parameters)
       schema = tool.schema
+      state = input_schema_state(tool)
+      reject_unsupported_input_dialect!(tool, state)
       # An input schema the validator cannot interpret asserts nothing: the
       # call goes out and the server judges its arguments.
-      return if warn_unusable_input_schema(tool)
+      return if state[:unusable]
       return unless schema.is_a?(Hash)
 
       required = schema['required'] || schema[:required]
@@ -1146,16 +1154,17 @@ module MCPClient
       result
     end
 
-    # Warn once per tool when its inputSchema cannot be used as a JSON
-    # Schema (MCP 2026-07-28: an unsupported dialect, a network `$ref` that
-    # is never dereferenced, or a schema beyond the resource bounds). The
-    # call still goes out — the server owns argument validation — but the
-    # host learns that local parameter checks are incomplete.
+    # What the preflight made of a tool's inputSchema, checked once per tool
+    # definition. A schema the validator cannot use is warned about (MCP
+    # 2026-07-28: an unsupported dialect, a network `$ref` that is never
+    # dereferenced, or a schema beyond the resource bounds); for everything
+    # but an unsupported dialect the call still goes out — the server owns
+    # argument validation — and the host learns that local parameter checks
+    # are incomplete.
     # @param tool [MCPClient::Tool]
-    # @return [void]
-    # @return [Boolean] whether the input schema is unusable for validation
-    def warn_unusable_input_schema(tool)
-      return false if tool.schema.nil?
+    # @return [Hash] :unusable and the :dialect that is not supported, if any
+    def input_schema_state(tool)
+      return {} if tool.schema.nil?
 
       # Keyed by the definition's identity as well, so a refreshed tool
       # definition (list_changed, cache expiry, HeaderMismatch recovery) is
@@ -1166,15 +1175,44 @@ module MCPClient
       @input_schema_warnings ||= {}
       key = [tool.server&.object_id, tool.name]
       known = @input_schema_warnings[key]
-      return known[:unusable] if known && known[:identity].equal?(tool_definition_identity(tool))
+      return known if known && known[:identity].equal?(tool_definition_identity(tool))
 
-      problems = MCPClient::SchemaValidator.check_schema(tool.schema)
-      @input_schema_warnings[key] = { identity: tool_definition_identity(tool), unusable: !problems.empty? }
-      return false if problems.empty?
+      preflight = {}
+      problems = MCPClient::SchemaValidator.check_schema(tool.schema, preflight)
+      state = { identity: tool_definition_identity(tool), unusable: !problems.empty?,
+                dialect: preflight[:unsupported_dialect] }
+      @input_schema_warnings[key] = state
+      warn_unusable_input_schema(tool, problems)
+      state
+    end
+
+    # @param problems [Array<String>] why the input schema is unusable
+    # @return [void]
+    def warn_unusable_input_schema(tool, problems)
+      return if problems.empty?
 
       @logger.warn("Tool '#{sanitize_peer_log_text(tool.name.to_s)}' input schema is not usable for validation: " \
                    "#{sanitize_peer_log_text(problems.join('; '))}")
-      true
+    end
+
+    # MCP 2026-07-28 basic "Implementation Requirements": a client "MUST
+    # handle unsupported dialects gracefully by returning an appropriate
+    # error indicating the dialect is not supported". A dialect this client
+    # does not implement is not a schema it may quietly skip — it cannot
+    # know what the arguments must look like, and the caller must be able to
+    # see that — so the call is refused before it is sent. SEP-2106 assigns
+    # no JSON-RPC code to this, so it is a library error, not a wire one.
+    # @param state [Hash] the memoized preflight state
+    # @return [void]
+    # @raise [MCPClient::Errors::ValidationError] when the dialect is unsupported
+    def reject_unsupported_input_dialect!(tool, state)
+      dialect = state[:dialect]
+      return unless dialect
+
+      raise MCPClient::Errors::ValidationError,
+            "Tool '#{sanitize_peer_log_text(tool.name.to_s)}' input schema declares the JSON Schema dialect " \
+            "#{sanitize_peer_log_text(dialect.inspect)[0, MAX_VIOLATION_TEXT]}: that dialect is not supported " \
+            "(supported: #{MCPClient::SchemaValidator::SUPPORTED_DIALECTS.join(', ')})"
     end
 
     # The token naming a tool definition ({MCPClient::Tool#schema_identity});

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1123,8 +1123,8 @@ module MCPClient
       key = [:structuredContent, 'structuredContent'].find { |k| result.key?(k) }
       unless key
         handle_structured_content_violation(
-          "Tool '#{tool.name}' declares an output schema but its successful result carries no structuredContent " \
-          '(required by the MCP tools spec)'
+          "Tool '#{sanitize_peer_log_text(tool.name.to_s)}' declares an output schema but its successful result " \
+          'carries no structuredContent (required by the MCP tools spec)'
         )
         return result
       end
@@ -1178,7 +1178,8 @@ module MCPClient
       return if unsupported.empty?
 
       @logger.warn(
-        "Structured content check for tool '#{tool.name}': validation is partial: schema uses unsupported " \
+        "Structured content check for tool '#{sanitize_peer_log_text(tool.name.to_s)}': validation is partial: " \
+        'schema uses unsupported ' \
         "keywords: #{unsupported.join(', ')} (full JSON Schema 2020-12 evaluation is not implemented, so " \
         'conforming-looking data may still violate the schema)'
       )

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -19,6 +19,10 @@ module MCPClient
     include MCPClient::Client::TaskSupport
     include MCPClient::Client::TaskApi
 
+    # Ceiling on the schema-violation text that reaches a log line or an
+    # exception (the validator already bounds its error count).
+    MAX_VIOLATION_TEXT = 4000
+
     # Elicitation modes implemented by this client (MCP 2025-11-25).
     # Requests with a mode outside this set are rejected with -32602.
     SUPPORTED_ELICITATION_MODES = %w[form url].freeze
@@ -1129,8 +1133,11 @@ module MCPClient
       # bounds) is a violation too, never a permissive pass.
       errors = MCPClient::SchemaValidator.validate(result[key], tool.output_schema)
       unless errors.empty?
+        # Schema and data text is peer-controlled: it is sanitized and
+        # bounded before it reaches a log line or an exception.
         handle_structured_content_violation(
-          "Structured content for tool '#{tool.name}' does not match its output schema: #{errors.join('; ')}"
+          "Structured content for tool '#{sanitize_peer_log_text(tool.name.to_s)}' does not match its output " \
+          "schema: #{sanitize_peer_log_text(errors.join('; '))[0, MAX_VIOLATION_TEXT]}"
         )
       end
       result
@@ -1146,12 +1153,15 @@ module MCPClient
     def warn_unusable_input_schema(tool)
       return if tool.schema.nil?
 
+      # Keyed by the schema itself as well, so a refreshed tool definition
+      # (list_changed, cache expiry, HeaderMismatch recovery) is re-checked.
       @input_schema_warnings ||= {}
       key = [tool.server&.object_id, tool.name]
-      return if @input_schema_warnings.key?(key)
+      identity = tool.schema.hash
+      return if @input_schema_warnings[key] == identity
 
       problems = MCPClient::SchemaValidator.check_schema(tool.schema)
-      @input_schema_warnings[key] = true
+      @input_schema_warnings[key] = identity
       return if problems.empty?
 
       @logger.warn("Tool '#{sanitize_peer_log_text(tool.name.to_s)}' input schema is not usable for validation: " \

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -729,12 +729,19 @@ module MCPClient
 
     # Whether a streamed chunk is the call's answer rather than an update on
     # its way. MCP 2026-07-28 makes `resultType` required and has clients
-    # treat an absent one as "complete", which is what every pre-2026 server
-    # sends.
+    # treat an absent one as "complete" — a rule for *results*, which is
+    # what every pre-2026 server sends. A chunk that carries no `resultType`
+    # and is shaped as no CallToolResult (a progress object, say) is an
+    # update on the way, not an answer to check against an output schema.
     # @param chunk [Object] one chunk of a streaming tools/call
     # @return [Boolean]
     def complete_call_result?(chunk)
-      chunk.is_a?(Hash) && MCPClient::JsonRpcCommon.result_type(chunk) == 'complete'
+      return false unless chunk.is_a?(Hash) && MCPClient::JsonRpcCommon.result_type(chunk) == 'complete'
+
+      # The members a CallToolResult is made of; a chunk carrying none of
+      # them (and no `resultType`) is not a result at all.
+      chunk.key?('resultType') || chunk.key?(:resultType) ||
+        %w[content structuredContent isError].any? { |member| chunk.key?(member) || chunk.key?(member.to_sym) }
     end
 
     # Hand the host's identity and request metadata to a transport.
@@ -1091,6 +1098,11 @@ module MCPClient
       schema = tool.schema
       state = input_schema_state(tool)
       reject_unsupported_dialect!(tool, state, 'input')
+      # An output schema nothing here could read is refused before the call
+      # too: the dialect error is due whatever the tool would answer, and a
+      # (possibly destructive) tool is not run for a result that cannot be
+      # checked.
+      reject_unsupported_dialect!(tool, output_schema_state(tool), 'output')
       # An input schema the validator cannot interpret asserts nothing: the
       # call goes out and the server judges its arguments.
       return if state[:unusable]
@@ -1137,6 +1149,10 @@ module MCPClient
     #   is missing from a successful result or does not match the schema
     def validate_structured_content!(tool, result)
       return result unless tool.structured_output? && result.is_a?(Hash)
+
+      # A dialect this client cannot read is an error for every result, an
+      # error result included (the MUST is not limited to successful ones).
+      reject_unsupported_dialect!(tool, output_schema_state(tool), 'output')
       return result if result['isError'] || result[:isError]
       # An unfinished result (MCP 2026-07-28 resultType "input_required") is
       # not a successful one either: it carries the continuation instead of
@@ -1146,7 +1162,6 @@ module MCPClient
       return result unless MCPClient::JsonRpcCommon.result_type(result) == 'complete'
 
       unsupported = warn_partial_schema_coverage(tool)
-      reject_unsupported_dialect!(tool, output_schema_state(tool), 'output')
       reject_partial_schema_coverage!(tool, unsupported)
 
       # MCP 2026-07-28: structuredContent "can be any JSON value (object,
@@ -1322,12 +1337,11 @@ module MCPClient
     end
 
     # :strict is a gate. A schema using an assertion this validator does not
-    # evaluate (the dynamic references, `unevaluatedItems` /
-    # `unevaluatedProperties` where a composition produces the annotations
-    # they read) cannot be shown to accept the result, and a result not shown
-    # to conform is refused there — a warning beside a returned value was a
-    # silent pass in everything but the log. A keyword that only annotates
-    # (`format`, `contentSchema`) decides nothing and does not refuse.
+    # evaluate (a dynamic reference the dynamic scope could re-bind) cannot
+    # be shown to accept the result, and a result not shown to conform is
+    # refused there — a warning beside a returned value was a silent pass in
+    # everything but the log. A keyword that only annotates (`format`,
+    # `contentSchema`) decides nothing and does not refuse.
     # @param tool [MCPClient::Tool] the tool whose output schema is being used
     # @param unsupported [Array<String>] what {#warn_partial_schema_coverage} found
     # @return [void]

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1156,23 +1156,32 @@ module MCPClient
     def warn_unusable_input_schema(tool)
       return false if tool.schema.nil?
 
-      # Keyed by the schema object itself as well, so a refreshed tool
+      # Keyed by the definition's identity as well, so a refreshed tool
       # definition (list_changed, cache expiry, HeaderMismatch recovery) is
-      # re-checked. The object, not its hash: hashing a peer-supplied
-      # document walks it whole (or overflows the stack) before the bounded
-      # check could reject it.
+      # re-checked while the copies the client cache hands out are not. The
+      # identity, not the schema's hash: hashing a peer-supplied document
+      # walks it whole (or overflows the stack) before the bounded check
+      # could reject it.
       @input_schema_warnings ||= {}
       key = [tool.server&.object_id, tool.name]
       known = @input_schema_warnings[key]
-      return known[:unusable] if known && known[:schema].equal?(tool.schema)
+      return known[:unusable] if known && known[:identity].equal?(tool_definition_identity(tool))
 
       problems = MCPClient::SchemaValidator.check_schema(tool.schema)
-      @input_schema_warnings[key] = { schema: tool.schema, unusable: !problems.empty? }
+      @input_schema_warnings[key] = { identity: tool_definition_identity(tool), unusable: !problems.empty? }
       return false if problems.empty?
 
       @logger.warn("Tool '#{sanitize_peer_log_text(tool.name.to_s)}' input schema is not usable for validation: " \
                    "#{sanitize_peer_log_text(problems.join('; '))}")
       true
+    end
+
+    # The token naming a tool definition ({MCPClient::Tool#schema_identity});
+    # a tool-like object without one is identified by itself.
+    # @param tool [MCPClient::Tool, Object]
+    # @return [Object]
+    def tool_definition_identity(tool)
+      tool.respond_to?(:schema_identity) ? tool.schema_identity : tool
     end
 
     # Warn (in both :warn and :strict modes) when a tool's output schema uses
@@ -1184,10 +1193,10 @@ module MCPClient
     def warn_partial_schema_coverage(tool)
       @output_schema_coverage ||= {}
       key = [tool.server&.object_id, tool.name]
-      return if @output_schema_coverage[key].equal?(tool.output_schema)
+      return if @output_schema_coverage[key].equal?(tool_definition_identity(tool))
 
       unsupported = MCPClient::SchemaValidator.unsupported_keywords(tool.output_schema)
-      @output_schema_coverage[key] = tool.output_schema
+      @output_schema_coverage[key] = tool_definition_identity(tool)
       return if unsupported.empty?
 
       @logger.warn(

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1182,6 +1182,12 @@ module MCPClient
       # not reach back over a legacy session.
       key = structured_content_key(result)
       key = nil if key && !result[key].is_a?(Hash) && legacy_server?(tool.server)
+      # Dropping the non-object leaves an error result what it was: one
+      # carrying no structured content, which it is allowed to be. Reporting
+      # it as a successful result missing its output would refuse — in
+      # :strict, raise on — a result the tools specification permits.
+      return result if key.nil? && (result['isError'] || result[:isError])
+
       unless key
         handle_structured_content_violation(
           "Tool '#{sanitize_peer_log_text(tool.name.to_s)}' declares an output schema but its successful result " \

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1129,6 +1129,12 @@ module MCPClient
       raise MCPClient::Errors::ValidationError, "Missing required parameters: #{missing.join(', ')}"
     end
 
+    # @param result [Hash] a tool result
+    # @return [Symbol, String, nil] the key its structuredContent sits under
+    def structured_content_key(result)
+      [:structuredContent, 'structuredContent'].find { |k| result.key?(k) }
+    end
+
     # Validate a tools/call result's structuredContent against the tool's
     # declared outputSchema (MCP 2025-11-25 server/tools spec: "Clients SHOULD
     # validate structured results against this schema"; a tool declaring an
@@ -1153,7 +1159,10 @@ module MCPClient
       # A dialect this client cannot read is an error for every result, an
       # error result included (the MUST is not limited to successful ones).
       reject_unsupported_dialect!(tool, output_schema_state(tool), 'output')
-      return result if result['isError'] || result[:isError]
+      # An error result may carry no structuredContent at all; one that does
+      # is bound by the output schema like any other (the tools specification
+      # exempts nothing about error results), so what is there is checked.
+      return result if (result['isError'] || result[:isError]) && !structured_content_key(result)
       # An unfinished result (MCP 2026-07-28 resultType "input_required") is
       # not a successful one either: it carries the continuation instead of
       # the tool's output. Checking it for structuredContent would fail the
@@ -1171,7 +1180,7 @@ module MCPClient
       # array, a string, a number, a boolean — is what it was there: no
       # structured content at all. The widening is a 2026-07-28 rule and does
       # not reach back over a legacy session.
-      key = [:structuredContent, 'structuredContent'].find { |k| result.key?(k) }
+      key = structured_content_key(result)
       key = nil if key && !result[key].is_a?(Hash) && legacy_server?(tool.server)
       unless key
         handle_structured_content_violation(
@@ -1337,7 +1346,7 @@ module MCPClient
     end
 
     # :strict is a gate. A schema using an assertion this validator does not
-    # evaluate (a dynamic reference the dynamic scope could re-bind) cannot
+    # evaluate (a dynamic reference only the evaluation path could bind) cannot
     # be shown to accept the result, and a result not shown to conform is
     # refused there — a warning beside a returned value was a silent pass in
     # everything but the log. A keyword that only annotates (`format`,

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -425,6 +425,7 @@ module MCPClient
       # each transport takes its own.
       servers.each do |server|
         CACHED_LIST_KINDS.each { |kind| refresh_server_cache(server, kind) }
+        forget_schema_checks
       end
     end
 
@@ -1286,6 +1287,25 @@ module MCPClient
       server.send(:take_called_tool_definition, tool_name.to_s)&.first
     end
 
+    # Forget the once-per-definition schema checks of the tool definitions a
+    # cache slice no longer holds. Their keys name a tool definition, so a
+    # server that keeps renaming its tools would otherwise grow both memos
+    # without bound; a definition still served is checked again on its next
+    # use, which its identity token decides anyway.
+    # @param server [MCPClient::ServerBase, nil] the server whose entries go,
+    #   or nil for every server
+    # @return [void]
+    def forget_schema_checks(server = nil)
+      [@input_schema_warnings, @output_schema_coverage].each do |memo|
+        next unless memo
+
+        if server
+          memo.delete_if { |(server_id, _name), _| server_id == server.object_id }
+        else
+          memo.clear
+        end
+      end
+    end
     # Generate a cache key for server-specific items
     # @param server [MCPClient::ServerBase] the server
     # @param item_id [String] the item identifier (name or URI)

--- a/lib/mcp_client/client/cache_slices.rb
+++ b/lib/mcp_client/client/cache_slices.rb
@@ -128,6 +128,7 @@ module MCPClient
           drop_cached_entries(cache, server)
           # This server's slice now stands for its whole list, empty or not.
           (@cache_filled[kind] ||= {}.compare_by_identity)[server] = true
+          forget_schema_checks(server) if kind == :tools
           if server.respond_to?(:current_params_fingerprint, true)
             # The slice is tied to the very transport entry its list came
             # from — its identity and the parameters that entry is bound to

--- a/lib/mcp_client/client/task_support.rb
+++ b/lib/mcp_client/client/task_support.rb
@@ -725,7 +725,7 @@ module MCPClient
       def validated_sync_result(result, tool)
         return result unless tool
 
-        validate_structured_content!(tool, result)
+        validate_called_result!(tool, result)
       end
 
       # The result a task delivered, validated against the definition the
@@ -740,7 +740,7 @@ module MCPClient
         tool = srv ? called_tool_for(task, srv) : called_tool_of(task)
         return result unless tool
 
-        validate_structured_content!(tool, result)
+        validate_called_result!(tool, result)
       end
 
       # The definition a handle carries, if the caller named the task with a

--- a/lib/mcp_client/http_transport_base/request_recovery.rb
+++ b/lib/mcp_client/http_transport_base/request_recovery.rb
@@ -97,6 +97,10 @@ module MCPClient
             retry
           end
         end
+      ensure
+        # A pin the retry never consumed (it raised before sending) must not
+        # outlive the request it was for.
+        clear_pinned_retry_definition
       end
 
       # Send the request, renegotiating the protocol version once if the server

--- a/lib/mcp_client/http_transport_base/request_recovery.rb
+++ b/lib/mcp_client/http_transport_base/request_recovery.rb
@@ -69,6 +69,11 @@ module MCPClient
             header_refreshed = true
             yield
             refresh_tools_after_header_mismatch(e)
+            # The rejected attempt did not run the tool; this retry is the
+            # send that would. A refreshed definition whose inputSchema
+            # declares an unreadable dialect must therefore stop the call
+            # here, not after it has been executed.
+            reject_unreadable_refreshed_schema!(params)
             retry
           rescue MCPClient::Errors::ResponseStreamClosedError => e
             # Modern Streamable HTTP has no resumption: "a broken response

--- a/lib/mcp_client/http_transport_base/tool_listing.rb
+++ b/lib/mcp_client/http_transport_base/tool_listing.rb
@@ -41,7 +41,7 @@ module MCPClient
       # @param params [Hash] the tools/call params being re-sent
       # @return [void]
       # @raise [MCPClient::Errors::ValidationError] when the refreshed input
-      #   schema declares a dialect this client does not implement
+      #   or output schema declares a dialect this client does not implement
       def reject_unreadable_refreshed_schema!(params)
         return unless params.is_a?(Hash)
 
@@ -51,13 +51,19 @@ module MCPClient
         # ({#mcp_param_headers} takes it): a second lookup could bring
         # another, unchecked one.
         pin_retry_definition(name, tool)
-        dialect = tool && MCPClient::SchemaValidator.unsupported_dialect(tool.schema)
-        return unless dialect
+        return unless tool
 
-        raise MCPClient::Errors::ValidationError,
-              "Tool #{sanitize_log_text(name.inspect)} input schema declares the JSON Schema dialect " \
-              "#{sanitize_log_text(dialect.inspect)[0, 128]}: that dialect is not supported " \
-              "(supported: #{MCPClient::SchemaValidator::SUPPORTED_DIALECTS.join(', ')})"
+        # Both schemas: a tool run under an output dialect nothing here can
+        # read would only be refused after it ran.
+        { 'input' => tool.schema, 'output' => tool.output_schema }.each do |side, schema|
+          dialect = schema.is_a?(Hash) && MCPClient::SchemaValidator.unsupported_dialect(schema)
+          next unless dialect
+
+          raise MCPClient::Errors::ValidationError,
+                "Tool #{sanitize_log_text(name.inspect)} #{side} schema declares the JSON Schema dialect " \
+                "#{sanitize_log_text(dialect.inspect)[0, 128]}: that dialect is not supported " \
+                "(supported: #{MCPClient::SchemaValidator::SUPPORTED_DIALECTS.join(', ')})"
+        end
       end
 
       # The Mcp-Param-* headers for a tools/call request (MCP 2026-07-28

--- a/lib/mcp_client/http_transport_base/tool_listing.rb
+++ b/lib/mcp_client/http_transport_base/tool_listing.rb
@@ -51,10 +51,21 @@ module MCPClient
         # ({#mcp_param_headers} takes it): a second lookup could bring
         # another, unchecked one.
         pin_retry_definition(name, tool)
+        reject_unreadable_tool_schema!(name, tool)
+      end
+
+      # Refuse a tool definition whose input or output schema declares a JSON
+      # Schema dialect this client cannot read, before the request it governs
+      # goes out: a tool run under an output dialect nothing here can read
+      # would only be refused after it ran, and the host would have paid for
+      # whatever it did.
+      # @param name [String] the tool name
+      # @param tool [MCPClient::Tool, nil] the definition the request goes out under
+      # @return [void]
+      # @raise [MCPClient::Errors::ValidationError]
+      def reject_unreadable_tool_schema!(name, tool)
         return unless tool
 
-        # Both schemas: a tool run under an output dialect nothing here can
-        # read would only be refused after it ran.
         { 'input' => tool.schema, 'output' => tool.output_schema }.each do |side, schema|
           dialect = schema.is_a?(Hash) && MCPClient::SchemaValidator.unsupported_dialect(schema)
           next unless dialect
@@ -84,8 +95,12 @@ module MCPClient
         tool = pinned ? pinned.first : known_tools_for_headers.find { |t| t.name.to_s == name }
         # The list the headers come from is the list this request goes out
         # under: a host re-resolving the tool after the call reads that
-        # definition back instead of asking for a possibly newer one.
+        # definition back instead of asking for a possibly newer one. It is
+        # also the definition the dialect guard has to read — this lookup may
+        # bring a newer one than the caller preflighted, and a pinned one has
+        # been checked already by the refresh that pinned it.
         note_called_tool_definition(name, tool)
+        reject_unreadable_tool_schema!(name, tool) unless pinned
         return {} unless tool
 
         MCPClient::HeaderParams.headers_for(tool.schema, params['arguments'] || params[:arguments])

--- a/lib/mcp_client/http_transport_base/tool_listing.rb
+++ b/lib/mcp_client/http_transport_base/tool_listing.rb
@@ -28,6 +28,34 @@ module MCPClient
         raise error
       end
 
+      # MCP 2026-07-28 basic "Implementation Requirements": a client "MUST
+      # handle unsupported dialects gracefully by returning an appropriate
+      # error indicating the dialect is not supported" — and, having done
+      # so, must not go on to act on the schema. MCPClient::Client refuses
+      # the dialect of the definition a call is prepared from, but the
+      # HeaderMismatch retry goes out under the definition the refresh
+      # brought instead, which this client never resolved. The rejection
+      # means the server did not execute the first attempt, so refusing the
+      # retry keeps the invariant the check is for: the call is never sent
+      # under a schema nothing could read.
+      # @param params [Hash] the tools/call params being re-sent
+      # @return [void]
+      # @raise [MCPClient::Errors::ValidationError] when the refreshed input
+      #   schema declares a dialect this client does not implement
+      def reject_unreadable_refreshed_schema!(params)
+        return unless params.is_a?(Hash)
+
+        name = (params['name'] || params[:name]).to_s
+        tool = known_tools_for_headers.find { |t| t.name.to_s == name }
+        dialect = tool && MCPClient::SchemaValidator.unsupported_dialect(tool.schema)
+        return unless dialect
+
+        raise MCPClient::Errors::ValidationError,
+              "Tool #{sanitize_log_text(name.inspect)} input schema declares the JSON Schema dialect " \
+              "#{sanitize_log_text(dialect.inspect)[0, 128]}: that dialect is not supported " \
+              "(supported: #{MCPClient::SchemaValidator::SUPPORTED_DIALECTS.join(', ')})"
+      end
+
       # The Mcp-Param-* headers for a tools/call request (MCP 2026-07-28
       # "Custom Headers from Tool Parameters"): the annotated arguments of the
       # tool, looked up in this transport's tool list (fetched on demand so a

--- a/lib/mcp_client/http_transport_base/tool_listing.rb
+++ b/lib/mcp_client/http_transport_base/tool_listing.rb
@@ -47,6 +47,10 @@ module MCPClient
 
         name = (params['name'] || params[:name]).to_s
         tool = known_tools_for_headers.find { |t| t.name.to_s == name }
+        # The definition checked here is the one the retry goes out under
+        # ({#mcp_param_headers} takes it): a second lookup could bring
+        # another, unchecked one.
+        pin_retry_definition(name, tool)
         dialect = tool && MCPClient::SchemaValidator.unsupported_dialect(tool.schema)
         return unless dialect
 
@@ -70,7 +74,8 @@ module MCPClient
         return {} unless params.is_a?(Hash)
 
         name = (params['name'] || params[:name]).to_s
-        tool = known_tools_for_headers.find { |t| t.name.to_s == name }
+        pinned = take_pinned_retry_definition(name)
+        tool = pinned ? pinned.first : known_tools_for_headers.find { |t| t.name.to_s == name }
         # The list the headers come from is the list this request goes out
         # under: a host re-resolving the tool after the call reads that
         # definition back instead of asking for a possibly newer one.

--- a/lib/mcp_client/result_caching.rb
+++ b/lib/mcp_client/result_caching.rb
@@ -375,7 +375,7 @@ module MCPClient
     def transport_thread_local_keys
       %i[served_entries_key recorded_entries_key response_received_key
          request_params_key round_trip_marker_key request_authorization_key
-         exchange_records_key called_tool_definition_key]
+         exchange_records_key called_tool_definition_key pinned_retry_definition_key]
         .select { |name| respond_to?(name, true) }
         .map { |name| send(name) }
     end

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -6,6 +6,7 @@ require_relative 'schema_validator/normalization'
 require_relative 'schema_validator/references'
 require_relative 'schema_validator/keyword_scan'
 require_relative 'schema_validator/composition'
+require_relative 'schema_validator/scalars'
 
 module MCPClient
   # Self-contained JSON Schema validator used to check a tool call result's
@@ -59,6 +60,7 @@ module MCPClient
     extend References
     extend KeywordScan
     extend Composition
+    extend Scalars
 
     # Raised inside a validation to abandon it (time budget, resource bound).
     class Aborted < StandardError; end
@@ -85,6 +87,19 @@ module MCPClient
     MAX_NODE_VISITS = 100_000
     MAX_ERRORS = 100
     MAX_VALUE_INSPECT = 64
+
+    # How deeply {.validate_node} may nest. The walk is plain recursion, so
+    # its depth is the interpreter's stack depth: the instance nests a level
+    # per array item or property, and a recursive `$ref` follows it down
+    # without bound (the hop budget restarts at every value, so that a
+    # recursive schema can describe deep data at all). A validation that
+    # outgrew the stack would raise SystemStackError past every bound this
+    # validator applies; nesting is counted instead, so the deepest instance
+    # aborts with one error like any other exhausted budget. The bound sits
+    # well above what a peer can send — `JSON.parse` refuses more than 100
+    # levels of nesting by default — and well below what the smallest stack
+    # this library runs on (a transport's reader thread) can carry.
+    MAX_NODE_DEPTH = 512
 
     # JSON Schema keywords that affect validation but that this validator
     # does not evaluate: assertion keywords (multipleOf, uniqueItems,
@@ -186,7 +201,7 @@ module MCPClient
     end
 
     # Per-validation state.
-    Context = Struct.new(:root, :deadline, :dialect, :visits, :errors, :speculative, :anchors, :undecided,
+    Context = Struct.new(:root, :deadline, :dialect, :visits, :errors, :speculative, :anchors, :undecided, :depth,
                          keyword_init: true)
 
     # Raised while normalizing a schema whose structure exceeds the bounds,
@@ -576,7 +591,8 @@ module MCPClient
       # subtrees its references adopted): a second one would make what a
       # reference resolves to depend on the order this instance applies them.
       ctx = Context.new(root: root, deadline: deadline, dialect: canonical_dialect(dialect(root)),
-                        visits: 0, errors: 0, speculative: 0, anchors: preflight[:anchors], undecided: 0)
+                        visits: 0, errors: 0, speculative: 0, anchors: preflight[:anchors], undecided: 0,
+                        depth: 0)
       validate_node(data, root, path, ctx, 0)
     rescue TooLarge => e
       ["#{path}: #{e.message}"]
@@ -584,7 +600,11 @@ module MCPClient
       ["#{path}: validation aborted: #{e.message}"]
     end
 
-    # Validate one value against one (sub)schema.
+    # Validate one value against one (sub)schema, under the bounds on the
+    # walk itself: one more node visited, one level deeper. The nesting is
+    # counted here rather than passed down, so every recursion into the walk
+    # is bounded — an instance nesting a level per item, a subschema, and a
+    # `$ref` followed from either.
     # @param data [Object] the value
     # @param schema [Object] a subschema (Hash or boolean)
     # @param path [String] location for error messages
@@ -594,6 +614,18 @@ module MCPClient
     # @raise [Aborted] when a bound is hit
     def self.validate_node(data, schema, path, ctx, ref_depth)
       count_visit(ctx)
+      ctx.depth += 1
+      raise Aborted, "instance or schema nesting deeper than #{MAX_NODE_DEPTH}" if ctx.depth > MAX_NODE_DEPTH
+
+      validate_node_keywords(data, schema, path, ctx, ref_depth)
+    ensure
+      ctx.depth -= 1
+    end
+
+    # Apply one (sub)schema's keywords to one value, the walk's own bounds
+    # already accounted for by {.validate_node}.
+    # @return [Array<String>] validation errors
+    def self.validate_node_keywords(data, schema, path, ctx, ref_depth)
       return [] if schema == true
       return count_errors(ctx, ["#{path}: schema false accepts no value"]) if schema == false
       return [] unless schema.is_a?(Hash)
@@ -845,97 +877,6 @@ module MCPClient
         errors.concat(validate_node(item, item_schema, "#{path}/#{idx}", ctx, 0))
       end
       errors.concat(validate_contains(data, schema, path, dialect))
-    end
-
-    # Validate a string against minLength/maxLength/pattern.
-    # @param data [String] the string
-    # @param schema [Hash] string-keyed schema
-    # @param path [String] location for error messages
-    # @return [Array<String>] validation errors
-    def self.validate_string(data, schema, path, deadline = nil)
-      errors = []
-      min_length = schema['minLength']
-      max_length = schema['maxLength']
-      if min_length.is_a?(Numeric) && data.length < min_length
-        errors << "#{path}: string is shorter than minLength #{min_length}"
-      end
-      if max_length.is_a?(Numeric) && data.length > max_length
-        errors << "#{path}: string is longer than maxLength #{max_length}"
-      end
-      errors.concat(validate_pattern(data, schema['pattern'], path, deadline))
-      errors
-    end
-
-    # Validate a string against a regular-expression pattern.
-    # Invalid patterns are not enforced.
-    #
-    # The pattern comes from the tool's outputSchema, i.e. from the remote
-    # server, so matching runs against the validation-wide deadline: neither a
-    # single expensive expression nor many cheap-looking ones can pin the
-    # calling thread. A match that exceeds the budget aborts the validation
-    # rather than silently accepting the value — the value was never shown
-    # to satisfy the schema.
-    # @param data [String] the string
-    # @param pattern [Object] the pattern keyword value
-    # @param path [String] location for error messages
-    # @param deadline [Float, nil] monotonic deadline for the whole validation
-    # @return [Array<String>] validation errors
-    # @raise [Aborted] when the budget is exhausted
-    def self.validate_pattern(data, pattern, path, deadline = nil)
-      return [] unless pattern.is_a?(String)
-
-      remaining = pattern_budget_remaining(deadline)
-      raise Aborted, "validation time budget exhausted before pattern #{clip(pattern.inspect)}" if remaining.zero?
-
-      return [] if data.match?(Regexp.new(pattern, timeout: remaining))
-
-      ["#{path}: string does not match pattern #{clip(pattern.inspect)}"]
-    rescue Regexp::TimeoutError
-      raise Aborted, "pattern #{clip(pattern.inspect)} exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"
-    rescue RegexpError
-      []
-    end
-
-    # Time left in the validation-wide budget.
-    # @param deadline [Float, nil] monotonic deadline, or nil for a lone match
-    # @return [Float] seconds available; 0.0 when exhausted
-    def self.pattern_budget_remaining(deadline)
-      return PATTERN_MATCH_TIMEOUT unless deadline
-
-      remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      return 0.0 if remaining <= 0
-
-      [remaining, MIN_PATTERN_MATCH_TIMEOUT].max
-    end
-
-    # Validate a number against its bounds. `minimum` / `maximum` and
-    # `exclusiveMinimum` / `exclusiveMaximum` are four independent numeric
-    # assertions in every supported dialect (draft-07 validation Sections
-    # 6.2.2-6.2.5); each present one is applied.
-    # @param data [Numeric] the number
-    # @param schema [Hash] string-keyed schema
-    # @param path [String] location for error messages
-    # @return [Array<String>] validation errors
-    def self.validate_number(data, schema, path, _dialect = nil)
-      errors = []
-      minimum = schema['minimum']
-      maximum = schema['maximum']
-      exclusive_min = schema['exclusiveMinimum']
-      exclusive_max = schema['exclusiveMaximum']
-      shown = clip_value(data)
-      if minimum.is_a?(Numeric) && data < minimum
-        errors << "#{path}: value #{shown} is less than minimum #{clip_value(minimum)}"
-      end
-      if maximum.is_a?(Numeric) && data > maximum
-        errors << "#{path}: value #{shown} is greater than maximum #{clip_value(maximum)}"
-      end
-      if exclusive_min.is_a?(Numeric) && data <= exclusive_min
-        errors << "#{path}: value #{shown} must be greater than exclusiveMinimum #{clip_value(exclusive_min)}"
-      end
-      if exclusive_max.is_a?(Numeric) && data >= exclusive_max
-        errors << "#{path}: value #{shown} must be less than exclusiveMaximum #{clip_value(exclusive_max)}"
-      end
-      errors
     end
 
     # Bound a piece of peer-derived text destined for a message.

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -20,9 +20,11 @@ module MCPClient
   # - allOf, anyOf, oneOf, not, if/then/else (composition)
   # - $ref to a location inside the same schema document (`#`, `#/$defs/x`,
   #   `#/definitions/x`, any JSON pointer, or a plain-name fragment `#name`
-  #   naming an `$anchor` / a draft-07 `$id: "#name"`), with $defs /
-  #   definitions; under draft-07 a $ref replaces its siblings, under
-  #   2019-09 and 2020-12 it applies alongside them
+  #   naming an `$anchor` / a draft-07 `$id: "#name"` of the referencing
+  #   schema's own resource — a subschema whose `$id` is a URI starts a new
+  #   resource), with $defs (2019-09, 2020-12) / definitions (draft-07);
+  #   under draft-07 a $ref replaces its siblings, under 2019-09 and 2020-12
+  #   it applies alongside them
   # - boolean schemas (true / false), at the root or as subschemas
   #
   # MCP 2026-07-28 rules honoured here:
@@ -141,7 +143,9 @@ module MCPClient
       'contentSchema' => [DEFAULT_DIALECT, DRAFT_2019_09],
       'minContains' => [DEFAULT_DIALECT, DRAFT_2019_09],
       'maxContains' => [DEFAULT_DIALECT, DRAFT_2019_09],
-      '$anchor' => [DEFAULT_DIALECT, DRAFT_2019_09]
+      '$anchor' => [DEFAULT_DIALECT, DRAFT_2019_09],
+      '$defs' => [DEFAULT_DIALECT, DRAFT_2019_09],
+      'definitions' => [DRAFT_07]
     }.freeze
 
     # Plain-name fragment syntax (JSON Schema 2020-12 Section 8.2.2).
@@ -206,36 +210,27 @@ module MCPClient
       end
 
       problems = []
-      walk_schema(root, root, 0, { count: 0, dialect: canonical_dialect(declared) }, problems)
+      counter = { count: 0, dialect: canonical_dialect(declared), walked: {}.compare_by_identity }
+      walk_schema(root, root, 0, counter, problems)
       problems.uniq
     end
 
-    # Walk every subschema position, checking bounds and references.
+    # Walk every subschema position, checking bounds and references. A
+    # schema object is walked once, however many positions or references
+    # lead to it, so a recursive schema stays within the bounds.
     # @return [void]
     def self.walk_schema(schema, root, depth, counter, problems)
-      return unless problems.empty?
-      return unless schema_value?(schema)
-
-      counter[:count] += 1
-      if counter[:count] > MAX_SUBSCHEMAS
-        problems << "schema has more than #{MAX_SUBSCHEMAS} subschemas"
-        return
-      end
-      return unless schema.is_a?(Hash)
-
-      if depth > MAX_SCHEMA_DEPTH
-        problems << "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}"
-        return
-      end
+      return unless problems.empty? && schema_value?(schema)
+      return unless admit_schema?(schema, depth, counter, problems)
 
       dialect = counter[:dialect]
-      check_ref(schema['$ref'], root, problems, dialect, counter) if schema.key?('$ref')
+      check_ref(schema, root, depth, problems, dialect, counter) if schema.key?('$ref')
       # draft-07: the $ref replaces its siblings, so the applicators next to
-      # it are never applied and are not preflighted either; $defs /
-      # definitions are a bag of reusable schemas, not applicators, and stay
-      # reachable through references.
+      # it are never applied and are not preflighted either; definitions are
+      # a bag of reusable schemas, not applicators, and stay reachable
+      # through references.
       if dialect == DRAFT_07 && schema.key?('$ref')
-        each_definition(schema) { |sub| walk_schema(sub, root, depth + 1, counter, problems) }
+        each_definition(schema, dialect) { |sub| walk_schema(sub, root, depth + 1, counter, problems) }
         return
       end
 
@@ -250,6 +245,27 @@ module MCPClient
       check_applicator_shapes(schema, dialect, problems)
       check_exclusive_bounds(schema, dialect, problems)
       each_subschema(schema, dialect) { |sub| walk_schema(sub, root, depth + 1, counter, problems) }
+    end
+
+    # Account for a schema object about to be walked: once per object, and
+    # within the subschema and nesting bounds.
+    # @return [Boolean] whether the object's keywords are to be walked
+    def self.admit_schema?(schema, depth, counter, problems)
+      return false if schema.is_a?(Hash) && counter[:walked].key?(schema)
+
+      counter[:walked][schema] = true if schema.is_a?(Hash)
+      counter[:count] += 1
+      if counter[:count] > MAX_SUBSCHEMAS
+        problems << "schema has more than #{MAX_SUBSCHEMAS} subschemas"
+        return false
+      end
+      return false unless schema.is_a?(Hash)
+
+      if depth > MAX_SCHEMA_DEPTH
+        problems << "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}"
+        return false
+      end
+      true
     end
 
     # Every applicator value must be a schema (object or boolean), an array
@@ -344,16 +360,24 @@ module MCPClient
       end
     end
 
-    # Yield the reusable schemas under $defs / definitions only.
+    # Yield the reusable schemas under the definition bag(s) the dialect
+    # defines (`$defs` in 2019-09 / 2020-12, `definitions` in draft-07; both
+    # when no dialect is given).
     # @return [void]
-    def self.each_definition(schema, &block)
+    def self.each_definition(schema, dialect = nil, &block)
       %w[$defs definitions].each do |keyword|
+        next unless keyword_known?(keyword, dialect)
+
         schema[keyword].each_value(&block) if schema[keyword].is_a?(Hash)
       end
     end
 
+    # Check the `$ref` of a schema object and preflight what it reaches: a
+    # pointer may lead into a bag the dialect does not walk (`definitions`
+    # under 2020-12), and what a reference applies must be usable too.
     # @return [void]
-    def self.check_ref(ref, root, problems, dialect, counter)
+    def self.check_ref(schema, root, depth, problems, dialect, counter)
+      ref = schema['$ref']
       unless ref.is_a?(String)
         problems << "$ref must be a string, got #{json_type(ref)}"
         return
@@ -364,7 +388,9 @@ module MCPClient
         return
       end
 
-      problem = ref_chain_problem(ref, root, dialect, counter)
+      problem = ref_chain_problem(ref, root, dialect, counter, from: schema) do |target|
+        walk_schema(target, root, depth + 1, counter, problems)
+      end
       problems << problem if problem
     end
 
@@ -380,10 +406,21 @@ module MCPClient
 
     # Follow a local reference (and the references it leads to) at
     # preflight: every hop must resolve to a schema, the chain must not
-    # cycle, and it must stay within MAX_REF_DEPTH.
+    # cycle, and it must stay within MAX_REF_DEPTH. Once the whole chain
+    # checks out, every target it reached is yielded so the caller can
+    # preflight what the reference applies.
     # @param resolver [Hash, Context] holder of the memoized anchor index
+    # @param from [Hash] the schema object holding the reference
     # @return [String, nil] the problem, if any
-    def self.ref_chain_problem(ref, root, dialect, resolver)
+    def self.ref_chain_problem(ref, root, dialect, resolver, from:, &block)
+      targets = []
+      problem = follow_ref_chain(ref, root, dialect, resolver, from) { |target| targets << target }
+      targets.each(&block) if problem.nil? && block
+      problem
+    end
+
+    # @return [String, nil] the problem, if any; each resolved target is yielded
+    def self.follow_ref_chain(ref, root, dialect, resolver, from)
       seen = []
       current = ref
       loop do
@@ -391,11 +428,14 @@ module MCPClient
         return "$ref chain #{clip(ref.inspect)} exceeds #{MAX_REF_DEPTH} hops" if seen.size >= MAX_REF_DEPTH
 
         seen << current
-        target = resolve_reference(root, current, dialect, resolver)
+        target = resolve_reference(root, current, dialect, resolver, from: from)
         return "unresolvable local $ref #{clip(current.inspect)}" if target.equal?(UNRESOLVED)
         return "$ref #{clip(current.inspect)} does not point at a schema" unless schema_value?(target)
+
+        yield target
         return nil unless target.is_a?(Hash) && target.key?('$ref')
 
+        from = target
         current = target['$ref']
         return "$ref must be a string, got #{json_type(current)}" unless current.is_a?(String)
         return "external $ref #{clip(current.inspect)} is not dereferenced" if external_ref?(current)
@@ -416,12 +456,16 @@ module MCPClient
     # top level or nested in subschemas). Property names that merely look like
     # keywords (e.g. a property called 'not') are not reported, and
     # data-carrying keywords (enum/const/default/examples) are not scanned.
+    # The scan stops at the same bounds as {.check_schema} (a schema beyond
+    # them is unusable anyway), so a huge server-supplied schema is never
+    # walked whole.
     # @param schema [Object] the JSON schema (string or symbol keys)
     # @return [Array<String>] unique unsupported keywords, in discovery order
     def self.unsupported_keywords(schema)
       found = []
       declared = dialect(schema)
-      collect_unsupported_keywords(schema, found, 0, declared && canonical_dialect(declared))
+      scan = { count: 0, dialect: declared && canonical_dialect(declared) }
+      collect_unsupported_keywords(schema, found, 0, scan)
       found.uniq
     end
 
@@ -429,14 +473,17 @@ module MCPClient
     # dialect does not define are unknown, not unsupported).
     # @param schema [Object] a (sub)schema; non-Hash values are ignored
     # @param found [Array<String>] accumulator
-    # @param dialect [String, nil] the canonical dialect
+    # @param scan [Hash] :count of subschemas seen so far and the canonical :dialect
     # @return [void]
-    def self.collect_unsupported_keywords(schema, found, depth, dialect)
+    def self.collect_unsupported_keywords(schema, found, depth, scan)
       return unless schema.is_a?(Hash) && depth <= MAX_SCHEMA_DEPTH
 
+      scan[:count] += 1
+      return if scan[:count] > MAX_SUBSCHEMAS
+
       schema = schema.transform_keys(&:to_s)
-      found.concat((schema.keys & UNSUPPORTED_KEYWORDS).select { |k| keyword_known?(k, dialect) })
-      each_subschema(schema, dialect) { |sub| collect_unsupported_keywords(sub, found, depth + 1, dialect) }
+      found.concat((schema.keys & UNSUPPORTED_KEYWORDS).select { |k| keyword_known?(k, scan[:dialect]) })
+      each_subschema(schema, scan[:dialect]) { |sub| collect_unsupported_keywords(sub, found, depth + 1, scan) }
     end
 
     # Validate data against a schema. An unusable schema (see
@@ -478,11 +525,11 @@ module MCPClient
 
       # draft-07: "$ref" replaces the schema it appears in; later drafts
       # apply it alongside the sibling keywords.
-      return validate_ref(data, schema['$ref'], path, ctx, ref_depth) if schema.key?('$ref') && ctx.dialect == DRAFT_07
+      return validate_ref(data, schema, path, ctx, ref_depth) if schema.key?('$ref') && ctx.dialect == DRAFT_07
 
       errors = []
       counted_before = ctx.errors
-      errors.concat(validate_ref(data, schema['$ref'], path, ctx, ref_depth)) if schema.key?('$ref')
+      errors.concat(validate_ref(data, schema, path, ctx, ref_depth)) if schema.key?('$ref')
       errors.concat(validate_type(data, schema['type'], path)) if schema.key?('type')
       errors.concat(validate_enum(data, schema, path))
       case data
@@ -535,9 +582,11 @@ module MCPClient
       deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
     end
 
-    # Apply a local $ref.
+    # Apply the local $ref of a schema object.
+    # @param schema [Hash] the schema object holding the `$ref`
     # @return [Array<String>] validation errors
-    def self.validate_ref(data, ref, path, ctx, ref_depth)
+    def self.validate_ref(data, schema, path, ctx, ref_depth)
+      ref = schema['$ref']
       if !ref.is_a?(String) || external_ref?(ref)
         return count_errors(ctx, ["#{path}: external $ref #{clip(ref.inspect)} is not dereferenced"])
       end
@@ -545,7 +594,7 @@ module MCPClient
         raise Aborted, "$ref chain exceeds #{MAX_REF_DEPTH} hops (cycle?) at #{clip(ref.inspect)}"
       end
 
-      target = resolve_reference(ctx.root, ref, ctx.dialect, ctx)
+      target = resolve_reference(ctx.root, ref, ctx.dialect, ctx, from: schema)
       return count_errors(ctx, ["#{path}: unresolvable local $ref #{clip(ref.inspect)}"]) if target.equal?(UNRESOLVED)
       unless schema_value?(target)
         return count_errors(ctx, ["#{path}: $ref #{clip(ref.inspect)} does not point at a schema"])

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -598,7 +598,7 @@ module MCPClient
 
       # A keyword the validator does not evaluate makes this node's verdict
       # partial: a pass here is not a proof for not / oneOf / if.
-      ctx.undecided += 1 if partial_keywords?(schema, dialect, data)
+      ctx.undecided += 1 if partial_keywords?(schema, dialect, data, ctx.deadline)
       errors = []
       counted_before = ctx.errors
       errors.concat(validate_ref(data, schema, path, ctx, ref_depth)) if schema.key?('$ref')

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -455,7 +455,8 @@ module MCPClient
           next
         end
 
-        target_depth = (counter[:depths] || {})[target] || (depth + 1)
+        target_depth = (counter[:depths] || {})[target] ||
+                       referenced_position_depth(hop, root, counter[:dialect], counter, from) || (depth + 1)
         walk_schema(target, root, target_depth, counter, problems, indexed_dialect(target, counter) || dialect)
       end
       problems << problem if problem

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -324,27 +324,6 @@ module MCPClient
       schema.is_a?(Hash)
     end
 
-    # The lexical nesting depth of every schema object reachable from the
-    # root (subschema positions, definition bags of any dialect), so a
-    # referenced target is bounded by where it is written, not by where it
-    # is referenced from: neither member order nor reference fan-out can
-    # change the verdict.
-    # @return [Hash{Hash => Integer}] identity-keyed
-    def self.lexical_depths(root, dialect)
-      depths = {}.compare_by_identity
-      pending = [[root, 0]]
-      while (schema, depth = pending.shift)
-        next unless schema.is_a?(Hash) && !depths.key?(schema)
-
-        depths[schema] = depth
-        break if depths.size > MAX_SUBSCHEMAS * 2
-
-        each_subschema(schema, dialect) { |sub| pending << [sub, depth + 1] }
-        each_foreign_definition(schema, dialect) { |sub| pending << [sub, depth + 1] }
-      end
-      depths
-    end
-
     # Every applicator value must be a schema (object or boolean), an array
     # of schemas or a map of schemas; anything else is not silently read as
     # "true". Keywords the dialect does not define are ignored.
@@ -465,11 +444,16 @@ module MCPClient
         return
       end
 
-      problem = ref_chain_problem(ref, root, counter[:dialect], counter, from: schema) do |target|
+      problem = ref_chain_problem(ref, root, counter[:dialect], counter, from: schema) do |target, hop, from|
         # What a reference reaches is walked under its own resource's dialect
         # and at its own lexical depth; a boolean target needs no preflight
-        # and is not charged per reference.
-        next unless target.is_a?(Hash)
+        # and is not charged per reference, but its position still obeys the
+        # depth bound.
+        unless target.is_a?(Hash)
+          position = referenced_position_depth(hop, root, counter[:dialect], counter, from)
+          problems << "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}" if position && position > MAX_SCHEMA_DEPTH
+          next
+        end
 
         target_depth = (counter[:depths] || {})[target] || (depth + 1)
         walk_schema(target, root, target_depth, counter, problems, indexed_dialect(target, counter) || dialect)
@@ -497,8 +481,8 @@ module MCPClient
     # @return [String, nil] the problem, if any
     def self.ref_chain_problem(ref, root, dialect, resolver, from:, &block)
       targets = []
-      problem = follow_ref_chain(ref, root, dialect, resolver, from) { |target| targets << target }
-      targets.each(&block) if problem.nil? && block
+      problem = follow_ref_chain(ref, root, dialect, resolver, from) { |*hop| targets << hop }
+      targets.each { |target, used, origin| block.call(target, used, origin) } if problem.nil? && block
       problem
     end
 
@@ -518,7 +502,7 @@ module MCPClient
         return "$ref chain #{clip(ref.inspect)} cycles" if target.is_a?(Hash) && seen.key?(target)
 
         seen[target] = true if target.is_a?(Hash)
-        yield target
+        yield target, current, from
         return nil unless target.is_a?(Hash) && target.key?('$ref')
 
         from = target

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -449,15 +449,21 @@ module MCPClient
         # and at its own lexical depth; a boolean target needs no preflight
         # and is charged once per distinct position (not per reference),
         # and that position still obeys the depth bound.
+        position, opaque = pointer_position(hop, root, counter[:dialect], counter, from)
         unless target.is_a?(Hash)
-          position = referenced_position_depth(hop, root, counter[:dialect], counter, from)
           problems << "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}" if position && position > MAX_SCHEMA_DEPTH
-          charge_boolean_target(hop, root, from, counter, problems)
+          # A boolean in a position the walk visits was admitted there; one
+          # behind an opaque keyword is charged here, once per position.
+          charge_boolean_target(hop, root, from, counter, problems) if opaque
           next
         end
 
-        target_depth = (counter[:depths] || {})[target] ||
-                       referenced_position_depth(hop, root, counter[:dialect], counter, from) || (depth + 1)
+        lexical = (counter[:depths] || {})[target]
+        target_depth = if opaque
+                         [position, lexical].compact.max || (depth + 1)
+                       else
+                         lexical || position || (depth + 1)
+                       end
         walk_schema(target, root, target_depth, counter, problems, indexed_dialect(target, counter) || dialect)
       end
       problems << problem if problem

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -447,11 +447,12 @@ module MCPClient
       problem = ref_chain_problem(ref, root, counter[:dialect], counter, from: schema) do |target, hop, from|
         # What a reference reaches is walked under its own resource's dialect
         # and at its own lexical depth; a boolean target needs no preflight
-        # and is not charged per reference, but its position still obeys the
-        # depth bound.
+        # and is charged once per distinct position (not per reference),
+        # and that position still obeys the depth bound.
         unless target.is_a?(Hash)
           position = referenced_position_depth(hop, root, counter[:dialect], counter, from)
           problems << "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}" if position && position > MAX_SCHEMA_DEPTH
+          charge_boolean_target(hop, root, from, counter, problems)
           next
         end
 
@@ -460,6 +461,25 @@ module MCPClient
         walk_schema(target, root, target_depth, counter, problems, indexed_dialect(target, counter) || dialect)
       end
       problems << problem if problem
+    end
+
+    # Count a boolean a reference reaches toward the subschema bound, once
+    # per distinct position (resource and decoded pointer): a document may
+    # not hide thousands of applied schemas behind pointer-addressable
+    # booleans.
+    # @return [void]
+    def self.charge_boolean_target(hop, root, from, counter, problems)
+      tokens = pointer_tokens(hop)
+      return unless tokens
+
+      resource = (counter[:anchors] && from && counter[:anchors][:resources][from]) || root
+      key = [resource.object_id, tokens]
+      seen = (counter[:boolean_targets] ||= {})
+      return if seen.key?(key)
+
+      seen[key] = true
+      counter[:count] += 1
+      problems << "schema has more than #{MAX_SUBSCHEMAS} subschemas" if counter[:count] > MAX_SUBSCHEMAS
     end
 
     # A `$dynamicRef` / `$recursiveRef` is not evaluated, but one pointing

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -449,12 +449,13 @@ module MCPClient
         # and at its own lexical depth; a boolean target needs no preflight
         # and is charged once per distinct position (not per reference),
         # and that position still obeys the depth bound.
-        position, opaque = pointer_position(hop, root, counter[:dialect], counter, from)
+        position, opaque, visited = pointer_position(hop, root, counter[:dialect], counter, from)
         unless target.is_a?(Hash)
           problems << "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}" if position && position > MAX_SCHEMA_DEPTH
           # A boolean in a position the walk visits was admitted there; one
-          # behind an opaque keyword is charged here, once per position.
-          charge_boolean_target(hop, root, from, counter, problems) if opaque
+          # the walk never reaches (behind an opaque keyword, or beside a
+          # draft-07 $ref) is charged here, once per position.
+          charge_boolean_target(hop, root, from, counter, problems) unless visited
           next
         end
 

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -1,43 +1,83 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 module MCPClient
   # Self-contained JSON Schema validator used to check a tool call result's
-  # structuredContent against the tool's declared outputSchema (MCP 2025-11-25
-  # server/tools spec: "Clients SHOULD validate structured results against this
-  # schema"; the default schema dialect is JSON Schema 2020-12 per SEP-1613).
+  # structuredContent against the tool's declared outputSchema (MCP server/tools
+  # spec: "Clients SHOULD validate structured results against this schema";
+  # the default schema dialect is JSON Schema 2020-12 per basic "JSON Schema
+  # Usage").
   #
-  # Only the common JSON Schema keywords are supported:
+  # Supported keywords:
   # - type (single value or array of values), enum, const
   # - properties, required (objects)
   # - items, minItems, maxItems (arrays)
   # - minLength, maxLength, pattern (strings)
   # - minimum, maximum, exclusiveMinimum, exclusiveMaximum (numbers)
+  # - allOf, anyOf, oneOf, not, if/then/else (composition)
+  # - $ref to a location inside the same schema document (`#`, `#/$defs/x`,
+  #   `#/definitions/x`, any JSON pointer), with $defs / definitions
+  # - boolean schemas (true / false)
   #
-  # The full JSON Schema 2020-12 vocabulary ($ref/$defs, allOf/anyOf/oneOf/not,
-  # conditional keywords, additionalProperties, format assertions, ...) is out
-  # of scope: unrecognized keywords are ignored rather than misapplied, so
-  # validation is best-effort — it may accept data a full validator would
-  # reject, but it does not reject data that conforms to the schema. So that
-  # this gap is never silent, {.unsupported_keywords} reports which unapplied
-  # validation keywords a schema uses; callers surface them as a warning.
+  # MCP 2026-07-28 rules honoured here:
+  # - a schema without `$schema` is 2020-12; the dialects in
+  #   SUPPORTED_DIALECTS are accepted and any other declared dialect is an
+  #   error (not a permissive pass);
+  # - `$ref` values that do not point inside the document (network URIs,
+  #   relative documents, urn:, file:) are never dereferenced, and a schema
+  #   carrying one is rejected rather than treated as permissive;
+  # - resource bounds: schema nesting depth, total subschema count, `$ref`
+  #   chain length and a per-validation time budget.
+  #
+  # The rest of the 2020-12 vocabulary (additionalProperties, format
+  # assertions, unevaluated*, ...) is out of scope: unrecognized keywords are
+  # ignored rather than misapplied, so validation is best-effort — it may
+  # accept data a full validator would reject, but it does not reject data
+  # that conforms to the schema. So that this gap is never silent,
+  # {.unsupported_keywords} reports which unapplied validation keywords a
+  # schema uses; callers surface them as a warning.
   module SchemaValidator
+    # The default dialect (basic "JSON Schema Usage": "When a schema does not
+    # include a $schema field, it defaults to JSON Schema 2020-12").
+    DEFAULT_DIALECT = 'https://json-schema.org/draft/2020-12/schema'
+
+    # Dialects this validator accepts: the keywords it evaluates have the
+    # same meaning in all three. Any other declared dialect is reported as
+    # unsupported ("MUST handle unsupported dialects gracefully by returning
+    # an appropriate error indicating the dialect is not supported").
+    SUPPORTED_DIALECTS = [
+      DEFAULT_DIALECT,
+      'https://json-schema.org/draft/2019-09/schema',
+      'http://json-schema.org/draft-07/schema'
+    ].freeze
+
+    # Resource bounds ("Composition-Keyword Resource Use": implementations
+    # SHOULD apply a maximum schema depth, a cap on the total number of
+    # subschemas, or a per-validation time budget). A schema comes from the
+    # remote server, so all three apply.
+    MAX_SCHEMA_DEPTH = 64
+    MAX_SUBSCHEMAS = 2000
+    MAX_REF_DEPTH = 32
+
     # JSON Schema 2020-12 keywords that affect validation but that this
-    # validator does not evaluate: applicator/reference keywords, assertion
-    # keywords (multipleOf, uniqueItems, contains bounds, property-count
-    # bounds, dependentRequired), and format (asserted by full validators in
-    # format-assertion mode). Their presence means validation is partial: data
-    # may pass here that a full validator would reject.
+    # validator does not evaluate: assertion keywords (multipleOf,
+    # uniqueItems, contains bounds, property-count bounds, dependentRequired),
+    # the remaining applicators, and format (asserted by full validators in
+    # format-assertion mode). Their presence means validation is partial:
+    # data may pass here that a full validator would reject.
     UNSUPPORTED_KEYWORDS = %w[
-      $ref $dynamicRef $defs allOf anyOf oneOf not if then else
+      $dynamicRef
       additionalProperties patternProperties propertyNames dependentSchemas
       prefixItems contains minContains maxContains uniqueItems
       multipleOf format dependentRequired minProperties maxProperties
       unevaluatedProperties unevaluatedItems
     ].freeze
 
-    # Wall-clock budget for ALL pattern matching in a single validate call.
-    # Schemas come from the remote server, so an expensive expression must not
-    # be able to monopolize the calling thread.
+    # Wall-clock budget for a single validate call (pattern matching and the
+    # walk itself). Schemas come from the remote server, so an expensive
+    # expression or a huge composition must not be able to monopolize the
+    # calling thread.
     #
     # The budget is for the whole operation, not per match: a per-match limit
     # multiplies, since the server also controls how many strings it sends
@@ -59,6 +99,135 @@ module MCPClient
 
     # Keywords whose value is an array of subschemas.
     SUBSCHEMA_ARRAY_KEYWORDS = %w[allOf anyOf oneOf prefixItems].freeze
+
+    # Per-validation state: the root document ($ref targets), the deadline
+    # and the number of $ref hops taken on the current path.
+    Context = Struct.new(:root, :deadline, keyword_init: true)
+
+    # The dialect a schema declares, or the default.
+    # @param schema [Object] the schema
+    # @return [String] the `$schema` value (without a trailing `#`), or DEFAULT_DIALECT
+    def self.dialect(schema)
+      return DEFAULT_DIALECT unless schema.is_a?(Hash)
+
+      declared = schema['$schema'] || schema[:$schema]
+      return DEFAULT_DIALECT unless declared.is_a?(String) && !declared.empty?
+
+      declared.sub(/#\z/, '')
+    end
+
+    # Whether a declared dialect is one this validator evaluates. The
+    # scheme is not significant (both http and https forms circulate).
+    # @param uri [String]
+    # @return [Boolean]
+    def self.supported_dialect?(uri)
+      canonical = uri.sub(/#\z/, '').sub(%r{\Ahttps?://}, '')
+      SUPPORTED_DIALECTS.any? { |d| d.sub(%r{\Ahttps?://}, '') == canonical }
+    end
+
+    # Check that a schema can be used at all: it is an object, its dialect
+    # is supported, it stays within the resource bounds, and every `$ref`
+    # resolves inside the document (a network or otherwise external `$ref`
+    # is never dereferenced and makes the schema unusable rather than
+    # permissive).
+    # @param schema [Object] the schema (string or symbol keys)
+    # @return [Array<String>] problems (empty when the schema is usable)
+    def self.check_schema(schema)
+      return ["schema must be an object, got #{json_type(schema)}"] unless schema.is_a?(Hash)
+
+      root = deep_stringify(schema)
+      declared = dialect(root)
+      unless supported_dialect?(declared)
+        return ["schema dialect #{declared.inspect} is not supported (supported: #{SUPPORTED_DIALECTS.join(', ')})"]
+      end
+
+      problems = []
+      walk_schema(root, root, 0, { count: 0 }, problems)
+      problems.uniq
+    end
+
+    # Walk every subschema position, checking bounds and references.
+    # @return [void]
+    def self.walk_schema(schema, root, depth, counter, problems)
+      return unless schema.is_a?(Hash)
+      return unless problems.empty?
+
+      if depth > MAX_SCHEMA_DEPTH
+        problems << "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}"
+        return
+      end
+      counter[:count] += 1
+      if counter[:count] > MAX_SUBSCHEMAS
+        problems << "schema has more than #{MAX_SUBSCHEMAS} subschemas"
+        return
+      end
+
+      check_ref(schema['$ref'], root, problems) if schema.key?('$ref')
+      schema.each do |keyword, value|
+        if SUBSCHEMA_KEYWORDS.include?(keyword)
+          walk_schema(value, root, depth + 1, counter, problems)
+        elsif SUBSCHEMA_MAP_KEYWORDS.include?(keyword) && value.is_a?(Hash)
+          value.each_value { |subschema| walk_schema(subschema, root, depth + 1, counter, problems) }
+        elsif SUBSCHEMA_ARRAY_KEYWORDS.include?(keyword) && value.is_a?(Array)
+          value.each { |subschema| walk_schema(subschema, root, depth + 1, counter, problems) }
+        end
+      end
+    end
+
+    # @return [void]
+    def self.check_ref(ref, root, problems)
+      unless ref.is_a?(String)
+        problems << "$ref must be a string, got #{json_type(ref)}"
+        return
+      end
+      if external_ref?(ref)
+        problems << "external $ref #{ref.inspect} is not dereferenced (only references inside the schema " \
+                    'document are resolved; network $ref resolution is disabled)'
+      elsif resolve_pointer(root, ref).equal?(UNRESOLVED)
+        problems << "unresolvable local $ref #{ref.inspect}"
+      end
+    end
+
+    # A reference that does not point inside this document: an absolute URI
+    # (http, https, urn, file, ...), a relative document, or anything that
+    # is not a bare fragment. None of these is ever fetched.
+    # @param ref [String]
+    # @return [Boolean]
+    def self.external_ref?(ref)
+      !ref.start_with?('#')
+    end
+
+    # Marker for a pointer that does not resolve (nil is a valid schema
+    # value position, so it cannot serve as the marker).
+    UNRESOLVED = Object.new.freeze
+
+    # Resolve a fragment JSON pointer (`#`, `#/$defs/x`, `#/a~1b`, with
+    # percent-encoding) within the root document.
+    # @param root [Hash] the root schema (string keys)
+    # @param ref [String] the `$ref` value
+    # @return [Object] the referenced value, or UNRESOLVED
+    def self.resolve_pointer(root, ref)
+      fragment = ref.delete_prefix('#')
+      fragment = URI.decode_www_form_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
+      return root if fragment.empty?
+      return UNRESOLVED unless fragment.start_with?('/')
+
+      fragment[1..].split('/', -1).reduce(root) do |node, token|
+        key = token.gsub('~1', '/').gsub('~0', '~')
+        case node
+        when Hash
+          return UNRESOLVED unless node.key?(key)
+
+          node[key]
+        when Array
+          return UNRESOLVED unless key.match?(/\A\d+\z/) && key.to_i < node.length
+
+          node[key.to_i]
+        else
+          return UNRESOLVED
+        end
+      end
+    end
 
     # List the unsupported JSON Schema keywords a schema uses (anywhere: at the
     # top level or nested in subschemas). Property names that merely look like
@@ -92,29 +261,99 @@ module MCPClient
       end
     end
 
-    # Validate data against a JSON Schema subset.
+    # Validate data against a schema. An unusable schema (see
+    # {.check_schema}) is reported as validation errors, never as a pass.
     # Schema and data hashes may use string or symbol keys.
     # @param data [Object] the value to validate
     # @param schema [Hash] the JSON schema
     # @param path [String] JSON-pointer-style location used in error messages
+    # @param deadline [Float, nil] monotonic deadline for the whole validation
     # @return [Array<String>] human-readable validation errors (empty if valid)
     def self.validate(data, schema, path: '#', deadline: nil)
-      return [] unless schema.is_a?(Hash)
+      problems = check_schema(schema)
+      return problems.map { |problem| "#{path}: #{problem}" } unless problems.empty?
 
       # One deadline covers the entire (recursive) validation.
       deadline ||= Process.clock_gettime(Process::CLOCK_MONOTONIC) + PATTERN_MATCH_TIMEOUT
+      root = deep_stringify(schema)
+      validate_node(data, root, path, Context.new(root: root, deadline: deadline), 0)
+    end
 
-      schema = schema.transform_keys(&:to_s)
+    # Validate one value against one (sub)schema.
+    # @param data [Object] the value
+    # @param schema [Object] a subschema (Hash or boolean)
+    # @param path [String] location for error messages
+    # @param ctx [Context] the validation context
+    # @param ref_depth [Integer] $ref hops taken to reach this schema
+    # @return [Array<String>] validation errors
+    def self.validate_node(data, schema, path, ctx, ref_depth)
+      return [] if schema == true
+      return ["#{path}: schema false accepts no value"] if schema == false
+      return [] unless schema.is_a?(Hash)
+      return ["#{path}: validation time budget exhausted"] if pattern_budget_remaining(ctx.deadline).zero?
+
       errors = []
+      errors.concat(validate_ref(data, schema['$ref'], path, ctx, ref_depth)) if schema.key?('$ref')
       errors.concat(validate_type(data, schema['type'], path)) if schema.key?('type')
       errors.concat(validate_enum(data, schema, path))
       case data
-      when Hash then errors.concat(validate_object(data, schema, path, deadline))
-      when Array then errors.concat(validate_array(data, schema, path, deadline))
-      when String then errors.concat(validate_string(data, schema, path, deadline))
+      when Hash then errors.concat(validate_object(data, schema, path, ctx, ref_depth))
+      when Array then errors.concat(validate_array(data, schema, path, ctx, ref_depth))
+      when String then errors.concat(validate_string(data, schema, path, ctx.deadline))
       when Numeric then errors.concat(validate_number(data, schema, path))
       end
+      errors.concat(validate_composition(data, schema, path, ctx, ref_depth))
       errors
+    end
+
+    # Apply a local $ref (2020-12: alongside the sibling keywords).
+    # @return [Array<String>] validation errors
+    def self.validate_ref(data, ref, path, ctx, ref_depth)
+      return ["#{path}: external $ref #{ref.inspect} is not dereferenced"] if !ref.is_a?(String) || external_ref?(ref)
+      if ref_depth >= MAX_REF_DEPTH
+        return ["#{path}: $ref chain exceeds #{MAX_REF_DEPTH} hops (cycle?) at #{ref.inspect}"]
+      end
+
+      target = resolve_pointer(ctx.root, ref)
+      return ["#{path}: unresolvable local $ref #{ref.inspect}"] if target.equal?(UNRESOLVED)
+
+      validate_node(data, target, path, ctx, ref_depth + 1)
+    end
+
+    # allOf / anyOf / oneOf / not / if-then-else.
+    # @return [Array<String>] validation errors
+    def self.validate_composition(data, schema, path, ctx, ref_depth)
+      errors = []
+      if schema['allOf'].is_a?(Array)
+        schema['allOf'].each_with_index do |sub, idx|
+          sub_errors = validate_node(data, sub, path, ctx, ref_depth)
+          errors << "#{path}: does not satisfy allOf/#{idx} (#{sub_errors.join('; ')})" unless sub_errors.empty?
+        end
+      end
+      if schema['anyOf'].is_a?(Array) &&
+         schema['anyOf'].none? { |sub| validate_node(data, sub, path, ctx, ref_depth).empty? }
+        errors << "#{path}: does not satisfy any schema in anyOf"
+      end
+      if schema['oneOf'].is_a?(Array)
+        matches = schema['oneOf'].count { |sub| validate_node(data, sub, path, ctx, ref_depth).empty? }
+        errors << "#{path}: satisfies #{matches} schemas in oneOf, expected exactly one" unless matches == 1
+      end
+      if schema.key?('not') && validate_node(data, schema['not'], path, ctx, ref_depth).empty?
+        errors << "#{path}: value satisfies the schema in not"
+      end
+      errors.concat(validate_conditional(data, schema, path, ctx, ref_depth))
+      errors
+    end
+
+    # if / then / else.
+    # @return [Array<String>] validation errors
+    def self.validate_conditional(data, schema, path, ctx, ref_depth)
+      return [] unless schema.key?('if')
+
+      branch = validate_node(data, schema['if'], path, ctx, ref_depth).empty? ? 'then' : 'else'
+      return [] unless schema.key?(branch)
+
+      validate_node(data, schema[branch], path, ctx, ref_depth)
     end
 
     # Validate the JSON type of a value.
@@ -195,7 +434,7 @@ module MCPClient
     # @param schema [Hash] string-keyed schema
     # @param path [String] location for error messages
     # @return [Array<String>] validation errors
-    def self.validate_object(data, schema, path, deadline = nil)
+    def self.validate_object(data, schema, path, ctx, ref_depth)
       errors = []
       Array(schema['required']).each do |raw_name|
         name = raw_name.to_s
@@ -205,7 +444,7 @@ module MCPClient
       return errors unless properties.is_a?(Hash)
 
       properties.each do |raw_name, prop_schema|
-        next unless prop_schema.is_a?(Hash)
+        next unless prop_schema.is_a?(Hash) || [true, false].include?(prop_schema)
 
         name = raw_name.to_s
         key = if data.key?(name)
@@ -215,7 +454,7 @@ module MCPClient
               end
         next if key.nil?
 
-        errors.concat(validate(data[key], prop_schema, path: "#{path}/#{name}", deadline: deadline))
+        errors.concat(validate_node(data[key], prop_schema, "#{path}/#{name}", ctx, ref_depth))
       end
       errors
     end
@@ -225,7 +464,7 @@ module MCPClient
     # @param schema [Hash] string-keyed schema
     # @param path [String] location for error messages
     # @return [Array<String>] validation errors
-    def self.validate_array(data, schema, path, deadline = nil)
+    def self.validate_array(data, schema, path, ctx, ref_depth)
       errors = []
       min_items = schema['minItems']
       max_items = schema['maxItems']
@@ -236,9 +475,9 @@ module MCPClient
         errors << "#{path}: expected at most #{max_items} items, got #{data.length}"
       end
       items = schema['items']
-      if items.is_a?(Hash)
+      if items.is_a?(Hash) || [true, false].include?(items)
         data.each_with_index do |item, idx|
-          errors.concat(validate(item, items, path: "#{path}/#{idx}", deadline: deadline))
+          errors.concat(validate_node(item, items, "#{path}/#{idx}", ctx, ref_depth))
         end
       end
       errors
@@ -292,9 +531,9 @@ module MCPClient
       []
     end
 
-    # Time left in the validation-wide pattern budget.
+    # Time left in the validation-wide budget.
     # @param deadline [Float, nil] monotonic deadline, or nil for a lone match
-    # @return [Float] seconds available for the next match; 0.0 when exhausted
+    # @return [Float] seconds available; 0.0 when exhausted
     def self.pattern_budget_remaining(deadline)
       return PATTERN_MATCH_TIMEOUT unless deadline
 
@@ -324,6 +563,19 @@ module MCPClient
         errors << "#{path}: value #{data} must be less than exclusiveMaximum #{exclusive_max}"
       end
       errors
+    end
+
+    # A copy of the schema with every Hash key as a String, so keyword
+    # lookups and JSON pointers see one key form. Values (enum members,
+    # const, defaults) are left as they are.
+    # @param node [Object]
+    # @return [Object]
+    def self.deep_stringify(node)
+      case node
+      when Hash then node.to_h { |key, value| [key.to_s, deep_stringify(value)] }
+      when Array then node.map { |value| deep_stringify(value) }
+      else node
+      end
     end
   end
 end

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -6,6 +6,7 @@ require_relative 'schema_validator/normalization'
 require_relative 'schema_validator/references'
 require_relative 'schema_validator/keyword_scan'
 require_relative 'schema_validator/composition'
+require_relative 'schema_validator/evaluation'
 require_relative 'schema_validator/scalars'
 
 module MCPClient
@@ -60,6 +61,7 @@ module MCPClient
     extend References
     extend KeywordScan
     extend Composition
+    extend Evaluation
     extend Scalars
 
     # Raised inside a validation to abandon it (time budget, resource bound).
@@ -88,30 +90,32 @@ module MCPClient
     MAX_ERRORS = 100
     MAX_VALUE_INSPECT = 64
 
-    # How deeply the walk may descend into the instance. The walk is plain
-    # recursion, so this drives the interpreter's stack: the instance nests a
-    # level per array item or property, and a recursive `$ref` follows it
-    # down without bound (the hop budget restarts at every value, so that a
-    # recursive schema can describe deep data at all). Counting the descent
-    # lets the deepest instance abort with one error like any other
-    # exhausted budget.
+    # How deeply the walk may descend into the instance. The descent into a
+    # child value is the walk's only recursion, so this is what drives the
+    # interpreter's stack: the instance nests a level per array item or
+    # property, and a recursive `$ref` follows it down without bound (the hop
+    # budget restarts at every value, so that a recursive schema can describe
+    # deep data at all). Counting the descent lets the deepest instance abort
+    # with one error like any other exhausted budget.
     #
     # Only a step into a child value — an array item or a property value —
-    # counts. The frames a schema spends on one value (a `$ref` hop, an
-    # allOf/anyOf/oneOf/if branch) do not: a recursive schema composed
-    # through a few `$defs` mixins applies several of them per instance
-    # level, and counting those would make the budget a fraction of the
-    # instance depth it names, so data a peer can legitimately send — its
-    # nesting under `JSON.parse`'s default limit of 100 — would abort. Those
-    # frames stay bounded by MAX_REF_DEPTH and MAX_NODE_VISITS instead, which
-    # is what already stops a schema recursing on one value forever.
+    # counts, and only such a step costs a frame. The schemas a node applies
+    # to one value (a `$ref` hop, an allOf/anyOf/oneOf/not/if branch) neither
+    # count nor recurse: a recursive schema composed through a few `$defs`
+    # mixins applies several of them per instance level, and both counting
+    # and recursing on those would scale with the mixin count, so data a peer
+    # can legitimately send — its nesting under `JSON.parse`'s default limit
+    # of 100 — would abort. {.validate_node} applies them iteratively (see
+    # {Evaluation}), bounded by MAX_REF_DEPTH and MAX_NODE_VISITS, which is
+    # what already stops a schema recursing on one value forever.
     #
     # The bound therefore sits well above the deepest instance a peer can
     # send, and below the number of levels the smallest stack this library
-    # runs on (a transport's reader thread) carries for a plain recursive
-    # schema. It cannot on its own promise the stack holds, since it does not
-    # bound what one level costs; {.validate} catches SystemStackError for
-    # the schema that spends more per level than the stack has to give.
+    # runs on (a transport's reader thread) carries — a figure that no longer
+    # depends on how a schema is composed, since what one level costs is now
+    # fixed. {.validate} still catches SystemStackError, as a backstop for a
+    # stack smaller than any this has been measured on rather than for
+    # anything a schema can provoke.
     MAX_NODE_DEPTH = 256
 
     # JSON Schema keywords that affect validation but that this validator
@@ -612,21 +616,31 @@ module MCPClient
     rescue Aborted => e
       ["#{path}: validation aborted: #{e.message}"]
     rescue SystemStackError
-      # MAX_NODE_DEPTH bounds how deep the instance may nest, but not what
-      # one level costs: a schema is free to spend a `$ref` chain and a stack
-      # of composition branches on every value, and the stack this runs on
-      # may be a transport reader thread's. The walk is plain recursion with
-      # no state outside `ctx`, so the unwound stack leaves nothing behind —
+      # A backstop, not a working bound: the `$ref` chain and the composition
+      # branches a schema spends on one value are applied iteratively, so
+      # what one instance level costs is fixed and MAX_NODE_DEPTH bounds the
+      # stack. Should some stack still be smaller than that — the walk holds
+      # no state outside `ctx` — the unwound stack leaves nothing behind, and
       # the validation ends the way an exhausted budget does, as one error,
       # never as a crash out of a tool call.
       ["#{path}: validation aborted: schema too deeply recursive for this stack"]
     end
 
-    # Validate one value against one (sub)schema, under the bound on the walk
-    # itself: one more node visited. Applying another schema to the same
-    # value does not nest the instance, so it is the `$ref` hop budget and
-    # the visit cap that bound it; {.validate_child} accounts for the steps
-    # that do nest.
+    # Validate one value against one (sub)schema, and against every schema
+    # that one leads to for the same value: a `$ref` hop, an
+    # allOf/anyOf/oneOf/not/if branch, a then/else. Applying another schema
+    # to the same value does not nest the instance, so it is the `$ref` hop
+    # budget and the visit cap that bound it; {.validate_child} accounts for
+    # the steps that do nest.
+    #
+    # Those same-instance applications run on the `pending` list here rather
+    # than on the Ruby stack (see {Evaluation}): a schema composed through N
+    # `$defs` mixins applies N of them to every instance level, and spending
+    # a frame on each would make the stack grow with the product of the
+    # instance depth and the mixin count — so data a peer can legitimately
+    # send would overflow the small stack of a transport's reader thread. A
+    # frame is spent only on the step into a child value, which is what
+    # MAX_NODE_DEPTH bounds.
     # @param data [Object] the value
     # @param schema [Object] a subschema (Hash or boolean)
     # @param path [String] location for error messages
@@ -635,8 +649,25 @@ module MCPClient
     # @return [Array<String>] validation errors
     # @raise [Aborted] when a bound is hit
     def self.validate_node(data, schema, path, ctx, ref_depth)
-      count_visit(ctx)
-      validate_node_keywords(data, schema, path, ctx, ref_depth)
+      pending = []
+      step = start_node(data, schema, path, ctx, ref_depth)
+      loop do
+        if step[0] == :apply
+          pending << step
+          # A speculative application's errors are a verdict, not output, and
+          # do not count toward MAX_ERRORS while it runs.
+          ctx.speculative += 1 if step[3]
+          step = start_node(data, step[1], path, ctx, step[2])
+          next
+        end
+
+        errors = step[1]
+        return errors if pending.empty?
+
+        resumed = pending.pop
+        ctx.speculative -= 1 if resumed[3]
+        step = resumed[4].call(errors)
+      end
     end
 
     # Validate a child of the value being validated — an array item or a
@@ -658,44 +689,6 @@ module MCPClient
       ctx.depth -= 1
     end
 
-    # Apply one (sub)schema's keywords to one value, the walk's own bounds
-    # already accounted for by {.validate_node}.
-    # @return [Array<String>] validation errors
-    def self.validate_node_keywords(data, schema, path, ctx, ref_depth)
-      return [] if schema == true
-      return count_errors(ctx, ["#{path}: schema false accepts no value"]) if schema == false
-      return [] unless schema.is_a?(Hash)
-
-      # draft-07: "$ref" replaces the schema it appears in; later drafts
-      # apply it alongside the sibling keywords. The dialect is the one of
-      # the schema resource the node belongs to.
-      dialect = node_dialect(schema, ctx)
-      return validate_ref(data, schema, path, ctx, ref_depth) if schema.key?('$ref') && dialect == DRAFT_07
-
-      errors = []
-      counted_before = ctx.errors
-      errors.concat(validate_ref(data, schema, path, ctx, ref_depth)) if schema.key?('$ref')
-      errors.concat(validate_type(data, schema['type'], path)) if schema.key?('type')
-      errors.concat(validate_enum(data, schema, path))
-      case data
-      when Hash then errors.concat(validate_object(data, schema, path, ctx))
-      when Array then errors.concat(validate_array(data, schema, path, ctx, dialect))
-      when String then errors.concat(validate_string(data, schema, path, ctx.deadline))
-      when Numeric then errors.concat(validate_number(data, schema, path, dialect))
-      end
-      errors.concat(validate_composition(data, schema, path, ctx, ref_depth))
-      # A keyword the validator does not evaluate makes this node's verdict
-      # partial: a pass here is not a proof for not / oneOf / if. A node its
-      # supported assertions already rejected is decided whatever else it
-      # holds, and pays for no such measurement: the coverage checks match
-      # server-controlled patterns, which must not be able to abort a
-      # validation the branch has settled.
-      ctx.undecided += 1 if errors.empty? && partial_keywords?(schema, dialect, data, ctx.deadline)
-      # Errors raised by nested nodes were counted when they were produced;
-      # only this node's own errors are new.
-      count_errors(ctx, errors, already_counted: ctx.errors - counted_before)
-    end
-
     # The dialect in force at a schema object during validation: the one
     # recorded for its resource by the anchor index (built once per
     # validation), else the root's.
@@ -703,17 +696,6 @@ module MCPClient
     def self.node_dialect(schema, ctx)
       ctx.anchors ||= anchor_index(ctx.root, ctx.dialect)
       indexed_dialect(schema, ctx) || ctx.dialect
-    end
-
-    # Run a branch whose errors are only a verdict (anyOf/oneOf candidates,
-    # not, if): they never count toward MAX_ERRORS. Bounds that abort the
-    # whole validation still propagate.
-    # @return [Object] the block's value
-    def self.speculative(ctx)
-      ctx.speculative += 1
-      yield
-    ensure
-      ctx.speculative -= 1
     end
 
     # Account for one node visit (boolean schemas included, so a huge array
@@ -741,27 +723,6 @@ module MCPClient
     # @return [Boolean] whether the validation-wide deadline has passed
     def self.budget_exhausted?(deadline)
       deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
-    end
-
-    # Apply the local $ref of a schema object.
-    # @param schema [Hash] the schema object holding the `$ref`
-    # @return [Array<String>] validation errors
-    def self.validate_ref(data, schema, path, ctx, ref_depth)
-      ref = schema['$ref']
-      if !ref.is_a?(String) || external_ref?(ref)
-        return count_errors(ctx, ["#{path}: external $ref #{clip(ref.inspect)} is not dereferenced"])
-      end
-      if ref_depth >= MAX_REF_DEPTH
-        raise Aborted, "$ref chain exceeds #{MAX_REF_DEPTH} hops (cycle?) at #{clip(ref.inspect)}"
-      end
-
-      target = resolve_reference(ctx.root, ref, ctx.dialect, ctx, from: schema)
-      return count_errors(ctx, ["#{path}: unresolvable local $ref #{clip(ref.inspect)}"]) if target.equal?(UNRESOLVED)
-      unless schema_value?(target)
-        return count_errors(ctx, ["#{path}: $ref #{clip(ref.inspect)} does not point at a schema"])
-      end
-
-      validate_node(data, target, path, ctx, ref_depth + 1)
     end
 
     # Validate the JSON type of a value.

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -10,6 +10,7 @@ require_relative 'schema_validator/keyword_scan'
 require_relative 'schema_validator/composition'
 require_relative 'schema_validator/evaluation'
 require_relative 'schema_validator/scalars'
+require_relative 'schema_validator/instances'
 
 module MCPClient
   # Self-contained JSON Schema validator used to check a tool call result's
@@ -51,12 +52,21 @@ module MCPClient
   #   per-validation time budget. Hitting a bound aborts the validation with
   #   one error: an aborted validation never reads as a pass.
   #
-  # The rest of the vocabulary (additionalProperties, format assertions,
-  # unevaluated*, additionalItems, dependencies, ...) is out of scope:
-  # unrecognized keywords are ignored rather than misapplied, so validation is
-  # best-effort — it may accept data a full validator would reject, but it
-  # does not reject data that conforms to the schema. So that this gap is
-  # never silent, {.unsupported_keywords} reports which unapplied validation
+  # - multipleOf (numbers), uniqueItems, contains with minContains /
+  #   maxContains, additionalItems (draft-07, 2019-09) (arrays)
+  # - minProperties, maxProperties, patternProperties, additionalProperties,
+  #   propertyNames, dependentRequired / dependentSchemas (2019-09, 2020-12)
+  #   and draft-07 dependencies (objects)
+  #
+  # What is left out is what cannot be decided without the annotations a
+  # whole composition produces (unevaluatedItems, unevaluatedProperties) or
+  # without a dynamic scope ($dynamicRef, $recursiveRef), plus the two
+  # keywords that only annotate in the default dialect (format, which full
+  # validators assert only in format-assertion mode, and contentSchema).
+  # Those are ignored rather than misapplied, so validation is best-effort
+  # there — it may accept data a full validator would reject, but it does not
+  # reject data that conforms to the schema. So that this gap is never
+  # silent, {.unsupported_keywords} reports which unapplied validation
   # keywords a schema uses; callers surface them as a warning.
   module SchemaValidator
     extend Dialects
@@ -68,6 +78,7 @@ module MCPClient
     extend Composition
     extend Evaluation
     extend Scalars
+    extend Instances
 
     # Raised inside a validation to abandon it (time budget, resource bound).
     class Aborted < StandardError; end
@@ -124,17 +135,22 @@ module MCPClient
     MAX_NODE_DEPTH = 256
 
     # JSON Schema keywords that affect validation but that this validator
-    # does not evaluate: assertion keywords (multipleOf, uniqueItems,
-    # contains bounds, property-count bounds, dependentRequired), the
-    # remaining applicators, draft-specific keywords, and format (asserted by
-    # full validators in format-assertion mode). Their presence means
+    # does not evaluate: the dynamic references (whose target depends on the
+    # dynamic scope a validation was entered through), the two keywords
+    # decided by annotations collected across a whole composition
+    # (`unevaluatedItems` / `unevaluatedProperties`), and the two that only
+    # annotate in the default dialect (`format`, asserted by full validators
+    # in format-assertion mode, and `contentSchema`). Their presence means
     # validation is partial: data may pass here that a full validator would
     # reject.
+    #
+    # Every other standard keyword is evaluated. A standard assertion left
+    # unevaluated is not a smaller report but a wrong verdict: it makes a
+    # composition branch undecided, and an undecided branch is accepted
+    # wherever the composition is monotonic (`allOf`, `anyOf`), so the
+    # instance passes a schema that rejects it.
     UNSUPPORTED_KEYWORDS = %w[
-      $dynamicRef $recursiveRef
-      additionalProperties patternProperties propertyNames dependentSchemas dependencies
-      additionalItems contains minContains maxContains uniqueItems contentSchema
-      multipleOf format dependentRequired minProperties maxProperties
+      $dynamicRef $recursiveRef contentSchema format
       unevaluatedProperties unevaluatedItems
     ].freeze
 
@@ -148,10 +164,8 @@ module MCPClient
     # 2020-12 Validation Section 6: keywords apply only to their type), so
     # it cannot leave a branch undecided.
     UNSUPPORTED_ASSERTIONS_BY_TYPE = {
-      Hash => %w[additionalProperties patternProperties propertyNames dependentSchemas dependencies
-                 dependentRequired minProperties maxProperties unevaluatedProperties],
-      Array => %w[additionalItems contains minContains maxContains uniqueItems unevaluatedItems],
-      Numeric => %w[multipleOf]
+      Hash => %w[unevaluatedProperties],
+      Array => %w[unevaluatedItems]
     }.freeze
 
     # Unsupported keywords that apply to every instance.
@@ -327,7 +341,8 @@ module MCPClient
     end
 
     # Problems the anchor index reveals: anchor names must be unique within
-    # a schema resource (JSON Schema 2020-12 Core Section 8.2.2) — a name
+    # a schema resource (JSON Schema 2020-12 Core Section 8.2.2) and a
+    # resource URI unique within the document (Section 9.1.2) — either
     # declared twice would bind a reference to whichever declaration the
     # walk met first — and an index that stopped at its bound before
     # reaching every object leaves references and resource dialects
@@ -339,6 +354,9 @@ module MCPClient
       problems = index[:duplicates].map do |name|
         "anchor #{clip(name.inspect)} is declared more than once in a schema resource"
       end
+      problems.concat(index[:duplicate_ids].uniq.map do |base|
+        "schema resource #{clip(base.inspect)} is declared more than once"
+      end)
       if index[:truncated]
         problems << 'schema has too many or too deeply nested objects to index its anchors ' \
                     "(more than #{MAX_SUBSCHEMAS}, or deeper than #{MAX_SCHEMA_DEPTH})"
@@ -436,8 +454,9 @@ module MCPClient
         problems << 'items must be a schema in JSON Schema 2020-12 (positional schemas go in prefixItems)'
       end
       check_applicator_shapes(schema, dialect, problems)
-      check_assertion_shapes(schema, problems)
+      check_assertion_shapes(schema, dialect, problems)
       check_exclusive_bounds(schema, dialect, problems)
+      check_identifier_shapes(schema, dialect, problems)
     end
 
     # Account for a schema (object or boolean) about to be walked: once per
@@ -561,10 +580,13 @@ module MCPClient
     # booleans.
     # @return [void]
     def self.charge_boolean_target(hop, root, from, counter, problems)
+      index = (counter[:anchors] ||= anchor_index(root, counter[:dialect]))
+      resource, hop = pointer_origin(index, root, hop, from)
+      return unless resource
+
       tokens = pointer_tokens(hop)
       return unless tokens
 
-      resource = (counter[:anchors] && from && counter[:anchors][:resources][from]) || root
       key = [resource.object_id, tokens]
       seen = (counter[:boolean_targets] ||= {})
       return if seen.key?(key)
@@ -580,7 +602,9 @@ module MCPClient
     # @return [void]
     def self.check_dynamic_ref(walk, schema, keyword, _dialect)
       ref = schema[keyword]
-      return unless ref.is_a?(String)
+      # A reference that is not a URI reference at all names nothing: it is
+      # not silently ignored (a malformed keyword is not an absent one).
+      return walk.problems << "#{keyword} must be a string, got #{json_type(ref)}" unless ref.is_a?(String)
       return unless external_ref?(ref, walk.root, walk.counter[:dialect], walk.counter, from: schema)
 
       walk.problems << "external #{keyword} #{clip(ref.inspect)} is not dereferenced"
@@ -852,83 +876,6 @@ module MCPClient
         errors << "#{path}: value #{clip_value(data)} does not equal const #{clip_value(schema['const'])}"
       end
       errors
-    end
-
-    # Validate an object against required/properties.
-    # @param data [Hash] the object
-    # @param schema [Hash] string-keyed schema
-    # @param path [String] location for error messages
-    # @return [Array<String>] validation errors
-    def self.validate_object(data, schema, path, ctx)
-      errors = []
-      Array(schema['required']).each do |raw_name|
-        name = raw_name.to_s
-        errors << "#{path}: missing required property '#{clip(name)}'" unless data.key?(name) || data.key?(name.to_sym)
-      end
-      properties = schema['properties']
-      return errors unless properties.is_a?(Hash)
-
-      properties.each do |raw_name, prop_schema|
-        next unless schema_value?(prop_schema)
-
-        name = raw_name.to_s
-        key = if data.key?(name)
-                name
-              elsif data.key?(name.to_sym)
-                name.to_sym
-              end
-        next if key.nil?
-
-        # A property is a smaller instance, so the hops taken to reach this
-        # schema cannot repeat forever below it: the budget counts a chain
-        # of references applied to one value, not how deep the data nests.
-        # The step down is what the depth bound counts.
-        errors.concat(validate_child(data[key], prop_schema, "#{path}/#{name}", ctx))
-      end
-      errors
-    end
-
-    # Validate an array against items/prefixItems/minItems/maxItems.
-    # 2020-12 puts positional schemas in `prefixItems` and the rest under
-    # `items`; draft-07 and 2019-09 put positional schemas in an `items`
-    # array. Both forms are honoured.
-    # @param data [Array] the array
-    # @param schema [Hash] string-keyed schema
-    # @param path [String] location for error messages
-    # @return [Array<String>] validation errors
-    def self.validate_array(data, schema, path, ctx, dialect = ctx.dialect)
-      errors = []
-      min_items = schema['minItems']
-      max_items = schema['maxItems']
-      if min_items.is_a?(Numeric) && data.length < min_items
-        errors << "#{path}: expected at least #{min_items} items, got #{data.length}"
-      end
-      if max_items.is_a?(Numeric) && data.length > max_items
-        errors << "#{path}: expected at most #{max_items} items, got #{data.length}"
-      end
-      items = schema['items']
-      # 2020-12 puts positional schemas in prefixItems (items must be a
-      # schema); draft-07 and 2019-09 put them in an items array and know no
-      # prefixItems.
-      positional = if dialect == DEFAULT_DIALECT
-                     schema['prefixItems'].is_a?(Array) ? schema['prefixItems'] : []
-                   else
-                     items.is_a?(Array) ? items : []
-                   end
-      data.each_with_index do |item, idx|
-        item_schema = if idx < positional.length
-                        positional[idx]
-                      elsif !items.is_a?(Array)
-                        items
-                      end
-        next unless schema_value?(item_schema)
-
-        # An item is a smaller instance: the hop budget starts over and the
-        # depth bound counts the step, so a recursive schema describes data
-        # of any depth up to it (see {.validate_object}).
-        errors.concat(validate_child(item, item_schema, "#{path}/#{idx}", ctx))
-      end
-      errors.concat(validate_contains(data, schema, path, dialect))
     end
 
     # Bound a piece of peer-derived text destined for a message.

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -225,8 +225,11 @@ module MCPClient
     end
 
     # {.check_schema} on an already normalized schema.
+    # @param counter [Hash] filled in with the preflight state (the memoized
+    #   anchor index included), so a caller going on to validate reads the
+    #   document the way the preflight read it
     # @return [Array<String>] problems
-    def self.check_normalized(root)
+    def self.check_normalized(root, counter = {})
       return [] if [true, false].include?(root)
       return ["schema must be an object or a boolean, got #{json_type(root)}"] unless root.is_a?(Hash)
 
@@ -238,8 +241,8 @@ module MCPClient
       end
 
       problems = []
-      counter = { count: 0, dialect: canonical_dialect(declared), walked: {}.compare_by_identity,
-                  depths: lexical_depths(root, canonical_dialect(declared)) }
+      counter.update(count: 0, dialect: canonical_dialect(declared), walked: {}.compare_by_identity,
+                     depths: lexical_depths(root, canonical_dialect(declared)))
       walk_schema(root, root, 0, counter, problems)
       problems.concat(anchor_index_problems(root, counter)) if problems.empty?
       problems.uniq
@@ -564,11 +567,16 @@ module MCPClient
       # document included.
       deadline ||= Process.clock_gettime(Process::CLOCK_MONOTONIC) + PATTERN_MATCH_TIMEOUT
       root = normalize_schema(schema, deadline: deadline)
-      problems = check_normalized(root)
+      # `preflight` comes back holding the state the check read the schema under.
+      problems = check_normalized(root, preflight = {})
       return problems.map { |problem| "#{path}: #{problem}" } unless problems.empty?
 
+      # The index the preflight built is the one this validation reads (the
+      # resources, dialects and anchors a schema was accepted under, and the
+      # subtrees its references adopted): a second one would make what a
+      # reference resolves to depend on the order this instance applies them.
       ctx = Context.new(root: root, deadline: deadline, dialect: canonical_dialect(dialect(root)),
-                        visits: 0, errors: 0, speculative: 0, anchors: nil, undecided: 0)
+                        visits: 0, errors: 0, speculative: 0, anchors: preflight[:anchors], undecided: 0)
       validate_node(data, root, path, ctx, 0)
     rescue TooLarge => e
       ["#{path}: #{e.message}"]
@@ -596,9 +604,6 @@ module MCPClient
       dialect = node_dialect(schema, ctx)
       return validate_ref(data, schema, path, ctx, ref_depth) if schema.key?('$ref') && dialect == DRAFT_07
 
-      # A keyword the validator does not evaluate makes this node's verdict
-      # partial: a pass here is not a proof for not / oneOf / if.
-      ctx.undecided += 1 if partial_keywords?(schema, dialect, data, ctx.deadline)
       errors = []
       counted_before = ctx.errors
       errors.concat(validate_ref(data, schema, path, ctx, ref_depth)) if schema.key?('$ref')
@@ -611,6 +616,13 @@ module MCPClient
       when Numeric then errors.concat(validate_number(data, schema, path, dialect))
       end
       errors.concat(validate_composition(data, schema, path, ctx, ref_depth))
+      # A keyword the validator does not evaluate makes this node's verdict
+      # partial: a pass here is not a proof for not / oneOf / if. A node its
+      # supported assertions already rejected is decided whatever else it
+      # holds, and pays for no such measurement: the coverage checks match
+      # server-controlled patterns, which must not be able to abort a
+      # validation the branch has settled.
+      ctx.undecided += 1 if errors.empty? && partial_keywords?(schema, dialect, data, ctx.deadline)
       # Errors raised by nested nodes were counted when they were produced;
       # only this node's own errors are new.
       count_errors(ctx, errors, already_counted: ctx.errors - counted_before)

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'uri'
+require_relative 'schema_validator/references'
 
 module MCPClient
   # Self-contained JSON Schema validator used to check a tool call result's
@@ -18,18 +19,22 @@ module MCPClient
   # - minimum, maximum, exclusiveMinimum, exclusiveMaximum (numbers)
   # - allOf, anyOf, oneOf, not, if/then/else (composition)
   # - $ref to a location inside the same schema document (`#`, `#/$defs/x`,
-  #   `#/definitions/x`, any JSON pointer), with $defs / definitions; under
-  #   draft-07 a $ref replaces its siblings, under 2019-09 and 2020-12 it
-  #   applies alongside them
+  #   `#/definitions/x`, any JSON pointer, or a plain-name fragment `#name`
+  #   naming an `$anchor` / a draft-07 `$id: "#name"`), with $defs /
+  #   definitions; under draft-07 a $ref replaces its siblings, under
+  #   2019-09 and 2020-12 it applies alongside them
   # - boolean schemas (true / false), at the root or as subschemas
   #
   # MCP 2026-07-28 rules honoured here:
   # - a schema without `$schema` is 2020-12; the dialects in
   #   SUPPORTED_DIALECTS are accepted and any other declared dialect is an
-  #   error (not a permissive pass);
-  # - `$ref` (and `$dynamicRef`) values that do not point inside the document
-  #   (network URIs, relative documents, urn:, file:) are never dereferenced,
-  #   and a schema carrying one is rejected rather than treated as permissive;
+  #   error (not a permissive pass); the keyword grammar follows the dialect
+  #   (DIALECT_KEYWORDS): a keyword the dialect does not define is ignored,
+  #   neither shape-checked nor reported;
+  # - `$ref` (and `$dynamicRef` / `$recursiveRef`) values that do not point
+  #   inside the document (network URIs, relative documents, urn:, file:)
+  #   are never dereferenced, and a schema carrying one is rejected rather
+  #   than treated as permissive;
   # - resource bounds: schema nesting depth, total subschema count, `$ref`
   #   chain length, number of nodes visited, number of errors produced and a
   #   per-validation time budget. Hitting a bound aborts the validation with
@@ -43,6 +48,8 @@ module MCPClient
   # never silent, {.unsupported_keywords} reports which unapplied validation
   # keywords a schema uses; callers surface them as a warning.
   module SchemaValidator
+    extend References
+
     # Raised inside a validation to abandon it (time budget, resource bound).
     class Aborted < StandardError; end
 
@@ -114,8 +121,41 @@ module MCPClient
     # Keywords whose value is data, not schema: never walked, never re-keyed.
     DATA_KEYWORDS = %w[enum const default examples].freeze
 
+    # Keywords that exist only in some dialects, with the dialects that
+    # define them. A keyword absent from this table exists in every
+    # supported dialect. Under a dialect that does not define a keyword the
+    # keyword is an unknown one: ignored, never shape-checked, walked,
+    # evaluated or reported as unsupported.
+    DIALECT_KEYWORDS = {
+      'prefixItems' => [DEFAULT_DIALECT],
+      '$dynamicRef' => [DEFAULT_DIALECT],
+      '$dynamicAnchor' => [DEFAULT_DIALECT],
+      '$recursiveRef' => [DRAFT_2019_09],
+      '$recursiveAnchor' => [DRAFT_2019_09],
+      'additionalItems' => [DRAFT_2019_09, DRAFT_07],
+      'dependencies' => [DRAFT_07],
+      'dependentSchemas' => [DEFAULT_DIALECT, DRAFT_2019_09],
+      'dependentRequired' => [DEFAULT_DIALECT, DRAFT_2019_09],
+      'unevaluatedItems' => [DEFAULT_DIALECT, DRAFT_2019_09],
+      'unevaluatedProperties' => [DEFAULT_DIALECT, DRAFT_2019_09],
+      'contentSchema' => [DEFAULT_DIALECT, DRAFT_2019_09],
+      'minContains' => [DEFAULT_DIALECT, DRAFT_2019_09],
+      'maxContains' => [DEFAULT_DIALECT, DRAFT_2019_09],
+      '$anchor' => [DEFAULT_DIALECT, DRAFT_2019_09]
+    }.freeze
+
+    # Plain-name fragment syntax (JSON Schema 2020-12 Section 8.2.2).
+    ANCHOR_NAME = /\A[A-Za-z_][-A-Za-z0-9._]*\z/
+
+    # @param keyword [String]
+    # @param dialect [String, nil] a canonical dialect, or nil for "any"
+    # @return [Boolean] whether the dialect defines the keyword
+    def self.keyword_known?(keyword, dialect)
+      dialect.nil? || !DIALECT_KEYWORDS.key?(keyword) || DIALECT_KEYWORDS[keyword].include?(dialect)
+    end
+
     # Per-validation state.
-    Context = Struct.new(:root, :deadline, :dialect, :visits, :errors, :speculative, keyword_init: true)
+    Context = Struct.new(:root, :deadline, :dialect, :visits, :errors, :speculative, :anchors, keyword_init: true)
 
     # The dialect a schema declares, or the default.
     # @param schema [Object] the schema
@@ -188,21 +228,38 @@ module MCPClient
         return
       end
 
-      check_ref(schema['$ref'], root, problems) if schema.key?('$ref')
-      check_dynamic_ref(schema['$dynamicRef'], problems) if schema.key?('$dynamicRef')
-      if counter[:dialect] == DEFAULT_DIALECT && schema['items'].is_a?(Array)
+      dialect = counter[:dialect]
+      check_ref(schema['$ref'], root, problems, dialect, counter) if schema.key?('$ref')
+      # draft-07: the $ref replaces its siblings, so the applicators next to
+      # it are never applied and are not preflighted either; $defs /
+      # definitions are a bag of reusable schemas, not applicators, and stay
+      # reachable through references.
+      if dialect == DRAFT_07 && schema.key?('$ref')
+        each_definition(schema) { |sub| walk_schema(sub, root, depth + 1, counter, problems) }
+        return
+      end
+
+      %w[$dynamicRef $recursiveRef].each do |keyword|
+        next unless schema.key?(keyword) && keyword_known?(keyword, dialect)
+
+        check_dynamic_ref(keyword, schema[keyword], problems)
+      end
+      if dialect == DEFAULT_DIALECT && schema['items'].is_a?(Array)
         problems << 'items must be a schema in JSON Schema 2020-12 (positional schemas go in prefixItems)'
       end
-      check_applicator_shapes(schema, problems)
-      each_subschema(schema) { |sub| walk_schema(sub, root, depth + 1, counter, problems) }
+      check_applicator_shapes(schema, dialect, problems)
+      check_exclusive_bounds(schema, dialect, problems)
+      each_subschema(schema, dialect) { |sub| walk_schema(sub, root, depth + 1, counter, problems) }
     end
 
     # Every applicator value must be a schema (object or boolean), an array
     # of schemas or a map of schemas; anything else is not silently read as
-    # "true".
+    # "true". Keywords the dialect does not define are ignored.
     # @return [void]
-    def self.check_applicator_shapes(schema, problems)
+    def self.check_applicator_shapes(schema, dialect, problems)
       schema.each do |keyword, value|
+        next unless keyword_known?(keyword, dialect)
+
         problem = applicator_shape_problem(keyword, value)
         problems << problem if problem
       end
@@ -213,6 +270,8 @@ module MCPClient
       if SUBSCHEMA_KEYWORDS.include?(keyword)
         tuple = keyword == 'items' && all_schemas?(value)
         "#{keyword} must be a schema" unless schema_value?(value) || tuple
+      elsif keyword == 'dependencies'
+        dependencies_shape_problem(value)
       elsif SUBSCHEMA_MAP_KEYWORDS.include?(keyword) && !%w[$defs definitions].include?(keyword)
         # $defs / definitions are a bag of reusable values: an entry that is
         # not a schema only matters once a $ref points at it.
@@ -222,30 +281,82 @@ module MCPClient
       end
     end
 
+    # draft-07: each dependencies entry is a schema or an array of property
+    # names.
+    # @return [String, nil]
+    def self.dependencies_shape_problem(value)
+      return if value.is_a?(Hash) && value.each_value.all? { |v| schema_value?(v) || property_names?(v) }
+
+      'dependencies entries must be schemas or arrays of property names'
+    end
+
+    # @param value [Object]
+    # @return [Boolean] whether value is an array of property names
+    def self.property_names?(value)
+      value.is_a?(Array) && value.all?(String)
+    end
+
+    # draft-07 exclusiveMinimum / exclusiveMaximum are booleans modifying
+    # minimum / maximum; 2019-09 and 2020-12 made them numbers. The other
+    # form is not silently ignored (it would turn a bound into a pass).
+    # @return [void]
+    def self.check_exclusive_bounds(schema, dialect, problems)
+      %w[exclusiveMinimum exclusiveMaximum].each do |keyword|
+        next unless schema.key?(keyword)
+
+        value = schema[keyword]
+        if dialect == DRAFT_07
+          problems << "#{keyword} must be a boolean in draft-07" unless [true, false].include?(value)
+        elsif !value.is_a?(Numeric)
+          problems << "#{keyword} must be a number in #{dialect}"
+        end
+      end
+    end
+
     # @param values [Object]
     # @return [Boolean] whether values is an array of schemas
     def self.all_schemas?(values)
       values.is_a?(Array) && values.all? { |v| schema_value?(v) }
     end
 
-    # Yield every subschema directly under a schema object.
+    # Yield every subschema directly under a schema object (skipping the
+    # keywords the dialect does not define; nil applies no dialect).
     # @return [void]
-    def self.each_subschema(schema, &block)
+    def self.each_subschema(schema, dialect = nil, &block)
       schema.each do |keyword, value|
-        next if DATA_KEYWORDS.include?(keyword)
+        next if DATA_KEYWORDS.include?(keyword) || !keyword_known?(keyword, dialect)
 
-        if SUBSCHEMA_KEYWORDS.include?(keyword)
-          value.is_a?(Array) ? value.each(&block) : yield(value)
-        elsif SUBSCHEMA_MAP_KEYWORDS.include?(keyword) && value.is_a?(Hash)
-          value.each_value(&block)
-        elsif SUBSCHEMA_ARRAY_KEYWORDS.include?(keyword) && value.is_a?(Array)
-          value.each(&block)
-        end
+        subschemas_under(keyword, value).each(&block)
+      end
+    end
+
+    # The subschema positions one keyword holds.
+    # @return [Array<Object>]
+    def self.subschemas_under(keyword, value)
+      if SUBSCHEMA_KEYWORDS.include?(keyword)
+        value.is_a?(Array) ? value : [value]
+      elsif keyword == 'dependencies'
+        # Property-name arrays are data; only the schema entries are walked.
+        value.is_a?(Hash) ? value.values.select { |v| schema_value?(v) } : []
+      elsif SUBSCHEMA_MAP_KEYWORDS.include?(keyword)
+        value.is_a?(Hash) ? value.values : []
+      elsif SUBSCHEMA_ARRAY_KEYWORDS.include?(keyword)
+        value.is_a?(Array) ? value : []
+      else
+        []
+      end
+    end
+
+    # Yield the reusable schemas under $defs / definitions only.
+    # @return [void]
+    def self.each_definition(schema, &block)
+      %w[$defs definitions].each do |keyword|
+        schema[keyword].each_value(&block) if schema[keyword].is_a?(Hash)
       end
     end
 
     # @return [void]
-    def self.check_ref(ref, root, problems)
+    def self.check_ref(ref, root, problems, dialect, counter)
       unless ref.is_a?(String)
         problems << "$ref must be a string, got #{json_type(ref)}"
         return
@@ -256,24 +367,26 @@ module MCPClient
         return
       end
 
-      problem = ref_chain_problem(ref, root)
+      problem = ref_chain_problem(ref, root, dialect, counter)
       problems << problem if problem
     end
 
-    # A `$dynamicRef` is not evaluated, but one pointing outside the document
-    # would need a fetch, which never happens: the schema is unusable.
+    # A `$dynamicRef` / `$recursiveRef` is not evaluated, but one pointing
+    # outside the document would need a fetch, which never happens: the
+    # schema is unusable.
     # @return [void]
-    def self.check_dynamic_ref(ref, problems)
+    def self.check_dynamic_ref(keyword, ref, problems)
       return unless ref.is_a?(String) && external_ref?(ref)
 
-      problems << "external $dynamicRef #{clip(ref.inspect)} is not dereferenced"
+      problems << "external #{keyword} #{clip(ref.inspect)} is not dereferenced"
     end
 
     # Follow a local reference (and the references it leads to) at
     # preflight: every hop must resolve to a schema, the chain must not
     # cycle, and it must stay within MAX_REF_DEPTH.
+    # @param resolver [Hash, Context] holder of the memoized anchor index
     # @return [String, nil] the problem, if any
-    def self.ref_chain_problem(ref, root)
+    def self.ref_chain_problem(ref, root, dialect, resolver)
       seen = []
       current = ref
       loop do
@@ -281,7 +394,7 @@ module MCPClient
         return "$ref chain #{clip(ref.inspect)} exceeds #{MAX_REF_DEPTH} hops" if seen.size >= MAX_REF_DEPTH
 
         seen << current
-        target = resolve_pointer(root, current)
+        target = resolve_reference(root, current, dialect, resolver)
         return "unresolvable local $ref #{clip(current.inspect)}" if target.equal?(UNRESOLVED)
         return "$ref #{clip(current.inspect)} does not point at a schema" unless schema_value?(target)
         return nil unless target.is_a?(Hash) && target.key?('$ref')
@@ -298,46 +411,9 @@ module MCPClient
       value.is_a?(Hash) || value == true || value == false
     end
 
-    # A reference that does not point inside this document: an absolute URI
-    # (http, https, urn, file, ...), a relative document, or anything that
-    # is not a bare fragment. None of these is ever fetched.
-    # @param ref [String]
-    # @return [Boolean]
-    def self.external_ref?(ref)
-      !ref.start_with?('#')
-    end
-
     # Marker for a pointer that does not resolve (nil is a valid schema
     # value position, so it cannot serve as the marker).
     UNRESOLVED = Object.new.freeze
-
-    # Resolve a fragment JSON pointer (`#`, `#/$defs/x`, `#/a~1b`, with
-    # percent-encoding per RFC 6901 Section 6) within the root document.
-    # @param root [Hash] the root schema (string keys)
-    # @param ref [String] the `$ref` value
-    # @return [Object] the referenced value, or UNRESOLVED
-    def self.resolve_pointer(root, ref)
-      fragment = ref.delete_prefix('#')
-      fragment = URI.decode_uri_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
-      return root if fragment.empty?
-      return UNRESOLVED unless fragment.start_with?('/')
-
-      fragment[1..].split('/', -1).reduce(root) do |node, token|
-        key = token.gsub('~1', '/').gsub('~0', '~')
-        case node
-        when Hash
-          return UNRESOLVED unless node.key?(key)
-
-          node[key]
-        when Array
-          return UNRESOLVED unless key.match?(/\A(0|[1-9]\d*)\z/) && key.to_i < node.length
-
-          node[key.to_i]
-        else
-          return UNRESOLVED
-        end
-      end
-    end
 
     # List the unsupported JSON Schema keywords a schema uses (anywhere: at the
     # top level or nested in subschemas). Property names that merely look like
@@ -347,20 +423,23 @@ module MCPClient
     # @return [Array<String>] unique unsupported keywords, in discovery order
     def self.unsupported_keywords(schema)
       found = []
-      collect_unsupported_keywords(schema, found, 0)
+      declared = dialect(schema)
+      collect_unsupported_keywords(schema, found, 0, declared && canonical_dialect(declared))
       found.uniq
     end
 
-    # Recursively collect unsupported keywords from a schema.
+    # Recursively collect unsupported keywords from a schema (keywords the
+    # dialect does not define are unknown, not unsupported).
     # @param schema [Object] a (sub)schema; non-Hash values are ignored
     # @param found [Array<String>] accumulator
+    # @param dialect [String, nil] the canonical dialect
     # @return [void]
-    def self.collect_unsupported_keywords(schema, found, depth)
+    def self.collect_unsupported_keywords(schema, found, depth, dialect)
       return unless schema.is_a?(Hash) && depth <= MAX_SCHEMA_DEPTH
 
       schema = schema.transform_keys(&:to_s)
-      found.concat(schema.keys & UNSUPPORTED_KEYWORDS)
-      each_subschema(schema) { |sub| collect_unsupported_keywords(sub, found, depth + 1) }
+      found.concat((schema.keys & UNSUPPORTED_KEYWORDS).select { |k| keyword_known?(k, dialect) })
+      each_subschema(schema, dialect) { |sub| collect_unsupported_keywords(sub, found, depth + 1, dialect) }
     end
 
     # Validate data against a schema. An unusable schema (see
@@ -380,7 +459,7 @@ module MCPClient
       deadline ||= Process.clock_gettime(Process::CLOCK_MONOTONIC) + PATTERN_MATCH_TIMEOUT
       root = schema.is_a?(Hash) ? deep_stringify(schema) : schema
       ctx = Context.new(root: root, deadline: deadline, dialect: canonical_dialect(dialect(root)),
-                        visits: 0, errors: 0, speculative: 0)
+                        visits: 0, errors: 0, speculative: 0, anchors: nil)
       validate_node(data, root, path, ctx, 0)
     rescue Aborted => e
       ["#{path}: validation aborted: #{e.message}"]
@@ -412,7 +491,7 @@ module MCPClient
       when Hash then errors.concat(validate_object(data, schema, path, ctx, ref_depth))
       when Array then errors.concat(validate_array(data, schema, path, ctx, ref_depth))
       when String then errors.concat(validate_string(data, schema, path, ctx.deadline))
-      when Numeric then errors.concat(validate_number(data, schema, path))
+      when Numeric then errors.concat(validate_number(data, schema, path, ctx.dialect))
       end
       errors.concat(validate_composition(data, schema, path, ctx, ref_depth))
       count_errors(ctx, errors)
@@ -466,7 +545,7 @@ module MCPClient
         raise Aborted, "$ref chain exceeds #{MAX_REF_DEPTH} hops (cycle?) at #{clip(ref.inspect)}"
       end
 
-      target = resolve_pointer(ctx.root, ref)
+      target = resolve_reference(ctx.root, ref, ctx.dialect, ctx)
       return count_errors(ctx, ["#{path}: unresolvable local $ref #{clip(ref.inspect)}"]) if target.equal?(UNRESOLVED)
       unless schema_value?(target)
         return count_errors(ctx, ["#{path}: $ref #{clip(ref.inspect)} does not point at a schema"])
@@ -721,19 +800,31 @@ module MCPClient
       [remaining, MIN_PATTERN_MATCH_TIMEOUT].max
     end
 
-    # Validate a number against inclusive/exclusive bounds.
+    # Validate a number against inclusive/exclusive bounds. Under draft-07
+    # `exclusiveMinimum: true` / `exclusiveMaximum: true` make `minimum` /
+    # `maximum` exclusive; 2019-09 and 2020-12 carry the bound in the
+    # keyword itself.
     # @param data [Numeric] the number
     # @param schema [Hash] string-keyed schema
     # @param path [String] location for error messages
+    # @param dialect [String, nil] the canonical dialect
     # @return [Array<String>] validation errors
-    def self.validate_number(data, schema, path)
+    def self.validate_number(data, schema, path, dialect = nil)
       errors = []
       minimum = schema['minimum']
       maximum = schema['maximum']
       exclusive_min = schema['exclusiveMinimum']
       exclusive_max = schema['exclusiveMaximum']
-      errors << "#{path}: value #{data} is less than minimum #{minimum}" if minimum.is_a?(Numeric) && data < minimum
-      errors << "#{path}: value #{data} is greater than maximum #{maximum}" if maximum.is_a?(Numeric) && data > maximum
+      if dialect == DRAFT_07
+        exclusive_min = exclusive_min == true ? minimum : nil
+        exclusive_max = exclusive_max == true ? maximum : nil
+      end
+      if minimum.is_a?(Numeric) && data < minimum && exclusive_min.nil?
+        errors << "#{path}: value #{data} is less than minimum #{minimum}"
+      end
+      if maximum.is_a?(Numeric) && data > maximum && exclusive_max.nil?
+        errors << "#{path}: value #{data} is greater than maximum #{maximum}"
+      end
       if exclusive_min.is_a?(Numeric) && data <= exclusive_min
         errors << "#{path}: value #{data} must be greater than exclusiveMinimum #{exclusive_min}"
       end

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -79,7 +79,7 @@ module MCPClient
     UNSUPPORTED_KEYWORDS = %w[
       $dynamicRef $recursiveRef
       additionalProperties patternProperties propertyNames dependentSchemas dependencies
-      additionalItems contains minContains maxContains uniqueItems
+      additionalItems contains minContains maxContains uniqueItems contentSchema
       multipleOf format dependentRequired minProperties maxProperties
       unevaluatedProperties unevaluatedItems
     ].freeze
@@ -102,7 +102,7 @@ module MCPClient
     # an array of positional subschemas in draft-07 / 2019-09).
     SUBSCHEMA_KEYWORDS = %w[
       items contains additionalProperties additionalItems propertyNames not if then else
-      unevaluatedItems unevaluatedProperties
+      unevaluatedItems unevaluatedProperties contentSchema
     ].freeze
 
     # Keywords whose value is a map of name => subschema.
@@ -115,7 +115,7 @@ module MCPClient
     DATA_KEYWORDS = %w[enum const default examples].freeze
 
     # Per-validation state.
-    Context = Struct.new(:root, :deadline, :dialect, :visits, :errors, keyword_init: true)
+    Context = Struct.new(:root, :deadline, :dialect, :visits, :errors, :speculative, keyword_init: true)
 
     # The dialect a schema declares, or the default.
     # @param schema [Object] the schema
@@ -193,7 +193,39 @@ module MCPClient
       if counter[:dialect] == DEFAULT_DIALECT && schema['items'].is_a?(Array)
         problems << 'items must be a schema in JSON Schema 2020-12 (positional schemas go in prefixItems)'
       end
+      check_applicator_shapes(schema, problems)
       each_subschema(schema) { |sub| walk_schema(sub, root, depth + 1, counter, problems) }
+    end
+
+    # Every applicator value must be a schema (object or boolean), an array
+    # of schemas or a map of schemas; anything else is not silently read as
+    # "true".
+    # @return [void]
+    def self.check_applicator_shapes(schema, problems)
+      schema.each do |keyword, value|
+        problem = applicator_shape_problem(keyword, value)
+        problems << problem if problem
+      end
+    end
+
+    # @return [String, nil] why an applicator value is malformed
+    def self.applicator_shape_problem(keyword, value)
+      if SUBSCHEMA_KEYWORDS.include?(keyword)
+        tuple = keyword == 'items' && all_schemas?(value)
+        "#{keyword} must be a schema" unless schema_value?(value) || tuple
+      elsif SUBSCHEMA_MAP_KEYWORDS.include?(keyword) && !%w[$defs definitions].include?(keyword)
+        # $defs / definitions are a bag of reusable values: an entry that is
+        # not a schema only matters once a $ref points at it.
+        "#{keyword} must be an object of schemas" unless value.is_a?(Hash) && all_schemas?(value.values)
+      elsif SUBSCHEMA_ARRAY_KEYWORDS.include?(keyword)
+        "#{keyword} must be an array of schemas" unless all_schemas?(value)
+      end
+    end
+
+    # @param values [Object]
+    # @return [Boolean] whether values is an array of schemas
+    def self.all_schemas?(values)
+      values.is_a?(Array) && values.all? { |v| schema_value?(v) }
     end
 
     # Yield every subschema directly under a schema object.
@@ -348,7 +380,7 @@ module MCPClient
       deadline ||= Process.clock_gettime(Process::CLOCK_MONOTONIC) + PATTERN_MATCH_TIMEOUT
       root = schema.is_a?(Hash) ? deep_stringify(schema) : schema
       ctx = Context.new(root: root, deadline: deadline, dialect: canonical_dialect(dialect(root)),
-                        visits: 0, errors: 0)
+                        visits: 0, errors: 0, speculative: 0)
       validate_node(data, root, path, ctx, 0)
     rescue Aborted => e
       ["#{path}: validation aborted: #{e.message}"]
@@ -363,13 +395,10 @@ module MCPClient
     # @return [Array<String>] validation errors
     # @raise [Aborted] when a bound is hit
     def self.validate_node(data, schema, path, ctx, ref_depth)
+      count_visit(ctx)
       return [] if schema == true
       return count_errors(ctx, ["#{path}: schema false accepts no value"]) if schema == false
       return [] unless schema.is_a?(Hash)
-
-      ctx.visits += 1
-      raise Aborted, "more than #{MAX_NODE_VISITS} schema nodes visited" if ctx.visits > MAX_NODE_VISITS
-      raise Aborted, 'validation time budget exhausted' if budget_exhausted?(ctx.deadline)
 
       # draft-07: "$ref" replaces the schema it appears in; later drafts
       # apply it alongside the sibling keywords.
@@ -394,16 +423,28 @@ module MCPClient
     # whole validation still propagate.
     # @return [Object] the block's value
     def self.speculative(ctx)
-      before = ctx.errors
+      ctx.speculative += 1
       yield
     ensure
-      ctx.errors = before
+      ctx.speculative -= 1
     end
 
-    # Account for produced errors against MAX_ERRORS.
+    # Account for one node visit (boolean schemas included, so a huge array
+    # under `items: true` still runs into the bounds).
+    # @raise [Aborted]
+    def self.count_visit(ctx)
+      ctx.visits += 1
+      raise Aborted, "more than #{MAX_NODE_VISITS} schema nodes visited" if ctx.visits > MAX_NODE_VISITS
+      raise Aborted, 'validation time budget exhausted' if budget_exhausted?(ctx.deadline)
+    end
+
+    # Account for produced errors against MAX_ERRORS. Errors inside a
+    # speculative branch are a verdict, not output, and do not count.
     # @return [Array<String>] the errors
     # @raise [Aborted]
     def self.count_errors(ctx, errors)
+      return errors if ctx.speculative.positive?
+
       ctx.errors += errors.size
       raise Aborted, "more than #{MAX_ERRORS} validation errors (output truncated)" if ctx.errors > MAX_ERRORS
 
@@ -541,10 +582,10 @@ module MCPClient
     def self.validate_enum(data, schema, path)
       errors = []
       if schema['enum'].is_a?(Array) && !schema['enum'].include?(data)
-        errors << "#{path}: value #{clip(data.inspect)} is not in enum #{clip(schema['enum'].inspect)}"
+        errors << "#{path}: value #{clip_value(data)} is not in enum #{clip_value(schema['enum'])}"
       end
       if schema.key?('const') && schema['const'] != data
-        errors << "#{path}: value #{clip(data.inspect)} does not equal const #{clip(schema['const'].inspect)}"
+        errors << "#{path}: value #{clip_value(data)} does not equal const #{clip_value(schema['const'])}"
       end
       errors
     end
@@ -729,6 +770,19 @@ module MCPClient
     def self.clip(text)
       text = text.to_s
       text.length > MAX_VALUE_INSPECT ? "#{text[0, MAX_VALUE_INSPECT]}..." : text
+    end
+
+    # A short rendering of a value for a message that never inspects a
+    # large value whole.
+    # @param value [Object]
+    # @return [String]
+    def self.clip_value(value)
+      case value
+      when String then clip(value[0, MAX_VALUE_INSPECT].inspect)
+      when Array then "array(#{value.length} items)"
+      when Hash then "object(#{value.length} keys)"
+      else clip(value.inspect)
+      end
     end
   end
 end

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -88,18 +88,31 @@ module MCPClient
     MAX_ERRORS = 100
     MAX_VALUE_INSPECT = 64
 
-    # How deeply {.validate_node} may nest. The walk is plain recursion, so
-    # its depth is the interpreter's stack depth: the instance nests a level
-    # per array item or property, and a recursive `$ref` follows it down
-    # without bound (the hop budget restarts at every value, so that a
-    # recursive schema can describe deep data at all). A validation that
-    # outgrew the stack would raise SystemStackError past every bound this
-    # validator applies; nesting is counted instead, so the deepest instance
-    # aborts with one error like any other exhausted budget. The bound sits
-    # well above what a peer can send — `JSON.parse` refuses more than 100
-    # levels of nesting by default — and well below what the smallest stack
-    # this library runs on (a transport's reader thread) can carry.
-    MAX_NODE_DEPTH = 512
+    # How deeply the walk may descend into the instance. The walk is plain
+    # recursion, so this drives the interpreter's stack: the instance nests a
+    # level per array item or property, and a recursive `$ref` follows it
+    # down without bound (the hop budget restarts at every value, so that a
+    # recursive schema can describe deep data at all). Counting the descent
+    # lets the deepest instance abort with one error like any other
+    # exhausted budget.
+    #
+    # Only a step into a child value — an array item or a property value —
+    # counts. The frames a schema spends on one value (a `$ref` hop, an
+    # allOf/anyOf/oneOf/if branch) do not: a recursive schema composed
+    # through a few `$defs` mixins applies several of them per instance
+    # level, and counting those would make the budget a fraction of the
+    # instance depth it names, so data a peer can legitimately send — its
+    # nesting under `JSON.parse`'s default limit of 100 — would abort. Those
+    # frames stay bounded by MAX_REF_DEPTH and MAX_NODE_VISITS instead, which
+    # is what already stops a schema recursing on one value forever.
+    #
+    # The bound therefore sits well above the deepest instance a peer can
+    # send, and below the number of levels the smallest stack this library
+    # runs on (a transport's reader thread) carries for a plain recursive
+    # schema. It cannot on its own promise the stack holds, since it does not
+    # bound what one level costs; {.validate} catches SystemStackError for
+    # the schema that spends more per level than the stack has to give.
+    MAX_NODE_DEPTH = 256
 
     # JSON Schema keywords that affect validation but that this validator
     # does not evaluate: assertion keywords (multipleOf, uniqueItems,
@@ -598,13 +611,22 @@ module MCPClient
       ["#{path}: #{e.message}"]
     rescue Aborted => e
       ["#{path}: validation aborted: #{e.message}"]
+    rescue SystemStackError
+      # MAX_NODE_DEPTH bounds how deep the instance may nest, but not what
+      # one level costs: a schema is free to spend a `$ref` chain and a stack
+      # of composition branches on every value, and the stack this runs on
+      # may be a transport reader thread's. The walk is plain recursion with
+      # no state outside `ctx`, so the unwound stack leaves nothing behind —
+      # the validation ends the way an exhausted budget does, as one error,
+      # never as a crash out of a tool call.
+      ["#{path}: validation aborted: schema too deeply recursive for this stack"]
     end
 
-    # Validate one value against one (sub)schema, under the bounds on the
-    # walk itself: one more node visited, one level deeper. The nesting is
-    # counted here rather than passed down, so every recursion into the walk
-    # is bounded — an instance nesting a level per item, a subschema, and a
-    # `$ref` followed from either.
+    # Validate one value against one (sub)schema, under the bound on the walk
+    # itself: one more node visited. Applying another schema to the same
+    # value does not nest the instance, so it is the `$ref` hop budget and
+    # the visit cap that bound it; {.validate_child} accounts for the steps
+    # that do nest.
     # @param data [Object] the value
     # @param schema [Object] a subschema (Hash or boolean)
     # @param path [String] location for error messages
@@ -614,10 +636,24 @@ module MCPClient
     # @raise [Aborted] when a bound is hit
     def self.validate_node(data, schema, path, ctx, ref_depth)
       count_visit(ctx)
-      ctx.depth += 1
-      raise Aborted, "instance or schema nesting deeper than #{MAX_NODE_DEPTH}" if ctx.depth > MAX_NODE_DEPTH
-
       validate_node_keywords(data, schema, path, ctx, ref_depth)
+    end
+
+    # Validate a child of the value being validated — an array item or a
+    # property value — against the subschema for it. This is the one step
+    # that nests the instance, so it is where the walk's depth is counted and
+    # where the `$ref` hop budget starts over (see {.validate_object}).
+    # @param data [Object] the child value
+    # @param schema [Object] the subschema for it (Hash or boolean)
+    # @param path [String] location for error messages
+    # @param ctx [Context] the validation context
+    # @return [Array<String>] validation errors
+    # @raise [Aborted] when a bound is hit
+    def self.validate_child(data, schema, path, ctx)
+      ctx.depth += 1
+      raise Aborted, "instance nested deeper than #{MAX_NODE_DEPTH}" if ctx.depth > MAX_NODE_DEPTH
+
+      validate_node(data, schema, path, ctx, 0)
     ensure
       ctx.depth -= 1
     end
@@ -831,7 +867,8 @@ module MCPClient
         # A property is a smaller instance, so the hops taken to reach this
         # schema cannot repeat forever below it: the budget counts a chain
         # of references applied to one value, not how deep the data nests.
-        errors.concat(validate_node(data[key], prop_schema, "#{path}/#{name}", ctx, 0))
+        # The step down is what the depth bound counts.
+        errors.concat(validate_child(data[key], prop_schema, "#{path}/#{name}", ctx))
       end
       errors
     end
@@ -871,10 +908,10 @@ module MCPClient
                       end
         next unless schema_value?(item_schema)
 
-        # An item is a smaller instance: the hop budget starts over, so a
-        # recursive schema describes data of any depth (see
-        # {.validate_object}).
-        errors.concat(validate_node(item, item_schema, "#{path}/#{idx}", ctx, 0))
+        # An item is a smaller instance: the hop budget starts over and the
+        # depth bound counts the step, so a recursive schema describes data
+        # of any depth up to it (see {.validate_object}).
+        errors.concat(validate_child(item, item_schema, "#{path}/#{idx}", ctx))
       end
       errors.concat(validate_contains(data, schema, path, dialect))
     end

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -101,6 +101,25 @@ module MCPClient
       unevaluatedProperties unevaluatedItems
     ].freeze
 
+    # Unsupported keywords that are annotations, not assertions (`format`
+    # is annotation-only in the default 2020-12 vocabulary, `contentSchema`
+    # only annotates): their presence decides nothing about an instance.
+    ANNOTATION_KEYWORDS = %w[format contentSchema].freeze
+
+    # Unsupported assertions by the instance type they apply to; an
+    # assertion of another type is a no-op for the instance (JSON Schema
+    # 2020-12 Validation Section 6: keywords apply only to their type), so
+    # it cannot leave a branch undecided.
+    UNSUPPORTED_ASSERTIONS_BY_TYPE = {
+      Hash => %w[additionalProperties patternProperties propertyNames dependentSchemas dependencies
+                 dependentRequired minProperties maxProperties unevaluatedProperties],
+      Array => %w[additionalItems contains minContains maxContains uniqueItems unevaluatedItems],
+      Numeric => %w[multipleOf]
+    }.freeze
+
+    # Unsupported keywords that apply to every instance.
+    UNSUPPORTED_ASSERTIONS_ANY_TYPE = %w[$dynamicRef $recursiveRef].freeze
+
     # Wall-clock budget for a single validate call (pattern matching and the
     # walk itself). Schemas come from the remote server, so an expensive
     # expression or a huge composition must not be able to monopolize the
@@ -238,7 +257,10 @@ module MCPClient
       problems = index[:duplicates].map do |name|
         "anchor #{clip(name.inspect)} is declared more than once in a schema resource"
       end
-      problems << "schema has too many objects to index its anchors (more than #{MAX_SUBSCHEMAS})" if index[:truncated]
+      if index[:truncated]
+        problems << 'schema has too many or too deeply nested objects to index its anchors ' \
+                    "(more than #{MAX_SUBSCHEMAS}, or deeper than #{MAX_SCHEMA_DEPTH})"
+      end
       problems
     end
 
@@ -538,7 +560,7 @@ module MCPClient
 
       # A keyword the validator does not evaluate makes this node's verdict
       # partial: a pass here is not a proof for not / oneOf / if.
-      ctx.undecided += 1 if partial_keywords?(schema, dialect)
+      ctx.undecided += 1 if partial_keywords?(schema, dialect, data)
       errors = []
       counted_before = ctx.errors
       errors.concat(validate_ref(data, schema, path, ctx, ref_depth)) if schema.key?('$ref')

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -3,7 +3,9 @@
 require 'uri'
 require_relative 'schema_validator/dialects'
 require_relative 'schema_validator/normalization'
+require_relative 'schema_validator/uri_references'
 require_relative 'schema_validator/references'
+require_relative 'schema_validator/shapes'
 require_relative 'schema_validator/keyword_scan'
 require_relative 'schema_validator/composition'
 require_relative 'schema_validator/evaluation'
@@ -28,7 +30,8 @@ module MCPClient
   #   `#/definitions/x`, any JSON pointer, or a plain-name fragment `#name`
   #   naming an `$anchor` / a draft-07 `$id: "#name"` of the referencing
   #   schema's own resource — a subschema whose `$id` is a URI starts a new
-  #   resource), with $defs (2019-09, 2020-12) / definitions (draft-07);
+  #   resource), with $defs (2019-09, 2020-12) and definitions, which the
+  #   modern dialects keep as the deprecated spelling of $defs;
   #   under draft-07 a $ref replaces its siblings, under 2019-09 and 2020-12
   #   it applies alongside them
   # - boolean schemas (true / false), at the root or as subschemas
@@ -58,7 +61,9 @@ module MCPClient
   module SchemaValidator
     extend Dialects
     extend Normalization
+    extend UriReferences
     extend References
+    extend Shapes
     extend KeywordScan
     extend Composition
     extend Evaluation
@@ -203,12 +208,29 @@ module MCPClient
       'minContains' => [DEFAULT_DIALECT, DRAFT_2019_09],
       'maxContains' => [DEFAULT_DIALECT, DRAFT_2019_09],
       '$anchor' => [DEFAULT_DIALECT, DRAFT_2019_09],
-      '$defs' => [DEFAULT_DIALECT, DRAFT_2019_09],
-      'definitions' => [DRAFT_07]
+      '$defs' => [DEFAULT_DIALECT, DRAFT_2019_09]
     }.freeze
 
-    # Plain-name fragment syntax (JSON Schema 2020-12 Section 8.2.2).
-    ANCHOR_NAME = /\A[A-Za-z_][-A-Za-z0-9._]*\z/
+    # Plain-name fragment syntax, per dialect: 2020-12 Core Section 8.2.2
+    # admits a leading underscore and no colon, while 2019-09 Core Section
+    # 8.2.3 and draft-07 Core Section 8.2.3 admit a colon and require a
+    # leading letter. A name legal in one dialect is not one in the other,
+    # and the dialect in force at the resource decides.
+    ANCHOR_NAME_BY_DIALECT = {
+      DEFAULT_DIALECT => /\A[A-Za-z_][-A-Za-z0-9._]*\z/,
+      DRAFT_2019_09 => /\A[A-Za-z][-A-Za-z0-9.:_]*\z/,
+      DRAFT_07 => /\A[A-Za-z][-A-Za-z0-9.:_]*\z/
+    }.freeze
+
+    # The 2020-12 plain-name syntax, the default when no dialect is known.
+    ANCHOR_NAME = ANCHOR_NAME_BY_DIALECT.fetch(DEFAULT_DIALECT)
+
+    # @param name [Object] the candidate plain name
+    # @param dialect [String, nil] the canonical dialect in force
+    # @return [Boolean] whether the dialect admits the name as a plain name
+    def self.anchor_name?(name, dialect)
+      name.is_a?(String) && name.match?(ANCHOR_NAME_BY_DIALECT.fetch(dialect, ANCHOR_NAME))
+    end
 
     # @param keyword [String]
     # @param dialect [String, nil] a canonical dialect, or nil for "any"
@@ -220,6 +242,11 @@ module MCPClient
     # Per-validation state.
     Context = Struct.new(:root, :deadline, :dialect, :visits, :errors, :speculative, :anchors, :undecided, :depth,
                          keyword_init: true)
+
+    # Per-preflight state: the document, the counter the walk accounts to,
+    # the problems it found, and the positions it has still to read (a
+    # stack, so the walk needs no interpreter frame of its own).
+    Walk = Struct.new(:root, :counter, :problems, :pending, keyword_init: true)
 
     # Raised while normalizing a schema whose structure exceeds the bounds,
     # so a peer-supplied document is never copied whole.
@@ -239,11 +266,28 @@ module MCPClient
     # otherwise external reference is never dereferenced and makes the
     # schema unusable rather than permissive).
     # @param schema [Object] the schema (string or symbol keys)
+    # @param counter [Hash] filled in with the preflight state, so a caller
+    #   can tell one kind of problem from another (`:unsupported_dialect`)
     # @return [Array<String>] problems (empty when the schema is usable)
-    def self.check_schema(schema)
-      check_normalized(normalize_schema(schema))
+    def self.check_schema(schema, counter = {})
+      check_normalized(normalize_schema(schema), counter)
     rescue TooLarge => e
       [e.message]
+    end
+
+    # The dialect a schema declares (at its root or at an embedded resource
+    # root) that this validator does not implement. MCP 2026-07-28 basic
+    # "Implementation Requirements": a client "MUST handle unsupported
+    # dialects gracefully by returning an appropriate error indicating the
+    # dialect is not supported", which a caller can only do once it can tell
+    # an unsupported dialect from every other reason a schema is unusable.
+    # @param schema [Object] the schema (string or symbol keys)
+    # @return [String, nil] the declared dialect, or nil when every dialect
+    #   the document declares is supported
+    def self.unsupported_dialect(schema)
+      state = {}
+      check_schema(schema, state)
+      state[:unsupported_dialect]
     end
 
     # A bounded, string-keyed copy of a schema (booleans pass through).
@@ -267,7 +311,9 @@ module MCPClient
 
       declared = dialect(root)
       return ['$schema must be a non-empty string naming the dialect'] if declared.nil?
+
       unless supported_dialect?(declared)
+        counter[:unsupported_dialect] = declared
         return ["schema dialect #{clip(declared.inspect)} is not supported " \
                 "(supported: #{SUPPORTED_DIALECTS.join(', ')})"]
       end
@@ -307,36 +353,91 @@ module MCPClient
     # walked under its own dialect.
     # @return [void]
     def self.walk_schema(schema, root, depth, counter, problems, dialect = counter[:dialect])
-      return unless problems.empty? && schema_value?(schema)
-      return unless admit_schema?(schema, depth, counter, problems)
+      walk = Walk.new(root: root, counter: counter, problems: problems,
+                      pending: [[schema, depth, dialect]])
+      until walk.pending.empty?
+        return unless problems.empty?
+
+        walk_position(walk, *walk.pending.pop)
+      end
+    end
+
+    # Walk one schema position and queue the positions it leads to. The
+    # queue is a stack and children are pushed in reverse, so a document is
+    # read depth-first and in document order, exactly as a recursive walk
+    # would read it — but a `$ref` chain hundreds of schemas long costs
+    # queue entries rather than interpreter frames, so a shallow document
+    # whose references chain deeply can no longer overflow the (small) stack
+    # of the thread a transport reads on. A reference is followed before the
+    # position's own subschemas, so it is pushed last.
+    # @return [void]
+    def self.walk_position(walk, schema, depth, dialect)
+      return unless schema_value?(schema)
+      return unless admit_schema?(schema, depth, walk.counter, walk.problems)
 
       if resource_root?(schema, dialect) && schema.key?('$schema')
         problem = embedded_dialect_problem(schema)
-        return problems << problem if problem
+        return record_embedded_dialect_problem(walk, schema, problem) if problem
 
         dialect = embedded_dialect(schema, dialect)
       end
-      check_ref(schema, root, depth, problems, dialect, counter) if schema.key?('$ref')
+      referenced = schema.key?('$ref') ? check_ref(walk, schema, depth, dialect) : []
       # draft-07: the $ref replaces its siblings, so the applicators next to
       # it are never applied and are not preflighted either; definitions are
       # a bag of reusable schemas, not applicators, and stay reachable
       # through references.
-      if dialect == DRAFT_07 && schema.key?('$ref')
-        each_definition(schema, dialect) { |sub| walk_schema(sub, root, depth + 1, counter, problems, dialect) }
-        return
-      end
+      return queue_definitions(walk, schema, depth, dialect, referenced) if dialect == DRAFT_07 && schema.key?('$ref')
 
+      check_keyword_shapes(walk, schema, dialect)
+      queue_subschemas(walk, schema, depth, dialect, referenced)
+    end
+
+    # @return [void]
+    def self.record_embedded_dialect_problem(walk, schema, problem)
+      declared = dialect(schema)
+      walk.counter[:unsupported_dialect] ||= declared if declared && !supported_dialect?(declared)
+      walk.problems << problem
+    end
+
+    # Queue the reusable schemas beside a draft-07 `$ref`, then what the
+    # reference reaches (walked first, so pushed last).
+    # @return [void]
+    def self.queue_definitions(walk, schema, depth, dialect, referenced)
+      positions = []
+      each_definition(schema, dialect) { |sub| positions << [sub, depth + 1, dialect] }
+      queue_positions(walk, positions, referenced)
+    end
+
+    # Queue every subschema position under a schema object, then what its
+    # reference reaches.
+    # @return [void]
+    def self.queue_subschemas(walk, schema, depth, dialect, referenced)
+      positions = []
+      each_subschema(schema, dialect) { |sub| positions << [sub, depth + 1, dialect] }
+      queue_positions(walk, positions, referenced)
+    end
+
+    # @return [void]
+    def self.queue_positions(walk, positions, referenced)
+      walk.pending.concat(positions.reverse)
+      walk.pending.concat(referenced.reverse)
+    end
+
+    # Every check a schema object's own keywords get.
+    # @return [void]
+    def self.check_keyword_shapes(walk, schema, dialect)
+      problems = walk.problems
       %w[$dynamicRef $recursiveRef].each do |keyword|
         next unless schema.key?(keyword) && keyword_known?(keyword, dialect)
 
-        check_dynamic_ref(keyword, schema[keyword], problems)
+        check_dynamic_ref(walk, schema, keyword, dialect)
       end
       if dialect == DEFAULT_DIALECT && schema['items'].is_a?(Array)
         problems << 'items must be a schema in JSON Schema 2020-12 (positional schemas go in prefixItems)'
       end
       check_applicator_shapes(schema, dialect, problems)
+      check_assertion_shapes(schema, problems)
       check_exclusive_bounds(schema, dialect, problems)
-      each_subschema(schema, dialect) { |sub| walk_schema(sub, root, depth + 1, counter, problems, dialect) }
     end
 
     # Account for a schema (object or boolean) about to be walked: once per
@@ -357,70 +458,6 @@ module MCPClient
         return false
       end
       schema.is_a?(Hash)
-    end
-
-    # Every applicator value must be a schema (object or boolean), an array
-    # of schemas or a map of schemas; anything else is not silently read as
-    # "true". Keywords the dialect does not define are ignored.
-    # @return [void]
-    def self.check_applicator_shapes(schema, dialect, problems)
-      schema.each do |keyword, value|
-        next unless keyword_known?(keyword, dialect)
-
-        problem = applicator_shape_problem(keyword, value)
-        problems << problem if problem
-      end
-    end
-
-    # @return [String, nil] why an applicator value is malformed
-    def self.applicator_shape_problem(keyword, value)
-      if SUBSCHEMA_KEYWORDS.include?(keyword)
-        tuple = keyword == 'items' && all_schemas?(value)
-        "#{keyword} must be a schema" unless schema_value?(value) || tuple
-      elsif keyword == 'dependencies'
-        dependencies_shape_problem(value)
-      elsif SUBSCHEMA_MAP_KEYWORDS.include?(keyword) && !%w[$defs definitions].include?(keyword)
-        # $defs / definitions are a bag of reusable values: an entry that is
-        # not a schema only matters once a $ref points at it.
-        "#{keyword} must be an object of schemas" unless value.is_a?(Hash) && all_schemas?(value.values)
-      elsif SUBSCHEMA_ARRAY_KEYWORDS.include?(keyword)
-        "#{keyword} must be an array of schemas" unless all_schemas?(value)
-      end
-    end
-
-    # draft-07: each dependencies entry is a schema or an array of property
-    # names.
-    # @return [String, nil]
-    def self.dependencies_shape_problem(value)
-      return if value.is_a?(Hash) && value.each_value.all? { |v| schema_value?(v) || property_names?(v) }
-
-      'dependencies entries must be schemas or arrays of property names'
-    end
-
-    # @param value [Object]
-    # @return [Boolean] whether value is an array of property names
-    def self.property_names?(value)
-      value.is_a?(Array) && value.all?(String)
-    end
-
-    # exclusiveMinimum / exclusiveMaximum are numbers in every supported
-    # dialect (draft-07 validation Sections 6.2.3 and 6.2.5, kept by 2019-09
-    # and 2020-12); the boolean modifier form belongs to draft-04, which is
-    # not supported, and is not silently ignored (it would turn a bound
-    # into a pass).
-    # @return [void]
-    def self.check_exclusive_bounds(schema, _dialect, problems)
-      %w[exclusiveMinimum exclusiveMaximum].each do |keyword|
-        next if !schema.key?(keyword) || schema[keyword].is_a?(Numeric)
-
-        problems << "#{keyword} must be a number (the draft-04 boolean form is not supported)"
-      end
-    end
-
-    # @param values [Object]
-    # @return [Boolean] whether values is an array of schemas
-    def self.all_schemas?(values)
-      values.is_a?(Array) && values.all? { |v| schema_value?(v) }
     end
 
     # Yield every subschema directly under a schema object (skipping the
@@ -452,8 +489,9 @@ module MCPClient
     end
 
     # Yield the reusable schemas under the definition bag(s) the dialect
-    # defines (`$defs` in 2019-09 / 2020-12, `definitions` in draft-07; both
-    # when no dialect is given).
+    # defines: `definitions` everywhere (2020-12 Validation Appendix A keeps
+    # it as the deprecated spelling of `$defs`) and `$defs` in 2019-09 and
+    # 2020-12; both when no dialect is given.
     # @return [void]
     def self.each_definition(schema, dialect = nil, &block)
       %w[$defs definitions].each do |keyword|
@@ -463,46 +501,58 @@ module MCPClient
       end
     end
 
-    # Check the `$ref` of a schema object and preflight what it reaches: a
-    # pointer may lead into a bag the dialect does not walk (`definitions`
-    # under 2020-12), and what a reference applies must be usable too.
-    # @return [void]
-    def self.check_ref(schema, root, depth, problems, dialect, counter)
+    # Check the `$ref` of a schema object and queue what it reaches: a
+    # pointer may lead into a bag the dialect does not walk (`$defs` under
+    # draft-07), and what a reference applies must be usable too.
+    # @return [Array<Array>] the positions the reference reaches
+    def self.check_ref(walk, schema, depth, dialect)
+      root = walk.root
+      counter = walk.counter
+      problems = walk.problems
       ref = schema['$ref']
       unless ref.is_a?(String)
         problems << "$ref must be a string, got #{json_type(ref)}"
-        return
+        return []
       end
-      if external_ref?(ref)
+      if external_ref?(ref, root, counter[:dialect], counter, from: schema)
         problems << "external $ref #{clip(ref.inspect)} is not dereferenced (only references inside the schema " \
                     'document are resolved; network $ref resolution is disabled)'
-        return
+        return []
       end
 
+      positions = []
       problem = ref_chain_problem(ref, root, counter[:dialect], counter, from: schema) do |target, hop, from|
-        # What a reference reaches is walked under its own resource's dialect
-        # and at its own lexical depth; a boolean target needs no preflight
-        # and is charged once per distinct position (not per reference),
-        # and that position still obeys the depth bound.
-        position, opaque, visited = pointer_position(hop, root, counter[:dialect], counter, from)
-        unless target.is_a?(Hash)
-          problems << "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}" if position && position > MAX_SCHEMA_DEPTH
-          # A boolean in a position the walk visits was admitted there; one
-          # the walk never reaches (behind an opaque keyword, or beside a
-          # draft-07 $ref) is charged here, once per position.
-          charge_boolean_target(hop, root, from, counter, problems) unless visited
-          next
-        end
-
-        lexical = (counter[:depths] || {})[target]
-        target_depth = if opaque
-                         [position, lexical].compact.max || (depth + 1)
-                       else
-                         lexical || position || (depth + 1)
-                       end
-        walk_schema(target, root, target_depth, counter, problems, indexed_dialect(target, counter) || dialect)
+        position = referenced_target_position(walk, target, hop, from, depth, dialect)
+        positions << position if position
       end
       problems << problem if problem
+      positions
+    end
+
+    # The position a reference's target is walked at: under its own
+    # resource's dialect and at its own lexical depth. A boolean target
+    # needs no preflight and is charged once per distinct position (not per
+    # reference), and that position still obeys the depth bound.
+    # @return [Array, nil] the position to walk, or nil for a boolean target
+    def self.referenced_target_position(walk, target, hop, from, depth, dialect)
+      counter = walk.counter
+      position, opaque, visited = pointer_position(hop, walk.root, counter[:dialect], counter, from)
+      unless target.is_a?(Hash)
+        walk.problems << "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}" if position && position > MAX_SCHEMA_DEPTH
+        # A boolean in a position the walk visits was admitted there; one
+        # the walk never reaches (behind an opaque keyword, or beside a
+        # draft-07 $ref) is charged here, once per position.
+        charge_boolean_target(hop, walk.root, from, counter, walk.problems) unless visited
+        return nil
+      end
+
+      lexical = (counter[:depths] || {})[target]
+      target_depth = if opaque
+                       [position, lexical].compact.max || (depth + 1)
+                     else
+                       lexical || position || (depth + 1)
+                     end
+      [target, target_depth, indexed_dialect(target, counter) || dialect]
     end
 
     # Count a boolean a reference reaches toward the subschema bound, once
@@ -528,10 +578,12 @@ module MCPClient
     # outside the document would need a fetch, which never happens: the
     # schema is unusable.
     # @return [void]
-    def self.check_dynamic_ref(keyword, ref, problems)
-      return unless ref.is_a?(String) && external_ref?(ref)
+    def self.check_dynamic_ref(walk, schema, keyword, _dialect)
+      ref = schema[keyword]
+      return unless ref.is_a?(String)
+      return unless external_ref?(ref, walk.root, walk.counter[:dialect], walk.counter, from: schema)
 
-      problems << "external #{keyword} #{clip(ref.inspect)} is not dereferenced"
+      walk.problems << "external #{keyword} #{clip(ref.inspect)} is not dereferenced"
     end
 
     # Follow a local reference (and the references it leads to) at
@@ -571,7 +623,9 @@ module MCPClient
         from = target
         current = target['$ref']
         return "$ref must be a string, got #{json_type(current)}" unless current.is_a?(String)
-        return "external $ref #{clip(current.inspect)} is not dereferenced" if external_ref?(current)
+        if external_ref?(current, root, dialect, resolver, from: from)
+          return "external $ref #{clip(current.inspect)} is not dereferenced"
+        end
       end
     end
 

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -838,7 +838,7 @@ module MCPClient
 
         errors.concat(validate_node(item, item_schema, "#{path}/#{idx}", ctx, ref_depth))
       end
-      errors
+      errors.concat(validate_contains(data, schema, path, dialect))
     end
 
     # Validate a string against minLength/maxLength/pattern.

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -12,64 +12,74 @@ module MCPClient
   # Supported keywords:
   # - type (single value or array of values), enum, const
   # - properties, required (objects)
-  # - items, minItems, maxItems (arrays)
+  # - items, prefixItems (2020-12) / tuple-form items (draft-07, 2019-09),
+  #   minItems, maxItems (arrays)
   # - minLength, maxLength, pattern (strings)
   # - minimum, maximum, exclusiveMinimum, exclusiveMaximum (numbers)
   # - allOf, anyOf, oneOf, not, if/then/else (composition)
   # - $ref to a location inside the same schema document (`#`, `#/$defs/x`,
-  #   `#/definitions/x`, any JSON pointer), with $defs / definitions
-  # - boolean schemas (true / false)
+  #   `#/definitions/x`, any JSON pointer), with $defs / definitions; under
+  #   draft-07 a $ref replaces its siblings, under 2019-09 and 2020-12 it
+  #   applies alongside them
+  # - boolean schemas (true / false), at the root or as subschemas
   #
   # MCP 2026-07-28 rules honoured here:
   # - a schema without `$schema` is 2020-12; the dialects in
   #   SUPPORTED_DIALECTS are accepted and any other declared dialect is an
   #   error (not a permissive pass);
-  # - `$ref` values that do not point inside the document (network URIs,
-  #   relative documents, urn:, file:) are never dereferenced, and a schema
-  #   carrying one is rejected rather than treated as permissive;
+  # - `$ref` (and `$dynamicRef`) values that do not point inside the document
+  #   (network URIs, relative documents, urn:, file:) are never dereferenced,
+  #   and a schema carrying one is rejected rather than treated as permissive;
   # - resource bounds: schema nesting depth, total subschema count, `$ref`
-  #   chain length and a per-validation time budget.
+  #   chain length, number of nodes visited, number of errors produced and a
+  #   per-validation time budget. Hitting a bound aborts the validation with
+  #   one error: an aborted validation never reads as a pass.
   #
-  # The rest of the 2020-12 vocabulary (additionalProperties, format
-  # assertions, unevaluated*, ...) is out of scope: unrecognized keywords are
-  # ignored rather than misapplied, so validation is best-effort — it may
-  # accept data a full validator would reject, but it does not reject data
-  # that conforms to the schema. So that this gap is never silent,
-  # {.unsupported_keywords} reports which unapplied validation keywords a
-  # schema uses; callers surface them as a warning.
+  # The rest of the vocabulary (additionalProperties, format assertions,
+  # unevaluated*, additionalItems, dependencies, ...) is out of scope:
+  # unrecognized keywords are ignored rather than misapplied, so validation is
+  # best-effort — it may accept data a full validator would reject, but it
+  # does not reject data that conforms to the schema. So that this gap is
+  # never silent, {.unsupported_keywords} reports which unapplied validation
+  # keywords a schema uses; callers surface them as a warning.
   module SchemaValidator
+    # Raised inside a validation to abandon it (time budget, resource bound).
+    class Aborted < StandardError; end
+
     # The default dialect (basic "JSON Schema Usage": "When a schema does not
     # include a $schema field, it defaults to JSON Schema 2020-12").
     DEFAULT_DIALECT = 'https://json-schema.org/draft/2020-12/schema'
+    DRAFT_2019_09 = 'https://json-schema.org/draft/2019-09/schema'
+    DRAFT_07 = 'http://json-schema.org/draft-07/schema'
 
-    # Dialects this validator accepts: the keywords it evaluates have the
-    # same meaning in all three. Any other declared dialect is reported as
-    # unsupported ("MUST handle unsupported dialects gracefully by returning
-    # an appropriate error indicating the dialect is not supported").
-    SUPPORTED_DIALECTS = [
-      DEFAULT_DIALECT,
-      'https://json-schema.org/draft/2019-09/schema',
-      'http://json-schema.org/draft-07/schema'
-    ].freeze
+    # Dialects this validator accepts. Any other declared dialect is
+    # reported as unsupported ("MUST handle unsupported dialects gracefully
+    # by returning an appropriate error indicating the dialect is not
+    # supported").
+    SUPPORTED_DIALECTS = [DEFAULT_DIALECT, DRAFT_2019_09, DRAFT_07].freeze
 
     # Resource bounds ("Composition-Keyword Resource Use": implementations
     # SHOULD apply a maximum schema depth, a cap on the total number of
     # subschemas, or a per-validation time budget). A schema comes from the
-    # remote server, so all three apply.
+    # remote server, so all of them apply.
     MAX_SCHEMA_DEPTH = 64
     MAX_SUBSCHEMAS = 2000
     MAX_REF_DEPTH = 32
+    MAX_NODE_VISITS = 100_000
+    MAX_ERRORS = 100
+    MAX_VALUE_INSPECT = 64
 
-    # JSON Schema 2020-12 keywords that affect validation but that this
-    # validator does not evaluate: assertion keywords (multipleOf,
-    # uniqueItems, contains bounds, property-count bounds, dependentRequired),
-    # the remaining applicators, and format (asserted by full validators in
-    # format-assertion mode). Their presence means validation is partial:
-    # data may pass here that a full validator would reject.
+    # JSON Schema keywords that affect validation but that this validator
+    # does not evaluate: assertion keywords (multipleOf, uniqueItems,
+    # contains bounds, property-count bounds, dependentRequired), the
+    # remaining applicators, draft-specific keywords, and format (asserted by
+    # full validators in format-assertion mode). Their presence means
+    # validation is partial: data may pass here that a full validator would
+    # reject.
     UNSUPPORTED_KEYWORDS = %w[
-      $dynamicRef
-      additionalProperties patternProperties propertyNames dependentSchemas
-      prefixItems contains minContains maxContains uniqueItems
+      $dynamicRef $recursiveRef
+      additionalProperties patternProperties propertyNames dependentSchemas dependencies
+      additionalItems contains minContains maxContains uniqueItems
       multipleOf format dependentRequired minProperties maxProperties
       unevaluatedProperties unevaluatedItems
     ].freeze
@@ -88,21 +98,24 @@ module MCPClient
     # still makes progress rather than failing every remaining pattern.
     MIN_PATTERN_MATCH_TIMEOUT = 0.01
 
-    # Keywords whose value is a single subschema to walk.
+    # Keywords whose value is a single subschema to walk (or, for `items`,
+    # an array of positional subschemas in draft-07 / 2019-09).
     SUBSCHEMA_KEYWORDS = %w[
-      items contains additionalProperties propertyNames not if then else
+      items contains additionalProperties additionalItems propertyNames not if then else
       unevaluatedItems unevaluatedProperties
     ].freeze
 
     # Keywords whose value is a map of name => subschema.
-    SUBSCHEMA_MAP_KEYWORDS = %w[properties patternProperties $defs definitions dependentSchemas].freeze
+    SUBSCHEMA_MAP_KEYWORDS = %w[properties patternProperties $defs definitions dependentSchemas dependencies].freeze
 
     # Keywords whose value is an array of subschemas.
     SUBSCHEMA_ARRAY_KEYWORDS = %w[allOf anyOf oneOf prefixItems].freeze
 
-    # Per-validation state: the root document ($ref targets), the deadline
-    # and the number of $ref hops taken on the current path.
-    Context = Struct.new(:root, :deadline, keyword_init: true)
+    # Keywords whose value is data, not schema: never walked, never re-keyed.
+    DATA_KEYWORDS = %w[enum const default examples].freeze
+
+    # Per-validation state.
+    Context = Struct.new(:root, :deadline, :dialect, :visits, :errors, keyword_init: true)
 
     # The dialect a schema declares, or the default.
     # @param schema [Object] the schema
@@ -116,29 +129,37 @@ module MCPClient
       declared.sub(/#\z/, '')
     end
 
-    # Whether a declared dialect is one this validator evaluates. The
-    # scheme is not significant (both http and https forms circulate).
+    # The supported dialect a declared URI stands for (scheme-insensitive),
+    # or nil.
+    # @param uri [String]
+    # @return [String, nil]
+    def self.canonical_dialect(uri)
+      canonical = uri.sub(/#\z/, '').sub(%r{\Ahttps?://}, '')
+      SUPPORTED_DIALECTS.find { |d| d.sub(%r{\Ahttps?://}, '') == canonical }
+    end
+
     # @param uri [String]
     # @return [Boolean]
     def self.supported_dialect?(uri)
-      canonical = uri.sub(/#\z/, '').sub(%r{\Ahttps?://}, '')
-      SUPPORTED_DIALECTS.any? { |d| d.sub(%r{\Ahttps?://}, '') == canonical }
+      !canonical_dialect(uri).nil?
     end
 
-    # Check that a schema can be used at all: it is an object, its dialect
-    # is supported, it stays within the resource bounds, and every `$ref`
-    # resolves inside the document (a network or otherwise external `$ref`
-    # is never dereferenced and makes the schema unusable rather than
-    # permissive).
+    # Check that a schema can be used at all: it is an object or a boolean,
+    # its dialect is supported, it stays within the resource bounds, and
+    # every `$ref` resolves inside the document to a schema (a network or
+    # otherwise external reference is never dereferenced and makes the
+    # schema unusable rather than permissive).
     # @param schema [Object] the schema (string or symbol keys)
     # @return [Array<String>] problems (empty when the schema is usable)
     def self.check_schema(schema)
-      return ["schema must be an object, got #{json_type(schema)}"] unless schema.is_a?(Hash)
+      return [] if [true, false].include?(schema)
+      return ["schema must be an object or a boolean, got #{json_type(schema)}"] unless schema.is_a?(Hash)
 
       root = deep_stringify(schema)
       declared = dialect(root)
       unless supported_dialect?(declared)
-        return ["schema dialect #{declared.inspect} is not supported (supported: #{SUPPORTED_DIALECTS.join(', ')})"]
+        return ["schema dialect #{clip(declared.inspect)} is not supported " \
+                "(supported: #{SUPPORTED_DIALECTS.join(', ')})"]
       end
 
       problems = []
@@ -149,27 +170,38 @@ module MCPClient
     # Walk every subschema position, checking bounds and references.
     # @return [void]
     def self.walk_schema(schema, root, depth, counter, problems)
-      return unless schema.is_a?(Hash)
       return unless problems.empty?
+      return unless schema_value?(schema)
 
-      if depth > MAX_SCHEMA_DEPTH
-        problems << "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}"
-        return
-      end
       counter[:count] += 1
       if counter[:count] > MAX_SUBSCHEMAS
         problems << "schema has more than #{MAX_SUBSCHEMAS} subschemas"
         return
       end
+      return unless schema.is_a?(Hash)
+
+      if depth > MAX_SCHEMA_DEPTH
+        problems << "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}"
+        return
+      end
 
       check_ref(schema['$ref'], root, problems) if schema.key?('$ref')
+      check_dynamic_ref(schema['$dynamicRef'], problems) if schema.key?('$dynamicRef')
+      each_subschema(schema) { |sub| walk_schema(sub, root, depth + 1, counter, problems) }
+    end
+
+    # Yield every subschema directly under a schema object.
+    # @return [void]
+    def self.each_subschema(schema, &block)
       schema.each do |keyword, value|
+        next if DATA_KEYWORDS.include?(keyword)
+
         if SUBSCHEMA_KEYWORDS.include?(keyword)
-          walk_schema(value, root, depth + 1, counter, problems)
+          value.is_a?(Array) ? value.each(&block) : yield(value)
         elsif SUBSCHEMA_MAP_KEYWORDS.include?(keyword) && value.is_a?(Hash)
-          value.each_value { |subschema| walk_schema(subschema, root, depth + 1, counter, problems) }
+          value.each_value(&block)
         elsif SUBSCHEMA_ARRAY_KEYWORDS.include?(keyword) && value.is_a?(Array)
-          value.each { |subschema| walk_schema(subschema, root, depth + 1, counter, problems) }
+          value.each(&block)
         end
       end
     end
@@ -181,11 +213,51 @@ module MCPClient
         return
       end
       if external_ref?(ref)
-        problems << "external $ref #{ref.inspect} is not dereferenced (only references inside the schema " \
+        problems << "external $ref #{clip(ref.inspect)} is not dereferenced (only references inside the schema " \
                     'document are resolved; network $ref resolution is disabled)'
-      elsif resolve_pointer(root, ref).equal?(UNRESOLVED)
-        problems << "unresolvable local $ref #{ref.inspect}"
+        return
       end
+
+      problem = ref_chain_problem(ref, root)
+      problems << problem if problem
+    end
+
+    # A `$dynamicRef` is not evaluated, but one pointing outside the document
+    # would need a fetch, which never happens: the schema is unusable.
+    # @return [void]
+    def self.check_dynamic_ref(ref, problems)
+      return unless ref.is_a?(String) && external_ref?(ref)
+
+      problems << "external $dynamicRef #{clip(ref.inspect)} is not dereferenced"
+    end
+
+    # Follow a local reference (and the references it leads to) at
+    # preflight: every hop must resolve to a schema, the chain must not
+    # cycle, and it must stay within MAX_REF_DEPTH.
+    # @return [String, nil] the problem, if any
+    def self.ref_chain_problem(ref, root)
+      seen = []
+      current = ref
+      loop do
+        return "$ref chain #{clip(ref.inspect)} cycles" if seen.include?(current)
+        return "$ref chain #{clip(ref.inspect)} exceeds #{MAX_REF_DEPTH} hops" if seen.size >= MAX_REF_DEPTH
+
+        seen << current
+        target = resolve_pointer(root, current)
+        return "unresolvable local $ref #{clip(current.inspect)}" if target.equal?(UNRESOLVED)
+        return "$ref #{clip(current.inspect)} does not point at a schema" unless schema_value?(target)
+        return nil unless target.is_a?(Hash) && target.key?('$ref')
+
+        current = target['$ref']
+        return "$ref must be a string, got #{json_type(current)}" unless current.is_a?(String)
+        return "external $ref #{clip(current.inspect)} is not dereferenced" if external_ref?(current)
+      end
+    end
+
+    # @param value [Object]
+    # @return [Boolean] whether the value is a schema (object or boolean)
+    def self.schema_value?(value)
+      value.is_a?(Hash) || value == true || value == false
     end
 
     # A reference that does not point inside this document: an absolute URI
@@ -202,13 +274,13 @@ module MCPClient
     UNRESOLVED = Object.new.freeze
 
     # Resolve a fragment JSON pointer (`#`, `#/$defs/x`, `#/a~1b`, with
-    # percent-encoding) within the root document.
+    # percent-encoding per RFC 6901 Section 6) within the root document.
     # @param root [Hash] the root schema (string keys)
     # @param ref [String] the `$ref` value
     # @return [Object] the referenced value, or UNRESOLVED
     def self.resolve_pointer(root, ref)
       fragment = ref.delete_prefix('#')
-      fragment = URI.decode_www_form_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
+      fragment = URI.decode_uri_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
       return root if fragment.empty?
       return UNRESOLVED unless fragment.start_with?('/')
 
@@ -220,7 +292,7 @@ module MCPClient
 
           node[key]
         when Array
-          return UNRESOLVED unless key.match?(/\A\d+\z/) && key.to_i < node.length
+          return UNRESOLVED unless key.match?(/\A(0|[1-9]\d*)\z/) && key.to_i < node.length
 
           node[key.to_i]
         else
@@ -237,7 +309,7 @@ module MCPClient
     # @return [Array<String>] unique unsupported keywords, in discovery order
     def self.unsupported_keywords(schema)
       found = []
-      collect_unsupported_keywords(schema, found)
+      collect_unsupported_keywords(schema, found, 0)
       found.uniq
     end
 
@@ -245,27 +317,20 @@ module MCPClient
     # @param schema [Object] a (sub)schema; non-Hash values are ignored
     # @param found [Array<String>] accumulator
     # @return [void]
-    def self.collect_unsupported_keywords(schema, found)
-      return unless schema.is_a?(Hash)
+    def self.collect_unsupported_keywords(schema, found, depth)
+      return unless schema.is_a?(Hash) && depth <= MAX_SCHEMA_DEPTH
 
       schema = schema.transform_keys(&:to_s)
       found.concat(schema.keys & UNSUPPORTED_KEYWORDS)
-      schema.each do |keyword, value|
-        if SUBSCHEMA_KEYWORDS.include?(keyword)
-          collect_unsupported_keywords(value, found)
-        elsif SUBSCHEMA_MAP_KEYWORDS.include?(keyword) && value.is_a?(Hash)
-          value.each_value { |subschema| collect_unsupported_keywords(subschema, found) }
-        elsif SUBSCHEMA_ARRAY_KEYWORDS.include?(keyword) && value.is_a?(Array)
-          value.each { |subschema| collect_unsupported_keywords(subschema, found) }
-        end
-      end
+      each_subschema(schema) { |sub| collect_unsupported_keywords(sub, found, depth + 1) }
     end
 
     # Validate data against a schema. An unusable schema (see
-    # {.check_schema}) is reported as validation errors, never as a pass.
+    # {.check_schema}) is reported as validation errors, never as a pass,
+    # and so is a validation that hit a resource bound.
     # Schema and data hashes may use string or symbol keys.
     # @param data [Object] the value to validate
-    # @param schema [Hash] the JSON schema
+    # @param schema [Hash, Boolean] the JSON schema
     # @param path [String] JSON-pointer-style location used in error messages
     # @param deadline [Float, nil] monotonic deadline for the whole validation
     # @return [Array<String>] human-readable validation errors (empty if valid)
@@ -275,8 +340,12 @@ module MCPClient
 
       # One deadline covers the entire (recursive) validation.
       deadline ||= Process.clock_gettime(Process::CLOCK_MONOTONIC) + PATTERN_MATCH_TIMEOUT
-      root = deep_stringify(schema)
-      validate_node(data, root, path, Context.new(root: root, deadline: deadline), 0)
+      root = schema.is_a?(Hash) ? deep_stringify(schema) : schema
+      ctx = Context.new(root: root, deadline: deadline, dialect: canonical_dialect(dialect(root)),
+                        visits: 0, errors: 0)
+      validate_node(data, root, path, ctx, 0)
+    rescue Aborted => e
+      ["#{path}: validation aborted: #{e.message}"]
     end
 
     # Validate one value against one (sub)schema.
@@ -286,11 +355,19 @@ module MCPClient
     # @param ctx [Context] the validation context
     # @param ref_depth [Integer] $ref hops taken to reach this schema
     # @return [Array<String>] validation errors
+    # @raise [Aborted] when a bound is hit
     def self.validate_node(data, schema, path, ctx, ref_depth)
       return [] if schema == true
-      return ["#{path}: schema false accepts no value"] if schema == false
+      return count_errors(ctx, ["#{path}: schema false accepts no value"]) if schema == false
       return [] unless schema.is_a?(Hash)
-      return ["#{path}: validation time budget exhausted"] if pattern_budget_remaining(ctx.deadline).zero?
+
+      ctx.visits += 1
+      raise Aborted, "more than #{MAX_NODE_VISITS} schema nodes visited" if ctx.visits > MAX_NODE_VISITS
+      raise Aborted, 'validation time budget exhausted' if budget_exhausted?(ctx.deadline)
+
+      # draft-07: "$ref" replaces the schema it appears in; later drafts
+      # apply it alongside the sibling keywords.
+      return validate_ref(data, schema['$ref'], path, ctx, ref_depth) if schema.key?('$ref') && ctx.dialect == DRAFT_07
 
       errors = []
       errors.concat(validate_ref(data, schema['$ref'], path, ctx, ref_depth)) if schema.key?('$ref')
@@ -303,19 +380,39 @@ module MCPClient
       when Numeric then errors.concat(validate_number(data, schema, path))
       end
       errors.concat(validate_composition(data, schema, path, ctx, ref_depth))
+      count_errors(ctx, errors)
+    end
+
+    # Account for produced errors against MAX_ERRORS.
+    # @return [Array<String>] the errors
+    # @raise [Aborted]
+    def self.count_errors(ctx, errors)
+      ctx.errors += errors.size
+      raise Aborted, "more than #{MAX_ERRORS} validation errors (output truncated)" if ctx.errors > MAX_ERRORS
+
       errors
     end
 
-    # Apply a local $ref (2020-12: alongside the sibling keywords).
+    # @return [Boolean] whether the validation-wide deadline has passed
+    def self.budget_exhausted?(deadline)
+      deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+    end
+
+    # Apply a local $ref.
     # @return [Array<String>] validation errors
     def self.validate_ref(data, ref, path, ctx, ref_depth)
-      return ["#{path}: external $ref #{ref.inspect} is not dereferenced"] if !ref.is_a?(String) || external_ref?(ref)
+      if !ref.is_a?(String) || external_ref?(ref)
+        return count_errors(ctx, ["#{path}: external $ref #{clip(ref.inspect)} is not dereferenced"])
+      end
       if ref_depth >= MAX_REF_DEPTH
-        return ["#{path}: $ref chain exceeds #{MAX_REF_DEPTH} hops (cycle?) at #{ref.inspect}"]
+        raise Aborted, "$ref chain exceeds #{MAX_REF_DEPTH} hops (cycle?) at #{clip(ref.inspect)}"
       end
 
       target = resolve_pointer(ctx.root, ref)
-      return ["#{path}: unresolvable local $ref #{ref.inspect}"] if target.equal?(UNRESOLVED)
+      return count_errors(ctx, ["#{path}: unresolvable local $ref #{clip(ref.inspect)}"]) if target.equal?(UNRESOLVED)
+      unless schema_value?(target)
+        return count_errors(ctx, ["#{path}: $ref #{clip(ref.inspect)} does not point at a schema"])
+      end
 
       validate_node(data, target, path, ctx, ref_depth + 1)
     end
@@ -327,7 +424,7 @@ module MCPClient
       if schema['allOf'].is_a?(Array)
         schema['allOf'].each_with_index do |sub, idx|
           sub_errors = validate_node(data, sub, path, ctx, ref_depth)
-          errors << "#{path}: does not satisfy allOf/#{idx} (#{sub_errors.join('; ')})" unless sub_errors.empty?
+          errors << "#{path}: does not satisfy allOf/#{idx} (#{clip(sub_errors.first.to_s)})" unless sub_errors.empty?
         end
       end
       if schema['anyOf'].is_a?(Array) &&
@@ -365,7 +462,7 @@ module MCPClient
       types = (type.is_a?(Array) ? type : [type]).map(&:to_s)
       return [] if types.any? { |t| type_match?(t, data) }
 
-      ["#{path}: expected type #{types.join(' or ')}, got #{json_type(data)}"]
+      ["#{path}: expected type #{clip(types.join(' or '))}, got #{json_type(data)}"]
     end
 
     # Whether a value matches a JSON Schema type name.
@@ -413,7 +510,9 @@ module MCPClient
       end
     end
 
-    # Validate enum/const membership.
+    # Validate enum/const membership. Symbol- and string-keyed objects are
+    # compared as given on both sides (the schema's data values are never
+    # re-keyed).
     # @param data [Object] the value
     # @param schema [Hash] string-keyed schema
     # @param path [String] location for error messages
@@ -421,10 +520,10 @@ module MCPClient
     def self.validate_enum(data, schema, path)
       errors = []
       if schema['enum'].is_a?(Array) && !schema['enum'].include?(data)
-        errors << "#{path}: value #{data.inspect} is not in enum #{schema['enum'].inspect}"
+        errors << "#{path}: value #{clip(data.inspect)} is not in enum #{clip(schema['enum'].inspect)}"
       end
       if schema.key?('const') && schema['const'] != data
-        errors << "#{path}: value #{data.inspect} does not equal const #{schema['const'].inspect}"
+        errors << "#{path}: value #{clip(data.inspect)} does not equal const #{clip(schema['const'].inspect)}"
       end
       errors
     end
@@ -438,13 +537,13 @@ module MCPClient
       errors = []
       Array(schema['required']).each do |raw_name|
         name = raw_name.to_s
-        errors << "#{path}: missing required property '#{name}'" unless data.key?(name) || data.key?(name.to_sym)
+        errors << "#{path}: missing required property '#{clip(name)}'" unless data.key?(name) || data.key?(name.to_sym)
       end
       properties = schema['properties']
       return errors unless properties.is_a?(Hash)
 
       properties.each do |raw_name, prop_schema|
-        next unless prop_schema.is_a?(Hash) || [true, false].include?(prop_schema)
+        next unless schema_value?(prop_schema)
 
         name = raw_name.to_s
         key = if data.key?(name)
@@ -459,7 +558,10 @@ module MCPClient
       errors
     end
 
-    # Validate an array against items/minItems/maxItems.
+    # Validate an array against items/prefixItems/minItems/maxItems.
+    # 2020-12 puts positional schemas in `prefixItems` and the rest under
+    # `items`; draft-07 and 2019-09 put positional schemas in an `items`
+    # array. Both forms are honoured.
     # @param data [Array] the array
     # @param schema [Hash] string-keyed schema
     # @param path [String] location for error messages
@@ -475,10 +577,17 @@ module MCPClient
         errors << "#{path}: expected at most #{max_items} items, got #{data.length}"
       end
       items = schema['items']
-      if items.is_a?(Hash) || [true, false].include?(items)
-        data.each_with_index do |item, idx|
-          errors.concat(validate_node(item, items, "#{path}/#{idx}", ctx, ref_depth))
-        end
+      positional = schema['prefixItems'].is_a?(Array) ? schema['prefixItems'] : []
+      positional = items if items.is_a?(Array)
+      data.each_with_index do |item, idx|
+        item_schema = if idx < positional.length
+                        positional[idx]
+                      elsif !items.is_a?(Array)
+                        items
+                      end
+        next unless schema_value?(item_schema)
+
+        errors.concat(validate_node(item, item_schema, "#{path}/#{idx}", ctx, ref_depth))
       end
       errors
     end
@@ -508,25 +617,26 @@ module MCPClient
     # The pattern comes from the tool's outputSchema, i.e. from the remote
     # server, so matching runs against the validation-wide deadline: neither a
     # single expensive expression nor many cheap-looking ones can pin the
-    # calling thread. A match that exceeds the budget is reported as a
-    # validation error rather than silently accepted — the value was never
-    # shown to satisfy the schema.
+    # calling thread. A match that exceeds the budget aborts the validation
+    # rather than silently accepting the value — the value was never shown
+    # to satisfy the schema.
     # @param data [String] the string
     # @param pattern [Object] the pattern keyword value
     # @param path [String] location for error messages
     # @param deadline [Float, nil] monotonic deadline for the whole validation
     # @return [Array<String>] validation errors
+    # @raise [Aborted] when the budget is exhausted
     def self.validate_pattern(data, pattern, path, deadline = nil)
       return [] unless pattern.is_a?(String)
 
       remaining = pattern_budget_remaining(deadline)
-      return ["#{path}: pattern matching budget exhausted before #{pattern.inspect}"] if remaining.zero?
+      raise Aborted, "validation time budget exhausted before pattern #{clip(pattern.inspect)}" if remaining.zero?
 
       return [] if data.match?(Regexp.new(pattern, timeout: remaining))
 
-      ["#{path}: string does not match pattern #{pattern.inspect}"]
+      ["#{path}: string does not match pattern #{clip(pattern.inspect)}"]
     rescue Regexp::TimeoutError
-      ["#{path}: pattern #{pattern.inspect} exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"]
+      raise Aborted, "pattern #{clip(pattern.inspect)} exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"
     rescue RegexpError
       []
     end
@@ -565,17 +675,33 @@ module MCPClient
       errors
     end
 
-    # A copy of the schema with every Hash key as a String, so keyword
-    # lookups and JSON pointers see one key form. Values (enum members,
-    # const, defaults) are left as they are.
+    # A copy of the schema with every structural Hash key as a String, so
+    # keyword lookups and JSON pointers see one key form. Data-carrying
+    # keywords (enum, const, default, examples) are left exactly as given,
+    # and the walk stops at the nesting bound.
     # @param node [Object]
+    # @param depth [Integer]
     # @return [Object]
-    def self.deep_stringify(node)
+    def self.deep_stringify(node, depth = 0)
+      return node if depth > MAX_SCHEMA_DEPTH + 1
+
       case node
-      when Hash then node.to_h { |key, value| [key.to_s, deep_stringify(value)] }
-      when Array then node.map { |value| deep_stringify(value) }
+      when Hash
+        node.to_h do |key, value|
+          name = key.to_s
+          [name, DATA_KEYWORDS.include?(name) ? value : deep_stringify(value, depth + 1)]
+        end
+      when Array then node.map { |value| deep_stringify(value, depth + 1) }
       else node
       end
+    end
+
+    # Bound a piece of peer-derived text destined for a message.
+    # @param text [String]
+    # @return [String]
+    def self.clip(text)
+      text = text.to_s
+      text.length > MAX_VALUE_INSPECT ? "#{text[0, MAX_VALUE_INSPECT]}..." : text
     end
   end
 end

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -296,20 +296,17 @@ module MCPClient
       value.is_a?(Array) && value.all?(String)
     end
 
-    # draft-07 exclusiveMinimum / exclusiveMaximum are booleans modifying
-    # minimum / maximum; 2019-09 and 2020-12 made them numbers. The other
-    # form is not silently ignored (it would turn a bound into a pass).
+    # exclusiveMinimum / exclusiveMaximum are numbers in every supported
+    # dialect (draft-07 validation Sections 6.2.3 and 6.2.5, kept by 2019-09
+    # and 2020-12); the boolean modifier form belongs to draft-04, which is
+    # not supported, and is not silently ignored (it would turn a bound
+    # into a pass).
     # @return [void]
-    def self.check_exclusive_bounds(schema, dialect, problems)
+    def self.check_exclusive_bounds(schema, _dialect, problems)
       %w[exclusiveMinimum exclusiveMaximum].each do |keyword|
-        next unless schema.key?(keyword)
+        next if !schema.key?(keyword) || schema[keyword].is_a?(Numeric)
 
-        value = schema[keyword]
-        if dialect == DRAFT_07
-          problems << "#{keyword} must be a boolean in draft-07" unless [true, false].include?(value)
-        elsif !value.is_a?(Numeric)
-          problems << "#{keyword} must be a number in #{dialect}"
-        end
+        problems << "#{keyword} must be a number (the draft-04 boolean form is not supported)"
       end
     end
 
@@ -484,6 +481,7 @@ module MCPClient
       return validate_ref(data, schema['$ref'], path, ctx, ref_depth) if schema.key?('$ref') && ctx.dialect == DRAFT_07
 
       errors = []
+      counted_before = ctx.errors
       errors.concat(validate_ref(data, schema['$ref'], path, ctx, ref_depth)) if schema.key?('$ref')
       errors.concat(validate_type(data, schema['type'], path)) if schema.key?('type')
       errors.concat(validate_enum(data, schema, path))
@@ -494,7 +492,9 @@ module MCPClient
       when Numeric then errors.concat(validate_number(data, schema, path, ctx.dialect))
       end
       errors.concat(validate_composition(data, schema, path, ctx, ref_depth))
-      count_errors(ctx, errors)
+      # Errors raised by nested nodes were counted when they were produced;
+      # only this node's own errors are new.
+      count_errors(ctx, errors, already_counted: ctx.errors - counted_before)
     end
 
     # Run a branch whose errors are only a verdict (anyOf/oneOf candidates,
@@ -521,10 +521,10 @@ module MCPClient
     # speculative branch are a verdict, not output, and do not count.
     # @return [Array<String>] the errors
     # @raise [Aborted]
-    def self.count_errors(ctx, errors)
+    def self.count_errors(ctx, errors, already_counted: 0)
       return errors if ctx.speculative.positive?
 
-      ctx.errors += errors.size
+      ctx.errors += errors.size - already_counted
       raise Aborted, "more than #{MAX_ERRORS} validation errors (output truncated)" if ctx.errors > MAX_ERRORS
 
       errors
@@ -800,31 +800,22 @@ module MCPClient
       [remaining, MIN_PATTERN_MATCH_TIMEOUT].max
     end
 
-    # Validate a number against inclusive/exclusive bounds. Under draft-07
-    # `exclusiveMinimum: true` / `exclusiveMaximum: true` make `minimum` /
-    # `maximum` exclusive; 2019-09 and 2020-12 carry the bound in the
-    # keyword itself.
+    # Validate a number against its bounds. `minimum` / `maximum` and
+    # `exclusiveMinimum` / `exclusiveMaximum` are four independent numeric
+    # assertions in every supported dialect (draft-07 validation Sections
+    # 6.2.2-6.2.5); each present one is applied.
     # @param data [Numeric] the number
     # @param schema [Hash] string-keyed schema
     # @param path [String] location for error messages
-    # @param dialect [String, nil] the canonical dialect
     # @return [Array<String>] validation errors
-    def self.validate_number(data, schema, path, dialect = nil)
+    def self.validate_number(data, schema, path, _dialect = nil)
       errors = []
       minimum = schema['minimum']
       maximum = schema['maximum']
       exclusive_min = schema['exclusiveMinimum']
       exclusive_max = schema['exclusiveMaximum']
-      if dialect == DRAFT_07
-        exclusive_min = exclusive_min == true ? minimum : nil
-        exclusive_max = exclusive_max == true ? maximum : nil
-      end
-      if minimum.is_a?(Numeric) && data < minimum && exclusive_min.nil?
-        errors << "#{path}: value #{data} is less than minimum #{minimum}"
-      end
-      if maximum.is_a?(Numeric) && data > maximum && exclusive_max.nil?
-        errors << "#{path}: value #{data} is greater than maximum #{maximum}"
-      end
+      errors << "#{path}: value #{data} is less than minimum #{minimum}" if minimum.is_a?(Numeric) && data < minimum
+      errors << "#{path}: value #{data} is greater than maximum #{maximum}" if maximum.is_a?(Numeric) && data > maximum
       if exclusive_min.is_a?(Numeric) && data <= exclusive_min
         errors << "#{path}: value #{data} must be greater than exclusiveMinimum #{exclusive_min}"
       end

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'uri'
+require_relative 'schema_validator/dialects'
+require_relative 'schema_validator/normalization'
 require_relative 'schema_validator/references'
 require_relative 'schema_validator/keyword_scan'
 
@@ -51,6 +53,8 @@ module MCPClient
   # never silent, {.unsupported_keywords} reports which unapplied validation
   # keywords a schema uses; callers surface them as a warning.
   module SchemaValidator
+    extend Dialects
+    extend Normalization
     extend References
     extend KeywordScan
 
@@ -167,41 +171,13 @@ module MCPClient
     # so a peer-supplied document is never copied whole.
     class TooLarge < StandardError; end
 
-    # Structural objects (schemas and the keyword maps holding them) a
-    # schema document may contain before it is rejected unread. A usable
-    # schema has at most MAX_SUBSCHEMAS subschemas, each with a handful of
-    # keyword maps at most, so this bound only ever stops documents the
-    # preflight would reject anyway.
+    # Structural elements (schemas, the keyword maps holding them, and array
+    # members — boolean subschemas included) a schema document may contain
+    # before it is rejected unread. A usable schema has at most
+    # MAX_SUBSCHEMAS subschemas, each with a handful of keyword maps at
+    # most, so this bound only ever stops documents the preflight would
+    # reject anyway.
     MAX_STRUCTURAL_OBJECTS = MAX_SUBSCHEMAS * 4
-
-    # The dialect a schema declares, or the default.
-    # @param schema [Object] the schema
-    # @return [String] the `$schema` value (without a trailing `#`), or DEFAULT_DIALECT
-    def self.dialect(schema)
-      return DEFAULT_DIALECT unless schema.is_a?(Hash)
-      return DEFAULT_DIALECT unless schema.key?('$schema') || schema.key?(:$schema)
-
-      declared = schema.key?('$schema') ? schema['$schema'] : schema[:$schema]
-      # A declaration that is present but unusable is not the default.
-      return nil unless declared.is_a?(String) && !declared.empty?
-
-      declared.sub(/#\z/, '')
-    end
-
-    # The supported dialect a declared URI stands for (scheme-insensitive),
-    # or nil.
-    # @param uri [String]
-    # @return [String, nil]
-    def self.canonical_dialect(uri)
-      canonical = uri.sub(/#\z/, '').sub(%r{\Ahttps?://}, '')
-      SUPPORTED_DIALECTS.find { |d| d.sub(%r{\Ahttps?://}, '') == canonical }
-    end
-
-    # @param uri [String]
-    # @return [Boolean]
-    def self.supported_dialect?(uri)
-      !canonical_dialect(uri).nil?
-    end
 
     # Check that a schema can be used at all: it is an object or a boolean,
     # its dialect is supported, it stays within the resource bounds, and
@@ -245,20 +221,27 @@ module MCPClient
 
     # Walk every subschema position, checking bounds and references. A
     # schema object is walked once, however many positions or references
-    # lead to it, so a recursive schema stays within the bounds.
+    # lead to it, so a recursive schema stays within the bounds. The dialect
+    # follows the resource: an embedded resource declaring `$schema` is
+    # walked under its own dialect.
     # @return [void]
-    def self.walk_schema(schema, root, depth, counter, problems)
+    def self.walk_schema(schema, root, depth, counter, problems, dialect = counter[:dialect])
       return unless problems.empty? && schema_value?(schema)
       return unless admit_schema?(schema, depth, counter, problems)
 
-      dialect = counter[:dialect]
+      if resource_start?(schema) && schema.key?('$schema')
+        problem = embedded_dialect_problem(schema)
+        return problems << problem if problem
+
+        dialect = embedded_dialect(schema, dialect)
+      end
       check_ref(schema, root, depth, problems, dialect, counter) if schema.key?('$ref')
       # draft-07: the $ref replaces its siblings, so the applicators next to
       # it are never applied and are not preflighted either; definitions are
       # a bag of reusable schemas, not applicators, and stay reachable
       # through references.
       if dialect == DRAFT_07 && schema.key?('$ref')
-        each_definition(schema, dialect) { |sub| walk_schema(sub, root, depth + 1, counter, problems) }
+        each_definition(schema, dialect) { |sub| walk_schema(sub, root, depth + 1, counter, problems, dialect) }
         return
       end
 
@@ -272,7 +255,7 @@ module MCPClient
       end
       check_applicator_shapes(schema, dialect, problems)
       check_exclusive_bounds(schema, dialect, problems)
-      each_subschema(schema, dialect) { |sub| walk_schema(sub, root, depth + 1, counter, problems) }
+      each_subschema(schema, dialect) { |sub| walk_schema(sub, root, depth + 1, counter, problems, dialect) }
     end
 
     # Account for a schema object about to be walked: once per object, and
@@ -416,8 +399,9 @@ module MCPClient
         return
       end
 
-      problem = ref_chain_problem(ref, root, dialect, counter, from: schema) do |target|
-        walk_schema(target, root, depth + 1, counter, problems)
+      problem = ref_chain_problem(ref, root, counter[:dialect], counter, from: schema) do |target|
+        # What a reference reaches is walked under its own resource's dialect.
+        walk_schema(target, root, depth + 1, counter, problems, indexed_dialect(target, counter) || dialect)
       end
       problems << problem if problem
     end
@@ -520,8 +504,10 @@ module MCPClient
       return [] unless schema.is_a?(Hash)
 
       # draft-07: "$ref" replaces the schema it appears in; later drafts
-      # apply it alongside the sibling keywords.
-      return validate_ref(data, schema, path, ctx, ref_depth) if schema.key?('$ref') && ctx.dialect == DRAFT_07
+      # apply it alongside the sibling keywords. The dialect is the one of
+      # the schema resource the node belongs to.
+      dialect = node_dialect(schema, ctx)
+      return validate_ref(data, schema, path, ctx, ref_depth) if schema.key?('$ref') && dialect == DRAFT_07
 
       errors = []
       counted_before = ctx.errors
@@ -530,14 +516,23 @@ module MCPClient
       errors.concat(validate_enum(data, schema, path))
       case data
       when Hash then errors.concat(validate_object(data, schema, path, ctx, ref_depth))
-      when Array then errors.concat(validate_array(data, schema, path, ctx, ref_depth))
+      when Array then errors.concat(validate_array(data, schema, path, ctx, ref_depth, dialect))
       when String then errors.concat(validate_string(data, schema, path, ctx.deadline))
-      when Numeric then errors.concat(validate_number(data, schema, path, ctx.dialect))
+      when Numeric then errors.concat(validate_number(data, schema, path, dialect))
       end
       errors.concat(validate_composition(data, schema, path, ctx, ref_depth))
       # Errors raised by nested nodes were counted when they were produced;
       # only this node's own errors are new.
       count_errors(ctx, errors, already_counted: ctx.errors - counted_before)
+    end
+
+    # The dialect in force at a schema object during validation: the one
+    # recorded for its resource by the anchor index (built once per
+    # validation), else the root's.
+    # @return [String, nil]
+    def self.node_dialect(schema, ctx)
+      ctx.anchors ||= anchor_index(ctx.root, ctx.dialect)
+      indexed_dialect(schema, ctx) || ctx.dialect
     end
 
     # Run a branch whose errors are only a verdict (anyOf/oneOf candidates,
@@ -754,7 +749,7 @@ module MCPClient
     # @param schema [Hash] string-keyed schema
     # @param path [String] location for error messages
     # @return [Array<String>] validation errors
-    def self.validate_array(data, schema, path, ctx, ref_depth)
+    def self.validate_array(data, schema, path, ctx, ref_depth, dialect = ctx.dialect)
       errors = []
       min_items = schema['minItems']
       max_items = schema['maxItems']
@@ -768,7 +763,7 @@ module MCPClient
       # 2020-12 puts positional schemas in prefixItems (items must be a
       # schema); draft-07 and 2019-09 put them in an items array and know no
       # prefixItems.
-      positional = if ctx.dialect == DEFAULT_DIALECT
+      positional = if dialect == DEFAULT_DIALECT
                      schema['prefixItems'].is_a?(Array) ? schema['prefixItems'] : []
                    else
                      items.is_a?(Array) ? items : []
@@ -861,44 +856,20 @@ module MCPClient
       maximum = schema['maximum']
       exclusive_min = schema['exclusiveMinimum']
       exclusive_max = schema['exclusiveMaximum']
-      errors << "#{path}: value #{data} is less than minimum #{minimum}" if minimum.is_a?(Numeric) && data < minimum
-      errors << "#{path}: value #{data} is greater than maximum #{maximum}" if maximum.is_a?(Numeric) && data > maximum
+      shown = clip_value(data)
+      if minimum.is_a?(Numeric) && data < minimum
+        errors << "#{path}: value #{shown} is less than minimum #{clip_value(minimum)}"
+      end
+      if maximum.is_a?(Numeric) && data > maximum
+        errors << "#{path}: value #{shown} is greater than maximum #{clip_value(maximum)}"
+      end
       if exclusive_min.is_a?(Numeric) && data <= exclusive_min
-        errors << "#{path}: value #{data} must be greater than exclusiveMinimum #{exclusive_min}"
+        errors << "#{path}: value #{shown} must be greater than exclusiveMinimum #{clip_value(exclusive_min)}"
       end
       if exclusive_max.is_a?(Numeric) && data >= exclusive_max
-        errors << "#{path}: value #{data} must be less than exclusiveMaximum #{exclusive_max}"
+        errors << "#{path}: value #{shown} must be less than exclusiveMaximum #{clip_value(exclusive_max)}"
       end
       errors
-    end
-
-    # A copy of the schema with every structural Hash key as a String, so
-    # keyword lookups and JSON pointers see one key form. Data-carrying
-    # keywords (enum, const, default, examples) are left exactly as given,
-    # the walk stops at the nesting bound, and — given a budget — the copy
-    # stops as soon as the document holds more structural objects than
-    # MAX_STRUCTURAL_OBJECTS, before the rest is ever read.
-    # @param node [Object]
-    # @param depth [Integer]
-    # @param budget [Hash, nil] :objects copied so far
-    # @return [Object]
-    # @raise [TooLarge] when the budget is exceeded
-    def self.deep_stringify(node, depth = 0, budget = nil)
-      return node if depth > MAX_SCHEMA_DEPTH + 1
-
-      case node
-      when Hash
-        if budget && (budget[:objects] += 1) > MAX_STRUCTURAL_OBJECTS
-          raise TooLarge, "schema has more than #{MAX_STRUCTURAL_OBJECTS} objects"
-        end
-
-        node.to_h do |key, value|
-          name = key.to_s
-          [name, DATA_KEYWORDS.include?(name) ? value : deep_stringify(value, depth + 1, budget)]
-        end
-      when Array then node.map { |value| deep_stringify(value, depth + 1, budget) }
-      else node
-      end
     end
 
     # Bound a piece of peer-derived text destined for a message.

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -216,7 +216,19 @@ module MCPClient
       problems = []
       counter = { count: 0, dialect: canonical_dialect(declared), walked: {}.compare_by_identity }
       walk_schema(root, root, 0, counter, problems)
+      problems.concat(duplicate_anchor_problems(root, counter)) if problems.empty?
       problems.uniq
+    end
+
+    # Anchor names must be unique within a schema resource (JSON Schema
+    # 2020-12 Core Section 8.2.2): a name declared twice would bind a
+    # reference to whichever declaration the walk met first, so the schema
+    # is unusable instead.
+    # @param resolver [Hash] holder of the memoized anchor index
+    # @return [Array<String>]
+    def self.duplicate_anchor_problems(root, resolver)
+      index = (resolver[:anchors] ||= anchor_index(root, resolver[:dialect]))
+      index[:duplicates].map { |name| "anchor #{clip(name.inspect)} is declared more than once in a schema resource" }
     end
 
     # Walk every subschema position, checking bounds and references. A
@@ -433,17 +445,20 @@ module MCPClient
 
     # @return [String, nil] the problem, if any; each resolved target is yielded
     def self.follow_ref_chain(ref, root, dialect, resolver, from)
-      seen = []
+      # A cycle is a chain returning to a schema it already reached: hops
+      # are told apart by where they land, not by their fragment text,
+      # since the same fragment means something else in another resource.
+      seen = {}.compare_by_identity
       current = ref
       loop do
-        return "$ref chain #{clip(ref.inspect)} cycles" if seen.include?(current)
         return "$ref chain #{clip(ref.inspect)} exceeds #{MAX_REF_DEPTH} hops" if seen.size >= MAX_REF_DEPTH
 
-        seen << current
         target = resolve_reference(root, current, dialect, resolver, from: from)
         return "unresolvable local $ref #{clip(current.inspect)}" if target.equal?(UNRESOLVED)
         return "$ref #{clip(current.inspect)} does not point at a schema" unless schema_value?(target)
+        return "$ref chain #{clip(ref.inspect)} cycles" if target.is_a?(Hash) && seen.key?(target)
 
+        seen[target] = true if target.is_a?(Hash)
         yield target
         return nil unless target.is_a?(Hash) && target.key?('$ref')
 

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -2,6 +2,7 @@
 
 require 'uri'
 require_relative 'schema_validator/references'
+require_relative 'schema_validator/keyword_scan'
 
 module MCPClient
   # Self-contained JSON Schema validator used to check a tool call result's
@@ -51,6 +52,7 @@ module MCPClient
   # keywords a schema uses; callers surface them as a warning.
   module SchemaValidator
     extend References
+    extend KeywordScan
 
     # Raised inside a validation to abandon it (time budget, resource bound).
     class Aborted < StandardError; end
@@ -161,6 +163,17 @@ module MCPClient
     # Per-validation state.
     Context = Struct.new(:root, :deadline, :dialect, :visits, :errors, :speculative, :anchors, keyword_init: true)
 
+    # Raised while normalizing a schema whose structure exceeds the bounds,
+    # so a peer-supplied document is never copied whole.
+    class TooLarge < StandardError; end
+
+    # Structural objects (schemas and the keyword maps holding them) a
+    # schema document may contain before it is rejected unread. A usable
+    # schema has at most MAX_SUBSCHEMAS subschemas, each with a handful of
+    # keyword maps at most, so this bound only ever stops documents the
+    # preflight would reject anyway.
+    MAX_STRUCTURAL_OBJECTS = MAX_SUBSCHEMAS * 4
+
     # The dialect a schema declares, or the default.
     # @param schema [Object] the schema
     # @return [String] the `$schema` value (without a trailing `#`), or DEFAULT_DIALECT
@@ -198,10 +211,25 @@ module MCPClient
     # @param schema [Object] the schema (string or symbol keys)
     # @return [Array<String>] problems (empty when the schema is usable)
     def self.check_schema(schema)
-      return [] if [true, false].include?(schema)
-      return ["schema must be an object or a boolean, got #{json_type(schema)}"] unless schema.is_a?(Hash)
+      check_normalized(normalize_schema(schema))
+    rescue TooLarge => e
+      [e.message]
+    end
 
-      root = deep_stringify(schema)
+    # A bounded, string-keyed copy of a schema (booleans pass through).
+    # @param schema [Object]
+    # @return [Object]
+    # @raise [TooLarge] when the document exceeds MAX_STRUCTURAL_OBJECTS
+    def self.normalize_schema(schema)
+      schema.is_a?(Hash) ? deep_stringify(schema, 0, { objects: 0 }) : schema
+    end
+
+    # {.check_schema} on an already normalized schema.
+    # @return [Array<String>] problems
+    def self.check_normalized(root)
+      return [] if [true, false].include?(root)
+      return ["schema must be an object or a boolean, got #{json_type(root)}"] unless root.is_a?(Hash)
+
       declared = dialect(root)
       return ['$schema must be a non-empty string naming the dialect'] if declared.nil?
       unless supported_dialect?(declared)
@@ -452,40 +480,6 @@ module MCPClient
     # value position, so it cannot serve as the marker).
     UNRESOLVED = Object.new.freeze
 
-    # List the unsupported JSON Schema keywords a schema uses (anywhere: at the
-    # top level or nested in subschemas). Property names that merely look like
-    # keywords (e.g. a property called 'not') are not reported, and
-    # data-carrying keywords (enum/const/default/examples) are not scanned.
-    # The scan stops at the same bounds as {.check_schema} (a schema beyond
-    # them is unusable anyway), so a huge server-supplied schema is never
-    # walked whole.
-    # @param schema [Object] the JSON schema (string or symbol keys)
-    # @return [Array<String>] unique unsupported keywords, in discovery order
-    def self.unsupported_keywords(schema)
-      found = []
-      declared = dialect(schema)
-      scan = { count: 0, dialect: declared && canonical_dialect(declared) }
-      collect_unsupported_keywords(schema, found, 0, scan)
-      found.uniq
-    end
-
-    # Recursively collect unsupported keywords from a schema (keywords the
-    # dialect does not define are unknown, not unsupported).
-    # @param schema [Object] a (sub)schema; non-Hash values are ignored
-    # @param found [Array<String>] accumulator
-    # @param scan [Hash] :count of subschemas seen so far and the canonical :dialect
-    # @return [void]
-    def self.collect_unsupported_keywords(schema, found, depth, scan)
-      return unless schema.is_a?(Hash) && depth <= MAX_SCHEMA_DEPTH
-
-      scan[:count] += 1
-      return if scan[:count] > MAX_SUBSCHEMAS
-
-      schema = schema.transform_keys(&:to_s)
-      found.concat((schema.keys & UNSUPPORTED_KEYWORDS).select { |k| keyword_known?(k, scan[:dialect]) })
-      each_subschema(schema, scan[:dialect]) { |sub| collect_unsupported_keywords(sub, found, depth + 1, scan) }
-    end
-
     # Validate data against a schema. An unusable schema (see
     # {.check_schema}) is reported as validation errors, never as a pass,
     # and so is a validation that hit a resource bound.
@@ -496,15 +490,17 @@ module MCPClient
     # @param deadline [Float, nil] monotonic deadline for the whole validation
     # @return [Array<String>] human-readable validation errors (empty if valid)
     def self.validate(data, schema, path: '#', deadline: nil)
-      problems = check_schema(schema)
+      root = normalize_schema(schema)
+      problems = check_normalized(root)
       return problems.map { |problem| "#{path}: #{problem}" } unless problems.empty?
 
       # One deadline covers the entire (recursive) validation.
       deadline ||= Process.clock_gettime(Process::CLOCK_MONOTONIC) + PATTERN_MATCH_TIMEOUT
-      root = schema.is_a?(Hash) ? deep_stringify(schema) : schema
       ctx = Context.new(root: root, deadline: deadline, dialect: canonical_dialect(dialect(root)),
                         visits: 0, errors: 0, speculative: 0, anchors: nil)
       validate_node(data, root, path, ctx, 0)
+    rescue TooLarge => e
+      ["#{path}: #{e.message}"]
     rescue Aborted => e
       ["#{path}: validation aborted: #{e.message}"]
     end
@@ -635,7 +631,9 @@ module MCPClient
     # if / then / else.
     # @return [Array<String>] validation errors
     def self.validate_conditional(data, schema, path, ctx, ref_depth)
-      return [] unless schema.key?('if')
+      # An `if` without `then` or `else` asserts nothing (JSON Schema 2020-12
+      # Section 10.2.2.1) and is not evaluated.
+      return [] unless schema.key?('if') && (schema.key?('then') || schema.key?('else'))
 
       branch = speculative(ctx) { validate_node(data, schema['if'], path, ctx, ref_depth).empty? } ? 'then' : 'else'
       return [] unless schema.key?(branch)
@@ -877,20 +875,28 @@ module MCPClient
     # A copy of the schema with every structural Hash key as a String, so
     # keyword lookups and JSON pointers see one key form. Data-carrying
     # keywords (enum, const, default, examples) are left exactly as given,
-    # and the walk stops at the nesting bound.
+    # the walk stops at the nesting bound, and — given a budget — the copy
+    # stops as soon as the document holds more structural objects than
+    # MAX_STRUCTURAL_OBJECTS, before the rest is ever read.
     # @param node [Object]
     # @param depth [Integer]
+    # @param budget [Hash, nil] :objects copied so far
     # @return [Object]
-    def self.deep_stringify(node, depth = 0)
+    # @raise [TooLarge] when the budget is exceeded
+    def self.deep_stringify(node, depth = 0, budget = nil)
       return node if depth > MAX_SCHEMA_DEPTH + 1
 
       case node
       when Hash
+        if budget && (budget[:objects] += 1) > MAX_STRUCTURAL_OBJECTS
+          raise TooLarge, "schema has more than #{MAX_STRUCTURAL_OBJECTS} objects"
+        end
+
         node.to_h do |key, value|
           name = key.to_s
-          [name, DATA_KEYWORDS.include?(name) ? value : deep_stringify(value, depth + 1)]
+          [name, DATA_KEYWORDS.include?(name) ? value : deep_stringify(value, depth + 1, budget)]
         end
-      when Array then node.map { |value| deep_stringify(value, depth + 1) }
+      when Array then node.map { |value| deep_stringify(value, depth + 1, budget) }
       else node
       end
     end

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -122,9 +122,11 @@ module MCPClient
     # @return [String] the `$schema` value (without a trailing `#`), or DEFAULT_DIALECT
     def self.dialect(schema)
       return DEFAULT_DIALECT unless schema.is_a?(Hash)
+      return DEFAULT_DIALECT unless schema.key?('$schema') || schema.key?(:$schema)
 
-      declared = schema['$schema'] || schema[:$schema]
-      return DEFAULT_DIALECT unless declared.is_a?(String) && !declared.empty?
+      declared = schema.key?('$schema') ? schema['$schema'] : schema[:$schema]
+      # A declaration that is present but unusable is not the default.
+      return nil unless declared.is_a?(String) && !declared.empty?
 
       declared.sub(/#\z/, '')
     end
@@ -157,13 +159,14 @@ module MCPClient
 
       root = deep_stringify(schema)
       declared = dialect(root)
+      return ['$schema must be a non-empty string naming the dialect'] if declared.nil?
       unless supported_dialect?(declared)
         return ["schema dialect #{clip(declared.inspect)} is not supported " \
                 "(supported: #{SUPPORTED_DIALECTS.join(', ')})"]
       end
 
       problems = []
-      walk_schema(root, root, 0, { count: 0 }, problems)
+      walk_schema(root, root, 0, { count: 0, dialect: canonical_dialect(declared) }, problems)
       problems.uniq
     end
 
@@ -187,6 +190,9 @@ module MCPClient
 
       check_ref(schema['$ref'], root, problems) if schema.key?('$ref')
       check_dynamic_ref(schema['$dynamicRef'], problems) if schema.key?('$dynamicRef')
+      if counter[:dialect] == DEFAULT_DIALECT && schema['items'].is_a?(Array)
+        problems << 'items must be a schema in JSON Schema 2020-12 (positional schemas go in prefixItems)'
+      end
       each_subschema(schema) { |sub| walk_schema(sub, root, depth + 1, counter, problems) }
     end
 
@@ -383,6 +389,17 @@ module MCPClient
       count_errors(ctx, errors)
     end
 
+    # Run a branch whose errors are only a verdict (anyOf/oneOf candidates,
+    # not, if): they never count toward MAX_ERRORS. Bounds that abort the
+    # whole validation still propagate.
+    # @return [Object] the block's value
+    def self.speculative(ctx)
+      before = ctx.errors
+      yield
+    ensure
+      ctx.errors = before
+    end
+
     # Account for produced errors against MAX_ERRORS.
     # @return [Array<String>] the errors
     # @raise [Aborted]
@@ -428,14 +445,18 @@ module MCPClient
         end
       end
       if schema['anyOf'].is_a?(Array) &&
-         schema['anyOf'].none? { |sub| validate_node(data, sub, path, ctx, ref_depth).empty? }
+         schema['anyOf'].none? { |sub| speculative(ctx) { validate_node(data, sub, path, ctx, ref_depth).empty? } }
         errors << "#{path}: does not satisfy any schema in anyOf"
       end
       if schema['oneOf'].is_a?(Array)
-        matches = schema['oneOf'].count { |sub| validate_node(data, sub, path, ctx, ref_depth).empty? }
+        matches = schema['oneOf'].count do |sub|
+          speculative(ctx) do
+            validate_node(data, sub, path, ctx, ref_depth).empty?
+          end
+        end
         errors << "#{path}: satisfies #{matches} schemas in oneOf, expected exactly one" unless matches == 1
       end
-      if schema.key?('not') && validate_node(data, schema['not'], path, ctx, ref_depth).empty?
+      if schema.key?('not') && speculative(ctx) { validate_node(data, schema['not'], path, ctx, ref_depth).empty? }
         errors << "#{path}: value satisfies the schema in not"
       end
       errors.concat(validate_conditional(data, schema, path, ctx, ref_depth))
@@ -447,7 +468,7 @@ module MCPClient
     def self.validate_conditional(data, schema, path, ctx, ref_depth)
       return [] unless schema.key?('if')
 
-      branch = validate_node(data, schema['if'], path, ctx, ref_depth).empty? ? 'then' : 'else'
+      branch = speculative(ctx) { validate_node(data, schema['if'], path, ctx, ref_depth).empty? } ? 'then' : 'else'
       return [] unless schema.key?(branch)
 
       validate_node(data, schema[branch], path, ctx, ref_depth)
@@ -577,8 +598,14 @@ module MCPClient
         errors << "#{path}: expected at most #{max_items} items, got #{data.length}"
       end
       items = schema['items']
-      positional = schema['prefixItems'].is_a?(Array) ? schema['prefixItems'] : []
-      positional = items if items.is_a?(Array)
+      # 2020-12 puts positional schemas in prefixItems (items must be a
+      # schema); draft-07 and 2019-09 put them in an items array and know no
+      # prefixItems.
+      positional = if ctx.dialect == DEFAULT_DIALECT
+                     schema['prefixItems'].is_a?(Array) ? schema['prefixItems'] : []
+                   else
+                     items.is_a?(Array) ? items : []
+                   end
       data.each_with_index do |item, idx|
         item_schema = if idx < positional.length
                         positional[idx]

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -238,7 +238,8 @@ module MCPClient
       end
 
       problems = []
-      counter = { count: 0, dialect: canonical_dialect(declared), walked: {}.compare_by_identity }
+      counter = { count: 0, dialect: canonical_dialect(declared), walked: {}.compare_by_identity,
+                  depths: lexical_depths(root, canonical_dialect(declared)) }
       walk_schema(root, root, 0, counter, problems)
       problems.concat(anchor_index_problems(root, counter)) if problems.empty?
       problems.uniq
@@ -303,8 +304,9 @@ module MCPClient
       each_subschema(schema, dialect) { |sub| walk_schema(sub, root, depth + 1, counter, problems, dialect) }
     end
 
-    # Account for a schema object about to be walked: once per object, and
-    # within the subschema and nesting bounds.
+    # Account for a schema (object or boolean) about to be walked: once per
+    # object, and within the subschema and nesting bounds — a boolean is a
+    # subschema too and obeys the depth bound.
     # @return [Boolean] whether the object's keywords are to be walked
     def self.admit_schema?(schema, depth, counter, problems)
       return false if schema.is_a?(Hash) && counter[:walked].key?(schema)
@@ -315,13 +317,32 @@ module MCPClient
         problems << "schema has more than #{MAX_SUBSCHEMAS} subschemas"
         return false
       end
-      return false unless schema.is_a?(Hash)
-
       if depth > MAX_SCHEMA_DEPTH
         problems << "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}"
         return false
       end
-      true
+      schema.is_a?(Hash)
+    end
+
+    # The lexical nesting depth of every schema object reachable from the
+    # root (subschema positions, definition bags of any dialect), so a
+    # referenced target is bounded by where it is written, not by where it
+    # is referenced from: neither member order nor reference fan-out can
+    # change the verdict.
+    # @return [Hash{Hash => Integer}] identity-keyed
+    def self.lexical_depths(root, dialect)
+      depths = {}.compare_by_identity
+      pending = [[root, 0]]
+      while (schema, depth = pending.shift)
+        next unless schema.is_a?(Hash) && !depths.key?(schema)
+
+        depths[schema] = depth
+        break if depths.size > MAX_SUBSCHEMAS * 2
+
+        each_subschema(schema, dialect) { |sub| pending << [sub, depth + 1] }
+        each_foreign_definition(schema, dialect) { |sub| pending << [sub, depth + 1] }
+      end
+      depths
     end
 
     # Every applicator value must be a schema (object or boolean), an array
@@ -445,8 +466,13 @@ module MCPClient
       end
 
       problem = ref_chain_problem(ref, root, counter[:dialect], counter, from: schema) do |target|
-        # What a reference reaches is walked under its own resource's dialect.
-        walk_schema(target, root, depth + 1, counter, problems, indexed_dialect(target, counter) || dialect)
+        # What a reference reaches is walked under its own resource's dialect
+        # and at its own lexical depth; a boolean target needs no preflight
+        # and is not charged per reference.
+        next unless target.is_a?(Hash)
+
+        target_depth = (counter[:depths] || {})[target] || (depth + 1)
+        walk_schema(target, root, target_depth, counter, problems, indexed_dialect(target, counter) || dialect)
       end
       problems << problem if problem
     end

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -194,10 +194,12 @@ module MCPClient
 
     # A bounded, string-keyed copy of a schema (booleans pass through).
     # @param schema [Object]
+    # @param deadline [Float, nil] monotonic deadline the copy runs under
     # @return [Object]
     # @raise [TooLarge] when the document exceeds MAX_STRUCTURAL_OBJECTS
-    def self.normalize_schema(schema)
-      schema.is_a?(Hash) ? deep_stringify(schema, 0, { objects: 0 }) : schema
+    # @raise [Aborted] when the deadline passed during the copy
+    def self.normalize_schema(schema, deadline: nil)
+      schema.is_a?(Hash) ? deep_stringify(schema, 0, { objects: 0, deadline: deadline }) : schema
     end
 
     # {.check_schema} on an already normalized schema.
@@ -489,12 +491,13 @@ module MCPClient
     # @param deadline [Float, nil] monotonic deadline for the whole validation
     # @return [Array<String>] human-readable validation errors (empty if valid)
     def self.validate(data, schema, path: '#', deadline: nil)
-      root = normalize_schema(schema)
+      # One deadline covers the entire validation, the copy of the peer's
+      # document included.
+      deadline ||= Process.clock_gettime(Process::CLOCK_MONOTONIC) + PATTERN_MATCH_TIMEOUT
+      root = normalize_schema(schema, deadline: deadline)
       problems = check_normalized(root)
       return problems.map { |problem| "#{path}: #{problem}" } unless problems.empty?
 
-      # One deadline covers the entire (recursive) validation.
-      deadline ||= Process.clock_gettime(Process::CLOCK_MONOTONIC) + PATTERN_MATCH_TIMEOUT
       ctx = Context.new(root: root, deadline: deadline, dialect: canonical_dialect(dialect(root)),
                         visits: 0, errors: 0, speculative: 0, anchors: nil)
       validate_node(data, root, path, ctx, 0)

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -610,8 +610,8 @@ module MCPClient
       errors.concat(validate_type(data, schema['type'], path)) if schema.key?('type')
       errors.concat(validate_enum(data, schema, path))
       case data
-      when Hash then errors.concat(validate_object(data, schema, path, ctx, ref_depth))
-      when Array then errors.concat(validate_array(data, schema, path, ctx, ref_depth, dialect))
+      when Hash then errors.concat(validate_object(data, schema, path, ctx))
+      when Array then errors.concat(validate_array(data, schema, path, ctx, dialect))
       when String then errors.concat(validate_string(data, schema, path, ctx.deadline))
       when Numeric then errors.concat(validate_number(data, schema, path, dialect))
       end
@@ -776,7 +776,7 @@ module MCPClient
     # @param schema [Hash] string-keyed schema
     # @param path [String] location for error messages
     # @return [Array<String>] validation errors
-    def self.validate_object(data, schema, path, ctx, ref_depth)
+    def self.validate_object(data, schema, path, ctx)
       errors = []
       Array(schema['required']).each do |raw_name|
         name = raw_name.to_s
@@ -796,7 +796,10 @@ module MCPClient
               end
         next if key.nil?
 
-        errors.concat(validate_node(data[key], prop_schema, "#{path}/#{name}", ctx, ref_depth))
+        # A property is a smaller instance, so the hops taken to reach this
+        # schema cannot repeat forever below it: the budget counts a chain
+        # of references applied to one value, not how deep the data nests.
+        errors.concat(validate_node(data[key], prop_schema, "#{path}/#{name}", ctx, 0))
       end
       errors
     end
@@ -809,7 +812,7 @@ module MCPClient
     # @param schema [Hash] string-keyed schema
     # @param path [String] location for error messages
     # @return [Array<String>] validation errors
-    def self.validate_array(data, schema, path, ctx, ref_depth, dialect = ctx.dialect)
+    def self.validate_array(data, schema, path, ctx, dialect = ctx.dialect)
       errors = []
       min_items = schema['minItems']
       max_items = schema['maxItems']
@@ -836,7 +839,10 @@ module MCPClient
                       end
         next unless schema_value?(item_schema)
 
-        errors.concat(validate_node(item, item_schema, "#{path}/#{idx}", ctx, ref_depth))
+        # An item is a smaller instance: the hop budget starts over, so a
+        # recursive schema describes data of any depth (see
+        # {.validate_object}).
+        errors.concat(validate_node(item, item_schema, "#{path}/#{idx}", ctx, 0))
       end
       errors.concat(validate_contains(data, schema, path, dialect))
     end

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -5,6 +5,7 @@ require_relative 'schema_validator/dialects'
 require_relative 'schema_validator/normalization'
 require_relative 'schema_validator/references'
 require_relative 'schema_validator/keyword_scan'
+require_relative 'schema_validator/composition'
 
 module MCPClient
   # Self-contained JSON Schema validator used to check a tool call result's
@@ -57,6 +58,7 @@ module MCPClient
     extend Normalization
     extend References
     extend KeywordScan
+    extend Composition
 
     # Raised inside a validation to abandon it (time budget, resource bound).
     class Aborted < StandardError; end
@@ -165,7 +167,8 @@ module MCPClient
     end
 
     # Per-validation state.
-    Context = Struct.new(:root, :deadline, :dialect, :visits, :errors, :speculative, :anchors, keyword_init: true)
+    Context = Struct.new(:root, :deadline, :dialect, :visits, :errors, :speculative, :anchors, :undecided,
+                         keyword_init: true)
 
     # Raised while normalizing a schema whose structure exceeds the bounds,
     # so a peer-supplied document is never copied whole.
@@ -218,19 +221,25 @@ module MCPClient
       problems = []
       counter = { count: 0, dialect: canonical_dialect(declared), walked: {}.compare_by_identity }
       walk_schema(root, root, 0, counter, problems)
-      problems.concat(duplicate_anchor_problems(root, counter)) if problems.empty?
+      problems.concat(anchor_index_problems(root, counter)) if problems.empty?
       problems.uniq
     end
 
-    # Anchor names must be unique within a schema resource (JSON Schema
-    # 2020-12 Core Section 8.2.2): a name declared twice would bind a
-    # reference to whichever declaration the walk met first, so the schema
-    # is unusable instead.
+    # Problems the anchor index reveals: anchor names must be unique within
+    # a schema resource (JSON Schema 2020-12 Core Section 8.2.2) — a name
+    # declared twice would bind a reference to whichever declaration the
+    # walk met first — and an index that stopped at its bound before
+    # reaching every object leaves references and resource dialects
+    # undecided, so either makes the schema unusable.
     # @param resolver [Hash] holder of the memoized anchor index
     # @return [Array<String>]
-    def self.duplicate_anchor_problems(root, resolver)
+    def self.anchor_index_problems(root, resolver)
       index = (resolver[:anchors] ||= anchor_index(root, resolver[:dialect]))
-      index[:duplicates].map { |name| "anchor #{clip(name.inspect)} is declared more than once in a schema resource" }
+      problems = index[:duplicates].map do |name|
+        "anchor #{clip(name.inspect)} is declared more than once in a schema resource"
+      end
+      problems << "schema has too many objects to index its anchors (more than #{MAX_SUBSCHEMAS})" if index[:truncated]
+      problems
     end
 
     # Walk every subschema position, checking bounds and references. A
@@ -243,7 +252,7 @@ module MCPClient
       return unless problems.empty? && schema_value?(schema)
       return unless admit_schema?(schema, depth, counter, problems)
 
-      if resource_start?(schema) && schema.key?('$schema')
+      if resource_root?(schema, dialect) && schema.key?('$schema')
         problem = embedded_dialect_problem(schema)
         return problems << problem if problem
 
@@ -499,7 +508,7 @@ module MCPClient
       return problems.map { |problem| "#{path}: #{problem}" } unless problems.empty?
 
       ctx = Context.new(root: root, deadline: deadline, dialect: canonical_dialect(dialect(root)),
-                        visits: 0, errors: 0, speculative: 0, anchors: nil)
+                        visits: 0, errors: 0, speculative: 0, anchors: nil, undecided: 0)
       validate_node(data, root, path, ctx, 0)
     rescue TooLarge => e
       ["#{path}: #{e.message}"]
@@ -527,6 +536,9 @@ module MCPClient
       dialect = node_dialect(schema, ctx)
       return validate_ref(data, schema, path, ctx, ref_depth) if schema.key?('$ref') && dialect == DRAFT_07
 
+      # A keyword the validator does not evaluate makes this node's verdict
+      # partial: a pass here is not a proof for not / oneOf / if.
+      ctx.undecided += 1 if partial_keywords?(schema, dialect)
       errors = []
       counted_before = ctx.errors
       errors.concat(validate_ref(data, schema, path, ctx, ref_depth)) if schema.key?('$ref')
@@ -610,48 +622,6 @@ module MCPClient
       end
 
       validate_node(data, target, path, ctx, ref_depth + 1)
-    end
-
-    # allOf / anyOf / oneOf / not / if-then-else.
-    # @return [Array<String>] validation errors
-    def self.validate_composition(data, schema, path, ctx, ref_depth)
-      errors = []
-      if schema['allOf'].is_a?(Array)
-        schema['allOf'].each_with_index do |sub, idx|
-          sub_errors = validate_node(data, sub, path, ctx, ref_depth)
-          errors << "#{path}: does not satisfy allOf/#{idx} (#{clip(sub_errors.first.to_s)})" unless sub_errors.empty?
-        end
-      end
-      if schema['anyOf'].is_a?(Array) &&
-         schema['anyOf'].none? { |sub| speculative(ctx) { validate_node(data, sub, path, ctx, ref_depth).empty? } }
-        errors << "#{path}: does not satisfy any schema in anyOf"
-      end
-      if schema['oneOf'].is_a?(Array)
-        matches = schema['oneOf'].count do |sub|
-          speculative(ctx) do
-            validate_node(data, sub, path, ctx, ref_depth).empty?
-          end
-        end
-        errors << "#{path}: satisfies #{matches} schemas in oneOf, expected exactly one" unless matches == 1
-      end
-      if schema.key?('not') && speculative(ctx) { validate_node(data, schema['not'], path, ctx, ref_depth).empty? }
-        errors << "#{path}: value satisfies the schema in not"
-      end
-      errors.concat(validate_conditional(data, schema, path, ctx, ref_depth))
-      errors
-    end
-
-    # if / then / else.
-    # @return [Array<String>] validation errors
-    def self.validate_conditional(data, schema, path, ctx, ref_depth)
-      # An `if` without `then` or `else` asserts nothing (JSON Schema 2020-12
-      # Section 10.2.2.1) and is not evaluated.
-      return [] unless schema.key?('if') && (schema.key?('then') || schema.key?('else'))
-
-      branch = speculative(ctx) { validate_node(data, schema['if'], path, ctx, ref_depth).empty? } ? 'then' : 'else'
-      return [] unless schema.key?(branch)
-
-      validate_node(data, schema[branch], path, ctx, ref_depth)
     end
 
     # Validate the JSON type of a value.

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -24,7 +24,8 @@ module MCPClient
   # - properties, required (objects)
   # - items, prefixItems (2020-12) / tuple-form items (draft-07, 2019-09),
   #   minItems, maxItems (arrays)
-  # - minLength, maxLength, pattern (strings)
+  # - minLength, maxLength, pattern (an ECMA-262 regular expression,
+  #   translated to the Ruby expression that means the same thing) (strings)
   # - minimum, maximum, exclusiveMinimum, exclusiveMaximum (numbers)
   # - allOf, anyOf, oneOf, not, if/then/else (composition)
   # - $ref to a location inside the same schema document (`#`, `#/$defs/x`,
@@ -58,14 +59,24 @@ module MCPClient
   #   propertyNames, dependentRequired / dependentSchemas (2019-09, 2020-12)
   #   and draft-07 dependencies (objects)
   #
-  # What is left out is what cannot be decided without the annotations a
-  # whole composition produces (unevaluatedItems, unevaluatedProperties) or
-  # without a dynamic scope ($dynamicRef, $recursiveRef), plus the two
-  # keywords that only annotate in the default dialect (format, which full
-  # validators assert only in format-assertion mode, and contentSchema).
-  # Those are ignored rather than misapplied, so validation is best-effort
-  # there — it may accept data a full validator would reject, but it does not
-  # reject data that conforms to the schema. So that this gap is never
+  # - unevaluatedItems, unevaluatedProperties at a node that produces every
+  #   annotation they read: with no in-place applicator beside them (and, for
+  #   items, no `contains`) they are `additionalItems` / `additionalProperties`
+  #   over what the node did not name
+  #
+  # What is left out is exactly what cannot be decided here:
+  # unevaluatedItems / unevaluatedProperties where an in-place applicator
+  # (allOf, anyOf, oneOf, if, $ref, dependentSchemas — or a `contains`, whose
+  # matches annotate the items they matched) contributes annotations
+  # collected across a whole composition, the dynamic references
+  # ($dynamicRef, $recursiveRef), whose target depends on the dynamic scope a
+  # validation was entered through, and the two keywords that only annotate
+  # in the default dialect (format, which full validators assert only in
+  # format-assertion mode, and contentSchema). Those are ignored rather than
+  # misapplied, so validation is best-effort there — it may accept data a
+  # full validator would reject, but it does not reject data that conforms to
+  # the schema, and an unevaluated keyword is never read as a match for a
+  # non-monotonic composition (not, oneOf, if). So that this gap is never
   # silent, {.unsupported_keywords} reports which unapplied validation
   # keywords a schema uses; callers surface them as a warning.
   module SchemaValidator
@@ -135,14 +146,21 @@ module MCPClient
     MAX_NODE_DEPTH = 256
 
     # JSON Schema keywords that affect validation but that this validator
-    # does not evaluate: the dynamic references (whose target depends on the
+    # may not evaluate: the dynamic references (whose target depends on the
     # dynamic scope a validation was entered through), the two keywords
     # decided by annotations collected across a whole composition
     # (`unevaluatedItems` / `unevaluatedProperties`), and the two that only
     # annotate in the default dialect (`format`, asserted by full validators
-    # in format-assertion mode, and `contentSchema`). Their presence means
-    # validation is partial: data may pass here that a full validator would
-    # reject.
+    # in format-assertion mode, and `contentSchema`). Where one of them is
+    # left unevaluated, validation is partial: data may pass here that a full
+    # validator would reject.
+    #
+    # The annotation-driven pair is only *sometimes* in this position: at a
+    # node that produces every annotation it reads there is no composition to
+    # collect anything from, and {Composition#unevaluated_applied?} says so —
+    # {Instances} applies the keyword there and the scan does not report it.
+    # The dynamic references are always here: a dynamic scope is not
+    # something a node can produce for itself.
     #
     # Every other standard keyword is evaluated. A standard assertion left
     # unevaluated is not a smaller report but a wrong verdict: it makes a
@@ -219,6 +237,7 @@ module MCPClient
       'unevaluatedItems' => [DEFAULT_DIALECT, DRAFT_2019_09],
       'unevaluatedProperties' => [DEFAULT_DIALECT, DRAFT_2019_09],
       'contentSchema' => [DEFAULT_DIALECT, DRAFT_2019_09],
+      'deprecated' => [DEFAULT_DIALECT, DRAFT_2019_09],
       'minContains' => [DEFAULT_DIALECT, DRAFT_2019_09],
       'maxContains' => [DEFAULT_DIALECT, DRAFT_2019_09],
       '$anchor' => [DEFAULT_DIALECT, DRAFT_2019_09],
@@ -782,6 +801,19 @@ module MCPClient
     def self.count_visit(ctx)
       ctx.visits += 1
       raise Aborted, "more than #{MAX_NODE_VISITS} schema nodes visited" if ctx.visits > MAX_NODE_VISITS
+
+      check_deadline(ctx)
+    end
+
+    # Consult the validation-wide deadline without spending the node-visit
+    # allowance. A loop over the instance's own members (an object's
+    # properties, an array's items) is as long as the peer made it and may
+    # decide a member without visiting a node for it, so the loop itself has
+    # to reach a checkpoint: otherwise the budget is only consulted between
+    # the nodes such a sweep happens to visit, and a wide enough instance
+    # runs past it — reported, inside a speculative branch, as a pass.
+    # @raise [Aborted]
+    def self.check_deadline(ctx)
       raise Aborted, 'validation time budget exhausted' if budget_exhausted?(ctx.deadline)
     end
 

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -10,6 +10,8 @@ require_relative 'schema_validator/keyword_scan'
 require_relative 'schema_validator/composition'
 require_relative 'schema_validator/evaluation'
 require_relative 'schema_validator/scalars'
+require_relative 'schema_validator/ecma_patterns'
+require_relative 'schema_validator/input_requirements'
 require_relative 'schema_validator/instances'
 
 module MCPClient
@@ -89,6 +91,8 @@ module MCPClient
     extend Composition
     extend Evaluation
     extend Scalars
+    extend EcmaPatterns
+    extend InputRequirements
     extend Instances
 
     # Raised inside a validation to abandon it (time budget, resource bound).
@@ -203,6 +207,12 @@ module MCPClient
     # still makes progress rather than failing every remaining pattern.
     MIN_PATTERN_MATCH_TIMEOUT = 0.01
 
+    # The longest `pattern` (or `patternProperties` key) a schema may carry.
+    # A pattern is translated and compiled before it is matched, and both
+    # cost what the peer's text costs; the depth and subschema bounds say
+    # nothing about one string, so its length is bounded on its own.
+    MAX_PATTERN_LENGTH = 10_000
+
     # Keywords whose value is a single subschema to walk (or, for `items`,
     # an array of positional subschemas in draft-07 / 2019-09).
     SUBSCHEMA_KEYWORDS = %w[
@@ -230,6 +240,7 @@ module MCPClient
       '$dynamicAnchor' => [DEFAULT_DIALECT],
       '$recursiveRef' => [DRAFT_2019_09],
       '$recursiveAnchor' => [DRAFT_2019_09],
+      '$vocabulary' => [DEFAULT_DIALECT, DRAFT_2019_09],
       'additionalItems' => [DRAFT_2019_09, DRAFT_07],
       'dependencies' => [DRAFT_07],
       'dependentSchemas' => [DEFAULT_DIALECT, DRAFT_2019_09],
@@ -476,6 +487,8 @@ module MCPClient
       check_assertion_shapes(schema, dialect, problems)
       check_exclusive_bounds(schema, dialect, problems)
       check_identifier_shapes(schema, dialect, problems)
+      check_core_keyword_shapes(schema, dialect, problems)
+      check_pattern_shapes(schema, dialect, problems)
     end
 
     # Account for a schema (object or boolean) about to be walked: once per

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'uri'
+require_relative 'schema_validator/annotations'
 require_relative 'schema_validator/dialects'
 require_relative 'schema_validator/normalization'
 require_relative 'schema_validator/uri_references'
@@ -150,48 +151,36 @@ module MCPClient
     MAX_NODE_DEPTH = 256
 
     # JSON Schema keywords that affect validation but that this validator
-    # may not evaluate: the dynamic references (whose target depends on the
-    # dynamic scope a validation was entered through), the two keywords
-    # decided by annotations collected across a whole composition
-    # (`unevaluatedItems` / `unevaluatedProperties`), and the two that only
+    # may not evaluate: the dynamic references where they are dynamic (a
+    # target the dynamic scope a validation was entered through could
+    # re-bind, which this validator does not track), and the two that only
     # annotate in the default dialect (`format`, asserted by full validators
     # in format-assertion mode, and `contentSchema`). Where one of them is
     # left unevaluated, validation is partial: data may pass here that a full
     # validator would reject.
     #
-    # The annotation-driven pair is only *sometimes* in this position: at a
-    # node that produces every annotation it reads there is no composition to
-    # collect anything from, and {Composition#unevaluated_applied?} says so —
-    # {Instances} applies the keyword there and the scan does not report it.
-    # The dynamic references are always here: a dynamic scope is not
-    # something a node can produce for itself.
+    # A dynamic reference is only *sometimes* in this position: one naming
+    # a pointer or a plain anchor is the `$ref` it resolves to, and is
+    # applied as one ({Evaluation#applied_references});
+    # {References#dynamic_reference?} tells the two apart, and the scan
+    # reports only the dynamic ones.
     #
-    # Every other standard keyword is evaluated. A standard assertion left
-    # unevaluated is not a smaller report but a wrong verdict: it makes a
-    # composition branch undecided, and an undecided branch is accepted
-    # wherever the composition is monotonic (`allOf`, `anyOf`), so the
-    # instance passes a schema that rejects it.
-    UNSUPPORTED_KEYWORDS = %w[
-      $dynamicRef $recursiveRef contentSchema format
-      unevaluatedProperties unevaluatedItems
-    ].freeze
+    # Every other standard keyword is evaluated — `unevaluatedItems` and
+    # `unevaluatedProperties` from the annotations {Evaluation} collects
+    # across a whole composition. A standard assertion left unevaluated is
+    # not a smaller report but a wrong verdict: it makes a composition
+    # branch undecided, and an undecided branch is accepted wherever the
+    # composition is monotonic (`allOf`, `anyOf`), so the instance passes a
+    # schema that rejects it.
+    UNSUPPORTED_KEYWORDS = %w[$dynamicRef $recursiveRef contentSchema format].freeze
 
     # Unsupported keywords that are annotations, not assertions (`format`
     # is annotation-only in the default 2020-12 vocabulary, `contentSchema`
     # only annotates): their presence decides nothing about an instance.
     ANNOTATION_KEYWORDS = %w[format contentSchema].freeze
 
-    # Unsupported assertions by the instance type they apply to; an
-    # assertion of another type is a no-op for the instance (JSON Schema
-    # 2020-12 Validation Section 6: keywords apply only to their type), so
-    # it cannot leave a branch undecided.
-    UNSUPPORTED_ASSERTIONS_BY_TYPE = {
-      Hash => %w[unevaluatedProperties],
-      Array => %w[unevaluatedItems]
-    }.freeze
-
-    # Unsupported keywords that apply to every instance.
-    UNSUPPORTED_ASSERTIONS_ANY_TYPE = %w[$dynamicRef $recursiveRef].freeze
+    # The references whose target may depend on the dynamic scope.
+    DYNAMIC_REFERENCE_KEYWORDS = %w[$dynamicRef $recursiveRef].freeze
 
     # Wall-clock budget for a single validate call (pattern matching and the
     # walk itself). Schemas come from the remote server, so an expensive
@@ -309,14 +298,22 @@ module MCPClient
     # every `$ref` resolves inside the document to a schema (a network or
     # otherwise external reference is never dereferenced and makes the
     # schema unusable rather than permissive).
+    # The check runs under a deadline like a validation does: the schema is
+    # the peer's, and reading it (translating and compiling its patterns
+    # above all) costs what the peer's text costs.
     # @param schema [Object] the schema (string or symbol keys)
     # @param counter [Hash] filled in with the preflight state, so a caller
     #   can tell one kind of problem from another (`:unsupported_dialect`)
+    # @param deadline [Float, nil] monotonic deadline for the whole check
+    #   (PATTERN_MATCH_TIMEOUT from now when none is given)
     # @return [Array<String>] problems (empty when the schema is usable)
-    def self.check_schema(schema, counter = {})
-      check_normalized(normalize_schema(schema), counter)
+    def self.check_schema(schema, counter = {}, deadline: nil)
+      counter[:deadline] = deadline || (Process.clock_gettime(Process::CLOCK_MONOTONIC) + PATTERN_MATCH_TIMEOUT)
+      check_normalized(normalize_schema(schema, deadline: counter[:deadline]), counter)
     rescue TooLarge => e
       [e.message]
+    rescue Aborted => e
+      ["validation aborted: #{e.message}"]
     end
 
     # The dialect a schema declares (at its root or at an embedded resource
@@ -366,6 +363,8 @@ module MCPClient
       counter.update(count: 0, dialect: canonical_dialect(declared), walked: {}.compare_by_identity,
                      depths: lexical_depths(root, canonical_dialect(declared)))
       walk_schema(root, root, 0, counter, problems)
+      exhausted = problems.empty? && budget_exhausted?(counter[:deadline])
+      problems << 'validation aborted: validation time budget exhausted during the schema check' if exhausted
       problems.concat(anchor_index_problems(root, counter)) if problems.empty?
       problems.uniq
     end
@@ -421,6 +420,11 @@ module MCPClient
     # @return [void]
     def self.walk_position(walk, schema, depth, dialect)
       return unless schema_value?(schema)
+      # The positions are as many as the peer's document holds, and each
+      # may cost a pattern's translation: the deadline is consulted before
+      # every one, and a check past it stops there ({.check_normalized}
+      # reports it).
+      return if budget_exhausted?(walk.counter[:deadline])
       return unless admit_schema?(schema, depth, walk.counter, walk.problems)
 
       if resource_root?(schema, dialect) && schema.key?('$schema')
@@ -428,6 +432,13 @@ module MCPClient
         return record_embedded_dialect_problem(walk, schema, problem) if problem
 
         dialect = embedded_dialect(schema, dialect)
+      elsif schema.key?('$schema') && !schema.equal?(walk.root) && !resource_start?(schema)
+        # A `$schema` is read at a schema resource root only (JSON Schema
+        # 2020-12 Core Section 8.1.1); anywhere else it is a malformed
+        # keyword, not an absent one.
+        walk.problems << '$schema is only allowed at a schema resource root (the document root, or a ' \
+                         'subschema declaring an $id)'
+        return
       end
       referenced = schema.key?('$ref') ? check_ref(walk, schema, depth, dialect) : []
       # draft-07: the $ref replaces its siblings, so the applicators next to
@@ -436,6 +447,7 @@ module MCPClient
       # through references.
       return queue_definitions(walk, schema, depth, dialect, referenced) if dialect == DRAFT_07 && schema.key?('$ref')
 
+      referenced.concat(check_dynamic_refs(walk, schema, depth, dialect))
       check_keyword_shapes(walk, schema, dialect)
       queue_subschemas(walk, schema, depth, dialect, referenced)
     end
@@ -475,11 +487,6 @@ module MCPClient
     # @return [void]
     def self.check_keyword_shapes(walk, schema, dialect)
       problems = walk.problems
-      %w[$dynamicRef $recursiveRef].each do |keyword|
-        next unless schema.key?(keyword) && keyword_known?(keyword, dialect)
-
-        check_dynamic_ref(walk, schema, keyword, dialect)
-      end
       if dialect == DEFAULT_DIALECT && schema['items'].is_a?(Array)
         problems << 'items must be a schema in JSON Schema 2020-12 (positional schemas go in prefixItems)'
       end
@@ -488,7 +495,7 @@ module MCPClient
       check_exclusive_bounds(schema, dialect, problems)
       check_identifier_shapes(schema, dialect, problems)
       check_core_keyword_shapes(schema, dialect, problems)
-      check_pattern_shapes(schema, dialect, problems)
+      check_pattern_shapes(schema, dialect, problems, walk.counter[:deadline])
     end
 
     # Account for a schema (object or boolean) about to be walked: once per
@@ -556,18 +563,18 @@ module MCPClient
     # pointer may lead into a bag the dialect does not walk (`$defs` under
     # draft-07), and what a reference applies must be usable too.
     # @return [Array<Array>] the positions the reference reaches
-    def self.check_ref(walk, schema, depth, dialect)
+    def self.check_ref(walk, schema, depth, dialect, keyword = '$ref')
       root = walk.root
       counter = walk.counter
       problems = walk.problems
-      ref = schema['$ref']
+      ref = schema[keyword]
       unless ref.is_a?(String)
-        problems << "$ref must be a string, got #{json_type(ref)}"
+        problems << "#{keyword} must be a string, got #{json_type(ref)}"
         return []
       end
       if external_ref?(ref, root, counter[:dialect], counter, from: schema)
-        problems << "external $ref #{clip(ref.inspect)} is not dereferenced (only references inside the schema " \
-                    'document are resolved; network $ref resolution is disabled)'
+        problems << "external #{keyword} #{clip(ref.inspect)} is not dereferenced (only references inside the " \
+                    'schema document are resolved; network $ref resolution is disabled)'
         return []
       end
 
@@ -576,7 +583,7 @@ module MCPClient
         position = referenced_target_position(walk, target, hop, from, depth, dialect)
         positions << position if position
       end
-      problems << problem if problem
+      problems << problem.sub('$ref', keyword) if problem
       positions
     end
 
@@ -628,18 +635,31 @@ module MCPClient
       problems << "schema has more than #{MAX_SUBSCHEMAS} subschemas" if counter[:count] > MAX_SUBSCHEMAS
     end
 
-    # A `$dynamicRef` / `$recursiveRef` is not evaluated, but one pointing
-    # outside the document would need a fetch, which never happens: the
-    # schema is unusable.
-    # @return [void]
-    def self.check_dynamic_ref(walk, schema, keyword, _dialect)
-      ref = schema[keyword]
-      # A reference that is not a URI reference at all names nothing: it is
-      # not silently ignored (a malformed keyword is not an absent one).
-      return walk.problems << "#{keyword} must be a string, got #{json_type(ref)}" unless ref.is_a?(String)
-      return unless external_ref?(ref, walk.root, walk.counter[:dialect], walk.counter, from: schema)
+    # The dynamic references of a schema object. One that names no dynamic
+    # anchor is the plain reference it resolves to and is checked (and what
+    # it reaches queued) exactly as a `$ref` is; a dynamic one is not
+    # evaluated, but one pointing outside the document would need a fetch,
+    # which never happens: the schema is unusable.
+    # @return [Array<Array>] the positions the plain ones reach
+    def self.check_dynamic_refs(walk, schema, depth, dialect)
+      DYNAMIC_REFERENCE_KEYWORDS.flat_map do |keyword|
+        next [] unless schema.key?(keyword) && keyword_known?(keyword, dialect)
 
-      walk.problems << "external #{keyword} #{clip(ref.inspect)} is not dereferenced"
+        ref = schema[keyword]
+        # A reference that is not a URI reference at all names nothing: it
+        # is not silently ignored (a malformed keyword is not an absent one).
+        unless ref.is_a?(String)
+          walk.problems << "#{keyword} must be a string, got #{json_type(ref)}"
+          next []
+        end
+        if external_ref?(ref, walk.root, walk.counter[:dialect], walk.counter, from: schema)
+          walk.problems << "external #{keyword} #{clip(ref.inspect)} is not dereferenced"
+          next []
+        end
+        next [] if dynamic_reference?(schema, keyword, walk.root, walk.counter[:dialect], walk.counter)
+
+        check_ref(walk, schema, depth, dialect, keyword)
+      end
     end
 
     # Follow a local reference (and the references it leads to) at
@@ -709,8 +729,9 @@ module MCPClient
       # document included.
       deadline ||= Process.clock_gettime(Process::CLOCK_MONOTONIC) + PATTERN_MATCH_TIMEOUT
       root = normalize_schema(schema, deadline: deadline)
-      # `preflight` comes back holding the state the check read the schema under.
-      problems = check_normalized(root, preflight = {})
+      # `preflight` comes back holding the state the check read the schema
+      # under; the check runs under the validation's deadline.
+      problems = check_normalized(root, preflight = { deadline: deadline })
       return problems.map { |problem| "#{path}: #{problem}" } unless problems.empty?
 
       # The index the preflight built is the one this validation reads (the
@@ -767,7 +788,7 @@ module MCPClient
           # A speculative application's errors are a verdict, not output, and
           # do not count toward MAX_ERRORS while it runs.
           ctx.speculative += 1 if step[3]
-          step = start_node(data, step[1], path, ctx, step[2])
+          step = start_node(data, step[1], path, ctx, step[2], collecting: step[5])
           next
         end
 
@@ -776,7 +797,9 @@ module MCPClient
 
         resumed = pending.pop
         ctx.speculative -= 1 if resumed[3]
-        step = resumed[4].call(errors)
+        # The finished application hands back its verdict and what it
+        # evaluated of the value, for the applicator that applied it.
+        step = resumed[4].call(errors, step[2])
       end
     end
 

--- a/lib/mcp_client/schema_validator.rb
+++ b/lib/mcp_client/schema_validator.rb
@@ -159,11 +159,9 @@ module MCPClient
     # left unevaluated, validation is partial: data may pass here that a full
     # validator would reject.
     #
-    # A dynamic reference is only *sometimes* in this position: one naming
-    # a pointer or a plain anchor is the `$ref` it resolves to, and is
-    # applied as one ({Evaluation#applied_references});
-    # {References#dynamic_reference?} tells the two apart, and the scan
-    # reports only the dynamic ones.
+    # A dynamic reference is not in this position: it is evaluated, against
+    # the dynamic scope the validation records as it enters each resource
+    # ({References#dynamic_binding}).
     #
     # Every other standard keyword is evaluated — `unevaluatedItems` and
     # `unevaluatedProperties` from the annotations {Evaluation} collects
@@ -172,7 +170,7 @@ module MCPClient
     # branch undecided, and an undecided branch is accepted wherever the
     # composition is monotonic (`allOf`, `anyOf`), so the instance passes a
     # schema that rejects it.
-    UNSUPPORTED_KEYWORDS = %w[$dynamicRef $recursiveRef contentSchema format].freeze
+    UNSUPPORTED_KEYWORDS = %w[contentSchema format].freeze
 
     # Unsupported keywords that are annotations, not assertions (`format`
     # is annotation-only in the default 2020-12 vocabulary, `contentSchema`
@@ -272,9 +270,12 @@ module MCPClient
       dialect.nil? || !DIALECT_KEYWORDS.key?(keyword) || DIALECT_KEYWORDS[keyword].include?(dialect)
     end
 
-    # Per-validation state.
+    # Per-validation state. `scope` is the dynamic scope: the schema
+    # resources the evaluation has entered, outermost first, which is what a
+    # dynamic reference binds against (JSON Schema 2020-12 Core Section
+    # 8.2.3.2).
     Context = Struct.new(:root, :deadline, :dialect, :visits, :errors, :speculative, :anchors, :undecided, :depth,
-                         keyword_init: true)
+                         :scope, keyword_init: true)
 
     # Per-preflight state: the document, the counter the walk accounts to,
     # the problems it found, and the positions it has still to read (a
@@ -656,8 +657,6 @@ module MCPClient
           walk.problems << "external #{keyword} #{clip(ref.inspect)} is not dereferenced"
           next []
         end
-        next [] if dynamic_reference?(schema, keyword, walk.root, walk.counter[:dialect], walk.counter)
-
         check_ref(walk, schema, depth, dialect, keyword)
       end
     end
@@ -740,7 +739,7 @@ module MCPClient
       # reference resolves to depend on the order this instance applies them.
       ctx = Context.new(root: root, deadline: deadline, dialect: canonical_dialect(dialect(root)),
                         visits: 0, errors: 0, speculative: 0, anchors: preflight[:anchors], undecided: 0,
-                        depth: 0)
+                        depth: 0, scope: [])
       validate_node(data, root, path, ctx, 0)
     rescue TooLarge => e
       ["#{path}: #{e.message}"]
@@ -781,6 +780,11 @@ module MCPClient
     # @raise [Aborted] when a bound is hit
     def self.validate_node(data, schema, path, ctx, ref_depth)
       pending = []
+      # The dynamic scope grows and shrinks with these applications, exactly
+      # as it does with the Ruby frames a recursive validator would spend:
+      # entering a schema of another resource enters that resource, and the
+      # application that entered it is the one that leaves it.
+      entered = [entered_scope?(ctx, schema)]
       step = start_node(data, schema, path, ctx, ref_depth)
       loop do
         if step[0] == :apply
@@ -788,11 +792,13 @@ module MCPClient
           # A speculative application's errors are a verdict, not output, and
           # do not count toward MAX_ERRORS while it runs.
           ctx.speculative += 1 if step[3]
+          entered << entered_scope?(ctx, step[1])
           step = start_node(data, step[1], path, ctx, step[2], collecting: step[5])
           next
         end
 
         errors = step[1]
+        leave_scope(ctx, entered.pop)
         return errors if pending.empty?
 
         resumed = pending.pop
@@ -801,6 +807,33 @@ module MCPClient
         # evaluated of the value, for the applicator that applied it.
         step = resumed[4].call(errors, step[2])
       end
+    ensure
+      entered&.each { |was_entered| leave_scope(ctx, was_entered) }
+    end
+
+    # Enter the schema resource a subschema belongs to, when applying it
+    # leaves the resource in force. A schema of the resource already
+    # innermost adds nothing a dynamic reference could read, so it is not
+    # pushed and its application has nothing to pop.
+    # @param ctx [Context] the validation context
+    # @param schema [Object] the subschema about to be applied
+    # @return [Boolean] whether the scope was pushed
+    def self.entered_scope?(ctx, schema)
+      return false unless schema.is_a?(Hash) && ctx.scope
+
+      ctx.anchors ||= anchor_index(ctx.root, ctx.dialect)
+      resource = ctx.anchors[:resources][schema] || ctx.root
+      return false if ctx.scope.last.equal?(resource)
+
+      ctx.scope.push(resource)
+      true
+    end
+
+    # @param ctx [Context] the validation context
+    # @param entered [Boolean] what {.entered_scope?} answered
+    # @return [void]
+    def self.leave_scope(ctx, entered)
+      ctx.scope.pop if entered && ctx.scope
     end
 
     # Validate a child of the value being validated — an array item or a

--- a/lib/mcp_client/schema_validator/annotations.rb
+++ b/lib/mcp_client/schema_validator/annotations.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module SchemaValidator
+    # What the schemas applied to one instance value evaluated of it: the
+    # annotation results `unevaluatedProperties` and `unevaluatedItems` read
+    # (JSON Schema 2020-12 Core Sections 11.2 and 11.3). One is kept per
+    # application of a schema to an object or an array, filled in by the
+    # keywords the node evaluates itself (`properties`, `patternProperties`,
+    # `additionalProperties`, `prefixItems`, `items`, `contains` and the two
+    # keywords themselves) and merged from every in-place applicator whose
+    # subschema passed — a failed subschema annotates nothing, and a cousin
+    # (a sibling branch of the same composition) never sees it.
+    class Evaluated
+      def initialize
+        @all = false
+        @names = {}
+        @prefix = 0
+        @indices = {}
+      end
+
+      # @return [Boolean] whether every member or item was evaluated
+      def all?
+        @all
+      end
+
+      # Every member or item is evaluated (an `items` schema, an
+      # `additionalProperties` schema, or the unevaluated keyword itself).
+      # @return [void]
+      def all!
+        @all = true
+      end
+
+      # @param name [Object] a property name (either key form)
+      # @return [void]
+      def name!(name)
+        @names[name.to_s] = true unless @all
+      end
+
+      # @param count [Integer] how many leading items a tuple evaluated
+      # @return [void]
+      def prefix!(count)
+        @prefix = count if count > @prefix
+      end
+
+      # @param index [Integer] an item `contains` matched
+      # @return [void]
+      def index!(index)
+        @indices[index] = true unless @all
+      end
+
+      # @param name [Object] a property name (either key form)
+      # @return [Boolean] whether the member was evaluated
+      def property?(name)
+        @all || @names.key?(name.to_s)
+      end
+
+      # @param index [Integer]
+      # @return [Boolean] whether the item was evaluated
+      def item?(index)
+        @all || index < @prefix || @indices.key?(index)
+      end
+
+      # Take over what a passed subschema evaluated of the same value.
+      # @param other [Evaluated, nil]
+      # @return [Evaluated] self
+      def merge!(other)
+        return self if other.nil?
+        return all! || self if other.all?
+
+        @names.merge!(other.names)
+        @prefix = other.prefix if other.prefix > @prefix
+        @indices.merge!(other.indices)
+        self
+      end
+
+      protected
+
+      attr_reader :names, :prefix, :indices
+    end
+  end
+end

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -28,14 +28,30 @@ module MCPClient
       # supported assertion rejected the value, :pass when every assertion
       # was evaluated and accepted it, :undecided when it was accepted only
       # as far as the validator could evaluate. Non-monotonic compositions
-      # (not, oneOf, if) never treat :undecided as a match.
+      # (not, oneOf, if) never treat :undecided as a match. A definite
+      # verdict leaves no uncertainty behind: what a failing branch could not
+      # evaluate does not matter once it failed.
       # @return [Symbol]
       def verdict(data, sub, path, ctx, ref_depth)
         before = ctx.undecided
         passed = speculative(ctx) { validate_node(data, sub, path, ctx, ref_depth).empty? }
-        return :fail unless passed
+        unless passed
+          ctx.undecided = before
+          return :fail
+        end
 
         ctx.undecided == before ? :pass : :undecided
+      end
+
+      # The verdicts of every branch. Uncertainty is kept only when it can
+      # change the outcome: once the composition is decided the count is
+      # restored to what it was before the branches ran.
+      # @return [Array<Symbol>]
+      def branch_verdicts(data, subs, path, ctx, ref_depth, decided:)
+        before = ctx.undecided
+        verdicts = subs.map { |sub| verdict(data, sub, path, ctx, ref_depth) }
+        ctx.undecided = before if decided.call(verdicts)
+        verdicts
       end
 
       # allOf / anyOf / oneOf / not / if-then-else.
@@ -48,16 +64,20 @@ module MCPClient
             errors << "#{path}: does not satisfy allOf/#{idx} (#{clip(sub_errors.first.to_s)})" unless sub_errors.empty?
           end
         end
-        # anyOf is monotonic: a partial pass is the permissive direction.
-        if schema['anyOf'].is_a?(Array) &&
-           schema['anyOf'].all? { |sub| verdict(data, sub, path, ctx, ref_depth) == :fail }
-          errors << "#{path}: does not satisfy any schema in anyOf"
+        # anyOf is monotonic: a definite pass decides it whatever the other
+        # branches, and only undecided branches leave it undecided.
+        if schema['anyOf'].is_a?(Array)
+          verdicts = branch_verdicts(data, schema['anyOf'], path, ctx, ref_depth,
+                                     decided: ->(vs) { vs.include?(:pass) || vs.all?(:fail) })
+          errors << "#{path}: does not satisfy any schema in anyOf" if verdicts.all?(:fail)
         end
         if schema['oneOf'].is_a?(Array)
-          verdicts = schema['oneOf'].map { |sub| verdict(data, sub, path, ctx, ref_depth) }
+          # Two definite passes decide it; with an undecided branch and at
+          # most one pass, "exactly one" cannot be told either way.
+          verdicts = branch_verdicts(data, schema['oneOf'], path, ctx, ref_depth,
+                                     decided: ->(vs) { vs.count(:pass) > 1 || vs.none?(:undecided) })
           matches = verdicts.count(:pass)
-          # With an undecided branch "exactly one" cannot be told either way.
-          if verdicts.none?(:undecided) && matches != 1
+          if matches > 1 || (verdicts.none?(:undecided) && matches != 1)
             errors << "#{path}: satisfies #{matches} schemas in oneOf, expected exactly one"
           end
         end

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -38,7 +38,7 @@ module MCPClient
         value = schema[keyword]
         case keyword
         when 'minContains', 'maxContains' then schema.key?('contains')
-        when 'additionalItems' then schema['items'].is_a?(Array)
+        when 'additionalItems' then schema['items'].is_a?(Array) && ![true, {}].include?(value)
         when 'additionalProperties', 'unevaluatedProperties', 'unevaluatedItems', 'propertyNames'
           ![true, {}].include?(value)
         when 'uniqueItems' then value == true

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -21,8 +21,12 @@ module MCPClient
       def partial_keywords?(schema, dialect, data)
         applicable = UNSUPPORTED_ASSERTIONS_ANY_TYPE +
                      UNSUPPORTED_ASSERTIONS_BY_TYPE.select { |type, _| data.is_a?(type) }.values.flatten
+        # draft-07 `format` asserts (Validation Section 7.2); the validator
+        # does not evaluate formats, so a string branch carrying one is
+        # undecided there, while 2019-09 / 2020-12 only annotate.
+        applicable += ['format'] if dialect == DRAFT_07 && data.is_a?(String)
         (schema.keys & applicable).any? do |keyword|
-          keyword_known?(keyword, dialect) && effective_assertion?(schema, keyword, data)
+          keyword_known?(keyword, dialect) && effective_assertion?(schema, keyword, data, dialect)
         end
       end
 
@@ -36,11 +40,11 @@ module MCPClient
       # cannot fail (additionalProperties true, uniqueItems false,
       # minProperties 0, an empty dependency map) decides nothing.
       # @return [Boolean]
-      def effective_assertion?(schema, keyword, data)
+      def effective_assertion?(schema, keyword, data, dialect = nil)
         value = schema[keyword]
         case keyword
         when 'contains', 'minContains', 'maxContains', 'additionalItems'
-          effective_array_assertion?(schema, keyword, value, data)
+          effective_array_assertion?(schema, keyword, value, data, dialect)
         when 'additionalProperties', 'unevaluatedProperties', 'unevaluatedItems', 'propertyNames'
           ![true, {}].include?(value)
         when 'uniqueItems' then value == true
@@ -55,9 +59,11 @@ module MCPClient
       # The array assertions whose effect depends on a companion keyword or
       # on the instance's length.
       # @return [Boolean]
-      def effective_array_assertion?(schema, keyword, value, data)
+      # A companion the dialect does not define (`minContains` under
+      # draft-07) changes nothing.
+      def effective_array_assertion?(schema, keyword, value, data, dialect = nil)
         case keyword
-        when 'contains' then schema['minContains'] != 0
+        when 'contains' then !(keyword_known?('minContains', dialect) && schema['minContains'].eql?(0))
         when 'minContains' then schema.key?('contains') && value.is_a?(Numeric) && value.positive?
         when 'maxContains' then schema.key?('contains')
         else

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -35,41 +35,106 @@ module MCPClient
       # (minContains / maxContains without contains, additionalItems beside
       # a non-tuple items — JSON Schema 2020-12 Validation Sections
       # 6.4.4-6.4.5, draft-07 Section 9.3.1.2), one the instance never
-      # reaches (additionalItems when the tuple covers every item), one its
-      # companion switches off (contains with minContains 0) or whose value
-      # cannot fail (additionalProperties true, uniqueItems false,
-      # minProperties 0, an empty dependency map) decides nothing.
+      # reaches (additionalItems or unevaluatedItems when the tuple or an
+      # items schema covers every item, additionalProperties or
+      # unevaluatedProperties when every property is covered, uniqueItems
+      # below two items, maxContains or maxProperties the instance cannot
+      # exceed, minProperties it already satisfies, a dependency none of
+      # whose triggers is present), one its companion switches off
+      # (contains with minContains 0) or whose value cannot fail
+      # (additionalProperties true, uniqueItems false, minProperties 0, an
+      # empty dependency map) decides nothing.
       # @return [Boolean]
       def effective_assertion?(schema, keyword, data, dialect = nil)
         value = schema[keyword]
         case keyword
-        when 'contains', 'minContains', 'maxContains', 'additionalItems'
+        when 'contains', 'minContains', 'maxContains', 'additionalItems', 'unevaluatedItems', 'uniqueItems'
           effective_array_assertion?(schema, keyword, value, data, dialect)
-        when 'additionalProperties', 'unevaluatedProperties', 'unevaluatedItems', 'propertyNames'
-          ![true, {}].include?(value)
-        when 'uniqueItems' then value == true
-        when 'minProperties' then value.is_a?(Numeric) && value.positive?
-        when 'maxProperties', 'multipleOf' then value.is_a?(Numeric)
-        when 'dependentRequired', 'dependentSchemas', 'dependencies', 'patternProperties'
-          !(value.is_a?(Hash) && value.empty?)
+        when 'additionalProperties', 'unevaluatedProperties', 'propertyNames', 'minProperties', 'maxProperties',
+             'dependentRequired', 'dependentSchemas', 'dependencies', 'patternProperties'
+          effective_object_assertion?(schema, keyword, value, data, dialect)
+        when 'multipleOf' then value.is_a?(Numeric) && data.is_a?(Numeric)
         else true
         end
       end
 
       # The array assertions whose effect depends on a companion keyword or
-      # on the instance's length.
+      # on the instance's length. A companion the dialect does not define
+      # (`minContains` under draft-07) changes nothing.
       # @return [Boolean]
-      # A companion the dialect does not define (`minContains` under
-      # draft-07) changes nothing.
       def effective_array_assertion?(schema, keyword, value, data, dialect = nil)
+        return false unless data.is_a?(Array)
+
         case keyword
         when 'contains' then !(keyword_known?('minContains', dialect) && schema['minContains'].eql?(0))
         when 'minContains' then schema.key?('contains') && value.is_a?(Numeric) && value.positive?
-        when 'maxContains' then schema.key?('contains')
+        when 'maxContains' then schema.key?('contains') && value.is_a?(Numeric) && data.length > value
+        when 'uniqueItems' then value == true && data.length > 1
         else
-          schema['items'].is_a?(Array) && ![true, {}].include?(value) &&
-            data.is_a?(Array) && data.length > schema['items'].length
+          # additionalItems (beside a tuple only) / unevaluatedItems: only
+          # items past what the tuple (or an items schema, which evaluates
+          # every item) covers.
+          return false if keyword == 'additionalItems' && !schema['items'].is_a?(Array)
+
+          ![true, {}].include?(value) && data.length > evaluated_item_count(schema, keyword, dialect)
         end
+      end
+
+      # How many leading items the tuple keywords in force evaluate, or
+      # infinity when an items schema evaluates them all.
+      # @return [Integer, Float]
+      def evaluated_item_count(schema, keyword, dialect)
+        tuple = schema['prefixItems'] if keyword_known?('prefixItems', dialect) && schema['prefixItems'].is_a?(Array)
+        tuple ||= schema['items'] if schema['items'].is_a?(Array)
+        return Float::INFINITY if keyword == 'unevaluatedItems' && schema_value?(schema['items'])
+
+        tuple ? tuple.length : 0
+      end
+
+      # The object assertions whose effect depends on the instance's
+      # properties.
+      # @return [Boolean]
+      def effective_object_assertion?(schema, keyword, value, data, dialect = nil)
+        return false unless data.is_a?(Hash)
+
+        case keyword
+        when 'additionalProperties', 'unevaluatedProperties'
+          ![true, {}].include?(value) && uncovered_property?(schema, keyword, data, dialect)
+        when 'propertyNames' then ![true, {}].include?(value) && !data.empty?
+        when 'minProperties' then value.is_a?(Numeric) && data.size < value
+        when 'maxProperties' then value.is_a?(Numeric) && data.size > value
+        when 'patternProperties' then value.is_a?(Hash) && !value.empty? && !data.empty?
+        else
+          value.is_a?(Hash) && value.keys.any? { |trigger| data.key?(trigger.to_s) }
+        end
+      end
+
+      # Whether the instance has a property the schema's own property
+      # applicators leave to the keyword: one named in `properties` is
+      # covered, one an `additionalProperties` schema evaluates is covered
+      # for `unevaluatedProperties`, and one matching a `patternProperties`
+      # pattern is covered (an unreadable pattern is assumed to match
+      # nothing, keeping the branch undecided).
+      # @return [Boolean]
+      def uncovered_property?(schema, keyword, data, dialect)
+        return false if keyword == 'unevaluatedProperties' && schema.key?('additionalProperties') &&
+                        keyword_known?('additionalProperties', dialect)
+
+        named = schema['properties'].is_a?(Hash) ? schema['properties'].keys.map(&:to_s) : []
+        patterns = schema['patternProperties'].is_a?(Hash) ? schema['patternProperties'].keys.map(&:to_s) : []
+        data.each_key.any? do |name|
+          name = name.to_s
+          next false if named.include?(name)
+
+          patterns.none? { |pattern| pattern_matches?(pattern, name) }
+        end
+      end
+
+      # @return [Boolean]
+      def pattern_matches?(pattern, name)
+        Regexp.new(pattern).match?(name)
+      rescue RegexpError, TypeError
+        false
       end
 
       # The verdict of a branch evaluated speculatively: :fail when a

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -2,15 +2,18 @@
 
 module MCPClient
   module SchemaValidator
-    # allOf / anyOf / oneOf / not / if-then-else evaluation. Extended into
-    # SchemaValidator, so the methods are its own.
+    # How complete a verdict on one value is, and the part of `contains` its
+    # bounds alone decide. Extended into SchemaValidator, so the methods are
+    # its own; {Evaluation} applies the composition keywords themselves and
+    # reads the answers here.
     #
-    # A branch is evaluated speculatively (its errors are a verdict, not
-    # output). anyOf and allOf are monotonic, so a branch that passes as far
-    # as the validator can evaluate it is accepted; not, oneOf and if are
-    # not, so a branch that still holds an unevaluated assertion applying to
-    # the instance is :undecided and never a match, while one decided by its
-    # evaluated keywords (or carrying only annotations) is a full verdict.
+    # A composition branch is evaluated speculatively (its errors are a
+    # verdict, not output). anyOf and allOf are monotonic, so a branch that
+    # passes as far as the validator can evaluate it is accepted; not, oneOf
+    # and if are not, so a branch that still holds an unevaluated assertion
+    # applying to the instance is :undecided and never a match, while one
+    # decided by its evaluated keywords (or carrying only annotations) is a
+    # full verdict.
     module Composition
       # Whether a schema object carries an assertion the validator does not
       # evaluate (in the dialect in force) that applies to this instance, so
@@ -307,99 +310,6 @@ module MCPClient
         raise Aborted, "pattern #{clip(pattern.inspect)} exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"
       rescue RegexpError, TypeError
         false
-      end
-
-      # The verdict of a branch evaluated speculatively: :fail when a
-      # supported assertion rejected the value, :pass when every assertion
-      # was evaluated and accepted it, :undecided when it was accepted only
-      # as far as the validator could evaluate. Non-monotonic compositions
-      # (not, oneOf, if) never treat :undecided as a match. A definite
-      # verdict leaves no uncertainty behind: what a failing branch could not
-      # evaluate does not matter once it failed.
-      # @return [Symbol]
-      def verdict(data, sub, path, ctx, ref_depth)
-        before = ctx.undecided
-        passed = speculative(ctx) { validate_node(data, sub, path, ctx, ref_depth).empty? }
-        unless passed
-          ctx.undecided = before
-          return :fail
-        end
-
-        ctx.undecided == before ? :pass : :undecided
-      end
-
-      # The verdicts of the branches. Evaluation stops as soon as the
-      # branches seen so far settle the composition (`stop`): a branch that
-      # cannot change the outcome is not evaluated, so it cannot abort a
-      # decided validation. Once the composition is decided — early, or
-      # after every branch (`decided`) — the uncertainty count is restored
-      # to what it was before the branches ran.
-      # @return [Array<Symbol>]
-      def branch_verdicts(data, subs, path, ctx, ref_depth, stop:, decided:)
-        before = ctx.undecided
-        verdicts = []
-        subs.each do |sub|
-          verdicts << verdict(data, sub, path, ctx, ref_depth)
-          break if stop.call(verdicts)
-        end
-        ctx.undecided = before if stop.call(verdicts) || decided.call(verdicts)
-        verdicts
-      end
-
-      # allOf / anyOf / oneOf / not / if-then-else.
-      # @return [Array<String>] validation errors
-      def validate_composition(data, schema, path, ctx, ref_depth)
-        errors = []
-        if schema['allOf'].is_a?(Array)
-          # The first failing branch decides allOf; later branches are not
-          # evaluated (they cannot change the outcome, but could abort it).
-          schema['allOf'].each_with_index do |sub, idx|
-            sub_errors = validate_node(data, sub, path, ctx, ref_depth)
-            next if sub_errors.empty?
-
-            errors << "#{path}: does not satisfy allOf/#{idx} (#{clip(sub_errors.first.to_s)})"
-            break
-          end
-        end
-        # anyOf is monotonic: a definite pass decides it whatever the other
-        # branches, and only undecided branches leave it undecided.
-        if schema['anyOf'].is_a?(Array)
-          verdicts = branch_verdicts(data, schema['anyOf'], path, ctx, ref_depth,
-                                     stop: ->(vs) { vs.include?(:pass) }, decided: ->(vs) { vs.all?(:fail) })
-          errors << "#{path}: does not satisfy any schema in anyOf" if verdicts.all?(:fail)
-        end
-        if schema['oneOf'].is_a?(Array)
-          # Two definite passes decide it; with an undecided branch and at
-          # most one pass, "exactly one" cannot be told either way.
-          verdicts = branch_verdicts(data, schema['oneOf'], path, ctx, ref_depth,
-                                     stop: ->(vs) { vs.count(:pass) > 1 }, decided: ->(vs) { vs.none?(:undecided) })
-          matches = verdicts.count(:pass)
-          if matches > 1 || (verdicts.none?(:undecided) && matches != 1)
-            errors << "#{path}: satisfies #{matches} schemas in oneOf, expected exactly one"
-          end
-        end
-        if schema.key?('not') && verdict(data, schema['not'], path, ctx, ref_depth) == :pass
-          errors << "#{path}: value satisfies the schema in not"
-        end
-        errors.concat(validate_conditional(data, schema, path, ctx, ref_depth))
-        errors
-      end
-
-      # if / then / else.
-      # @return [Array<String>] validation errors
-      def validate_conditional(data, schema, path, ctx, ref_depth)
-        # An `if` without `then` or `else` asserts nothing (JSON Schema 2020-12
-        # Section 10.2.2.1) and is not evaluated.
-        return [] unless schema.key?('if') && (schema.key?('then') || schema.key?('else'))
-
-        case verdict(data, schema['if'], path, ctx, ref_depth)
-        when :pass then branch = 'then'
-        when :fail then branch = 'else'
-        else return [] # undecided: neither branch is known to apply
-        end
-        return [] unless schema.key?(branch)
-
-        validate_node(data, schema[branch], path, ctx, ref_depth)
       end
     end
   end

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -152,16 +152,18 @@ module MCPClient
         max if max.is_a?(Numeric)
       end
 
-      # Apply the part of `contains` the array's length alone decides. The
-      # number of matching items is never more than the array holds and
-      # never less than none, so a bound outside that range is an assertion
-      # this validator settles whatever the item schema says (JSON Schema
-      # 2020-12 Validation Sections 6.4.4-6.4.5: the default minContains is
-      # 1, so any contains rejects the empty array). A tautological schema
-      # (`true` / `{}`) matches every item and `false` none, which pins the
-      # count exactly; a contains that has to be matched item by item leaves
-      # only the bounds its length cannot reach decided, and the rest
-      # unevaluated.
+      # Apply the part of `contains` the bounds alone decide. The number of
+      # matching items is never more than the array holds and never less
+      # than none, so a bound outside that range is an assertion this
+      # validator settles whatever the item schema says (JSON Schema 2020-12
+      # Validation Sections 6.4.4-6.4.5: the default minContains is 1, so
+      # any contains rejects the empty array). Bounds that cannot overlap
+      # each other settle it too: `minContains` above `maxContains` admits
+      # no count at all, so the keyword fails before the item schema is
+      # ever consulted. A tautological schema (`true` / `{}`) matches every
+      # item and `false` none, which pins the count exactly; a contains
+      # that has to be matched item by item leaves only what its bounds
+      # decide, and the rest unevaluated.
       # @param data [Array] the instance
       # @param schema [Hash] string-keyed schema
       # @param path [String] location for error messages
@@ -173,6 +175,16 @@ module MCPClient
         low, high = contains_count_range(data, schema, dialect)
         min = contains_min(schema, dialect)
         max = contains_max(schema, dialect)
+        errors = contains_length_errors(path, low, high, min, max)
+        return errors unless errors.empty? && max && min > max
+
+        ["#{path}: contains requires between #{min} and #{max} matching items, which no count satisfies"]
+      end
+
+      # The bounds the array's own length settles: a lower bound above the
+      # highest count the array can reach, an upper bound below the lowest.
+      # @return [Array<String>] validation errors
+      def contains_length_errors(path, low, high, min, max)
         errors = []
         errors << "#{path}: expected at least #{min} items matching contains, got #{contains_seen(low, high, high)}" \
           if high < min

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -17,8 +17,10 @@ module MCPClient
       # its verdict is only partial. Annotations (`format`, `contentSchema`)
       # and assertions of another instance type decide nothing and leave the
       # verdict whole.
+      # @param deadline [Float, nil] monotonic deadline the checks run under
+      #   (the coverage checks match server-controlled patterns)
       # @return [Boolean]
-      def partial_keywords?(schema, dialect, data)
+      def partial_keywords?(schema, dialect, data, deadline = nil)
         applicable = UNSUPPORTED_ASSERTIONS_ANY_TYPE +
                      UNSUPPORTED_ASSERTIONS_BY_TYPE.select { |type, _| data.is_a?(type) }.values.flatten
         # draft-07 `format` asserts (Validation Section 7.2); the validator
@@ -26,7 +28,7 @@ module MCPClient
         # undecided there, while 2019-09 / 2020-12 only annotate.
         applicable += ['format'] if dialect == DRAFT_07 && data.is_a?(String)
         (schema.keys & applicable).any? do |keyword|
-          keyword_known?(keyword, dialect) && effective_assertion?(schema, keyword, data, dialect)
+          keyword_known?(keyword, dialect) && effective_assertion?(schema, keyword, data, dialect, deadline)
         end
       end
 
@@ -45,14 +47,14 @@ module MCPClient
       # (additionalProperties true, uniqueItems false, minProperties 0, an
       # empty dependency map) decides nothing.
       # @return [Boolean]
-      def effective_assertion?(schema, keyword, data, dialect = nil)
+      def effective_assertion?(schema, keyword, data, dialect = nil, deadline = nil)
         value = schema[keyword]
         case keyword
         when 'contains', 'minContains', 'maxContains', 'additionalItems', 'unevaluatedItems', 'uniqueItems'
           effective_array_assertion?(schema, keyword, value, data, dialect)
         when 'additionalProperties', 'unevaluatedProperties', 'propertyNames', 'minProperties', 'maxProperties',
              'dependentRequired', 'dependentSchemas', 'dependencies', 'patternProperties'
-          effective_object_assertion?(schema, keyword, value, data, dialect)
+          effective_object_assertion?(schema, keyword, value, data, dialect, deadline)
         when 'multipleOf' then value.is_a?(Numeric) && data.is_a?(Numeric)
         else true
         end
@@ -119,29 +121,42 @@ module MCPClient
       # The object assertions whose effect depends on the instance's
       # properties.
       # @return [Boolean]
-      def effective_object_assertion?(schema, keyword, value, data, dialect = nil)
+      def effective_object_assertion?(schema, keyword, value, data, dialect = nil, deadline = nil)
         return false unless data.is_a?(Hash)
 
         case keyword
         when 'additionalProperties', 'unevaluatedProperties'
-          ![true, {}].include?(value) && uncovered_property?(schema, keyword, data, dialect)
+          ![true, {}].include?(value) && uncovered_property?(schema, keyword, data, dialect, deadline)
         when 'propertyNames' then ![true, {}].include?(value) && !data.empty?
         when 'minProperties' then value.is_a?(Numeric) && data.size < value
         when 'maxProperties' then value.is_a?(Numeric) && data.size > value
-        when 'patternProperties' then effective_pattern_properties?(value, data)
+        when 'patternProperties' then effective_pattern_properties?(value, data, deadline)
         else
-          value.is_a?(Hash) && value.any? { |trigger, dep| data.key?(trigger.to_s) && dependency_can_fail?(dep) }
+          # An instance may carry either key form, so a trigger is present
+          # when either form is (like `required` and `properties`).
+          value.is_a?(Hash) &&
+            value.any? { |trigger, dep| property_present?(data, trigger) && dependency_can_fail?(dep) }
         end
+      end
+
+      # @param data [Hash] the instance
+      # @param name [Object] the property name a schema keyword names
+      # @return [Boolean] whether the instance carries the property in either
+      #   key form
+      def property_present?(data, name)
+        name = name.to_s
+        data.key?(name) || data.key?(name.to_sym)
       end
 
       # `patternProperties` asserts only through a pattern some property
       # name matches whose schema is not a tautology.
       # @return [Boolean]
-      def effective_pattern_properties?(value, data)
+      def effective_pattern_properties?(value, data, deadline = nil)
         return false unless value.is_a?(Hash) && data.is_a?(Hash)
 
         value.any? do |pattern, sub|
-          ![true, {}].include?(sub) && data.each_key.any? { |name| pattern_matches?(pattern.to_s, name.to_s) }
+          ![true, {}].include?(sub) &&
+            data.each_key.any? { |name| pattern_matches?(pattern.to_s, name.to_s, deadline) }
         end
       end
 
@@ -159,7 +174,7 @@ module MCPClient
       # pattern is covered (an unreadable pattern is assumed to match
       # nothing, keeping the branch undecided).
       # @return [Boolean]
-      def uncovered_property?(schema, keyword, data, dialect)
+      def uncovered_property?(schema, keyword, data, dialect, deadline = nil)
         return false if keyword == 'unevaluatedProperties' && schema.key?('additionalProperties') &&
                         keyword_known?('additionalProperties', dialect)
 
@@ -169,13 +184,25 @@ module MCPClient
           name = name.to_s
           next false if named.include?(name)
 
-          patterns.none? { |pattern| pattern_matches?(pattern, name) }
+          patterns.none? { |pattern| pattern_matches?(pattern, name, deadline) }
         end
       end
 
+      # Match a server-supplied pattern against a property name. Both come
+      # from the peer, so — exactly like {.validate_pattern} — the match runs
+      # under the validation-wide deadline: a backtracking expression here
+      # decides only whether a branch is undecided, and must not be able to
+      # hold the calling thread for it.
+      # @param deadline [Float, nil] monotonic deadline for the whole validation
       # @return [Boolean]
-      def pattern_matches?(pattern, name)
-        Regexp.new(pattern).match?(name)
+      # @raise [Aborted] when the budget is exhausted
+      def pattern_matches?(pattern, name, deadline = nil)
+        remaining = pattern_budget_remaining(deadline)
+        raise Aborted, "validation time budget exhausted before pattern #{clip(pattern.inspect)}" if remaining.zero?
+
+        Regexp.new(pattern, timeout: remaining).match?(name)
+      rescue Regexp::TimeoutError
+        raise Aborted, "pattern #{clip(pattern.inspect)} exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"
       rescue RegexpError, TypeError
         false
       end

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -21,7 +21,33 @@ module MCPClient
       def partial_keywords?(schema, dialect, data)
         applicable = UNSUPPORTED_ASSERTIONS_ANY_TYPE +
                      UNSUPPORTED_ASSERTIONS_BY_TYPE.select { |type, _| data.is_a?(type) }.values.flatten
-        (schema.keys & applicable).any? { |keyword| keyword_known?(keyword, dialect) }
+        (schema.keys & applicable).any? do |keyword|
+          keyword_known?(keyword, dialect) && effective_assertion?(schema, keyword, dialect)
+        end
+      end
+
+      # Whether an unevaluated assertion can still change the result: a
+      # keyword that has no effect without its companion (minContains /
+      # maxContains without contains, additionalItems beside a non-tuple
+      # items — JSON Schema 2020-12 Validation Sections 6.4.4-6.4.5, draft-07
+      # Section 9.3.1.2) or whose value cannot fail (additionalProperties
+      # true, uniqueItems false, minProperties 0, an empty dependency map)
+      # decides nothing and leaves the verdict whole.
+      # @return [Boolean]
+      def effective_assertion?(schema, keyword, _dialect)
+        value = schema[keyword]
+        case keyword
+        when 'minContains', 'maxContains' then schema.key?('contains')
+        when 'additionalItems' then schema['items'].is_a?(Array)
+        when 'additionalProperties', 'unevaluatedProperties', 'unevaluatedItems', 'propertyNames'
+          ![true, {}].include?(value)
+        when 'uniqueItems' then value == true
+        when 'minProperties' then value.is_a?(Numeric) && value.positive?
+        when 'maxProperties', 'multipleOf' then value.is_a?(Numeric)
+        when 'dependentRequired', 'dependentSchemas', 'dependencies', 'patternProperties'
+          !(value.is_a?(Hash) && value.empty?)
+        else true
+        end
       end
 
       # The verdict of a branch evaluated speculatively: :fail when a
@@ -43,14 +69,21 @@ module MCPClient
         ctx.undecided == before ? :pass : :undecided
       end
 
-      # The verdicts of every branch. Uncertainty is kept only when it can
-      # change the outcome: once the composition is decided the count is
-      # restored to what it was before the branches ran.
+      # The verdicts of the branches. Evaluation stops as soon as the
+      # branches seen so far settle the composition (`stop`): a branch that
+      # cannot change the outcome is not evaluated, so it cannot abort a
+      # decided validation. Once the composition is decided — early, or
+      # after every branch (`decided`) — the uncertainty count is restored
+      # to what it was before the branches ran.
       # @return [Array<Symbol>]
-      def branch_verdicts(data, subs, path, ctx, ref_depth, decided:)
+      def branch_verdicts(data, subs, path, ctx, ref_depth, stop:, decided:)
         before = ctx.undecided
-        verdicts = subs.map { |sub| verdict(data, sub, path, ctx, ref_depth) }
-        ctx.undecided = before if decided.call(verdicts)
+        verdicts = []
+        subs.each do |sub|
+          verdicts << verdict(data, sub, path, ctx, ref_depth)
+          break if stop.call(verdicts)
+        end
+        ctx.undecided = before if stop.call(verdicts) || decided.call(verdicts)
         verdicts
       end
 
@@ -59,23 +92,28 @@ module MCPClient
       def validate_composition(data, schema, path, ctx, ref_depth)
         errors = []
         if schema['allOf'].is_a?(Array)
+          # The first failing branch decides allOf; later branches are not
+          # evaluated (they cannot change the outcome, but could abort it).
           schema['allOf'].each_with_index do |sub, idx|
             sub_errors = validate_node(data, sub, path, ctx, ref_depth)
-            errors << "#{path}: does not satisfy allOf/#{idx} (#{clip(sub_errors.first.to_s)})" unless sub_errors.empty?
+            next if sub_errors.empty?
+
+            errors << "#{path}: does not satisfy allOf/#{idx} (#{clip(sub_errors.first.to_s)})"
+            break
           end
         end
         # anyOf is monotonic: a definite pass decides it whatever the other
         # branches, and only undecided branches leave it undecided.
         if schema['anyOf'].is_a?(Array)
           verdicts = branch_verdicts(data, schema['anyOf'], path, ctx, ref_depth,
-                                     decided: ->(vs) { vs.include?(:pass) || vs.all?(:fail) })
+                                     stop: ->(vs) { vs.include?(:pass) }, decided: ->(vs) { vs.all?(:fail) })
           errors << "#{path}: does not satisfy any schema in anyOf" if verdicts.all?(:fail)
         end
         if schema['oneOf'].is_a?(Array)
           # Two definite passes decide it; with an undecided branch and at
           # most one pass, "exactly one" cannot be told either way.
           verdicts = branch_verdicts(data, schema['oneOf'], path, ctx, ref_depth,
-                                     decided: ->(vs) { vs.count(:pass) > 1 || vs.none?(:undecided) })
+                                     stop: ->(vs) { vs.count(:pass) > 1 }, decided: ->(vs) { vs.none?(:undecided) })
           matches = verdicts.count(:pass)
           if matches > 1 || (verdicts.none?(:undecided) && matches != 1)
             errors << "#{path}: satisfies #{matches} schemas in oneOf, expected exactly one"

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -2,10 +2,9 @@
 
 module MCPClient
   module SchemaValidator
-    # How complete a verdict on one value is, and the part of `contains` its
-    # bounds alone decide. Extended into SchemaValidator, so the methods are
-    # its own; {Evaluation} applies the composition keywords themselves and
-    # reads the answers here.
+    # How complete a verdict on one value is. Extended into SchemaValidator,
+    # so the methods are its own; {Evaluation} applies the composition
+    # keywords themselves and reads the answers here.
     #
     # A composition branch is evaluated speculatively (its errors are a
     # verdict, not output). anyOf and allOf are monotonic, so a branch that
@@ -14,6 +13,13 @@ module MCPClient
     # applying to the instance is :undecided and never a match, while one
     # decided by its evaluated keywords (or carrying only annotations) is a
     # full verdict.
+    #
+    # Every standard assertion whose verdict this validator can reach is
+    # evaluated ({SchemaValidator.validate_object},
+    # {SchemaValidator.validate_array}, {SchemaValidator.validate_number}),
+    # so what is left here is only what genuinely cannot be decided: the two
+    # keywords read off the annotations a whole composition produces, the
+    # dynamic references, and `format` where it asserts.
     module Composition
       # Whether a schema object carries an assertion the validator does not
       # evaluate (in the dialect in force) that applies to this instance, so
@@ -36,107 +42,35 @@ module MCPClient
       end
 
       # Whether an unevaluated assertion can still change the result for
-      # this instance: a keyword that has no effect without its companion
-      # (minContains / maxContains without contains, additionalItems beside
-      # a non-tuple items — JSON Schema 2020-12 Validation Sections
-      # 6.4.4-6.4.5, draft-07 Section 9.3.1.2), one the instance never
-      # reaches (additionalItems or unevaluatedItems when the tuple or an
-      # items schema covers every item, additionalProperties or
-      # unevaluatedProperties when every property is covered, uniqueItems
-      # below two items, maxContains or maxProperties the instance cannot
-      # exceed, minProperties it already satisfies, a dependency none of
-      # whose triggers is present), one its companion switches off
-      # (contains with minContains 0) or whose value cannot fail
-      # (additionalProperties true, uniqueItems false, minProperties 0, an
-      # empty dependency map) decides nothing.
+      # this instance. `unevaluatedItems` and `unevaluatedProperties` are
+      # decided by the annotations a whole composition produces, so they
+      # assert only where the schema's own applicators leave the instance
+      # uncovered (a tuple, an `items` schema or an `additionalItems` beside
+      # a tuple evaluates every item; a named, pattern-matched or
+      # `additionalProperties`-covered member every property) and only where
+      # their value can fail at all. The dynamic references and a draft-07
+      # `format` always can.
       # @return [Boolean]
       def effective_assertion?(schema, keyword, data, dialect = nil, deadline = nil)
         value = schema[keyword]
         case keyword
-        when 'contains', 'minContains', 'maxContains', 'additionalItems', 'unevaluatedItems', 'uniqueItems'
-          effective_array_assertion?(schema, keyword, value, data, dialect)
-        when 'additionalProperties', 'unevaluatedProperties', 'propertyNames', 'minProperties', 'maxProperties',
-             'dependentRequired', 'dependentSchemas', 'dependencies', 'patternProperties'
-          effective_object_assertion?(schema, keyword, value, data, dialect, deadline)
-        when 'multipleOf' then value.is_a?(Numeric) && data.is_a?(Numeric)
+        when 'unevaluatedItems' then effective_unevaluated_items?(schema, value, data, dialect)
+        when 'unevaluatedProperties'
+          data.is_a?(Hash) && ![true, {}].include?(value) && uncovered_property?(schema, data, deadline)
         else true
         end
       end
 
-      # The array assertions whose effect depends on a companion keyword or
-      # on the instance's length. A companion the dialect does not define
-      # (`minContains` under draft-07) changes nothing.
-      # @return [Boolean]
-      def effective_array_assertion?(schema, keyword, value, data, dialect = nil)
+      # @return [Boolean] whether `unevaluatedItems` can still reject an item
+      def effective_unevaluated_items?(schema, value, data, dialect)
         return false unless data.is_a?(Array)
 
-        case keyword
-        when 'contains' then effective_contains?(schema, data, dialect)
-        when 'minContains', 'maxContains' then effective_contains_bound?(schema, keyword, value, data, dialect)
-        when 'uniqueItems' then value == true && data.length > 1
-        else
-          # additionalItems (beside a tuple only) / unevaluatedItems: only
-          # items past what the tuple (or an items schema, which evaluates
-          # every item) covers.
-          return false if keyword == 'additionalItems' && !schema['items'].is_a?(Array)
-
-          ![true, {}].include?(value) && data.length > evaluated_item_count(schema, keyword, dialect)
-        end
+        ![true, {}].include?(value) && data.length > evaluated_item_count(schema, dialect)
       end
 
       # @return [Boolean] whether a contains schema in force matches every item
       def contains_everything?(schema, dialect)
         keyword_known?('contains', dialect) && [true, {}].include?(schema['contains'])
-      end
-
-      # @return [Boolean] whether a contains schema in force matches no item
-      def contains_nothing?(schema, dialect)
-        keyword_known?('contains', dialect) && schema['contains'] == false
-      end
-
-      # Whether the number of matching items is known without evaluating the
-      # item schema: the array's own length when `contains` matches every
-      # item, zero when it matches none.
-      # @return [Boolean]
-      def contains_count_known?(schema, dialect)
-        contains_everything?(schema, dialect) || contains_nothing?(schema, dialect)
-      end
-
-      # The range the number of matching items lies in, read off the array's
-      # length alone (JSON Schema 2020-12 Validation Section 6.4.4: the
-      # count is between none and all of the items).
-      # @return [Array(Integer, Integer)] the lowest and highest count
-      def contains_count_range(data, schema, dialect)
-        return [data.length, data.length] if contains_everything?(schema, dialect)
-        return [0, 0] if contains_nothing?(schema, dialect)
-
-        [0, data.length]
-      end
-
-      # Whether `contains` can still change the result: not when its
-      # companion switches it off (minContains 0), not when the count is
-      # known from the array's length (a tautological schema matches every
-      # item, `false` none), and not when the array is too short to reach
-      # minContains whatever its items are, since
-      # {SchemaValidator.validate_contains} then decides the keyword outright.
-      # @return [Boolean]
-      def effective_contains?(schema, data, dialect)
-        return false if contains_count_known?(schema, dialect)
-
-        min = contains_min(schema, dialect)
-        min.positive? && data.length >= min
-      end
-
-      # A `contains` bound asserts only beside a `contains` this validator
-      # leaves unevaluated, and only where the array's length does not
-      # already settle it: a lower bound that requires a match the array is
-      # long enough to hold, an upper bound the instance can exceed.
-      # @return [Boolean]
-      def effective_contains_bound?(schema, keyword, value, data, dialect)
-        return false unless schema.key?('contains') && value.is_a?(Numeric) &&
-                            !contains_count_known?(schema, dialect)
-
-        keyword == 'minContains' ? value.positive? && data.length >= value : data.length > value
       end
 
       # The number of matching items `contains` requires: its companion
@@ -155,89 +89,19 @@ module MCPClient
         max if max.is_a?(Numeric)
       end
 
-      # Apply the part of `contains` the bounds alone decide. The number of
-      # matching items is never more than the array holds and never less
-      # than none, so a bound outside that range is an assertion this
-      # validator settles whatever the item schema says (JSON Schema 2020-12
-      # Validation Sections 6.4.4-6.4.5: the default minContains is 1, so
-      # any contains rejects the empty array). Bounds that cannot overlap
-      # each other settle it too: `minContains` above `maxContains` admits
-      # no count at all, so the keyword fails before the item schema is
-      # ever consulted. A tautological schema (`true` / `{}`) matches every
-      # item and `false` none, which pins the count exactly; a contains
-      # that has to be matched item by item leaves only what its bounds
-      # decide, and the rest unevaluated.
-      # @param data [Array] the instance
-      # @param schema [Hash] string-keyed schema
-      # @param path [String] location for error messages
-      # @param dialect [String, nil] the dialect in force
-      # @return [Array<String>] validation errors
-      def validate_contains(data, schema, path, dialect)
-        return [] unless keyword_known?('contains', dialect) && schema_value?(schema['contains'])
-
-        low, high = contains_count_range(data, schema, dialect)
-        min = contains_min(schema, dialect)
-        max = contains_max(schema, dialect)
-        errors = contains_length_errors(path, low, high, min, max)
-        return errors unless errors.empty? && max && min > max
-
-        ["#{path}: contains requires between #{min} and #{max} matching items, which no count satisfies"]
-      end
-
-      # The bounds the array's own length settles: a lower bound above the
-      # highest count the array can reach, an upper bound below the lowest.
-      # @return [Array<String>] validation errors
-      def contains_length_errors(path, low, high, min, max)
-        errors = []
-        errors << "#{path}: expected at least #{min} items matching contains, got #{contains_seen(low, high, high)}" \
-          if high < min
-        errors << "#{path}: expected at most #{max} items matching contains, got #{contains_seen(low, high, low)}" \
-          if max && low > max
-        errors
-      end
-
-      # How the count reads in an error: the number itself when the array's
-      # length pins it, else the bound the error rests on.
-      # @return [String]
-      def contains_seen(low, high, bound)
-        return bound.to_s if low == high
-
-        "#{bound == high ? 'at most' : 'at least'} #{bound}"
-      end
-
       # How many leading items the tuple keywords in force evaluate, or
-      # infinity when an items schema (or a contains schema matching every
-      # item — JSON Schema 2020-12 Core Section 10.3.1.3) evaluates them all.
+      # infinity when an items schema, an `additionalItems` beside the tuple
+      # or a contains schema matching every item (JSON Schema 2020-12 Core
+      # Section 10.3.1.3) evaluates them all.
       # @return [Integer, Float]
-      def evaluated_item_count(schema, keyword, dialect)
+      def evaluated_item_count(schema, dialect)
         tuple = schema['prefixItems'] if keyword_known?('prefixItems', dialect) && schema['prefixItems'].is_a?(Array)
         tuple ||= schema['items'] if schema['items'].is_a?(Array)
-        if keyword == 'unevaluatedItems' && (schema_value?(schema['items']) || contains_everything?(schema, dialect))
-          return Float::INFINITY
-        end
+        return Float::INFINITY if schema_value?(schema['items']) || contains_everything?(schema, dialect) ||
+                                  (tuple && keyword_known?('additionalItems', dialect) &&
+                                   schema_value?(schema['additionalItems']))
 
         tuple ? tuple.length : 0
-      end
-
-      # The object assertions whose effect depends on the instance's
-      # properties.
-      # @return [Boolean]
-      def effective_object_assertion?(schema, keyword, value, data, dialect = nil, deadline = nil)
-        return false unless data.is_a?(Hash)
-
-        case keyword
-        when 'additionalProperties', 'unevaluatedProperties'
-          ![true, {}].include?(value) && uncovered_property?(schema, keyword, data, dialect, deadline)
-        when 'propertyNames' then ![true, {}].include?(value) && !data.empty?
-        when 'minProperties' then value.is_a?(Numeric) && data.size < value
-        when 'maxProperties' then value.is_a?(Numeric) && data.size > value
-        when 'patternProperties' then effective_pattern_properties?(value, data, deadline)
-        else
-          # An instance may carry either key form, so a trigger is present
-          # when either form is (like `required` and `properties`).
-          value.is_a?(Hash) &&
-            value.any? { |trigger, dep| property_present?(data, trigger) && dependency_can_fail?(dep, data) }
-        end
       end
 
       # @param data [Hash] the instance
@@ -249,39 +113,15 @@ module MCPClient
         data.key?(name) || data.key?(name.to_sym)
       end
 
-      # `patternProperties` asserts only through a pattern some property
-      # name matches whose schema is not a tautology.
-      # @return [Boolean]
-      def effective_pattern_properties?(value, data, deadline = nil)
-        return false unless value.is_a?(Hash) && data.is_a?(Hash)
-
-        value.any? do |pattern, sub|
-          ![true, {}].include?(sub) &&
-            data.each_key.any? { |name| pattern_matches?(pattern.to_s, name.to_s, deadline) }
-        end
-      end
-
-      # A dependency whose value cannot fail (a required list every name of
-      # which the instance already carries — an empty list included — or a
-      # schema of true / {}) decides nothing for a present trigger.
-      # @param data [Hash] the instance
-      # @return [Boolean]
-      def dependency_can_fail?(dep, data)
-        return dep.any? { |name| !property_present?(data, name) } if dep.is_a?(Array)
-
-        ![true, {}].include?(dep)
-      end
-
       # Whether the instance has a property the schema's own property
-      # applicators leave to the keyword: one named in `properties` is
-      # covered, one an `additionalProperties` schema evaluates is covered
-      # for `unevaluatedProperties`, and one matching a `patternProperties`
-      # pattern is covered (an unreadable pattern is assumed to match
-      # nothing, keeping the branch undecided).
+      # applicators leave to `unevaluatedProperties`: one named in
+      # `properties` is covered, one an `additionalProperties` schema
+      # evaluates is covered, and one matching a `patternProperties` pattern
+      # is covered (an unreadable pattern is assumed to match nothing,
+      # keeping the branch undecided).
       # @return [Boolean]
-      def uncovered_property?(schema, keyword, data, dialect, deadline = nil)
-        return false if keyword == 'unevaluatedProperties' && schema.key?('additionalProperties') &&
-                        keyword_known?('additionalProperties', dialect)
+      def uncovered_property?(schema, data, deadline = nil)
+        return false if schema.key?('additionalProperties') && schema_value?(schema['additionalProperties'])
 
         named = schema['properties'].is_a?(Hash) ? schema['properties'].keys.map(&:to_s) : []
         patterns = schema['patternProperties'].is_a?(Hash) ? schema['patternProperties'].keys.map(&:to_s) : []
@@ -296,8 +136,7 @@ module MCPClient
       # Match a server-supplied pattern against a property name. Both come
       # from the peer, so — exactly like {.validate_pattern} — the match runs
       # under the validation-wide deadline: a backtracking expression here
-      # decides only whether a branch is undecided, and must not be able to
-      # hold the calling thread for it.
+      # must not be able to hold the calling thread.
       # @param deadline [Float, nil] monotonic deadline for the whole validation
       # @return [Boolean]
       # @raise [Aborted] when the budget is exhausted
@@ -305,7 +144,7 @@ module MCPClient
         remaining = pattern_budget_remaining(deadline)
         raise Aborted, "validation time budget exhausted before pattern #{clip(pattern.inspect)}" if remaining.zero?
 
-        Regexp.new(pattern, timeout: remaining).match?(name)
+        ecma_regexp(pattern, remaining).match?(name)
       rescue Regexp::TimeoutError
         raise Aborted, "pattern #{clip(pattern.inspect)} exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"
       rescue RegexpError, TypeError

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -22,23 +22,25 @@ module MCPClient
         applicable = UNSUPPORTED_ASSERTIONS_ANY_TYPE +
                      UNSUPPORTED_ASSERTIONS_BY_TYPE.select { |type, _| data.is_a?(type) }.values.flatten
         (schema.keys & applicable).any? do |keyword|
-          keyword_known?(keyword, dialect) && effective_assertion?(schema, keyword, dialect)
+          keyword_known?(keyword, dialect) && effective_assertion?(schema, keyword, data)
         end
       end
 
-      # Whether an unevaluated assertion can still change the result: a
-      # keyword that has no effect without its companion (minContains /
-      # maxContains without contains, additionalItems beside a non-tuple
-      # items — JSON Schema 2020-12 Validation Sections 6.4.4-6.4.5, draft-07
-      # Section 9.3.1.2) or whose value cannot fail (additionalProperties
-      # true, uniqueItems false, minProperties 0, an empty dependency map)
-      # decides nothing and leaves the verdict whole.
+      # Whether an unevaluated assertion can still change the result for
+      # this instance: a keyword that has no effect without its companion
+      # (minContains / maxContains without contains, additionalItems beside
+      # a non-tuple items — JSON Schema 2020-12 Validation Sections
+      # 6.4.4-6.4.5, draft-07 Section 9.3.1.2), one the instance never
+      # reaches (additionalItems when the tuple covers every item), one its
+      # companion switches off (contains with minContains 0) or whose value
+      # cannot fail (additionalProperties true, uniqueItems false,
+      # minProperties 0, an empty dependency map) decides nothing.
       # @return [Boolean]
-      def effective_assertion?(schema, keyword, _dialect)
+      def effective_assertion?(schema, keyword, data)
         value = schema[keyword]
         case keyword
-        when 'minContains', 'maxContains' then schema.key?('contains')
-        when 'additionalItems' then schema['items'].is_a?(Array) && ![true, {}].include?(value)
+        when 'contains', 'minContains', 'maxContains', 'additionalItems'
+          effective_array_assertion?(schema, keyword, value, data)
         when 'additionalProperties', 'unevaluatedProperties', 'unevaluatedItems', 'propertyNames'
           ![true, {}].include?(value)
         when 'uniqueItems' then value == true
@@ -47,6 +49,20 @@ module MCPClient
         when 'dependentRequired', 'dependentSchemas', 'dependencies', 'patternProperties'
           !(value.is_a?(Hash) && value.empty?)
         else true
+        end
+      end
+
+      # The array assertions whose effect depends on a companion keyword or
+      # on the instance's length.
+      # @return [Boolean]
+      def effective_array_assertion?(schema, keyword, value, data)
+        case keyword
+        when 'contains' then schema['minContains'] != 0
+        when 'minContains' then schema.key?('contains') && value.is_a?(Numeric) && value.positive?
+        when 'maxContains' then schema.key?('contains')
+        else
+          schema['items'].is_a?(Array) && ![true, {}].include?(value) &&
+            data.is_a?(Array) && data.length > schema['items'].length
         end
       end
 

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -8,13 +8,20 @@ module MCPClient
     # A branch is evaluated speculatively (its errors are a verdict, not
     # output). anyOf and allOf are monotonic, so a branch that passes as far
     # as the validator can evaluate it is accepted; not, oneOf and if are
-    # not, so such a branch is :undecided and never a match.
+    # not, so a branch that still holds an unevaluated assertion applying to
+    # the instance is :undecided and never a match, while one decided by its
+    # evaluated keywords (or carrying only annotations) is a full verdict.
     module Composition
       # Whether a schema object carries an assertion the validator does not
-      # evaluate (in the dialect in force), so its verdict is only partial.
+      # evaluate (in the dialect in force) that applies to this instance, so
+      # its verdict is only partial. Annotations (`format`, `contentSchema`)
+      # and assertions of another instance type decide nothing and leave the
+      # verdict whole.
       # @return [Boolean]
-      def partial_keywords?(schema, dialect)
-        (schema.keys & UNSUPPORTED_KEYWORDS).any? { |keyword| keyword_known?(keyword, dialect) }
+      def partial_keywords?(schema, dialect, data)
+        applicable = UNSUPPORTED_ASSERTIONS_ANY_TYPE +
+                     UNSUPPORTED_ASSERTIONS_BY_TYPE.select { |type, _| data.is_a?(type) }.values.flatten
+        (schema.keys & applicable).any? { |keyword| keyword_known?(keyword, dialect) }
       end
 
       # The verdict of a branch evaluated speculatively: :fail when a

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module SchemaValidator
+    # allOf / anyOf / oneOf / not / if-then-else evaluation. Extended into
+    # SchemaValidator, so the methods are its own.
+    #
+    # A branch is evaluated speculatively (its errors are a verdict, not
+    # output). anyOf and allOf are monotonic, so a branch that passes as far
+    # as the validator can evaluate it is accepted; not, oneOf and if are
+    # not, so such a branch is :undecided and never a match.
+    module Composition
+      # Whether a schema object carries an assertion the validator does not
+      # evaluate (in the dialect in force), so its verdict is only partial.
+      # @return [Boolean]
+      def partial_keywords?(schema, dialect)
+        (schema.keys & UNSUPPORTED_KEYWORDS).any? { |keyword| keyword_known?(keyword, dialect) }
+      end
+
+      # The verdict of a branch evaluated speculatively: :fail when a
+      # supported assertion rejected the value, :pass when every assertion
+      # was evaluated and accepted it, :undecided when it was accepted only
+      # as far as the validator could evaluate. Non-monotonic compositions
+      # (not, oneOf, if) never treat :undecided as a match.
+      # @return [Symbol]
+      def verdict(data, sub, path, ctx, ref_depth)
+        before = ctx.undecided
+        passed = speculative(ctx) { validate_node(data, sub, path, ctx, ref_depth).empty? }
+        return :fail unless passed
+
+        ctx.undecided == before ? :pass : :undecided
+      end
+
+      # allOf / anyOf / oneOf / not / if-then-else.
+      # @return [Array<String>] validation errors
+      def validate_composition(data, schema, path, ctx, ref_depth)
+        errors = []
+        if schema['allOf'].is_a?(Array)
+          schema['allOf'].each_with_index do |sub, idx|
+            sub_errors = validate_node(data, sub, path, ctx, ref_depth)
+            errors << "#{path}: does not satisfy allOf/#{idx} (#{clip(sub_errors.first.to_s)})" unless sub_errors.empty?
+          end
+        end
+        # anyOf is monotonic: a partial pass is the permissive direction.
+        if schema['anyOf'].is_a?(Array) &&
+           schema['anyOf'].all? { |sub| verdict(data, sub, path, ctx, ref_depth) == :fail }
+          errors << "#{path}: does not satisfy any schema in anyOf"
+        end
+        if schema['oneOf'].is_a?(Array)
+          verdicts = schema['oneOf'].map { |sub| verdict(data, sub, path, ctx, ref_depth) }
+          matches = verdicts.count(:pass)
+          # With an undecided branch "exactly one" cannot be told either way.
+          if verdicts.none?(:undecided) && matches != 1
+            errors << "#{path}: satisfies #{matches} schemas in oneOf, expected exactly one"
+          end
+        end
+        if schema.key?('not') && verdict(data, schema['not'], path, ctx, ref_depth) == :pass
+          errors << "#{path}: value satisfies the schema in not"
+        end
+        errors.concat(validate_conditional(data, schema, path, ctx, ref_depth))
+        errors
+      end
+
+      # if / then / else.
+      # @return [Array<String>] validation errors
+      def validate_conditional(data, schema, path, ctx, ref_depth)
+        # An `if` without `then` or `else` asserts nothing (JSON Schema 2020-12
+        # Section 10.2.2.1) and is not evaluated.
+        return [] unless schema.key?('if') && (schema.key?('then') || schema.key?('else'))
+
+        case verdict(data, schema['if'], path, ctx, ref_depth)
+        when :pass then branch = 'then'
+        when :fail then branch = 'else'
+        else return [] # undecided: neither branch is known to apply
+        end
+        return [] unless schema.key?(branch)
+
+        validate_node(data, schema[branch], path, ctx, ref_depth)
+      end
+    end
+  end
+end

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -68,9 +68,8 @@ module MCPClient
         return false unless data.is_a?(Array)
 
         case keyword
-        when 'contains' then effective_contains?(schema, value, data, dialect)
-        when 'minContains' then schema.key?('contains') && value.is_a?(Numeric) && value.positive?
-        when 'maxContains' then schema.key?('contains') && value.is_a?(Numeric) && data.length > value
+        when 'contains' then effective_contains?(schema, dialect)
+        when 'minContains', 'maxContains' then effective_contains_bound?(schema, keyword, value, data, dialect)
         when 'uniqueItems' then value == true && data.length > 1
         else
           # additionalItems (beside a tuple only) / unevaluatedItems: only
@@ -89,19 +88,63 @@ module MCPClient
 
       # Whether `contains` can still change the result: not when its
       # companion switches it off (minContains 0), and not when a
-      # tautological schema (true / {}) matches every item and the array
-      # already holds the items it requires (JSON Schema 2020-12 Validation
-      # Section 6.4.4: the default minContains is 1).
+      # tautological schema (true / {}) matches every item, since the count
+      # it asserts on is then the array's own length and
+      # {SchemaValidator.validate_contains} decides the keyword outright.
       # @return [Boolean]
-      def effective_contains?(schema, value, data, dialect)
-        min = 1
-        if keyword_known?('minContains', dialect) && schema['minContains'].is_a?(Numeric)
-          min = schema['minContains']
-          return false if min <= 0
-        end
-        return true unless [true, {}].include?(value)
+      def effective_contains?(schema, dialect)
+        !contains_everything?(schema, dialect) && contains_min(schema, dialect).positive?
+      end
 
-        data.length < min
+      # A `contains` bound asserts only beside a `contains` this validator
+      # leaves unevaluated: a lower bound that requires a match, an upper
+      # bound the instance can exceed.
+      # @return [Boolean]
+      def effective_contains_bound?(schema, keyword, value, data, dialect)
+        return false unless schema.key?('contains') && value.is_a?(Numeric) &&
+                            !contains_everything?(schema, dialect)
+
+        keyword == 'minContains' ? value.positive? : data.length > value
+      end
+
+      # The number of matching items `contains` requires: its companion
+      # where the dialect defines one and gives it a number, else the
+      # default of 1 (JSON Schema 2020-12 Validation Section 6.4.4).
+      # @return [Numeric]
+      def contains_min(schema, dialect)
+        min = schema['minContains'] if keyword_known?('minContains', dialect)
+        min.is_a?(Numeric) ? min : 1
+      end
+
+      # @return [Numeric, nil] the number of matching items `contains`
+      #   allows, when the dialect defines the companion and it is a number
+      def contains_max(schema, dialect)
+        max = schema['maxContains'] if keyword_known?('maxContains', dialect)
+        max if max.is_a?(Numeric)
+      end
+
+      # Apply a `contains` whose schema matches every item (`true` / `{}`):
+      # the number of matching items is then the array's own length, so the
+      # keyword and its companions are assertions this validator decides
+      # rather than ones that only leave a branch undecided (JSON Schema
+      # 2020-12 Validation Section 6.4.4: the default minContains is 1, so a
+      # tautological contains rejects the empty array). A contains whose
+      # schema has to be matched item by item stays unevaluated.
+      # @param data [Array] the instance
+      # @param schema [Hash] string-keyed schema
+      # @param path [String] location for error messages
+      # @param dialect [String, nil] the dialect in force
+      # @return [Array<String>] validation errors
+      def validate_contains(data, schema, path, dialect)
+        return [] unless contains_everything?(schema, dialect)
+
+        errors = []
+        min = contains_min(schema, dialect)
+        max = contains_max(schema, dialect)
+        count = data.length
+        errors << "#{path}: expected at least #{min} items matching contains, got #{count}" if count < min
+        errors << "#{path}: expected at most #{max} items matching contains, got #{count}" if max && count > max
+        errors
       end
 
       # How many leading items the tuple keywords in force evaluate, or
@@ -135,7 +178,7 @@ module MCPClient
           # An instance may carry either key form, so a trigger is present
           # when either form is (like `required` and `properties`).
           value.is_a?(Hash) &&
-            value.any? { |trigger, dep| property_present?(data, trigger) && dependency_can_fail?(dep) }
+            value.any? { |trigger, dep| property_present?(data, trigger) && dependency_can_fail?(dep, data) }
         end
       end
 
@@ -160,11 +203,15 @@ module MCPClient
         end
       end
 
-      # A dependency whose value cannot fail (an empty required list, a
+      # A dependency whose value cannot fail (a required list every name of
+      # which the instance already carries — an empty list included — or a
       # schema of true / {}) decides nothing for a present trigger.
+      # @param data [Hash] the instance
       # @return [Boolean]
-      def dependency_can_fail?(dep)
-        dep.is_a?(Array) ? !dep.empty? : ![true, {}].include?(dep)
+      def dependency_can_fail?(dep, data)
+        return dep.any? { |name| !property_present?(data, name) } if dep.is_a?(Array)
+
+        ![true, {}].include?(dep)
       end
 
       # Whether the instance has a property the schema's own property

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -66,7 +66,7 @@ module MCPClient
         return false unless data.is_a?(Array)
 
         case keyword
-        when 'contains' then !(keyword_known?('minContains', dialect) && schema['minContains'].eql?(0))
+        when 'contains' then effective_contains?(schema, value, data, dialect)
         when 'minContains' then schema.key?('contains') && value.is_a?(Numeric) && value.positive?
         when 'maxContains' then schema.key?('contains') && value.is_a?(Numeric) && data.length > value
         when 'uniqueItems' then value == true && data.length > 1
@@ -80,13 +80,38 @@ module MCPClient
         end
       end
 
+      # @return [Boolean] whether a contains schema in force matches every item
+      def contains_everything?(schema, dialect)
+        keyword_known?('contains', dialect) && [true, {}].include?(schema['contains'])
+      end
+
+      # Whether `contains` can still change the result: not when its
+      # companion switches it off (minContains 0), and not when a
+      # tautological schema (true / {}) matches every item and the array
+      # already holds the items it requires (JSON Schema 2020-12 Validation
+      # Section 6.4.4: the default minContains is 1).
+      # @return [Boolean]
+      def effective_contains?(schema, value, data, dialect)
+        min = 1
+        if keyword_known?('minContains', dialect) && schema['minContains'].is_a?(Numeric)
+          min = schema['minContains']
+          return false if min <= 0
+        end
+        return true unless [true, {}].include?(value)
+
+        data.length < min
+      end
+
       # How many leading items the tuple keywords in force evaluate, or
-      # infinity when an items schema evaluates them all.
+      # infinity when an items schema (or a contains schema matching every
+      # item — JSON Schema 2020-12 Core Section 10.3.1.3) evaluates them all.
       # @return [Integer, Float]
       def evaluated_item_count(schema, keyword, dialect)
         tuple = schema['prefixItems'] if keyword_known?('prefixItems', dialect) && schema['prefixItems'].is_a?(Array)
         tuple ||= schema['items'] if schema['items'].is_a?(Array)
-        return Float::INFINITY if keyword == 'unevaluatedItems' && schema_value?(schema['items'])
+        if keyword == 'unevaluatedItems' && (schema_value?(schema['items']) || contains_everything?(schema, dialect))
+          return Float::INFINITY
+        end
 
         tuple ? tuple.length : 0
       end
@@ -103,10 +128,28 @@ module MCPClient
         when 'propertyNames' then ![true, {}].include?(value) && !data.empty?
         when 'minProperties' then value.is_a?(Numeric) && data.size < value
         when 'maxProperties' then value.is_a?(Numeric) && data.size > value
-        when 'patternProperties' then value.is_a?(Hash) && !value.empty? && !data.empty?
+        when 'patternProperties' then effective_pattern_properties?(value, data)
         else
-          value.is_a?(Hash) && value.keys.any? { |trigger| data.key?(trigger.to_s) }
+          value.is_a?(Hash) && value.any? { |trigger, dep| data.key?(trigger.to_s) && dependency_can_fail?(dep) }
         end
+      end
+
+      # `patternProperties` asserts only through a pattern some property
+      # name matches whose schema is not a tautology.
+      # @return [Boolean]
+      def effective_pattern_properties?(value, data)
+        return false unless value.is_a?(Hash) && data.is_a?(Hash)
+
+        value.any? do |pattern, sub|
+          ![true, {}].include?(sub) && data.each_key.any? { |name| pattern_matches?(pattern.to_s, name.to_s) }
+        end
+      end
+
+      # A dependency whose value cannot fail (an empty required list, a
+      # schema of true / {}) decides nothing for a present trigger.
+      # @return [Boolean]
+      def dependency_can_fail?(dep)
+        dep.is_a?(Array) ? !dep.empty? : ![true, {}].include?(dep)
       end
 
       # Whether the instance has a property the schema's own property

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -68,7 +68,7 @@ module MCPClient
         return false unless data.is_a?(Array)
 
         case keyword
-        when 'contains' then effective_contains?(schema, dialect)
+        when 'contains' then effective_contains?(schema, data, dialect)
         when 'minContains', 'maxContains' then effective_contains_bound?(schema, keyword, value, data, dialect)
         when 'uniqueItems' then value == true && data.length > 1
         else
@@ -86,25 +86,54 @@ module MCPClient
         keyword_known?('contains', dialect) && [true, {}].include?(schema['contains'])
       end
 
-      # Whether `contains` can still change the result: not when its
-      # companion switches it off (minContains 0), and not when a
-      # tautological schema (true / {}) matches every item, since the count
-      # it asserts on is then the array's own length and
-      # {SchemaValidator.validate_contains} decides the keyword outright.
+      # @return [Boolean] whether a contains schema in force matches no item
+      def contains_nothing?(schema, dialect)
+        keyword_known?('contains', dialect) && schema['contains'] == false
+      end
+
+      # Whether the number of matching items is known without evaluating the
+      # item schema: the array's own length when `contains` matches every
+      # item, zero when it matches none.
       # @return [Boolean]
-      def effective_contains?(schema, dialect)
-        !contains_everything?(schema, dialect) && contains_min(schema, dialect).positive?
+      def contains_count_known?(schema, dialect)
+        contains_everything?(schema, dialect) || contains_nothing?(schema, dialect)
+      end
+
+      # The range the number of matching items lies in, read off the array's
+      # length alone (JSON Schema 2020-12 Validation Section 6.4.4: the
+      # count is between none and all of the items).
+      # @return [Array(Integer, Integer)] the lowest and highest count
+      def contains_count_range(data, schema, dialect)
+        return [data.length, data.length] if contains_everything?(schema, dialect)
+        return [0, 0] if contains_nothing?(schema, dialect)
+
+        [0, data.length]
+      end
+
+      # Whether `contains` can still change the result: not when its
+      # companion switches it off (minContains 0), not when the count is
+      # known from the array's length (a tautological schema matches every
+      # item, `false` none), and not when the array is too short to reach
+      # minContains whatever its items are, since
+      # {SchemaValidator.validate_contains} then decides the keyword outright.
+      # @return [Boolean]
+      def effective_contains?(schema, data, dialect)
+        return false if contains_count_known?(schema, dialect)
+
+        min = contains_min(schema, dialect)
+        min.positive? && data.length >= min
       end
 
       # A `contains` bound asserts only beside a `contains` this validator
-      # leaves unevaluated: a lower bound that requires a match, an upper
-      # bound the instance can exceed.
+      # leaves unevaluated, and only where the array's length does not
+      # already settle it: a lower bound that requires a match the array is
+      # long enough to hold, an upper bound the instance can exceed.
       # @return [Boolean]
       def effective_contains_bound?(schema, keyword, value, data, dialect)
         return false unless schema.key?('contains') && value.is_a?(Numeric) &&
-                            !contains_everything?(schema, dialect)
+                            !contains_count_known?(schema, dialect)
 
-        keyword == 'minContains' ? value.positive? : data.length > value
+        keyword == 'minContains' ? value.positive? && data.length >= value : data.length > value
       end
 
       # The number of matching items `contains` requires: its companion
@@ -123,28 +152,42 @@ module MCPClient
         max if max.is_a?(Numeric)
       end
 
-      # Apply a `contains` whose schema matches every item (`true` / `{}`):
-      # the number of matching items is then the array's own length, so the
-      # keyword and its companions are assertions this validator decides
-      # rather than ones that only leave a branch undecided (JSON Schema
-      # 2020-12 Validation Section 6.4.4: the default minContains is 1, so a
-      # tautological contains rejects the empty array). A contains whose
-      # schema has to be matched item by item stays unevaluated.
+      # Apply the part of `contains` the array's length alone decides. The
+      # number of matching items is never more than the array holds and
+      # never less than none, so a bound outside that range is an assertion
+      # this validator settles whatever the item schema says (JSON Schema
+      # 2020-12 Validation Sections 6.4.4-6.4.5: the default minContains is
+      # 1, so any contains rejects the empty array). A tautological schema
+      # (`true` / `{}`) matches every item and `false` none, which pins the
+      # count exactly; a contains that has to be matched item by item leaves
+      # only the bounds its length cannot reach decided, and the rest
+      # unevaluated.
       # @param data [Array] the instance
       # @param schema [Hash] string-keyed schema
       # @param path [String] location for error messages
       # @param dialect [String, nil] the dialect in force
       # @return [Array<String>] validation errors
       def validate_contains(data, schema, path, dialect)
-        return [] unless contains_everything?(schema, dialect)
+        return [] unless keyword_known?('contains', dialect) && schema_value?(schema['contains'])
 
-        errors = []
+        low, high = contains_count_range(data, schema, dialect)
         min = contains_min(schema, dialect)
         max = contains_max(schema, dialect)
-        count = data.length
-        errors << "#{path}: expected at least #{min} items matching contains, got #{count}" if count < min
-        errors << "#{path}: expected at most #{max} items matching contains, got #{count}" if max && count > max
+        errors = []
+        errors << "#{path}: expected at least #{min} items matching contains, got #{contains_seen(low, high, high)}" \
+          if high < min
+        errors << "#{path}: expected at most #{max} items matching contains, got #{contains_seen(low, high, low)}" \
+          if max && low > max
         errors
+      end
+
+      # How the count reads in an error: the number itself when the array's
+      # length pins it, else the bound the error rests on.
+      # @return [String]
+      def contains_seen(low, high, bound)
+        return bound.to_s if low == high
+
+        "#{bound == high ? 'at most' : 'at least'} #{bound}"
       end
 
       # How many leading items the tuple keywords in force evaluate, or

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -16,91 +16,31 @@ module MCPClient
     #
     # Every standard assertion whose verdict this validator can reach is
     # evaluated ({SchemaValidator.validate_object},
-    # {SchemaValidator.validate_array}, {SchemaValidator.validate_number}),
-    # so what is left here is only what genuinely cannot be decided: the two
-    # annotation-driven keywords *where a composition produces the
-    # annotations they read* ({#unevaluated_applied?} tells the two cases
-    # apart), the dynamic references, and `format` where it asserts.
+    # {SchemaValidator.validate_array}, {SchemaValidator.validate_number},
+    # and the unevaluated keywords from the annotations {Evaluation}
+    # collects), so what is left here is only what genuinely cannot be
+    # decided: a dynamic reference whose target the dynamic scope could
+    # re-bind, and `format` where it asserts.
     module Composition
       # Whether a schema object carries an assertion the validator does not
       # evaluate (in the dialect in force) that applies to this instance, so
-      # its verdict is only partial. Annotations (`format`, `contentSchema`)
-      # and assertions of another instance type decide nothing and leave the
-      # verdict whole.
-      # @param deadline [Float, nil] monotonic deadline the checks run under
-      #   (the coverage checks match server-controlled patterns)
+      # its verdict is only partial. Annotations (`format` in 2019-09 and
+      # 2020-12, `contentSchema`) decide nothing and leave the verdict whole;
+      # draft-07 `format` asserts (Validation Section 7.2), and the validator
+      # does not evaluate formats, so a string branch carrying one is
+      # undecided there.
+      # @param schema [Hash] the schema object
+      # @param dialect [String, nil] the dialect in force at it
+      # @param data [Object] the instance
+      # @param ctx [Context] the validation context
       # @return [Boolean]
-      def partial_keywords?(schema, dialect, data, deadline = nil)
-        applicable = UNSUPPORTED_ASSERTIONS_ANY_TYPE +
-                     UNSUPPORTED_ASSERTIONS_BY_TYPE.select { |type, _| data.is_a?(type) }.values.flatten
-        # draft-07 `format` asserts (Validation Section 7.2); the validator
-        # does not evaluate formats, so a string branch carrying one is
-        # undecided there, while 2019-09 / 2020-12 only annotate.
-        applicable += ['format'] if dialect == DRAFT_07 && data.is_a?(String)
-        (schema.keys & applicable).any? do |keyword|
-          keyword_known?(keyword, dialect) && effective_assertion?(schema, keyword, data, dialect, deadline)
+      def partial_keywords?(schema, dialect, data, ctx)
+        return true if dialect == DRAFT_07 && data.is_a?(String) && schema.key?('format')
+
+        DYNAMIC_REFERENCE_KEYWORDS.any? do |keyword|
+          schema.key?(keyword) && keyword_known?(keyword, dialect) &&
+            dynamic_reference?(schema, keyword, ctx.root, ctx.dialect, ctx)
         end
-      end
-
-      # Whether an unevaluated assertion can still change the result for
-      # this instance. `unevaluatedItems` and `unevaluatedProperties` are
-      # decided by the annotations a whole composition produces, so they
-      # assert only where the schema's own applicators leave the instance
-      # uncovered (a tuple, an `items` schema or an `additionalItems` beside
-      # a tuple evaluates every item; a named, pattern-matched or
-      # `additionalProperties`-covered member every property), only where
-      # their value can fail at all, and only where this node did not
-      # evaluate them itself ({#unevaluated_applied?}). The dynamic
-      # references and a draft-07 `format` always can.
-      # @return [Boolean]
-      def effective_assertion?(schema, keyword, data, dialect = nil, deadline = nil)
-        value = schema[keyword]
-        return false if unevaluated_applied?(schema, keyword, dialect)
-
-        case keyword
-        when 'unevaluatedItems' then effective_unevaluated_items?(schema, value, data, dialect)
-        when 'unevaluatedProperties'
-          data.is_a?(Hash) && ![true, {}].include?(value) && uncovered_property?(schema, data, deadline)
-        else true
-        end
-      end
-
-      # The in-place applicators: keywords that apply another schema to the
-      # same instance, and so contribute annotations of their own to the ones
-      # `unevaluatedItems` / `unevaluatedProperties` read. (`not` contributes
-      # none: it succeeds exactly when its subschema failed, and a failed
-      # subschema annotates nothing.)
-      IN_PLACE_APPLICATORS = %w[$ref $dynamicRef $recursiveRef allOf anyOf oneOf if dependentSchemas
-                                dependencies].freeze
-
-      # Whether this node evaluates one of the annotation-driven keywords
-      # itself. It can where every annotation the keyword reads is produced
-      # by the node's own applicators: no in-place applicator (which would
-      # contribute annotations collected across a composition), and — for
-      # `unevaluatedItems` — no `contains`, whose matching items are
-      # annotated as evaluated (JSON Schema 2020-12 Core Section 10.3.1.3).
-      # There the keyword is `additionalProperties` / `additionalItems` over
-      # what this node did not name, which {Instances} applies.
-      # @return [Boolean]
-      def unevaluated_applied?(schema, keyword, dialect)
-        return false unless %w[unevaluatedItems unevaluatedProperties].include?(keyword)
-        return false unless keyword_known?(keyword, dialect) && schema_value?(schema[keyword])
-        return false if IN_PLACE_APPLICATORS.any? { |kw| schema.key?(kw) && keyword_known?(kw, dialect) }
-        return true unless keyword == 'unevaluatedItems'
-
-        !(keyword_known?('contains', dialect) && schema_value?(schema['contains']))
-      end
-
-      # @return [Boolean] whether `unevaluatedItems` can still reject an item
-      def effective_unevaluated_items?(schema, value, data, dialect)
-        return false unless data.is_a?(Array)
-
-        ![true, {}].include?(value) && data.length > evaluated_item_count(schema, dialect)
-      end
-
-      # @return [Boolean] whether a contains schema in force matches every item
-      def contains_everything?(schema, dialect)
-        keyword_known?('contains', dialect) && [true, {}].include?(schema['contains'])
       end
 
       # The number of matching items `contains` requires: its companion
@@ -119,21 +59,6 @@ module MCPClient
         max if max.is_a?(Numeric)
       end
 
-      # How many leading items the tuple keywords in force evaluate, or
-      # infinity when an items schema, an `additionalItems` beside the tuple
-      # or a contains schema matching every item (JSON Schema 2020-12 Core
-      # Section 10.3.1.3) evaluates them all.
-      # @return [Integer, Float]
-      def evaluated_item_count(schema, dialect)
-        tuple = schema['prefixItems'] if keyword_known?('prefixItems', dialect) && schema['prefixItems'].is_a?(Array)
-        tuple ||= schema['items'] if schema['items'].is_a?(Array)
-        return Float::INFINITY if schema_value?(schema['items']) || contains_everything?(schema, dialect) ||
-                                  (tuple && keyword_known?('additionalItems', dialect) &&
-                                   schema_value?(schema['additionalItems']))
-
-        tuple ? tuple.length : 0
-      end
-
       # @param data [Hash] the instance
       # @param name [Object] the property name a schema keyword names
       # @return [Boolean] whether the instance carries the property in either
@@ -141,26 +66,6 @@ module MCPClient
       def property_present?(data, name)
         name = name.to_s
         data.key?(name) || data.key?(name.to_sym)
-      end
-
-      # Whether the instance has a property the schema's own property
-      # applicators leave to `unevaluatedProperties`: one named in
-      # `properties` is covered, one an `additionalProperties` schema
-      # evaluates is covered, and one matching a `patternProperties` pattern
-      # is covered (an unreadable pattern is assumed to match nothing,
-      # keeping the branch undecided).
-      # @return [Boolean]
-      def uncovered_property?(schema, data, deadline = nil)
-        return false if schema.key?('additionalProperties') && schema_value?(schema['additionalProperties'])
-
-        named = schema['properties'].is_a?(Hash) ? schema['properties'].keys.map(&:to_s) : []
-        patterns = schema['patternProperties'].is_a?(Hash) ? schema['patternProperties'].keys.map(&:to_s) : []
-        data.each_key.any? do |name|
-          name = name.to_s
-          next false if named.include?(name)
-
-          patterns.none? { |pattern| pattern_matches?(pattern, name, deadline) }
-        end
       end
 
       # Match a server-supplied pattern against a property name. Both come

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -28,19 +28,15 @@ module MCPClient
       # 2020-12, `contentSchema`) decide nothing and leave the verdict whole;
       # draft-07 `format` asserts (Validation Section 7.2), and the validator
       # does not evaluate formats, so a string branch carrying one is
-      # undecided there.
+      # undecided there. Dynamic references are evaluated, against the
+      # dynamic scope, and leave no verdict partial.
       # @param schema [Hash] the schema object
       # @param dialect [String, nil] the dialect in force at it
       # @param data [Object] the instance
-      # @param ctx [Context] the validation context
+      # @param _ctx [Context] the validation context
       # @return [Boolean]
-      def partial_keywords?(schema, dialect, data, ctx)
-        return true if dialect == DRAFT_07 && data.is_a?(String) && schema.key?('format')
-
-        DYNAMIC_REFERENCE_KEYWORDS.any? do |keyword|
-          schema.key?(keyword) && keyword_known?(keyword, dialect) &&
-            dynamic_reference?(schema, keyword, ctx.root, ctx.dialect, ctx)
-        end
+      def partial_keywords?(schema, dialect, data, _ctx)
+        dialect == DRAFT_07 && data.is_a?(String) && schema.key?('format')
       end
 
       # The number of matching items `contains` requires: its companion

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -18,8 +18,9 @@ module MCPClient
     # evaluated ({SchemaValidator.validate_object},
     # {SchemaValidator.validate_array}, {SchemaValidator.validate_number}),
     # so what is left here is only what genuinely cannot be decided: the two
-    # keywords read off the annotations a whole composition produces, the
-    # dynamic references, and `format` where it asserts.
+    # annotation-driven keywords *where a composition produces the
+    # annotations they read* ({#unevaluated_applied?} tells the two cases
+    # apart), the dynamic references, and `format` where it asserts.
     module Composition
       # Whether a schema object carries an assertion the validator does not
       # evaluate (in the dialect in force) that applies to this instance, so
@@ -47,18 +48,47 @@ module MCPClient
       # assert only where the schema's own applicators leave the instance
       # uncovered (a tuple, an `items` schema or an `additionalItems` beside
       # a tuple evaluates every item; a named, pattern-matched or
-      # `additionalProperties`-covered member every property) and only where
-      # their value can fail at all. The dynamic references and a draft-07
-      # `format` always can.
+      # `additionalProperties`-covered member every property), only where
+      # their value can fail at all, and only where this node did not
+      # evaluate them itself ({#unevaluated_applied?}). The dynamic
+      # references and a draft-07 `format` always can.
       # @return [Boolean]
       def effective_assertion?(schema, keyword, data, dialect = nil, deadline = nil)
         value = schema[keyword]
+        return false if unevaluated_applied?(schema, keyword, dialect)
+
         case keyword
         when 'unevaluatedItems' then effective_unevaluated_items?(schema, value, data, dialect)
         when 'unevaluatedProperties'
           data.is_a?(Hash) && ![true, {}].include?(value) && uncovered_property?(schema, data, deadline)
         else true
         end
+      end
+
+      # The in-place applicators: keywords that apply another schema to the
+      # same instance, and so contribute annotations of their own to the ones
+      # `unevaluatedItems` / `unevaluatedProperties` read. (`not` contributes
+      # none: it succeeds exactly when its subschema failed, and a failed
+      # subschema annotates nothing.)
+      IN_PLACE_APPLICATORS = %w[$ref $dynamicRef $recursiveRef allOf anyOf oneOf if dependentSchemas
+                                dependencies].freeze
+
+      # Whether this node evaluates one of the annotation-driven keywords
+      # itself. It can where every annotation the keyword reads is produced
+      # by the node's own applicators: no in-place applicator (which would
+      # contribute annotations collected across a composition), and — for
+      # `unevaluatedItems` — no `contains`, whose matching items are
+      # annotated as evaluated (JSON Schema 2020-12 Core Section 10.3.1.3).
+      # There the keyword is `additionalProperties` / `additionalItems` over
+      # what this node did not name, which {Instances} applies.
+      # @return [Boolean]
+      def unevaluated_applied?(schema, keyword, dialect)
+        return false unless %w[unevaluatedItems unevaluatedProperties].include?(keyword)
+        return false unless keyword_known?(keyword, dialect) && schema_value?(schema[keyword])
+        return false if IN_PLACE_APPLICATORS.any? { |kw| schema.key?(kw) && keyword_known?(kw, dialect) }
+        return true unless keyword == 'unevaluatedItems'
+
+        !(keyword_known?('contains', dialect) && schema_value?(schema['contains']))
       end
 
       # @return [Boolean] whether `unevaluatedItems` can still reject an item

--- a/lib/mcp_client/schema_validator/composition.rb
+++ b/lib/mcp_client/schema_validator/composition.rb
@@ -174,7 +174,7 @@ module MCPClient
         remaining = pattern_budget_remaining(deadline)
         raise Aborted, "validation time budget exhausted before pattern #{clip(pattern.inspect)}" if remaining.zero?
 
-        ecma_regexp(pattern, remaining).match?(name)
+        ecma_regexp(pattern, remaining, deadline).match?(name)
       rescue Regexp::TimeoutError
         raise Aborted, "pattern #{clip(pattern.inspect)} exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"
       rescue RegexpError, TypeError

--- a/lib/mcp_client/schema_validator/dialects.rb
+++ b/lib/mcp_client/schema_validator/dialects.rb
@@ -46,7 +46,7 @@ module MCPClient
       # @return [String, nil] the canonical dialect, or nil when the embedded
       #   declaration is malformed or unsupported
       def embedded_dialect(schema, inherited)
-        return inherited unless resource_start?(schema) && schema.key?('$schema')
+        return inherited unless resource_root?(schema, inherited) && schema.key?('$schema')
 
         declared = dialect(schema)
         declared && canonical_dialect(declared)

--- a/lib/mcp_client/schema_validator/dialects.rb
+++ b/lib/mcp_client/schema_validator/dialects.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module SchemaValidator
+    # Dialect selection: the `$schema` a document (or an embedded resource
+    # root) declares, its canonical supported form, and the problems an
+    # unusable declaration reports. Extended into SchemaValidator, so the
+    # methods are its own.
+    module Dialects
+      # The dialect a schema declares, or the default.
+      # @param schema [Object] the schema
+      # @return [String] the `$schema` value (without a trailing `#`), or DEFAULT_DIALECT
+      def dialect(schema)
+        return DEFAULT_DIALECT unless schema.is_a?(Hash)
+        return DEFAULT_DIALECT unless schema.key?('$schema') || schema.key?(:$schema)
+
+        declared = schema.key?('$schema') ? schema['$schema'] : schema[:$schema]
+        # A declaration that is present but unusable is not the default.
+        return nil unless declared.is_a?(String) && !declared.empty?
+
+        declared.sub(/#\z/, '')
+      end
+
+      # The supported dialect a declared URI stands for (scheme-insensitive),
+      # or nil.
+      # @param uri [String]
+      # @return [String, nil]
+      def canonical_dialect(uri)
+        canonical = uri.sub(/#\z/, '').sub(%r{\Ahttps?://}, '')
+        SUPPORTED_DIALECTS.find { |d| d.sub(%r{\Ahttps?://}, '') == canonical }
+      end
+
+      # @param uri [String]
+      # @return [Boolean]
+      def supported_dialect?(uri)
+        !canonical_dialect(uri).nil?
+      end
+
+      # The dialect in force at a schema object: an embedded resource root (a
+      # subschema whose `$id` is a URI) may declare its own `$schema`, which
+      # is that resource's dialect (JSON Schema 2020-12 Core Section 8.1.1);
+      # anywhere else the inherited dialect applies (a `$schema` that is not
+      # at a resource root is ignored).
+      # @param schema [Hash]
+      # @param inherited [String, nil] the enclosing resource's dialect
+      # @return [String, nil] the canonical dialect, or nil when the embedded
+      #   declaration is malformed or unsupported
+      def embedded_dialect(schema, inherited)
+        return inherited unless resource_start?(schema) && schema.key?('$schema')
+
+        declared = dialect(schema)
+        declared && canonical_dialect(declared)
+      end
+
+      # @return [String, nil] why an embedded resource's `$schema` is unusable
+      def embedded_dialect_problem(schema)
+        declared = dialect(schema)
+        return 'embedded resource $schema must be a non-empty string naming the dialect' if declared.nil?
+        return nil if supported_dialect?(declared)
+
+        "embedded resource dialect #{clip(declared.inspect)} is not supported " \
+          "(supported: #{SUPPORTED_DIALECTS.join(', ')})"
+      end
+    end
+  end
+end

--- a/lib/mcp_client/schema_validator/ecma_patterns.rb
+++ b/lib/mcp_client/schema_validator/ecma_patterns.rb
@@ -105,6 +105,7 @@ module MCPClient
         scan[:order] = count_capture_groups(chars)
         scan[:groups] = scan[:order].length
         scan[:names] = scan[:order].compact
+        scan[:generated] = generated_name_prefix(scan[:names])
         while scan[:index] < chars.length
           note_translation_progress(scan)
           chars[scan[:index]] == '[' ? copy_character_class(scan) : copy_ecma_token(scan)
@@ -157,7 +158,18 @@ module MCPClient
       # @param number [Integer] the group's number, from 1
       # @return [String]
       def group_name_for(scan, number)
-        scan[:order][number - 1] || "__mcp_g#{number}"
+        scan[:order][number - 1] || "#{scan[:generated]}#{number}"
+      end
+
+      # A prefix for the generated names that none of the pattern's own
+      # names begins with, so a written `(?<__mcp_g1>` can never be the
+      # group a numeric back-reference is rewritten to name.
+      # @param names [Array<String>] the names the pattern wrote
+      # @return [String]
+      def generated_name_prefix(names)
+        prefix = +'__mcp_g'
+        prefix << '_' while names.any? { |name| name.start_with?(prefix) }
+        prefix
       end
 
       # The name of a `(?<name>` group opening at the index of its `<`.

--- a/lib/mcp_client/schema_validator/ecma_patterns.rb
+++ b/lib/mcp_client/schema_validator/ecma_patterns.rb
@@ -1,0 +1,413 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module SchemaValidator
+    # The rewrite of an ECMA-262 pattern as the Ruby expression that means
+    # the same thing. JSON Schema 2020-12 Core Section 4.3 requires patterns
+    # to be interpreted as ECMA-262 regular expressions, and Ruby's differ
+    # from them in both directions: what Ruby accepts that ECMA-262 rejects
+    # makes the validator accept a value the schema refuses, and the
+    # converse rejects a conforming one (and, through `not` or
+    # `additionalProperties: false`, flips both). Extended into
+    # SchemaValidator, so the methods are its own.
+    #
+    # A pattern comes from the remote peer and is as long as the peer made
+    # it, so the translation is one linear pass over its characters that
+    # consults the validation-wide deadline as it goes, and a pattern past
+    # MAX_PATTERN_LENGTH is refused before it is read at all.
+    module EcmaPatterns
+      # A pattern that is no ECMA-262 expression: syntax ECMA-262 does not
+      # define (Ruby's inline flags, possessive quantifiers, atomic groups,
+      # comments) or an expression neither dialect accepts. A RegexpError,
+      # so every caller that rescues an unreadable expression sees it.
+      class SyntaxError < RegexpError; end
+
+      # What each ECMA-262 anchor means in Ruby: the ends of the subject,
+      # never a line boundary.
+      ECMA_ANCHORS = { '^' => '\\A', '$' => '\\z' }.freeze
+
+      # ECMA-262 `.` matches every character except the four line
+      # terminators; Ruby's excludes only "\n".
+      ECMA_DOT = '[^\\n\\r\\u2028\\u2029]'
+
+      # The members of ECMA-262's `\s` (WhiteSpace plus LineTerminator):
+      # Ruby's is `[ \t\r\n\f\v]` and knows none of the Unicode spaces, so a
+      # non-breaking space failed a pattern ECMAScript satisfies.
+      ECMA_SPACE_MEMBERS = '\\t\\n\\v\\f\\r \\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff'
+
+      # A character class matching nothing, which is what ECMA-262 makes of
+      # `[]` — Ruby cannot compile that at all, so the pattern used to be
+      # dropped and every string satisfied it.
+      ECMA_EMPTY_CLASS = '[^\\s\\S]'
+
+      # Its complement: ECMA-262 `[^]` matches any character, line
+      # terminators included.
+      ECMA_ANY_CLASS = '[\\s\\S]'
+
+      # The escapes ECMA-262 defines, which Ruby reads the same way: the
+      # class escapes, the assertions, the control escapes, a hex or
+      # control-letter escape and a Unicode property. `\s` / `\S` are
+      # defined by both but over different sets, the digits are
+      # back-references or legacy octal escapes, `\u` may spell a surrogate
+      # pair and `\k` a named back-reference, so those are rewritten rather
+      # than kept.
+      ECMA_KEPT_ESCAPES = 'bBdDwWfnrtvxcpP'
+
+      # The characters that may follow `(?` in ECMA-262: a non-capturing
+      # group, a lookahead, and (after `<`) a lookbehind or a named group.
+      # Anything else Ruby reads as an inline option, an atomic group, a
+      # comment or its own named-group syntax, none of which ECMA-262 has.
+      ECMA_GROUP_OPENERS = ':=!<'
+
+      # How many characters the translation reads between two looks at the
+      # deadline.
+      TRANSLATION_CHECK_INTERVAL = 256
+
+      # The Ruby expression an ECMA-262 pattern means.
+      # @param pattern [String] the peer's pattern
+      # @param timeout [Float] seconds the match may take
+      # @param deadline [Float, nil] monotonic deadline the translation runs under
+      # @return [Regexp]
+      # @raise [RegexpError] when the pattern is not a usable expression
+      # @raise [Aborted] when the deadline passes during the translation
+      def ecma_regexp(pattern, timeout, deadline = nil)
+        Regexp.new(ecma_source(pattern, deadline), timeout: timeout)
+      end
+
+      # Rewrite an ECMA-262 pattern as Ruby regexp source. Everything
+      # ECMA-262 defines is kept; what only Ruby defines is either read the
+      # way ECMA-262 reads it — an escape ECMA-262 does not define is an
+      # identity escape there (Annex B.1.2), so `\A` is a literal "A" and not
+      # the start of the subject — or refused where ECMA-262 refuses it.
+      # @param pattern [String] the peer's pattern
+      # @param deadline [Float, nil] monotonic deadline the translation runs under
+      # @return [String] Ruby regexp source
+      # @raise [SyntaxError] for syntax ECMA-262 does not define
+      # @raise [Aborted] when the deadline passes during the translation
+      def ecma_source(pattern, deadline = nil)
+        raise SyntaxError, "pattern is longer than #{MAX_PATTERN_LENGTH} characters" if
+          pattern.length > MAX_PATTERN_LENGTH
+
+        chars = pattern.chars
+        scan = { chars: chars, index: 0, out: +'', deadline: deadline, read: 0, last: :none }
+        scan[:groups], scan[:names] = count_capture_groups(chars)
+        while scan[:index] < chars.length
+          note_translation_progress(scan)
+          chars[scan[:index]] == '[' ? copy_character_class(scan) : copy_ecma_token(scan)
+        end
+        scan[:out]
+      end
+
+      # Consult the deadline every TRANSLATION_CHECK_INTERVAL characters.
+      # @raise [Aborted]
+      def note_translation_progress(scan)
+        scan[:read] += 1
+        return unless (scan[:read] % TRANSLATION_CHECK_INTERVAL).zero?
+
+        raise Aborted, 'validation time budget exhausted while translating a pattern' if
+          budget_exhausted?(scan[:deadline])
+      end
+
+      # The capturing groups a pattern declares, in one pass: what a numeric
+      # escape refers to depends on how many there are (Annex B.1.4: a
+      # number past the count is a legacy octal escape), and a named escape
+      # on which names exist.
+      # @return [Array(Integer, Array<String>)] the count and the names
+      def count_capture_groups(chars)
+        count = 0
+        names = []
+        index = 0
+        in_class = false
+        while index < chars.length
+          char = chars[index]
+          if char == '\\'
+            index += 2
+            next
+          end
+          in_class = true if char == '['
+          in_class = false if char == ']' && in_class
+          if char == '(' && !in_class
+            count += 1 if chars[index + 1] != '?'
+            name = group_name_at(chars, index + 2)
+            if name
+              count += 1
+              names << name
+            end
+          end
+          index += 1
+        end
+        [count, names]
+      end
+
+      # The name of a `(?<name>` group opening at the index of its `<`.
+      # @return [String, nil]
+      def group_name_at(chars, index)
+        return nil unless chars[index] == '<' && !'=!'.include?(chars[index + 1].to_s)
+
+        close = index + 1
+        close += 1 while close < chars.length && chars[close] != '>'
+        chars[(index + 1)...close].join if close < chars.length
+      end
+
+      # Copy one token from outside a character class.
+      # @return [void]
+      def copy_ecma_token(scan)
+        char = scan[:chars][scan[:index]]
+        case char
+        when '\\' then copy_escape(scan, in_class: false)
+        when '(' then copy_group_opener(scan)
+        when '*', '+', '?' then copy_quantifier(scan, char)
+        when '{' then copy_brace(scan)
+        else copy_plain_token(scan, char)
+        end
+      end
+
+      # A character that is neither an escape, a group opener nor a
+      # quantifier.
+      # @return [void]
+      def copy_plain_token(scan, char)
+        scan[:index] += 1
+        case char
+        when '^', '$'
+          emit(scan, ECMA_ANCHORS[char], :none)
+        when '.' then emit(scan, ECMA_DOT, :atom)
+        when '|' then emit(scan, char, :none)
+        # A `]` or `}` that closes nothing is a literal in ECMA-262 (Annex
+        # B.1.4); Ruby reads a bare `}` the same way but is spared the guess.
+        when ']', '}' then emit(scan, "\\#{char}", :atom)
+        else emit(scan, char, :atom)
+        end
+      end
+
+      # Append translated source and record what kind of token it was.
+      # @return [void]
+      def emit(scan, source, kind)
+        scan[:out] << source
+        scan[:last] = kind
+      end
+
+      # A `(`: a capturing group, or `(?` followed by one of the openers
+      # ECMA-262 defines. Ruby's other `(?` forms are refused.
+      # @return [void]
+      def copy_group_opener(scan)
+        chars = scan[:chars]
+        index = scan[:index]
+        if chars[index + 1] != '?'
+          scan[:index] += 1
+          return emit(scan, '(', :none)
+        end
+
+        opener = chars[index + 2].to_s
+        unless ECMA_GROUP_OPENERS.include?(opener) && !opener.empty?
+          raise SyntaxError,
+                "invalid group at index #{index}"
+        end
+
+        if opener == '<' && !'=!'.include?(chars[index + 3].to_s) && !group_name_at(chars, index + 2)
+          raise SyntaxError, "invalid group name at index #{index}"
+        end
+
+        scan[:index] += 3
+        emit(scan, "(?#{opener}", :none)
+      end
+
+      # A `*`, `+` or `?`: a quantifier on the preceding atom, or the lazy
+      # marker on the preceding quantifier. ECMA-262 has nothing else for
+      # them to be: on nothing, or on a quantifier (Ruby's possessive `++`,
+      # nested `+*`), they are a syntax error ("Nothing to repeat").
+      # @return [void]
+      def copy_quantifier(scan, char)
+        scan[:index] += 1
+        case scan[:last]
+        when :atom then emit(scan, char, :quantifier)
+        when :quantifier
+          raise SyntaxError, "nothing to repeat at index #{scan[:index] - 1}" unless char == '?'
+
+          emit(scan, char, :lazy)
+        else
+          raise SyntaxError, "nothing to repeat at index #{scan[:index] - 1}"
+        end
+      end
+
+      # A `{`: a counted quantifier when it spells one (`{n}`, `{n,}`,
+      # `{n,m}`), else a literal brace (Annex B.1.4). Ruby also reads `{,m}`
+      # as a quantifier, so a literal is escaped rather than copied.
+      # @return [void]
+      def copy_brace(scan)
+        chars = scan[:chars]
+        index = scan[:index]
+        close = index + 1
+        close += 1 while close < chars.length && chars[close] != '}' && close - index <= 32
+        body = chars[(index + 1)...close].join
+        unless chars[close] == '}' && body.match?(/\A\d+(,\d*)?\z/)
+          scan[:index] += 1
+          return emit(scan, '\\{', :atom)
+        end
+
+        raise SyntaxError, "nothing to repeat at index #{index}" unless scan[:last] == :atom
+
+        scan[:index] = close + 1
+        emit(scan, "{#{body}}", :quantifier)
+      end
+
+      # One escape sequence, outside or inside a character class.
+      # @return [void]
+      def copy_escape(scan, in_class:)
+        chars = scan[:chars]
+        char = chars[scan[:index] + 1]
+        # A trailing backslash is no expression in either dialect; Ruby says so.
+        if char.nil?
+          scan[:index] += 1
+          return emit(scan, '\\', :atom)
+        end
+
+        scan[:index] += 2
+        case char
+        when '0'..'9' then copy_numeric_escape(scan, char, in_class: in_class)
+        when 'u' then copy_unicode_escape(scan)
+        when 'k' then copy_named_reference(scan, in_class: in_class)
+        else emit(scan, ecma_escape(char, in_class: in_class), 'bB'.include?(char) && !in_class ? :none : :atom)
+        end
+      end
+
+      # One escape's Ruby spelling. An escape ECMA-262 leaves undefined is
+      # an identity escape: the character itself.
+      # @param char [String] what followed the backslash
+      # @param in_class [Boolean] whether the escape sits in a character class
+      # @return [String]
+      def ecma_escape(char, in_class:)
+        return in_class ? ECMA_SPACE_MEMBERS : "[#{ECMA_SPACE_MEMBERS}]" if char == 's'
+        # Inside a class Ruby reads the nested one as a union, which is
+        # what a member set complement means there.
+        return "[^#{ECMA_SPACE_MEMBERS}]" if char == 'S'
+        # `\B` asserts outside a class and is an identity escape inside one.
+        return 'B' if in_class && char == 'B'
+        return "\\#{char}" if ECMA_KEPT_ESCAPES.include?(char)
+
+        # An identity escape: a letter stands for itself, and punctuation
+        # keeps the backslash (which means the same in both dialects).
+        char.match?(/[A-Za-z]/) ? char : "\\#{char}"
+      end
+
+      # A `\` followed by digits: a back-reference to a group the pattern
+      # declares, else (Annex B.1.4) a legacy octal escape of up to three
+      # octal digits, or the identity escapes `8` and `9`. A back-reference
+      # to a group that did not participate matches the empty string in
+      # ECMA-262 and fails in Ruby, so it is written as the conditional Ruby
+      # reads that way.
+      # @return [void]
+      def copy_numeric_escape(scan, first, in_class:)
+        chars = scan[:chars]
+        digits = +first
+        (digits << chars[scan[:index]]) && scan[:index] += 1 while chars[scan[:index]].to_s.match?(/\d/)
+        number = digits.to_i
+        if number.positive? && number <= scan[:groups] && !in_class
+          return emit(scan, "(?(#{number})\\#{number}|)", :atom)
+        end
+
+        octal = digits.match(/\A[0-7]{1,3}/)&.to_s
+        octal = octal[0, 2] if octal && octal.length == 3 && octal.to_i(8) > 255
+        if octal.nil?
+          # `8` and `9` stand for themselves; the digits after them too.
+          return emit(scan, digits, :atom)
+        end
+
+        emit(scan, format('\\x%02X', octal.to_i(8)) + digits[octal.length..], :atom)
+      end
+
+      # `\uXXXX`: a code unit, which Ruby reads as a code point. A surrogate
+      # pair (ECMA-262 without the `u` flag matches the two units of one
+      # character) is joined into the character it encodes; a lone
+      # surrogate is no character any string carries, so it matches
+      # nothing. A `\u` that spells no code unit is an identity escape.
+      # @return [void]
+      def copy_unicode_escape(scan)
+        high = hex_code_unit(scan, scan[:index])
+        return emit(scan, 'u', :atom) unless high
+
+        scan[:index] += 4
+        low = nil
+        if high.between?(0xD800, 0xDBFF) && scan[:chars][scan[:index]] == '\\' && scan[:chars][scan[:index] + 1] == 'u'
+          low = hex_code_unit(scan, scan[:index] + 2)
+          low = nil unless low&.between?(0xDC00, 0xDFFF)
+        end
+        if low
+          scan[:index] += 6
+          return emit(scan, format('\\u{%X}', 0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00)), :atom)
+        end
+        return emit(scan, ECMA_EMPTY_CLASS, :atom) if high.between?(0xD800, 0xDFFF)
+
+        emit(scan, format('\\u%04X', high), :atom)
+      end
+
+      # @return [Integer, nil] the four hex digits at an index, as a number
+      def hex_code_unit(scan, index)
+        text = scan[:chars][index, 4]&.join.to_s
+        text.match?(/\A\h{4}\z/) ? text.to_i(16) : nil
+      end
+
+      # `\k<name>`: a named back-reference where the pattern declares named
+      # groups (with the same empty-match rule as a numbered one); with none
+      # declared it is an identity escape for "k" (Annex B.1.2).
+      # @return [void]
+      def copy_named_reference(scan, in_class:)
+        return emit(scan, 'k', :atom) if scan[:names].empty? || in_class
+
+        name = group_name_at(scan[:chars], scan[:index])
+        unless name && scan[:names].include?(name)
+          raise SyntaxError,
+                "invalid named reference at index #{scan[:index] - 2}"
+        end
+
+        scan[:index] += name.length + 2
+        emit(scan, "(?(<#{name}>)\\k<#{name}>|)", :atom)
+      end
+
+      # Copy a character class, which ECMA-262 and Ruby read differently: an
+      # empty class is legal there and matches nothing, and `[` and `&`
+      # inside a class are literals rather than the openers of Ruby's nested
+      # classes and set intersection.
+      # @return [void]
+      def copy_character_class(scan)
+        chars = scan[:chars]
+        opening = scan[:index]
+        negated = chars[opening + 1] == '^'
+        scan[:index] = opening + (negated ? 2 : 1)
+        outer = scan[:out]
+        scan[:out] = +''
+        while scan[:index] < chars.length && chars[scan[:index]] != ']'
+          note_translation_progress(scan)
+          if chars[scan[:index]] == '\\'
+            copy_escape(scan, in_class: true)
+          else
+            emit(scan, class_member(chars[scan[:index]]), :atom)
+            scan[:index] += 1
+          end
+        end
+        body = scan[:out]
+        scan[:out] = outer
+        # Unterminated: no expression in either dialect.
+        raise SyntaxError, "unterminated character class at index #{opening}" if scan[:index] >= chars.length
+
+        scan[:index] += 1
+        emit(scan, class_source(body, negated), :atom)
+      end
+
+      # @return [String] the Ruby spelling of one unescaped class member
+      def class_member(char)
+        # Ruby reads a nested `[` as another class and `&&` as intersection;
+        # ECMA-262 has neither, so both are literals there.
+        ['[', '&'].include?(char) ? "\\#{char}" : char
+      end
+
+      # @param body [String] the translated members
+      # @param negated [Boolean] whether the class was written with a `^`
+      # @return [String] the Ruby character class
+      def class_source(body, negated)
+        return negated ? ECMA_ANY_CLASS : ECMA_EMPTY_CLASS if body.empty?
+
+        negated ? "[^#{body}]" : "[#{body}]"
+      end
+    end
+  end
+end

--- a/lib/mcp_client/schema_validator/ecma_patterns.rb
+++ b/lib/mcp_client/schema_validator/ecma_patterns.rb
@@ -45,13 +45,25 @@ module MCPClient
       ECMA_ANY_CLASS = '[\\s\\S]'
 
       # The escapes ECMA-262 defines, which Ruby reads the same way: the
-      # class escapes, the assertions, the control escapes, a hex or
-      # control-letter escape and a Unicode property. `\s` / `\S` are
-      # defined by both but over different sets, the digits are
-      # back-references or legacy octal escapes, `\u` may spell a surrogate
-      # pair and `\k` a named back-reference, so those are rewritten rather
-      # than kept.
-      ECMA_KEPT_ESCAPES = 'bBdDwWfnrtvxcpP'
+      # class escapes, the control escapes, a hex or control-letter escape
+      # and a Unicode property. `\s` / `\S` are defined by both but over
+      # different sets, `\b` / `\B` over different word characters, the
+      # digits are back-references or legacy octal escapes, `\u` may spell
+      # a surrogate pair and `\k` a named back-reference, so those are
+      # rewritten rather than kept.
+      ECMA_KEPT_ESCAPES = 'dDwWfnrtvxcpP'
+
+      # ECMA-262's word characters: `\w` is [A-Za-z0-9_] there, and its
+      # word-boundary assertions are defined over exactly those, while Ruby's
+      # `\b` knows every Unicode letter — so "é" has a boundary in Ruby and
+      # none in ECMA-262.
+      ECMA_WORD = '[A-Za-z0-9_]'
+
+      # `\b`: a word character on exactly one side.
+      ECMA_WORD_BOUNDARY = "(?:(?<=#{ECMA_WORD})(?!#{ECMA_WORD})|(?<!#{ECMA_WORD})(?=#{ECMA_WORD}))".freeze
+
+      # `\B`: word characters on both sides, or on neither.
+      ECMA_NON_BOUNDARY = "(?:(?<=#{ECMA_WORD})(?=#{ECMA_WORD})|(?<!#{ECMA_WORD})(?!#{ECMA_WORD}))".freeze
 
       # The characters that may follow `(?` in ECMA-262: a non-capturing
       # group, a lookahead, and (after `<`) a lookbehind or a named group.
@@ -89,8 +101,10 @@ module MCPClient
           pattern.length > MAX_PATTERN_LENGTH
 
         chars = pattern.chars
-        scan = { chars: chars, index: 0, out: +'', deadline: deadline, read: 0, last: :none }
-        scan[:groups], scan[:names] = count_capture_groups(chars)
+        scan = { chars: chars, index: 0, out: +'', deadline: deadline, read: 0, last: :none, opened: 0 }
+        scan[:order] = count_capture_groups(chars)
+        scan[:groups] = scan[:order].length
+        scan[:names] = scan[:order].compact
         while scan[:index] < chars.length
           note_translation_progress(scan)
           chars[scan[:index]] == '[' ? copy_character_class(scan) : copy_ecma_token(scan)
@@ -108,14 +122,16 @@ module MCPClient
           budget_exhausted?(scan[:deadline])
       end
 
-      # The capturing groups a pattern declares, in one pass: what a numeric
-      # escape refers to depends on how many there are (Annex B.1.4: a
-      # number past the count is a legacy octal escape), and a named escape
-      # on which names exist.
-      # @return [Array(Integer, Array<String>)] the count and the names
+      # The capturing groups a pattern declares, in order and in one pass:
+      # what a numeric escape refers to depends on how many there are (Annex
+      # B.1.4: a number past the count is a legacy octal escape) and on which
+      # one it names — ECMA-262 numbers named and unnamed groups alike,
+      # left to right, while Ruby stops capturing unnamed groups once a
+      # named one exists, so the numbering is kept here and every group is
+      # written as a named one there ({#copy_group_opener}).
+      # @return [Array<String, nil>] each group's name, nil for an unnamed one
       def count_capture_groups(chars)
-        count = 0
-        names = []
+        order = []
         index = 0
         in_class = false
         while index < chars.length
@@ -127,16 +143,21 @@ module MCPClient
           in_class = true if char == '['
           in_class = false if char == ']' && in_class
           if char == '(' && !in_class
-            count += 1 if chars[index + 1] != '?'
+            order << nil if chars[index + 1] != '?'
             name = group_name_at(chars, index + 2)
-            if name
-              count += 1
-              names << name
-            end
+            order << name if name
           end
           index += 1
         end
-        [count, names]
+        order
+      end
+
+      # The Ruby name of a capturing group, by its ECMA-262 number: its own
+      # where it has one, a generated one otherwise.
+      # @param number [Integer] the group's number, from 1
+      # @return [String]
+      def group_name_for(scan, number)
+        scan[:order][number - 1] || "__mcp_g#{number}"
       end
 
       # The name of a `(?<name>` group opening at the index of its `<`.
@@ -194,7 +215,9 @@ module MCPClient
         index = scan[:index]
         if chars[index + 1] != '?'
           scan[:index] += 1
-          return emit(scan, '(', :none)
+          scan[:opened] += 1
+          # Beside a named group Ruby would not capture this one at all.
+          return emit(scan, scan[:names].empty? ? '(' : "(?<#{group_name_for(scan, scan[:opened])}>", :none)
         end
 
         opener = chars[index + 2].to_s
@@ -203,8 +226,10 @@ module MCPClient
                 "invalid group at index #{index}"
         end
 
-        if opener == '<' && !'=!'.include?(chars[index + 3].to_s) && !group_name_at(chars, index + 2)
-          raise SyntaxError, "invalid group name at index #{index}"
+        if opener == '<' && !'=!'.include?(chars[index + 3].to_s)
+          raise SyntaxError, "invalid group name at index #{index}" unless group_name_at(chars, index + 2)
+
+          scan[:opened] += 1
         end
 
         scan[:index] += 3
@@ -280,8 +305,10 @@ module MCPClient
         # Inside a class Ruby reads the nested one as a union, which is
         # what a member set complement means there.
         return "[^#{ECMA_SPACE_MEMBERS}]" if char == 'S'
+        # `\b` is a backspace inside a class and a word boundary outside it;
         # `\B` asserts outside a class and is an identity escape inside one.
-        return 'B' if in_class && char == 'B'
+        return in_class ? '\\b' : ECMA_WORD_BOUNDARY if char == 'b'
+        return in_class ? 'B' : ECMA_NON_BOUNDARY if char == 'B'
         return "\\#{char}" if ECMA_KEPT_ESCAPES.include?(char)
 
         # An identity escape: a letter stands for itself, and punctuation
@@ -302,7 +329,10 @@ module MCPClient
         (digits << chars[scan[:index]]) && scan[:index] += 1 while chars[scan[:index]].to_s.match?(/\d/)
         number = digits.to_i
         if number.positive? && number <= scan[:groups] && !in_class
-          return emit(scan, "(?(#{number})\\#{number}|)", :atom)
+          return emit(scan, "(?(#{number})\\#{number}|)", :atom) if scan[:names].empty?
+
+          name = group_name_for(scan, number)
+          return emit(scan, "(?(<#{name}>)\\k<#{name}>|)", :atom)
         end
 
         octal = digits.match(/\A[0-7]{1,3}/)&.to_s

--- a/lib/mcp_client/schema_validator/ecma_patterns.rb
+++ b/lib/mcp_client/schema_validator/ecma_patterns.rb
@@ -22,6 +22,23 @@ module MCPClient
       # so every caller that rescues an unreadable expression sees it.
       class SyntaxError < RegexpError; end
 
+      # A pattern that IS an ECMA-262 expression but whose meaning Ruby's
+      # engine cannot be made to reproduce, so translating it would answer
+      # some instances wrongly. The two engines differ in two ways no
+      # rewriting bridges:
+      #
+      # - ECMA-262 clears the captures inside a quantified group at the start
+      #   of every iteration (a back-reference to a group the last iteration
+      #   did not enter matches the empty string); Ruby keeps whatever the
+      #   last iteration that entered it captured. `^(a|(b))*\2$` accepts
+      #   "aba" and refuses "abab" there, and exactly the opposite here.
+      # - ECMA-262 lookbehind is variable-length (ES2018); Ruby's is not.
+      #
+      # Refusing the schema is the only honest answer left: a verdict from
+      # the other engine's rules would accept structured content the schema
+      # forbids as readily as it would refuse conforming content.
+      class Untranslatable < RegexpError; end
+
       # What each ECMA-262 anchor means in Ruby: the ends of the subject,
       # never a line boundary.
       ECMA_ANCHORS = { '^' => '\\A', '$' => '\\z' }.freeze
@@ -81,9 +98,18 @@ module MCPClient
       # @param deadline [Float, nil] monotonic deadline the translation runs under
       # @return [Regexp]
       # @raise [RegexpError] when the pattern is not a usable expression
+      # @raise [Untranslatable] when it is one Ruby cannot reproduce
       # @raise [Aborted] when the deadline passes during the translation
       def ecma_regexp(pattern, timeout, deadline = nil)
         Regexp.new(ecma_source(pattern, deadline), timeout: timeout)
+      rescue RegexpError => e
+        # ECMA-262 lookbehind has been variable-length since ES2018 and
+        # Ruby's never has been: the pattern is a good expression this
+        # engine cannot be given, not a bad one.
+        raise Untranslatable, "variable-length lookbehind cannot be evaluated faithfully (#{e.message})" if
+          e.message.include?('look-behind')
+
+        raise
       end
 
       # Rewrite an ECMA-262 pattern as Ruby regexp source. Everything
@@ -105,6 +131,7 @@ module MCPClient
         scan[:order] = count_capture_groups(chars)
         scan[:groups] = scan[:order].length
         scan[:names] = scan[:order].compact
+        scan[:repeated] = repeated_capture_groups(chars)
         scan[:generated] = generated_name_prefix(scan[:names])
         while scan[:index] < chars.length
           note_translation_progress(scan)
@@ -341,6 +368,7 @@ module MCPClient
         (digits << chars[scan[:index]]) && scan[:index] += 1 while chars[scan[:index]].to_s.match?(/\d/)
         number = digits.to_i
         if number.positive? && number <= scan[:groups] && !in_class
+          reject_repeated_reference(scan, number)
           return emit(scan, "(?(#{number})\\#{number}|)", :atom) if scan[:names].empty?
 
           name = group_name_for(scan, number)
@@ -402,7 +430,91 @@ module MCPClient
         end
 
         scan[:index] += name.length + 2
+        reject_repeated_reference(scan, scan[:order].index(name) + 1)
         emit(scan, "(?(<#{name}>)\\k<#{name}>|)", :atom)
+      end
+
+      # A back-reference to a group a quantifier may repeat reads one way in
+      # ECMA-262 (cleared at each iteration) and another in Ruby (kept), and
+      # the difference decides instances either way round, so the pattern is
+      # refused rather than answered.
+      # @param number [Integer] the group the reference names
+      # @return [void]
+      # @raise [Untranslatable]
+      def reject_repeated_reference(scan, number)
+        return unless scan[:repeated].include?(number)
+
+        raise Untranslatable,
+              "a back-reference to group #{number}, which a quantifier repeats, cannot be evaluated faithfully " \
+              "(ECMA-262 clears the group's capture at each repetition and Ruby keeps it)"
+      end
+
+      # The capturing groups a quantifier may repeat: those inside (or being)
+      # a group followed by a quantifier that allows a second iteration.
+      # `?` and `{0,1}` allow only one, so nothing is ever cleared between
+      # iterations there and the existing "did the group participate"
+      # conditional already reads the way ECMA-262 does. Read in one pass,
+      # skipping escapes and character classes, so a `(` written as a
+      # literal opens nothing.
+      # @param chars [Array<String>] the pattern
+      # @return [Array<Integer>] the group numbers
+      def repeated_capture_groups(chars)
+        state = { open: [], repeated: [], number: 0, index: 0, in_class: false }
+        while state[:index] < chars.length
+          char = chars[state[:index]]
+          state[:index] += 1
+          next state[:index] += 1 if char == '\\'
+          next state[:in_class] = true if char == '[' && !state[:in_class]
+          next state[:in_class] = false if char == ']' && state[:in_class]
+          next if state[:in_class]
+
+          open_repeat_group(state, chars) if char == '('
+          close_repeat_group(state, chars) if char == ')'
+        end
+        state[:repeated]
+      end
+
+      # @return [void]
+      def open_repeat_group(state, chars)
+        capturing = chars[state[:index]] != '?' || group_name_at(chars, state[:index] + 1).to_s != ''
+        number = capturing ? (state[:number] += 1) : nil
+        state[:open] << { number: number, inner: [] }
+      end
+
+      # @return [void]
+      def close_repeat_group(state, chars)
+        group = state[:open].pop
+        return unless group
+
+        members = group[:inner] + [group[:number]].compact
+        state[:repeated].concat(members) if quantifier_at?(chars, state[:index])
+        parent = state[:open].last
+        parent ? parent[:inner].concat(members) : nil
+      end
+
+      # @return [Boolean] whether the quantifier at an index admits a second
+      #   iteration, which is when ECMA-262's per-iteration clearing of the
+      #   captures inside it can be seen at all
+      def quantifier_at?(chars, index)
+        char = chars[index]
+        return true if ['*', '+'].include?(char)
+        return false unless char == '{'
+
+        bounds = chars[index..].join[/\A\{(\d+)(,(\d*))?\}/, 0]
+        return false unless bounds
+
+        repeated_bounds?(Regexp.last_match(1).to_i, Regexp.last_match(2), Regexp.last_match(3))
+      end
+
+      # @param least [Integer] the `{n` of the quantifier
+      # @param comma [String, nil] its `,`, when it has one
+      # @param most [String, nil] its `m`, when it has one
+      # @return [Boolean] whether it admits two iterations
+      def repeated_bounds?(least, comma, most)
+        return least >= 2 if comma.nil?
+        return true if most.nil? || most.empty?
+
+        most.to_i >= 2
       end
 
       # Copy a character class, which ECMA-262 and Ruby read differently: an

--- a/lib/mcp_client/schema_validator/evaluation.rb
+++ b/lib/mcp_client/schema_validator/evaluation.rb
@@ -91,7 +91,9 @@ module MCPClient
       def ref_target(app)
         ctx = app.ctx
         ref = app.schema['$ref']
-        return ref_problem(app, "external $ref #{clip(ref.inspect)} is not dereferenced") if unusable_ref?(ref)
+        if unusable_ref?(ref, ctx, app.schema)
+          return ref_problem(app, "external $ref #{clip(ref.inspect)} is not dereferenced")
+        end
         if app.ref_depth >= MAX_REF_DEPTH
           raise Aborted, "$ref chain exceeds #{MAX_REF_DEPTH} hops (cycle?) at #{clip(ref.inspect)}"
         end
@@ -104,9 +106,11 @@ module MCPClient
       end
 
       # @param ref [Object] the `$ref` value
+      # @param ctx [Context] the validation context
+      # @param from [Hash] the schema object holding the reference
       # @return [Boolean] whether it is a reference this validator never follows
-      def unusable_ref?(ref)
-        !ref.is_a?(String) || external_ref?(ref)
+      def unusable_ref?(ref, ctx, from)
+        !ref.is_a?(String) || external_ref?(ref, ctx.root, ctx.dialect, ctx, from: from)
       end
 
       # @param app [Application]
@@ -234,7 +238,8 @@ module MCPClient
 
       # if / then / else. An `if` without `then` or `else` asserts nothing
       # (JSON Schema 2020-12 Section 10.2.2.1) and is not evaluated; an
-      # undecided condition applies neither branch.
+      # undecided condition applies neither branch, but may still be settled
+      # by the branches agreeing ({#unconditional_conditional}).
       # @param app [Application]
       # @return [Array] a step
       def compose_conditional(app, &cont)
@@ -243,13 +248,51 @@ module MCPClient
 
         branch_verdict(app, schema['if']) do |verdict|
           branch = { pass: 'then', fail: 'else' }[verdict]
-          next cont.call if branch.nil? || !schema.key?(branch)
+          next unconditional_conditional(app, cont) if branch.nil?
+          next cont.call unless schema.key?(branch)
 
           [:apply, schema[branch], app.ref_depth, false, lambda do |errors|
             app.errors.concat(errors)
             cont.call
           end]
         end
+      end
+
+      # A condition this validator cannot decide still settles the instance
+      # when both outcomes reject it: exactly one of `then` and `else` is
+      # applied (JSON Schema 2020-12 Section 10.2.2.2 and 10.2.2.3), so a
+      # value both of them reject is invalid whichever way the condition
+      # goes. Reporting nothing there would turn a definite failure into a
+      # pass — and, under :strict, accept a result the schema rejects. Only
+      # a definite rejection counts on each side; what a branch could not
+      # evaluate leaves the conditional undecided as before.
+      # @param app [Application]
+      # @param cont [Proc] what follows the conditional
+      # @return [Array] a step
+      def unconditional_conditional(app, cont)
+        schema = app.schema
+        return cont.call unless schema.key?('then') && schema.key?('else')
+
+        undecided = app.ctx.undecided
+        [:apply, schema['then'], app.ref_depth, true, lambda do |then_errors|
+          next resume_conditional(app, undecided, cont) if then_errors.empty?
+
+          [:apply, schema['else'], app.ref_depth, true, lambda do |else_errors|
+            unless else_errors.empty?
+              app.errors << "#{app.path}: fails both then and else of an if this validator cannot decide " \
+                            "(#{clip(then_errors.first.to_s)})"
+            end
+            resume_conditional(app, undecided, cont)
+          end]
+        end]
+      end
+
+      # Resume after measuring the branches: what they could not evaluate is
+      # not this node's uncertainty (the condition's already is).
+      # @return [Array] a step
+      def resume_conditional(app, undecided, cont)
+        app.ctx.undecided = undecided
+        cont.call
       end
 
       # The verdicts of a keyword's branches. Evaluation stops as soon as the

--- a/lib/mcp_client/schema_validator/evaluation.rb
+++ b/lib/mcp_client/schema_validator/evaluation.rb
@@ -38,7 +38,8 @@ module MCPClient
 
       # The composition keywords, in the order they are applied. Each step
       # takes the application and a continuation, and returns a step.
-      COMPOSITION_STEPS = %i[compose_all_of compose_any_of compose_one_of compose_not compose_conditional].freeze
+      COMPOSITION_STEPS = %i[compose_all_of compose_any_of compose_one_of compose_not compose_conditional
+                             compose_dependent_schemas].freeze
 
       # Begin applying one (sub)schema to the value, under the bound on the
       # walk itself: one more node visited.
@@ -130,9 +131,15 @@ module MCPClient
         schema = app.schema
         errors = app.errors
         errors.concat(validate_type(data, schema['type'], app.path)) if schema.key?('type')
+        # A node its own `type` already rejected is decided: the keywords for
+        # the value's actual type could only add detail, and evaluating them
+        # would spend the peer's `patternProperties` expressions and item
+        # schemas on a value this schema has refused.
+        return compose(app) unless errors.empty?
+
         errors.concat(validate_enum(data, schema, app.path))
         case data
-        when Hash then errors.concat(validate_object(data, schema, app.path, app.ctx))
+        when Hash then errors.concat(validate_object(data, schema, app.path, app.ctx, app.dialect))
         when Array then errors.concat(validate_array(data, schema, app.path, app.ctx, app.dialect))
         when String then errors.concat(validate_string(data, schema, app.path, app.ctx.deadline))
         when Numeric then errors.concat(validate_number(data, schema, app.path, app.dialect))
@@ -163,6 +170,57 @@ module MCPClient
         ctx = app.ctx
         ctx.undecided += 1 if app.errors.empty? && partial_keywords?(app.schema, app.dialect, app.data, ctx.deadline)
         [:done, count_errors(ctx, app.errors, already_counted: ctx.errors - app.counted_before)]
+      end
+
+      # The schema half of a dependency: `dependentSchemas` in 2019-09 and
+      # 2020-12, and the schema entries of draft-07's `dependencies` (JSON
+      # Schema 2020-12 Core Section 10.2.2.4, draft-07 Section 6.5.7). Each
+      # dependency whose trigger the instance carries applies its schema to
+      # that same instance, so — like allOf — it runs on the trampoline
+      # rather than on the interpreter's stack.
+      # @param app [Application]
+      # @return [Array] a step
+      def compose_dependent_schemas(app, &cont)
+        return cont.call unless app.data.is_a?(Hash)
+
+        subs = triggered_dependencies(app)
+        return cont.call if subs.empty?
+
+        dependency_branch(app, subs, 0, cont)
+      end
+
+      # @param app [Application]
+      # @return [Array<Array(String, Object)>] the trigger and schema of every
+      #   dependency the instance turns on, in document order
+      def triggered_dependencies(app)
+        subs = []
+        %w[dependentSchemas dependencies].each do |keyword|
+          map = app.schema[keyword] if keyword_known?(keyword, app.dialect)
+          next unless map.is_a?(Hash)
+
+          map.each do |trigger, sub|
+            subs << [trigger.to_s, sub] if schema_value?(sub) && property_present?(app.data, trigger)
+          end
+        end
+        subs
+      end
+
+      # @param app [Application]
+      # @param subs [Array] the triggered dependencies
+      # @param idx [Integer] the dependency to apply
+      # @param cont [Proc] what follows
+      # @return [Array] a step
+      def dependency_branch(app, subs, idx, cont)
+        return cont.call if idx >= subs.length
+
+        trigger, sub = subs[idx]
+        [:apply, sub, app.ref_depth, false, lambda do |errors|
+          next dependency_branch(app, subs, idx + 1, cont) if errors.empty?
+
+          app.errors << "#{app.path}: does not satisfy the schema required by property " \
+                        "'#{clip(trigger)}' (#{clip(errors.first.to_s)})"
+          dependency_branch(app, subs, idx + 1, cont)
+        end]
       end
 
       # allOf: the first failing branch decides it, and later branches are

--- a/lib/mcp_client/schema_validator/evaluation.rb
+++ b/lib/mcp_client/schema_validator/evaluation.rb
@@ -1,0 +1,307 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module SchemaValidator
+    # Applying schemas to one instance value, without recursing per schema.
+    # Extended into SchemaValidator, so the methods are its own.
+    #
+    # A validation walks two things at once: down the instance, and — at each
+    # value — through the schemas that apply to it. Only the first nests the
+    # data, and only the first is counted by MAX_NODE_DEPTH; the second is a
+    # `$ref` hop or a composition branch applied to the *same* value, bounded
+    # by MAX_REF_DEPTH and the node-visit cap instead.
+    #
+    # A schema composed through a handful of `$defs` mixins applies several
+    # of those per instance level, so if each of them cost a Ruby frame the
+    # stack would grow with the product of the instance depth and the mixin
+    # count — and a conforming result would abort on a transport reader
+    # thread's stack, which is where a tool call is validated. So the
+    # same-instance applications run on an explicit stack here (this
+    # module's `pending` list) rather than on the interpreter's: a step is
+    # requested by returning `[:apply, schema, ref_depth, speculative,
+    # continuation]` and finished by returning `[:done, errors]`, and
+    # {SchemaValidator.validate_node} drives the two until the outermost
+    # application is done. A Ruby frame is then spent only on a step into a
+    # child value ({SchemaValidator.validate_child}), which is exactly what
+    # MAX_NODE_DEPTH bounds.
+    module Evaluation
+      # One (sub)schema being applied to one value: the instance and the
+      # context are fixed for a whole trampoline (the same value throughout),
+      # the rest is what this application accumulates.
+      # @!attribute errors
+      #   @return [Array<String>] this node's own errors so far
+      # @!attribute counted_before
+      #   @return [Integer] ctx.errors when the application began, so only
+      #     this node's own errors are charged to MAX_ERRORS
+      Application = Struct.new(:data, :path, :ctx, :schema, :dialect, :ref_depth, :errors, :counted_before,
+                               keyword_init: true)
+
+      # The composition keywords, in the order they are applied. Each step
+      # takes the application and a continuation, and returns a step.
+      COMPOSITION_STEPS = %i[compose_all_of compose_any_of compose_one_of compose_not compose_conditional].freeze
+
+      # Begin applying one (sub)schema to the value, under the bound on the
+      # walk itself: one more node visited.
+      # @param data [Object] the value
+      # @param schema [Object] a subschema (Hash or boolean)
+      # @param path [String] location for error messages
+      # @param ctx [Context] the validation context
+      # @param ref_depth [Integer] $ref hops taken to reach this schema
+      # @return [Array] a step: [:done, errors] or [:apply, ...]
+      # @raise [Aborted] when a bound is hit
+      def start_node(data, schema, path, ctx, ref_depth)
+        count_visit(ctx)
+        return [:done, []] if schema == true
+        return [:done, count_errors(ctx, ["#{path}: schema false accepts no value"])] if schema == false
+        return [:done, []] unless schema.is_a?(Hash)
+
+        app = Application.new(data: data, path: path, ctx: ctx, schema: schema,
+                              dialect: node_dialect(schema, ctx), ref_depth: ref_depth,
+                              errors: [], counted_before: ctx.errors)
+        schema.key?('$ref') ? apply_ref(app) : apply_keywords(app)
+      end
+
+      # Apply the local `$ref` of a schema object. draft-07: "$ref" replaces
+      # the schema it appears in; later drafts apply it alongside the sibling
+      # keywords.
+      # @param app [Application]
+      # @return [Array] a step
+      def apply_ref(app)
+        replaces = app.dialect == DRAFT_07
+        kind, target = ref_target(app)
+        if kind == :errors
+          return [:done, target] if replaces
+
+          app.errors.concat(target)
+          return apply_keywords(app)
+        end
+
+        [:apply, target, app.ref_depth + 1, false, lambda do |errors|
+          next [:done, errors] if replaces
+
+          app.errors.concat(errors)
+          apply_keywords(app)
+        end]
+      end
+
+      # Resolve the reference a schema object carries.
+      # @param app [Application]
+      # @return [Array(Symbol, Object)] [:target, schema] or [:errors, errors]
+      # @raise [Aborted] when the hop budget is exhausted
+      def ref_target(app)
+        ctx = app.ctx
+        ref = app.schema['$ref']
+        return ref_problem(app, "external $ref #{clip(ref.inspect)} is not dereferenced") if unusable_ref?(ref)
+        if app.ref_depth >= MAX_REF_DEPTH
+          raise Aborted, "$ref chain exceeds #{MAX_REF_DEPTH} hops (cycle?) at #{clip(ref.inspect)}"
+        end
+
+        target = resolve_reference(ctx.root, ref, ctx.dialect, ctx, from: app.schema)
+        return ref_problem(app, "unresolvable local $ref #{clip(ref.inspect)}") if target.equal?(UNRESOLVED)
+        return ref_problem(app, "$ref #{clip(ref.inspect)} does not point at a schema") unless schema_value?(target)
+
+        [:target, target]
+      end
+
+      # @param ref [Object] the `$ref` value
+      # @return [Boolean] whether it is a reference this validator never follows
+      def unusable_ref?(ref)
+        !ref.is_a?(String) || external_ref?(ref)
+      end
+
+      # @param app [Application]
+      # @param message [String] the problem, without the location
+      # @return [Array(Symbol, Array<String>)]
+      def ref_problem(app, message)
+        [:errors, count_errors(app.ctx, ["#{app.path}: #{message}"])]
+      end
+
+      # Apply the assertions this validator evaluates for the value's own
+      # type, then hand over to the composition keywords. A step into a child
+      # value happens here, and is the one place a Ruby frame is spent.
+      # @param app [Application]
+      # @return [Array] a step
+      def apply_keywords(app)
+        data = app.data
+        schema = app.schema
+        errors = app.errors
+        errors.concat(validate_type(data, schema['type'], app.path)) if schema.key?('type')
+        errors.concat(validate_enum(data, schema, app.path))
+        case data
+        when Hash then errors.concat(validate_object(data, schema, app.path, app.ctx))
+        when Array then errors.concat(validate_array(data, schema, app.path, app.ctx, app.dialect))
+        when String then errors.concat(validate_string(data, schema, app.path, app.ctx.deadline))
+        when Numeric then errors.concat(validate_number(data, schema, app.path, app.dialect))
+        end
+        compose(app)
+      end
+
+      # Run the composition keywords in order, each handed the step that
+      # continues with the next.
+      # @param app [Application]
+      # @param index [Integer] the composition keyword to apply
+      # @return [Array] a step
+      def compose(app, index = 0)
+        return finish_node(app) if index >= COMPOSITION_STEPS.length
+
+        send(COMPOSITION_STEPS[index], app) { compose(app, index + 1) }
+      end
+
+      # Finish an application: a keyword the validator does not evaluate
+      # makes this node's verdict partial, so a pass here is not a proof for
+      # not / oneOf / if. A node its supported assertions already rejected is
+      # decided whatever else it holds, and pays for no such measurement.
+      # Errors raised by nested nodes were counted when they were produced;
+      # only this node's own errors are new.
+      # @param app [Application]
+      # @return [Array] a step
+      def finish_node(app)
+        ctx = app.ctx
+        ctx.undecided += 1 if app.errors.empty? && partial_keywords?(app.schema, app.dialect, app.data, ctx.deadline)
+        [:done, count_errors(ctx, app.errors, already_counted: ctx.errors - app.counted_before)]
+      end
+
+      # allOf: the first failing branch decides it, and later branches are
+      # not evaluated (they cannot change the outcome, but could abort it).
+      # @param app [Application]
+      # @return [Array] a step
+      def compose_all_of(app, &cont)
+        subs = app.schema['allOf']
+        return cont.call unless subs.is_a?(Array)
+
+        all_of_branch(app, subs, 0, cont)
+      end
+
+      # @param app [Application]
+      # @param subs [Array] the allOf branches
+      # @param idx [Integer] the branch to evaluate
+      # @param cont [Proc] what follows allOf
+      # @return [Array] a step
+      def all_of_branch(app, subs, idx, cont)
+        return cont.call if idx >= subs.length
+
+        [:apply, subs[idx], app.ref_depth, false, lambda do |errors|
+          next all_of_branch(app, subs, idx + 1, cont) if errors.empty?
+
+          app.errors << "#{app.path}: does not satisfy allOf/#{idx} (#{clip(errors.first.to_s)})"
+          cont.call
+        end]
+      end
+
+      # anyOf is monotonic: a definite pass decides it whatever the other
+      # branches, and only undecided branches leave it undecided.
+      # @param app [Application]
+      # @return [Array] a step
+      def compose_any_of(app, &cont)
+        subs = app.schema['anyOf']
+        return cont.call unless subs.is_a?(Array)
+
+        branch_verdicts(app, subs, stop: ->(vs) { vs.include?(:pass) },
+                                   decided: ->(vs) { vs.all?(:fail) }) do |verdicts|
+          app.errors << "#{app.path}: does not satisfy any schema in anyOf" if verdicts.all?(:fail)
+          cont.call
+        end
+      end
+
+      # oneOf: two definite passes decide it; with an undecided branch and at
+      # most one pass, "exactly one" cannot be told either way.
+      # @param app [Application]
+      # @return [Array] a step
+      def compose_one_of(app, &cont)
+        subs = app.schema['oneOf']
+        return cont.call unless subs.is_a?(Array)
+
+        branch_verdicts(app, subs, stop: ->(vs) { vs.count(:pass) > 1 },
+                                   decided: ->(vs) { vs.none?(:undecided) }) do |verdicts|
+          matches = verdicts.count(:pass)
+          if matches > 1 || (verdicts.none?(:undecided) && matches != 1)
+            app.errors << "#{app.path}: satisfies #{matches} schemas in oneOf, expected exactly one"
+          end
+          cont.call
+        end
+      end
+
+      # @param app [Application]
+      # @return [Array] a step
+      def compose_not(app, &cont)
+        return cont.call unless app.schema.key?('not')
+
+        branch_verdict(app, app.schema['not']) do |verdict|
+          app.errors << "#{app.path}: value satisfies the schema in not" if verdict == :pass
+          cont.call
+        end
+      end
+
+      # if / then / else. An `if` without `then` or `else` asserts nothing
+      # (JSON Schema 2020-12 Section 10.2.2.1) and is not evaluated; an
+      # undecided condition applies neither branch.
+      # @param app [Application]
+      # @return [Array] a step
+      def compose_conditional(app, &cont)
+        schema = app.schema
+        return cont.call unless schema.key?('if') && (schema.key?('then') || schema.key?('else'))
+
+        branch_verdict(app, schema['if']) do |verdict|
+          branch = { pass: 'then', fail: 'else' }[verdict]
+          next cont.call if branch.nil? || !schema.key?(branch)
+
+          [:apply, schema[branch], app.ref_depth, false, lambda do |errors|
+            app.errors.concat(errors)
+            cont.call
+          end]
+        end
+      end
+
+      # The verdicts of a keyword's branches. Evaluation stops as soon as the
+      # branches seen so far settle the composition (`stop`): a branch that
+      # cannot change the outcome is not evaluated, so it cannot abort a
+      # decided validation. Once the composition is decided — early, or after
+      # every branch (`decided`) — the uncertainty count is restored to what
+      # it was before the branches ran.
+      # @param app [Application]
+      # @param subs [Array] the branches
+      # @return [Array] a step
+      def branch_verdicts(app, subs, stop:, decided:, &cont)
+        before = app.ctx.undecided
+        verdicts = []
+        advance = nil
+        advance = lambda do
+          if verdicts.length >= subs.length || stop.call(verdicts)
+            app.ctx.undecided = before if stop.call(verdicts) || decided.call(verdicts)
+            next cont.call(verdicts)
+          end
+
+          branch_verdict(app, subs[verdicts.length]) do |verdict|
+            verdicts << verdict
+            advance.call
+          end
+        end
+        advance.call
+      end
+
+      # The verdict of a branch evaluated speculatively (its errors are a
+      # verdict, not output): :fail when a supported assertion rejected the
+      # value, :pass when every assertion was evaluated and accepted it,
+      # :undecided when it was accepted only as far as the validator could
+      # evaluate. Non-monotonic compositions (not, oneOf, if) never treat
+      # :undecided as a match. A definite verdict leaves no uncertainty
+      # behind: what a failing branch could not evaluate does not matter once
+      # it failed.
+      # @param app [Application]
+      # @param sub [Object] the branch schema
+      # @return [Array] a step
+      def branch_verdict(app, sub, &cont)
+        ctx = app.ctx
+        before = ctx.undecided
+        [:apply, sub, app.ref_depth, true, lambda do |errors|
+          unless errors.empty?
+            ctx.undecided = before
+            next cont.call(:fail)
+          end
+
+          cont.call(ctx.undecided == before ? :pass : :undecided)
+        end]
+      end
+    end
+  end
+end

--- a/lib/mcp_client/schema_validator/evaluation.rb
+++ b/lib/mcp_client/schema_validator/evaluation.rb
@@ -55,11 +55,10 @@ module MCPClient
                              compose_dependent_schemas].freeze
 
       # The keywords that apply another schema to the same instance before
-      # the node's own keywords: `$ref`, and the dynamic references where
-      # they name no dynamic anchor and so are the plain references the
-      # specification says they are (2020-12 Core Section 8.2.3.2, 2019-09
-      # Core Section 8.2.4.2.1). Applied in this order, each alongside the
-      # others (draft-07's `$ref` alone replaces its siblings).
+      # the node's own keywords: `$ref` and the dynamic references (2020-12
+      # Core Section 8.2.3.2, 2019-09 Core Section 8.2.4.2.1). Applied in
+      # this order, each alongside the others (draft-07's `$ref` alone
+      # replaces its siblings).
       REFERENCE_KEYWORDS = %w[$ref $dynamicRef $recursiveRef].freeze
 
       # Begin applying one (sub)schema to the value, under the bound on the
@@ -97,17 +96,14 @@ module MCPClient
         end
       end
 
-      # The reference keywords a node applies as plain references: `$ref`
-      # and each dynamic reference that names no dynamic anchor (one that
-      # does is left unevaluated, see {Composition#partial_keywords?}).
+      # The reference keywords a node applies: `$ref` and the dynamic
+      # references the dialect defines. Where a dynamic reference binds is
+      # {References#dynamic_binding}'s business, and {#ref_target} asks it
+      # once the plain target has resolved.
       # @param app [Application]
       # @return [Array<String>]
       def applied_references(app)
-        REFERENCE_KEYWORDS.select do |keyword|
-          next false unless app.schema.key?(keyword) && keyword_known?(keyword, app.dialect)
-
-          keyword == '$ref' || !dynamic_reference?(app.schema, keyword, app.ctx.root, app.ctx.dialect, app.ctx)
-        end
+        REFERENCE_KEYWORDS.select { |keyword| app.schema.key?(keyword) && keyword_known?(keyword, app.dialect) }
       end
 
       # Apply the references a schema object carries, one after the other,

--- a/lib/mcp_client/schema_validator/evaluation.rb
+++ b/lib/mcp_client/schema_validator/evaluation.rb
@@ -19,11 +19,18 @@ module MCPClient
     # same-instance applications run on an explicit stack here (this
     # module's `pending` list) rather than on the interpreter's: a step is
     # requested by returning `[:apply, schema, ref_depth, speculative,
-    # continuation]` and finished by returning `[:done, errors]`, and
-    # {SchemaValidator.validate_node} drives the two until the outermost
-    # application is done. A Ruby frame is then spent only on a step into a
-    # child value ({SchemaValidator.validate_child}), which is exactly what
-    # MAX_NODE_DEPTH bounds.
+    # continuation, collect]` and finished by returning `[:done, errors,
+    # evaluated]`, and {SchemaValidator.validate_node} drives the two until
+    # the outermost application is done. A Ruby frame is then spent only on
+    # a step into a child value ({SchemaValidator.validate_child}), which is
+    # exactly what MAX_NODE_DEPTH bounds.
+    #
+    # Every application of a schema to an object or an array keeps what it
+    # evaluated of the value (an {Evaluated}): the annotations
+    # `unevaluatedProperties` and `unevaluatedItems` read, collected from the
+    # node's own keywords and from every in-place applicator whose subschema
+    # passed. A subschema hands its own record back with its verdict, and a
+    # failed one hands back nothing.
     module Evaluation
       # One (sub)schema being applied to one value: the instance and the
       # context are fixed for a whole trampoline (the same value throughout),
@@ -33,13 +40,27 @@ module MCPClient
       # @!attribute counted_before
       #   @return [Integer] ctx.errors when the application began, so only
       #     this node's own errors are charged to MAX_ERRORS
+      # @!attribute evaluated
+      #   @return [Evaluated, nil] what was evaluated of an object or array
+      # @!attribute collecting
+      #   @return [Boolean] whether an unevaluated keyword at this node or at
+      #     one applying it to the same value reads the annotations, so every
+      #     branch that passes must be evaluated rather than the first one
       Application = Struct.new(:data, :path, :ctx, :schema, :dialect, :ref_depth, :errors, :counted_before,
-                               keyword_init: true)
+                               :evaluated, :collecting, keyword_init: true)
 
       # The composition keywords, in the order they are applied. Each step
       # takes the application and a continuation, and returns a step.
       COMPOSITION_STEPS = %i[compose_all_of compose_any_of compose_one_of compose_not compose_conditional
                              compose_dependent_schemas].freeze
+
+      # The keywords that apply another schema to the same instance before
+      # the node's own keywords: `$ref`, and the dynamic references where
+      # they name no dynamic anchor and so are the plain references the
+      # specification says they are (2020-12 Core Section 8.2.3.2, 2019-09
+      # Core Section 8.2.4.2.1). Applied in this order, each alongside the
+      # others (draft-07's `$ref` alone replaces its siblings).
+      REFERENCE_KEYWORDS = %w[$ref $dynamicRef $recursiveRef].freeze
 
       # Begin applying one (sub)schema to the value, under the bound on the
       # walk itself: one more node visited.
@@ -48,65 +69,100 @@ module MCPClient
       # @param path [String] location for error messages
       # @param ctx [Context] the validation context
       # @param ref_depth [Integer] $ref hops taken to reach this schema
-      # @return [Array] a step: [:done, errors] or [:apply, ...]
+      # @param collecting [Boolean] whether the annotations this application
+      #   produces are read by an unevaluated keyword above it
+      # @return [Array] a step: [:done, errors, evaluated] or [:apply, ...]
       # @raise [Aborted] when a bound is hit
-      def start_node(data, schema, path, ctx, ref_depth)
+      def start_node(data, schema, path, ctx, ref_depth, collecting: false)
         count_visit(ctx)
-        return [:done, []] if schema == true
-        return [:done, count_errors(ctx, ["#{path}: schema false accepts no value"])] if schema == false
-        return [:done, []] unless schema.is_a?(Hash)
+        return [:done, [], nil] if schema == true
+        return [:done, count_errors(ctx, ["#{path}: schema false accepts no value"]), nil] if schema == false
+        return [:done, [], nil] unless schema.is_a?(Hash)
 
-        app = Application.new(data: data, path: path, ctx: ctx, schema: schema,
-                              dialect: node_dialect(schema, ctx), ref_depth: ref_depth,
-                              errors: [], counted_before: ctx.errors)
-        schema.key?('$ref') ? apply_ref(app) : apply_keywords(app)
+        dialect = node_dialect(schema, ctx)
+        app = Application.new(data: data, path: path, ctx: ctx, schema: schema, dialect: dialect,
+                              ref_depth: ref_depth, errors: [], counted_before: ctx.errors,
+                              evaluated: (Evaluated.new if data.is_a?(Hash) || data.is_a?(Array)),
+                              collecting: collecting || reads_annotations?(schema, dialect))
+        apply_references(app, applied_references(app))
       end
 
-      # Apply the local `$ref` of a schema object. draft-07: "$ref" replaces
-      # the schema it appears in; later drafts apply it alongside the sibling
-      # keywords.
+      # @param schema [Hash]
+      # @param dialect [String, nil]
+      # @return [Boolean] whether the node carries an unevaluated keyword
+      #   that reads the annotations of the schemas applied to its value
+      def reads_annotations?(schema, dialect)
+        %w[unevaluatedProperties unevaluatedItems].any? do |keyword|
+          keyword_known?(keyword, dialect) && schema_value?(schema[keyword])
+        end
+      end
+
+      # The reference keywords a node applies as plain references: `$ref`
+      # and each dynamic reference that names no dynamic anchor (one that
+      # does is left unevaluated, see {Composition#partial_keywords?}).
       # @param app [Application]
+      # @return [Array<String>]
+      def applied_references(app)
+        REFERENCE_KEYWORDS.select do |keyword|
+          next false unless app.schema.key?(keyword) && keyword_known?(keyword, app.dialect)
+
+          keyword == '$ref' || !dynamic_reference?(app.schema, keyword, app.ctx.root, app.ctx.dialect, app.ctx)
+        end
+      end
+
+      # Apply the references a schema object carries, one after the other,
+      # then its own keywords. draft-07: "$ref" replaces the schema it
+      # appears in; later drafts apply it alongside the sibling keywords.
+      # @param app [Application]
+      # @param keywords [Array<String>] the references still to apply
       # @return [Array] a step
-      def apply_ref(app)
-        replaces = app.dialect == DRAFT_07
-        kind, target = ref_target(app)
+      def apply_references(app, keywords)
+        return apply_keywords(app) if keywords.empty?
+
+        keyword = keywords.first
+        replaces = keyword == '$ref' && app.dialect == DRAFT_07
+        kind, target = ref_target(app, keyword)
         if kind == :errors
-          return [:done, target] if replaces
+          return [:done, target, app.evaluated] if replaces
 
           app.errors.concat(target)
-          return apply_keywords(app)
+          return apply_references(app, keywords.drop(1))
         end
 
-        [:apply, target, app.ref_depth + 1, false, lambda do |errors|
-          next [:done, errors] if replaces
+        [:apply, target, app.ref_depth + 1, false, lambda do |errors, evaluated|
+          next [:done, errors, evaluated] if replaces
 
           app.errors.concat(errors)
-          apply_keywords(app)
-        end]
+          app.evaluated&.merge!(evaluated) if errors.empty?
+          apply_references(app, keywords.drop(1))
+        end, app.collecting]
       end
 
-      # Resolve the reference a schema object carries.
+      # Resolve a reference a schema object carries.
       # @param app [Application]
+      # @param keyword [String] `$ref`, or a dynamic reference applied as one
       # @return [Array(Symbol, Object)] [:target, schema] or [:errors, errors]
       # @raise [Aborted] when the hop budget is exhausted
-      def ref_target(app)
+      def ref_target(app, keyword = '$ref')
         ctx = app.ctx
-        ref = app.schema['$ref']
+        ref = app.schema[keyword]
         if unusable_ref?(ref, ctx, app.schema)
-          return ref_problem(app, "external $ref #{clip(ref.inspect)} is not dereferenced")
+          return ref_problem(app, "external #{keyword} #{clip(ref.inspect)} is not dereferenced")
         end
         if app.ref_depth >= MAX_REF_DEPTH
-          raise Aborted, "$ref chain exceeds #{MAX_REF_DEPTH} hops (cycle?) at #{clip(ref.inspect)}"
+          raise Aborted, "#{keyword} chain exceeds #{MAX_REF_DEPTH} hops (cycle?) at #{clip(ref.inspect)}"
         end
 
         target = resolve_reference(ctx.root, ref, ctx.dialect, ctx, from: app.schema)
-        return ref_problem(app, "unresolvable local $ref #{clip(ref.inspect)}") if target.equal?(UNRESOLVED)
-        return ref_problem(app, "$ref #{clip(ref.inspect)} does not point at a schema") unless schema_value?(target)
+        return ref_problem(app, "unresolvable local #{keyword} #{clip(ref.inspect)}") if target.equal?(UNRESOLVED)
+        unless schema_value?(target)
+          return ref_problem(app, "#{keyword} #{clip(ref.inspect)} does not point at a schema")
+        end
 
         [:target, target]
       end
 
-      # @param ref [Object] the `$ref` value
+      # @param ref [Object] the reference's value
       # @param ctx [Context] the validation context
       # @param from [Hash] the schema object holding the reference
       # @return [Boolean] whether it is a reference this validator never follows
@@ -139,8 +195,8 @@ module MCPClient
 
         errors.concat(validate_enum(data, schema, app.path))
         case data
-        when Hash then errors.concat(validate_object(data, schema, app.path, app.ctx, app.dialect))
-        when Array then errors.concat(validate_array(data, schema, app.path, app.ctx, app.dialect))
+        when Hash then errors.concat(validate_object(data, schema, app.path, app.ctx, app.dialect, app.evaluated))
+        when Array then errors.concat(validate_array(data, schema, app.path, app.ctx, app.dialect, app.evaluated))
         when String then errors.concat(validate_string(data, schema, app.path, app.ctx.deadline))
         when Numeric then errors.concat(validate_number(data, schema, app.path, app.dialect))
         end
@@ -158,18 +214,37 @@ module MCPClient
         send(COMPOSITION_STEPS[index], app) { compose(app, index + 1) }
       end
 
-      # Finish an application: a keyword the validator does not evaluate
-      # makes this node's verdict partial, so a pass here is not a proof for
-      # not / oneOf / if. A node its supported assertions already rejected is
-      # decided whatever else it holds, and pays for no such measurement.
-      # Errors raised by nested nodes were counted when they were produced;
-      # only this node's own errors are new.
+      # Finish an application. The unevaluated keywords come last: they read
+      # what every other keyword and every passed applicator evaluated of the
+      # value. A keyword the validator does not evaluate makes this node's
+      # verdict partial, so a pass here is not a proof for not / oneOf / if.
+      # A node its supported assertions already rejected is decided whatever
+      # else it holds, and pays for no such measurement. Errors raised by
+      # nested nodes were counted when they were produced; only this node's
+      # own errors are new.
       # @param app [Application]
       # @return [Array] a step
       def finish_node(app)
         ctx = app.ctx
-        ctx.undecided += 1 if app.errors.empty? && partial_keywords?(app.schema, app.dialect, app.data, ctx.deadline)
-        [:done, count_errors(ctx, app.errors, already_counted: ctx.errors - app.counted_before)]
+        apply_unevaluated(app) if app.errors.empty? && app.evaluated
+        ctx.undecided += 1 if app.errors.empty? && partial_keywords?(app.schema, app.dialect, app.data, ctx)
+        [:done, count_errors(ctx, app.errors, already_counted: ctx.errors - app.counted_before), app.evaluated]
+      end
+
+      # `unevaluatedProperties` / `unevaluatedItems` (JSON Schema 2020-12
+      # Core Sections 11.3 and 11.2): the keyword's schema applies to every
+      # member or item nothing applied to this value evaluated, and what it
+      # validated counts as evaluated from then on.
+      # @param app [Application]
+      # @return [void]
+      def apply_unevaluated(app)
+        keyword = app.data.is_a?(Hash) ? 'unevaluatedProperties' : 'unevaluatedItems'
+        sub = app.schema[keyword]
+        return unless keyword_known?(keyword, app.dialect) && schema_value?(sub)
+
+        errors = app.data.is_a?(Hash) ? unevaluated_property_errors(app, sub) : unevaluated_item_errors(app, sub)
+        app.errors.concat(errors)
+        app.evaluated.all!
       end
 
       # The schema half of a dependency: `dependentSchemas` in 2019-09 and
@@ -214,13 +289,15 @@ module MCPClient
         return cont.call if idx >= subs.length
 
         trigger, sub = subs[idx]
-        [:apply, sub, app.ref_depth, false, lambda do |errors|
-          next dependency_branch(app, subs, idx + 1, cont) if errors.empty?
-
-          app.errors << "#{app.path}: does not satisfy the schema required by property " \
-                        "'#{clip(trigger)}' (#{clip(errors.first.to_s)})"
+        [:apply, sub, app.ref_depth, false, lambda do |errors, evaluated|
+          if errors.empty?
+            app.evaluated&.merge!(evaluated)
+          else
+            app.errors << "#{app.path}: does not satisfy the schema required by property " \
+                          "'#{clip(trigger)}' (#{clip(errors.first.to_s)})"
+          end
           dependency_branch(app, subs, idx + 1, cont)
-        end]
+        end, app.collecting]
       end
 
       # allOf: the first failing branch decides it, and later branches are
@@ -242,25 +319,36 @@ module MCPClient
       def all_of_branch(app, subs, idx, cont)
         return cont.call if idx >= subs.length
 
-        [:apply, subs[idx], app.ref_depth, false, lambda do |errors|
-          next all_of_branch(app, subs, idx + 1, cont) if errors.empty?
+        [:apply, subs[idx], app.ref_depth, false, lambda do |errors, evaluated|
+          if errors.empty?
+            app.evaluated&.merge!(evaluated)
+            next all_of_branch(app, subs, idx + 1, cont)
+          end
 
           app.errors << "#{app.path}: does not satisfy allOf/#{idx} (#{clip(errors.first.to_s)})"
           cont.call
-        end]
+        end, app.collecting]
       end
 
       # anyOf is monotonic: a definite pass decides it whatever the other
-      # branches, and only undecided branches leave it undecided.
+      # branches, and only undecided branches leave it undecided. Where an
+      # unevaluated keyword reads the annotations, every branch is evaluated
+      # (each one that passes contributes what it evaluated); otherwise the
+      # first definite pass ends it, so a branch that cannot change the
+      # outcome cannot abort a decided validation.
       # @param app [Application]
       # @return [Array] a step
       def compose_any_of(app, &cont)
         subs = app.schema['anyOf']
         return cont.call unless subs.is_a?(Array)
 
-        branch_verdicts(app, subs, stop: ->(vs) { vs.include?(:pass) },
-                                   decided: ->(vs) { vs.all?(:fail) }) do |verdicts|
-          app.errors << "#{app.path}: does not satisfy any schema in anyOf" if verdicts.all?(:fail)
+        branch_verdicts(app, subs, stop: ->(vs) { !app.collecting && vs.include?(:pass) },
+                                   decided: ->(vs) { vs.all?(:fail) }) do |verdicts, evaluations|
+          if verdicts.all?(:fail)
+            app.errors << "#{app.path}: does not satisfy any schema in anyOf"
+          else
+            merge_passed(app, verdicts, evaluations)
+          end
           cont.call
         end
       end
@@ -274,13 +362,23 @@ module MCPClient
         return cont.call unless subs.is_a?(Array)
 
         branch_verdicts(app, subs, stop: ->(vs) { vs.count(:pass) > 1 },
-                                   decided: ->(vs) { vs.none?(:undecided) }) do |verdicts|
+                                   decided: ->(vs) { vs.none?(:undecided) }) do |verdicts, evaluations|
           matches = verdicts.count(:pass)
           if matches > 1 || (verdicts.none?(:undecided) && matches != 1)
             app.errors << "#{app.path}: satisfies #{matches} schemas in oneOf, expected exactly one"
+          elsif matches == 1
+            merge_passed(app, verdicts, evaluations)
           end
           cont.call
         end
+      end
+
+      # Take over what every passed branch evaluated of the value.
+      # @return [void]
+      def merge_passed(app, verdicts, evaluations)
+        return unless app.evaluated
+
+        verdicts.each_with_index { |verdict, idx| app.evaluated.merge!(evaluations[idx]) if verdict == :pass }
       end
 
       # @param app [Application]
@@ -288,7 +386,7 @@ module MCPClient
       def compose_not(app, &cont)
         return cont.call unless app.schema.key?('not')
 
-        branch_verdict(app, app.schema['not']) do |verdict|
+        branch_verdict(app, app.schema['not']) do |verdict, _evaluated|
           app.errors << "#{app.path}: value satisfies the schema in not" if verdict == :pass
           cont.call
         end
@@ -297,22 +395,26 @@ module MCPClient
       # if / then / else. An `if` without `then` or `else` asserts nothing
       # (JSON Schema 2020-12 Section 10.2.2.1) and is not evaluated; an
       # undecided condition applies neither branch, but may still be settled
-      # by the branches agreeing ({#unconditional_conditional}).
+      # by the branches agreeing ({#unconditional_conditional}). A condition
+      # that passed evaluated the value, and so does the branch applied.
       # @param app [Application]
       # @return [Array] a step
       def compose_conditional(app, &cont)
         schema = app.schema
         return cont.call unless schema.key?('if') && (schema.key?('then') || schema.key?('else'))
 
-        branch_verdict(app, schema['if']) do |verdict|
+        branch_verdict(app, schema['if']) do |verdict, evaluated|
           branch = { pass: 'then', fail: 'else' }[verdict]
           next unconditional_conditional(app, cont) if branch.nil?
+
+          app.evaluated&.merge!(evaluated) if verdict == :pass
           next cont.call unless schema.key?(branch)
 
-          [:apply, schema[branch], app.ref_depth, false, lambda do |errors|
+          [:apply, schema[branch], app.ref_depth, false, lambda do |errors, branch_evaluated|
             app.errors.concat(errors)
+            app.evaluated&.merge!(branch_evaluated) if errors.empty?
             cont.call
-          end]
+          end, app.collecting]
         end
       end
 
@@ -332,17 +434,17 @@ module MCPClient
         return cont.call unless schema.key?('then') && schema.key?('else')
 
         undecided = app.ctx.undecided
-        [:apply, schema['then'], app.ref_depth, true, lambda do |then_errors|
+        [:apply, schema['then'], app.ref_depth, true, lambda do |then_errors, _evaluated|
           next resume_conditional(app, undecided, cont) if then_errors.empty?
 
-          [:apply, schema['else'], app.ref_depth, true, lambda do |else_errors|
+          [:apply, schema['else'], app.ref_depth, true, lambda do |else_errors, _else_evaluated|
             unless else_errors.empty?
               app.errors << "#{app.path}: fails both then and else of an if this validator cannot decide " \
                             "(#{clip(then_errors.first.to_s)})"
             end
             resume_conditional(app, undecided, cont)
-          end]
-        end]
+          end, app.collecting]
+        end, app.collecting]
       end
 
       # Resume after measuring the branches: what they could not evaluate is
@@ -353,27 +455,30 @@ module MCPClient
         cont.call
       end
 
-      # The verdicts of a keyword's branches. Evaluation stops as soon as the
-      # branches seen so far settle the composition (`stop`): a branch that
-      # cannot change the outcome is not evaluated, so it cannot abort a
-      # decided validation. Once the composition is decided — early, or after
-      # every branch (`decided`) — the uncertainty count is restored to what
-      # it was before the branches ran.
+      # The verdicts of a keyword's branches, and what each branch evaluated.
+      # Evaluation stops as soon as the branches seen so far settle the
+      # composition (`stop`): a branch that cannot change the outcome is not
+      # evaluated, so it cannot abort a decided validation. Once the
+      # composition is decided — early, or after every branch (`decided`) —
+      # the uncertainty count is restored to what it was before the branches
+      # ran.
       # @param app [Application]
       # @param subs [Array] the branches
       # @return [Array] a step
       def branch_verdicts(app, subs, stop:, decided:, &cont)
         before = app.ctx.undecided
         verdicts = []
+        evaluations = []
         advance = nil
         advance = lambda do
           if verdicts.length >= subs.length || stop.call(verdicts)
             app.ctx.undecided = before if stop.call(verdicts) || decided.call(verdicts)
-            next cont.call(verdicts)
+            next cont.call(verdicts, evaluations)
           end
 
-          branch_verdict(app, subs[verdicts.length]) do |verdict|
+          branch_verdict(app, subs[verdicts.length]) do |verdict, evaluated|
             verdicts << verdict
+            evaluations << evaluated
             advance.call
           end
         end
@@ -387,21 +492,22 @@ module MCPClient
       # evaluate. Non-monotonic compositions (not, oneOf, if) never treat
       # :undecided as a match. A definite verdict leaves no uncertainty
       # behind: what a failing branch could not evaluate does not matter once
-      # it failed.
+      # it failed. The continuation also receives what the branch evaluated
+      # of the value (nothing, for a failed one).
       # @param app [Application]
       # @param sub [Object] the branch schema
       # @return [Array] a step
       def branch_verdict(app, sub, &cont)
         ctx = app.ctx
         before = ctx.undecided
-        [:apply, sub, app.ref_depth, true, lambda do |errors|
+        [:apply, sub, app.ref_depth, true, lambda do |errors, evaluated|
           unless errors.empty?
             ctx.undecided = before
-            next cont.call(:fail)
+            next cont.call(:fail, nil)
           end
 
-          cont.call(ctx.undecided == before ? :pass : :undecided)
-        end]
+          cont.call(ctx.undecided == before ? :pass : :undecided, evaluated)
+        end, app.collecting]
       end
     end
   end

--- a/lib/mcp_client/schema_validator/evaluation.rb
+++ b/lib/mcp_client/schema_validator/evaluation.rb
@@ -155,6 +155,11 @@ module MCPClient
 
         target = resolve_reference(ctx.root, ref, ctx.dialect, ctx, from: app.schema)
         return ref_problem(app, "unresolvable local #{keyword} #{clip(ref.inspect)}") if target.equal?(UNRESOLVED)
+
+        if keyword != '$ref'
+          kind, bound = dynamic_binding(app.schema, keyword, ctx.root, ctx.dialect, ctx)
+          target = bound if kind == :bound
+        end
         unless schema_value?(target)
           return ref_problem(app, "#{keyword} #{clip(ref.inspect)} does not point at a schema")
         end
@@ -392,16 +397,18 @@ module MCPClient
         end
       end
 
-      # if / then / else. An `if` without `then` or `else` asserts nothing
-      # (JSON Schema 2020-12 Section 10.2.2.1) and is not evaluated; an
-      # undecided condition applies neither branch, but may still be settled
-      # by the branches agreeing ({#unconditional_conditional}). A condition
-      # that passed evaluated the value, and so does the branch applied.
+      # if / then / else. An `if` asserts nothing by itself, but it is
+      # evaluated even without `then` or `else`: the annotations of a
+      # condition that passed are what an `unevaluated*` beside it reads
+      # (JSON Schema 2020-12 Section 10.2.2.1). An undecided condition
+      # applies neither branch, but may still be settled by the branches
+      # agreeing ({#unconditional_conditional}). A condition that passed
+      # evaluated the value, and so does the branch applied.
       # @param app [Application]
       # @return [Array] a step
       def compose_conditional(app, &cont)
         schema = app.schema
-        return cont.call unless schema.key?('if') && (schema.key?('then') || schema.key?('else'))
+        return cont.call unless schema.key?('if')
 
         branch_verdict(app, schema['if']) do |verdict, evaluated|
           branch = { pass: 'then', fail: 'else' }[verdict]

--- a/lib/mcp_client/schema_validator/input_requirements.rb
+++ b/lib/mcp_client/schema_validator/input_requirements.rb
@@ -47,16 +47,27 @@ module MCPClient
       end
 
       # One position's requirements, and what it applies next. Under draft-07
-      # nothing beside a `$ref` is applied (draft-07 Core Section 8.3).
+      # nothing beside a `$ref` is applied (draft-07 Core Section 8.3) — the
+      # draft-07 of the resource the position belongs to, which an embedded
+      # resource declares for itself (2020-12 Core Section 9.3.2), not the
+      # document root's.
       # @return [void]
       def read_requirements(node, root, scan)
         ref = node['$ref']
         queue_referenced(node, ref, root, scan) if ref.is_a?(String)
-        return if scan[:dialect] == DRAFT_07 && node.key?('$ref')
+        return if position_dialect(node, root, scan) == DRAFT_07 && node.key?('$ref')
 
         scan[:required].concat(node['required'].map(&:to_s)) if node['required'].is_a?(Array)
         scan[:properties] = node['properties'].merge(scan[:properties]) if node['properties'].is_a?(Hash)
         scan[:pending].concat(node['allOf'].reverse) if node['allOf'].is_a?(Array)
+      end
+
+      # The dialect in force at a position: the one the anchor index recorded
+      # for its resource, else the root's.
+      # @return [String, nil]
+      def position_dialect(node, root, scan)
+        scan[:anchors] ||= anchor_index(root, scan[:dialect])
+        indexed_dialect(node, scan) || scan[:dialect]
       end
 
       # Queue what a local reference reaches (an external one is never

--- a/lib/mcp_client/schema_validator/input_requirements.rb
+++ b/lib/mcp_client/schema_validator/input_requirements.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module SchemaValidator
+    # What an input schema requires of every instance, read through the
+    # applicators that apply unconditionally: the root, what its `$ref`
+    # chain reaches, and each `allOf` member (each of those recursively).
+    # The tools specification says clients SHOULD follow `$ref` resolution
+    # when validating tool inputs, and SEP-2106 made `$ref` and `allOf` legal
+    # on an inputSchema: a `required` behind them is as required as one at
+    # the root. A branch the instance may or may not satisfy (`anyOf`,
+    # `oneOf`, `if`) decides nothing here and is left to the server, which
+    # MUST validate the arguments anyway. Extended into SchemaValidator, so
+    # the methods are its own.
+    module InputRequirements
+      # @param schema [Object] the input schema (string or symbol keys)
+      # @return [Array(Array<String>, Hash{String => Object})] the required
+      #   property names, and the declared properties by name (a property
+      #   declared nearer the root wins)
+      def input_requirements(schema)
+        root = normalize_schema(schema)
+        return [[], {}] unless root.is_a?(Hash)
+
+        declared = dialect(root)
+        scan = { count: 0, dialect: declared && canonical_dialect(declared), anchors: nil,
+                 walked: {}.compare_by_identity, required: [], properties: {}, pending: [root] }
+        read_requirement_positions(root, scan)
+        [scan[:required].uniq, scan[:properties]]
+      rescue TooLarge
+        # Unusable anyway: the preflight reports it.
+        [[], {}]
+      end
+
+      # Read every queued position, bounded like the preflight walk.
+      # @return [void]
+      def read_requirement_positions(root, scan)
+        until scan[:pending].empty?
+          node = scan[:pending].pop
+          next unless node.is_a?(Hash) && !scan[:walked].key?(node)
+
+          scan[:walked][node] = true
+          scan[:count] += 1
+          return if scan[:count] > MAX_SUBSCHEMAS
+
+          read_requirements(node, root, scan)
+        end
+      end
+
+      # One position's requirements, and what it applies next. Under draft-07
+      # nothing beside a `$ref` is applied (draft-07 Core Section 8.3).
+      # @return [void]
+      def read_requirements(node, root, scan)
+        ref = node['$ref']
+        queue_referenced(node, ref, root, scan) if ref.is_a?(String)
+        return if scan[:dialect] == DRAFT_07 && node.key?('$ref')
+
+        scan[:required].concat(node['required'].map(&:to_s)) if node['required'].is_a?(Array)
+        scan[:properties] = node['properties'].merge(scan[:properties]) if node['properties'].is_a?(Hash)
+        scan[:pending].concat(node['allOf'].reverse) if node['allOf'].is_a?(Array)
+      end
+
+      # Queue what a local reference reaches (an external one is never
+      # dereferenced, and an unresolvable one is the preflight's to report).
+      # @return [void]
+      def queue_referenced(node, ref, root, scan)
+        return if external_ref?(ref, root, scan[:dialect], scan, from: node)
+
+        target = resolve_reference(root, ref, scan[:dialect], scan, from: node)
+        scan[:pending] << target unless target.equal?(UNRESOLVED)
+      end
+    end
+  end
+end

--- a/lib/mcp_client/schema_validator/instances.rb
+++ b/lib/mcp_client/schema_validator/instances.rb
@@ -1,0 +1,319 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module SchemaValidator
+    # The keywords that apply to one instance value's own type: the object
+    # and array vocabularies, and the bookkeeping they need. Extended into
+    # SchemaValidator, so the methods are its own; {Evaluation} calls them
+    # once per schema position and {Composition} reads what they left
+    # undecided.
+    #
+    # Everything here is decided by the instance and this schema object
+    # alone, which is why it can be evaluated at all: `unevaluatedItems` and
+    # `unevaluatedProperties` are decided by annotations produced across a
+    # whole composition and stay out.
+    module Instances
+      # Validate an object against the keywords that apply to it: `required`,
+      # the property-count bounds, the required half of a dependency, the
+      # `properties` schemas, and the schemas that decide the members those do
+      # not name (`patternProperties`, `additionalProperties`, `propertyNames`).
+      # @param data [Hash] the object
+      # @param schema [Hash] string-keyed schema
+      # @param path [String] location for error messages
+      # @return [Array<String>] validation errors
+      def validate_object(data, schema, path, ctx, dialect = ctx.dialect)
+        errors = []
+        Array(schema['required']).each do |raw_name|
+          name = raw_name.to_s
+          errors << "#{path}: missing required property '#{clip(name)}'" unless property_present?(data, name)
+        end
+        errors.concat(validate_property_counts(data, schema, path))
+        errors.concat(validate_dependent_required(data, schema, path, dialect))
+        errors.concat(validate_named_properties(data, schema, path, ctx))
+        errors.concat(validate_other_properties(data, schema, path, ctx, dialect))
+      end
+
+      # minProperties / maxProperties (JSON Schema 2020-12 Validation Sections
+      # 6.5.1-6.5.2).
+      # @return [Array<String>] validation errors
+      def validate_property_counts(data, schema, path)
+        errors = []
+        min = schema['minProperties']
+        max = schema['maxProperties']
+        if min.is_a?(Numeric) && data.size < min
+          errors << "#{path}: object has #{data.size} properties, fewer than minProperties #{min}"
+        end
+        if max.is_a?(Numeric) && data.size > max
+          errors << "#{path}: object has #{data.size} properties, more than maxProperties #{max}"
+        end
+        errors
+      end
+
+      # The required half of a dependency: `dependentRequired` in 2019-09 and
+      # 2020-12, and the property-name arrays of draft-07's `dependencies`
+      # (JSON Schema 2020-12 Validation Section 6.5.4, draft-07 Section 6.5.7).
+      # @return [Array<String>] validation errors
+      def validate_dependent_required(data, schema, path, dialect)
+        errors = []
+        %w[dependentRequired dependencies].each do |keyword|
+          map = schema[keyword] if keyword_known?(keyword, dialect)
+          next unless map.is_a?(Hash)
+
+          map.each do |trigger, dependents|
+            next unless dependents.is_a?(Array) && property_present?(data, trigger)
+
+            dependents.each do |name|
+              next if property_present?(data, name)
+
+              errors << "#{path}: property '#{clip(trigger.to_s)}' requires property '#{clip(name.to_s)}'"
+            end
+          end
+        end
+        errors
+      end
+
+      # The `properties` schemas, applied in the order the schema names them.
+      # @return [Array<String>] validation errors
+      def validate_named_properties(data, schema, path, ctx)
+        properties = schema['properties']
+        return [] unless properties.is_a?(Hash)
+
+        errors = []
+        properties.each do |raw_name, prop_schema|
+          next unless schema_value?(prop_schema)
+
+          name = raw_name.to_s
+          key = data.key?(name) ? name : (name.to_sym if data.key?(name.to_sym))
+          next if key.nil?
+
+          # A property is a smaller instance, so the hops taken to reach this
+          # schema cannot repeat forever below it: the budget counts a chain
+          # of references applied to one value, not how deep the data nests.
+          # The step down is what the depth bound counts.
+          errors.concat(validate_child(data[key], prop_schema, "#{path}/#{name}", ctx))
+        end
+        errors
+      end
+
+      # The property applicators that decide members `properties` does not
+      # name: every name is checked against `propertyNames`, a member whose
+      # name matches a `patternProperties` pattern is validated against each
+      # matching schema, and one left over by both goes to
+      # `additionalProperties` (JSON Schema 2020-12 Core Sections 10.3.2.1-3).
+      # @return [Array<String>] validation errors
+      def validate_other_properties(data, schema, path, ctx, dialect)
+        patterns = schema['patternProperties'] if keyword_known?('patternProperties', dialect)
+        patterns = nil unless patterns.is_a?(Hash)
+        names = schema_value?(schema['propertyNames']) ? schema['propertyNames'] : nil
+        additional = schema['additionalProperties'] if schema_value?(schema['additionalProperties'])
+        return [] if patterns.nil? && names.nil? && additional.nil?
+
+        named = schema['properties'].is_a?(Hash) ? schema['properties'].keys.map(&:to_s) : []
+        data.flat_map do |key, value|
+          property_errors(key.to_s, value, path, ctx,
+                          names: names, patterns: patterns, additional: additional, named: named)
+        end
+      end
+
+      # One member's errors under the property applicators.
+      # @return [Array<String>] validation errors
+      def property_errors(name, value, path, ctx, names:, patterns:, additional:, named:)
+        errors = names.nil? ? [] : property_name_errors(name, names, path, ctx)
+        matched = false
+        patterns&.each do |pattern, sub|
+          next unless schema_value?(sub) && pattern_matches?(pattern.to_s, name, ctx.deadline)
+
+          matched = true
+          errors.concat(validate_child(value, sub, "#{path}/#{name}", ctx))
+        end
+        return errors if matched || named.include?(name) || additional.nil?
+        return errors.push("#{path}: property '#{clip(name)}' is not allowed (additionalProperties is false)") if
+          additional == false
+
+        errors.concat(validate_child(value, additional, "#{path}/#{name}", ctx))
+      end
+
+      # `propertyNames` applies its schema to each property *name* (a string),
+      # so what it rejects is reported as one error about the name rather than
+      # as a type error about a value the instance does not hold there.
+      # @return [Array<String>] validation errors
+      def property_name_errors(name, sub, path, ctx)
+        errors = speculatively(ctx) { validate_child(name, sub, "#{path}/#{name}", ctx) }
+        return [] if errors.empty?
+
+        ["#{path}: property name '#{clip(name)}' does not satisfy propertyNames (#{clip(errors.first.to_s)})"]
+      end
+
+      # Run a block whose errors are a verdict rather than output, so they are
+      # not charged to MAX_ERRORS (only what the caller reports is).
+      # @return [Object] the block's value
+      def speculatively(ctx)
+        ctx.speculative += 1
+        yield
+      ensure
+        ctx.speculative -= 1
+      end
+
+      # Validate an array against items/prefixItems/minItems/maxItems.
+      # 2020-12 puts positional schemas in `prefixItems` and the rest under
+      # `items`; draft-07 and 2019-09 put positional schemas in an `items`
+      # array and send what follows the tuple to `additionalItems`. Both forms
+      # are honoured.
+      # @param data [Array] the array
+      # @param schema [Hash] string-keyed schema
+      # @param path [String] location for error messages
+      # @return [Array<String>] validation errors
+      def validate_array(data, schema, path, ctx, dialect = ctx.dialect)
+        errors = []
+        min_items = schema['minItems']
+        max_items = schema['maxItems']
+        if min_items.is_a?(Numeric) && data.length < min_items
+          errors << "#{path}: expected at least #{min_items} items, got #{data.length}"
+        end
+        if max_items.is_a?(Numeric) && data.length > max_items
+          errors << "#{path}: expected at most #{max_items} items, got #{data.length}"
+        end
+        errors.concat(validate_unique_items(data, schema, path, ctx))
+        errors.concat(validate_items(data, schema, path, ctx, dialect))
+        errors.concat(validate_contains(data, schema, path, ctx, dialect))
+      end
+
+      # The item schemas: the positional ones first, then the schema that
+      # covers what follows them.
+      # @return [Array<String>] validation errors
+      def validate_items(data, schema, path, ctx, dialect)
+        items = schema['items']
+        # 2020-12 puts positional schemas in prefixItems (items must be a
+        # schema); draft-07 and 2019-09 put them in an items array and know no
+        # prefixItems.
+        positional = if dialect == DEFAULT_DIALECT
+                       schema['prefixItems'].is_a?(Array) ? schema['prefixItems'] : []
+                     else
+                       items.is_a?(Array) ? items : []
+                     end
+        # Past a draft-07 / 2019-09 tuple it is `additionalItems` that applies.
+        rest = if items.is_a?(Array)
+                 schema['additionalItems'] if keyword_known?('additionalItems', dialect)
+               else
+                 items
+               end
+        errors = []
+        data.each_with_index do |item, idx|
+          item_schema = idx < positional.length ? positional[idx] : rest
+          next unless schema_value?(item_schema)
+
+          if item_schema == false && idx >= positional.length && items.is_a?(Array)
+            errors << "#{path}: item #{idx} is not allowed (additionalItems is false)"
+            next
+          end
+
+          # An item is a smaller instance: the hop budget starts over and the
+          # depth bound counts the step, so a recursive schema describes data
+          # of any depth up to it (see {.validate_named_properties}).
+          errors.concat(validate_child(item, item_schema, "#{path}/#{idx}", ctx))
+        end
+        errors
+      end
+
+      # uniqueItems (JSON Schema 2020-12 Validation Section 6.4.3). Equality is
+      # JSON's, not Ruby's: 1 and 1.0 are the same number and two objects with
+      # the same members are equal whatever order they were written in, so the
+      # items are compared by a canonical form rather than by identity or by
+      # `eql?`.
+      # @return [Array<String>] validation errors
+      # @raise [Aborted] when a bound is hit
+      def validate_unique_items(data, schema, path, ctx)
+        return [] unless schema['uniqueItems'] == true
+
+        seen = {}
+        data.each_with_index do |item, idx|
+          count_visit(ctx)
+          key = comparable_value(item, 0)
+          first = seen[key]
+          unless first.nil?
+            return ["#{path}: items #{first} and #{idx} are equal, but uniqueItems requires every item to differ"]
+          end
+
+          seen[key] = idx
+        end
+        []
+      end
+
+      # A value in the form JSON equality compares: numbers as exact rationals
+      # (so 1 and 1.0 agree), objects as their members sorted by name and with
+      # either Ruby key form read as the same name.
+      # @param value [Object] the instance value
+      # @param depth [Integer] how far into the value this is
+      # @return [Object] a value that hashes and compares as JSON equality does
+      # @raise [Aborted] when the value nests beyond the bound
+      def comparable_value(value, depth)
+        raise Aborted, "instance nested deeper than #{MAX_NODE_DEPTH}" if depth > MAX_NODE_DEPTH
+
+        case value
+        when Hash then value.map { |k, v| [k.to_s, comparable_value(v, depth + 1)] }.sort_by(&:first)
+        when Array then value.map { |v| comparable_value(v, depth + 1) }
+        when Numeric then exact_number(value)
+        else value
+        end
+      end
+
+      # @return [Object] the number as an exact rational, or as written when
+      #   no rational describes it (an infinity a Ruby caller passed in)
+      def exact_number(value)
+        value.to_r
+      rescue RangeError, NoMethodError
+        value
+      end
+
+      # `contains` (JSON Schema 2020-12 Validation Sections 6.4.4-6.4.5): the
+      # items are matched one by one and counted, and the count must lie
+      # between `minContains` (1 by default) and `maxContains`. An item the
+      # validator could only partly evaluate is neither a match nor a
+      # non-match: it widens the range the count may lie in, and where the
+      # bounds do not settle the keyword either way the node's verdict is
+      # partial, exactly as an unevaluated assertion makes it.
+      # @param data [Array] the instance
+      # @param schema [Hash] string-keyed schema
+      # @param path [String] location for error messages
+      # @param dialect [String, nil] the dialect in force
+      # @return [Array<String>] validation errors
+      def validate_contains(data, schema, path, ctx, dialect)
+        return [] unless keyword_known?('contains', dialect) && schema_value?(schema['contains'])
+
+        min = contains_min(schema, dialect)
+        max = contains_max(schema, dialect)
+        # Bounds that cannot overlap admit no count at all, so the keyword
+        # fails before an item is ever matched against the schema.
+        if max && min > max
+          return ["#{path}: contains requires between #{min} and #{max} matching items, which no count satisfies"]
+        end
+
+        hits, unsure = count_contains_matches(data, schema['contains'], path, ctx)
+        errors = []
+        errors << "#{path}: expected at least #{min} items matching contains, got #{hits}" if hits + unsure < min
+        errors << "#{path}: expected at most #{max} items matching contains, got #{hits}" if max && hits > max
+        ctx.undecided += 1 if errors.empty? && unsure.positive? && (hits < min || (max && hits + unsure > max))
+        errors
+      end
+
+      # Match a `contains` schema against every item. The matches are a
+      # verdict, not output, so they are evaluated speculatively and what they
+      # could not evaluate is not left behind as this node's uncertainty.
+      # @return [Array(Integer, Integer)] the items that matched, and those the
+      #   validator could not decide
+      def count_contains_matches(data, sub, path, ctx)
+        hits = 0
+        unsure = 0
+        data.each_with_index do |item, idx|
+          before = ctx.undecided
+          errors = speculatively(ctx) { validate_child(item, sub, "#{path}/#{idx}", ctx) }
+          if errors.empty?
+            ctx.undecided > before ? unsure += 1 : hits += 1
+          end
+          ctx.undecided = before
+        end
+        [hits, unsure]
+      end
+    end
+  end
+end

--- a/lib/mcp_client/schema_validator/instances.rb
+++ b/lib/mcp_client/schema_validator/instances.rb
@@ -9,9 +9,10 @@ module MCPClient
     # undecided.
     #
     # Everything here is decided by the instance and this schema object
-    # alone, which is why it can be evaluated at all: `unevaluatedItems` and
-    # `unevaluatedProperties` are decided by annotations produced across a
-    # whole composition and stay out.
+    # alone, which is why it can be evaluated at all — `unevaluatedItems` and
+    # `unevaluatedProperties` included, but only at a node that produces
+    # every annotation they read ({Composition#unevaluated_applied?}); where
+    # a composition produces them, they stay out.
     module Instances
       # Validate an object against the keywords that apply to it: `required`,
       # the property-count bounds, the required half of a dependency, the
@@ -31,6 +32,47 @@ module MCPClient
         errors.concat(validate_dependent_required(data, schema, path, dialect))
         errors.concat(validate_named_properties(data, schema, path, ctx))
         errors.concat(validate_other_properties(data, schema, path, ctx, dialect))
+        errors.concat(validate_unevaluated_properties(data, schema, path, ctx, dialect))
+      end
+
+      # `unevaluatedProperties` (JSON Schema 2020-12 Core Section 11.3),
+      # where this node produces every annotation it reads: it then applies
+      # to exactly the members `properties`, `patternProperties` and
+      # `additionalProperties` left over, which is what
+      # {Composition#uncovered_property?} already answers. A node carrying an
+      # in-place applicator is another matter — the annotations come from a
+      # whole composition there — and stays unevaluated (and reported).
+      # @return [Array<String>] validation errors
+      def validate_unevaluated_properties(data, schema, path, ctx, dialect)
+        sub = schema['unevaluatedProperties']
+        return [] unless unevaluated_applied?(schema, 'unevaluatedProperties', dialect)
+        # An `additionalProperties` schema evaluates every member the node did
+        # not name, so nothing is left over (and one that is `false` has
+        # already failed the node).
+        return [] if schema.key?('additionalProperties') && schema_value?(schema['additionalProperties'])
+
+        named = schema['properties'].is_a?(Hash) ? schema['properties'].keys.map(&:to_s) : []
+        patterns = schema['patternProperties'].is_a?(Hash) ? schema['patternProperties'].keys.map(&:to_s) : []
+        data.flat_map do |key, value|
+          check_deadline(ctx)
+          name = key.to_s
+          next [] if named.include?(name) || patterns.any? { |p| pattern_matches?(p, name, ctx.deadline) }
+
+          unevaluated_errors(value, sub, "#{path}/#{name}", ctx,
+                             "#{path}: property '#{clip(name)}' is not allowed (unevaluatedProperties is false)")
+        end
+      end
+
+      # What one member or item left unevaluated costs: the keyword's schema
+      # applied to it, or — where that schema is `false` — one error.
+      # @return [Array<String>] validation errors
+      def unevaluated_errors(value, sub, path, ctx, refusal)
+        if sub == false
+          count_visit(ctx)
+          return [refusal]
+        end
+
+        validate_child(value, sub, path, ctx)
       end
 
       # minProperties / maxProperties (JSON Schema 2020-12 Validation Sections
@@ -110,6 +152,11 @@ module MCPClient
 
         named = schema['properties'].is_a?(Hash) ? schema['properties'].keys.map(&:to_s) : []
         data.flat_map do |key, value|
+          # How wide this sweep is the peer's choice, not the schema's, and a
+          # member the applicators decide without descending into it visits no
+          # node of its own: the deadline is consulted here so a huge object
+          # cannot run the walk past the budget between two nodes it visits.
+          check_deadline(ctx)
           property_errors(key.to_s, value, path, ctx,
                           names: names, patterns: patterns, additional: additional, named: named)
         end
@@ -127,8 +174,13 @@ module MCPClient
           errors.concat(validate_child(value, sub, "#{path}/#{name}", ctx))
         end
         return errors if matched || named.include?(name) || additional.nil?
-        return errors.push("#{path}: property '#{clip(name)}' is not allowed (additionalProperties is false)") if
-          additional == false
+
+        # A rejected member costs an error rather than a descent, so it is
+        # charged here: the count is what stops a peer-sized object.
+        if additional == false
+          count_visit(ctx)
+          return errors.push("#{path}: property '#{clip(name)}' is not allowed (additionalProperties is false)")
+        end
 
         errors.concat(validate_child(value, additional, "#{path}/#{name}", ctx))
       end
@@ -175,7 +227,32 @@ module MCPClient
         end
         errors.concat(validate_unique_items(data, schema, path, ctx))
         errors.concat(validate_items(data, schema, path, ctx, dialect))
+        errors.concat(validate_unevaluated_items(data, schema, path, ctx, dialect))
         errors.concat(validate_contains(data, schema, path, ctx, dialect))
+      end
+
+      # `unevaluatedItems` (JSON Schema 2020-12 Core Section 11.2) at a node
+      # that produces every annotation it reads: the items past the ones the
+      # tuple keywords in force evaluated, which
+      # {Composition#evaluated_item_count} already counts. As with
+      # `unevaluatedProperties`, a node carrying an in-place applicator — or
+      # a `contains`, whose matches annotate the items they matched — keeps
+      # the keyword unevaluated and reported.
+      # @return [Array<String>] validation errors
+      def validate_unevaluated_items(data, schema, path, ctx, dialect)
+        sub = schema['unevaluatedItems']
+        return [] unless unevaluated_applied?(schema, 'unevaluatedItems', dialect)
+
+        covered = evaluated_item_count(schema, dialect)
+        return [] if covered == Float::INFINITY || data.length <= covered
+
+        errors = []
+        (covered...data.length).each do |idx|
+          check_deadline(ctx)
+          errors.concat(unevaluated_errors(data[idx], sub, "#{path}/#{idx}", ctx,
+                                           "#{path}: item #{idx} is not allowed (unevaluatedItems is false)"))
+        end
+        errors
       end
 
       # The item schemas: the positional ones first, then the schema that
@@ -197,12 +274,18 @@ module MCPClient
                else
                  items
                end
+        return [] if positional.empty? && !schema_value?(rest)
+
         errors = []
         data.each_with_index do |item, idx|
+          # As in {.validate_other_properties}: the array's length is the
+          # peer's, and an item the tuple tail rejects visits no node.
+          check_deadline(ctx)
           item_schema = idx < positional.length ? positional[idx] : rest
           next unless schema_value?(item_schema)
 
           if item_schema == false && idx >= positional.length && items.is_a?(Array)
+            count_visit(ctx)
             errors << "#{path}: item #{idx} is not allowed (additionalItems is false)"
             next
           end
@@ -228,7 +311,7 @@ module MCPClient
         seen = {}
         data.each_with_index do |item, idx|
           count_visit(ctx)
-          key = comparable_value(item, 0)
+          key = comparable_value(item, 0, ctx)
           first = seen[key]
           unless first.nil?
             return ["#{path}: items #{first} and #{idx} are equal, but uniqueItems requires every item to differ"]
@@ -242,17 +325,30 @@ module MCPClient
       # A value in the form JSON equality compares: numbers as exact rationals
       # (so 1 and 1.0 agree), objects as their members sorted by name and with
       # either Ruby key form read as the same name.
+      #
+      # The form carries the JSON type, because JSON equality begins with it:
+      # an object is never equal to an array, however their members line up
+      # (JSON Schema 2020-12 Core Section 4.2.2). Encoding both as a bare
+      # Ruby Array made `[{}, []]` and `[{"a": 1}, [["a", 1]]]` read as
+      # duplicates, so :strict rejected a conforming result — and, through
+      # `not`, accepted one the schema rejects.
+      #
+      # Canonicalizing a value walks all of it, and the value came from the
+      # peer, so every node is accounted for like any other the walk visits.
       # @param value [Object] the instance value
       # @param depth [Integer] how far into the value this is
+      # @param ctx [Context] the validation context
       # @return [Object] a value that hashes and compares as JSON equality does
-      # @raise [Aborted] when the value nests beyond the bound
-      def comparable_value(value, depth)
+      # @raise [Aborted] when the value nests beyond the bound, or a budget is hit
+      def comparable_value(value, depth, ctx)
         raise Aborted, "instance nested deeper than #{MAX_NODE_DEPTH}" if depth > MAX_NODE_DEPTH
 
+        count_visit(ctx)
         case value
-        when Hash then value.map { |k, v| [k.to_s, comparable_value(v, depth + 1)] }.sort_by(&:first)
-        when Array then value.map { |v| comparable_value(v, depth + 1) }
-        when Numeric then exact_number(value)
+        when Hash then [:object, value.map { |k, v| [k.to_s, comparable_value(v, depth + 1, ctx)] }.sort_by(&:first)]
+        when Array then [:array, value.map { |v| comparable_value(v, depth + 1, ctx) }]
+        when Numeric then [:number, exact_number(value)]
+        when String then [:string, value]
         else value
         end
       end

--- a/lib/mcp_client/schema_validator/instances.rb
+++ b/lib/mcp_client/schema_validator/instances.rb
@@ -9,10 +9,10 @@ module MCPClient
     # undecided.
     #
     # Everything here is decided by the instance and this schema object
-    # alone, which is why it can be evaluated at all — `unevaluatedItems` and
-    # `unevaluatedProperties` included, but only at a node that produces
-    # every annotation they read ({Composition#unevaluated_applied?}); where
-    # a composition produces them, they stay out.
+    # alone, which is why it can be evaluated at all. What the keywords
+    # evaluate of the value is recorded on the application's {Evaluated} as
+    # they go, and `unevaluatedItems` / `unevaluatedProperties` read that
+    # record once every applicator has run ({Evaluation#apply_unevaluated}).
     module Instances
       # Validate an object against the keywords that apply to it: `required`,
       # the property-count bounds, the required half of a dependency, the
@@ -21,8 +21,10 @@ module MCPClient
       # @param data [Hash] the object
       # @param schema [Hash] string-keyed schema
       # @param path [String] location for error messages
+      # @param evaluated [Evaluated, nil] where the members the keywords
+      #   evaluate are recorded
       # @return [Array<String>] validation errors
-      def validate_object(data, schema, path, ctx, dialect = ctx.dialect)
+      def validate_object(data, schema, path, ctx, dialect = ctx.dialect, evaluated = nil)
         errors = []
         Array(schema['required']).each do |raw_name|
           name = raw_name.to_s
@@ -30,34 +32,27 @@ module MCPClient
         end
         errors.concat(validate_property_counts(data, schema, path))
         errors.concat(validate_dependent_required(data, schema, path, dialect))
-        errors.concat(validate_named_properties(data, schema, path, ctx))
-        errors.concat(validate_other_properties(data, schema, path, ctx, dialect))
-        errors.concat(validate_unevaluated_properties(data, schema, path, ctx, dialect))
+        errors.concat(validate_named_properties(data, schema, path, ctx, evaluated))
+        errors.concat(validate_other_properties(data, schema, path, ctx, dialect, evaluated))
       end
 
-      # `unevaluatedProperties` (JSON Schema 2020-12 Core Section 11.3),
-      # where this node produces every annotation it reads: it then applies
-      # to exactly the members `properties`, `patternProperties` and
-      # `additionalProperties` left over, which is what
-      # {Composition#uncovered_property?} already answers. A node carrying an
-      # in-place applicator is another matter — the annotations come from a
-      # whole composition there — and stays unevaluated (and reported).
+      # `unevaluatedProperties` (JSON Schema 2020-12 Core Section 11.3): the
+      # keyword's schema applies to every member nothing applied to the
+      # value evaluated — not this node's own property keywords, not any
+      # applicator that passed. The members are as many as the peer sent, so
+      # the sweep consults the deadline as it goes.
+      # @param app [Evaluation::Application] the finished application
+      # @param sub [Object] the keyword's schema
       # @return [Array<String>] validation errors
-      def validate_unevaluated_properties(data, schema, path, ctx, dialect)
-        sub = schema['unevaluatedProperties']
-        return [] unless unevaluated_applied?(schema, 'unevaluatedProperties', dialect)
-        # An `additionalProperties` schema evaluates every member the node did
-        # not name, so nothing is left over (and one that is `false` has
-        # already failed the node).
-        return [] if schema.key?('additionalProperties') && schema_value?(schema['additionalProperties'])
-
-        named = schema['properties'].is_a?(Hash) ? schema['properties'].keys.map(&:to_s) : []
-        patterns = schema['patternProperties'].is_a?(Hash) ? schema['patternProperties'].keys.map(&:to_s) : []
+      def unevaluated_property_errors(app, sub)
+        data = app.data
+        ctx = app.ctx
+        path = app.path
         data.flat_map do |key, value|
           check_deadline(ctx)
-          name = key.to_s
-          next [] if named.include?(name) || patterns.any? { |p| pattern_matches?(p, name, ctx.deadline) }
+          next [] if app.evaluated.property?(key)
 
+          name = key.to_s
           unevaluated_errors(value, sub, "#{path}/#{name}", ctx,
                              "#{path}: property '#{clip(name)}' is not allowed (unevaluatedProperties is false)")
         end
@@ -115,8 +110,9 @@ module MCPClient
       end
 
       # The `properties` schemas, applied in the order the schema names them.
+      # Each member the keyword names is evaluated by it (its annotation).
       # @return [Array<String>] validation errors
-      def validate_named_properties(data, schema, path, ctx)
+      def validate_named_properties(data, schema, path, ctx, evaluated = nil)
         properties = schema['properties']
         return [] unless properties.is_a?(Hash)
 
@@ -128,6 +124,7 @@ module MCPClient
           key = data.key?(name) ? name : (name.to_sym if data.key?(name.to_sym))
           next if key.nil?
 
+          evaluated&.name!(name)
           # A property is a smaller instance, so the hops taken to reach this
           # schema cannot repeat forever below it: the budget counts a chain
           # of references applied to one value, not how deep the data nests.
@@ -143,7 +140,7 @@ module MCPClient
       # matching schema, and one left over by both goes to
       # `additionalProperties` (JSON Schema 2020-12 Core Sections 10.3.2.1-3).
       # @return [Array<String>] validation errors
-      def validate_other_properties(data, schema, path, ctx, dialect)
+      def validate_other_properties(data, schema, path, ctx, dialect, evaluated = nil)
         patterns = schema['patternProperties'] if keyword_known?('patternProperties', dialect)
         patterns = nil unless patterns.is_a?(Hash)
         names = schema_value?(schema['propertyNames']) ? schema['propertyNames'] : nil
@@ -157,20 +154,24 @@ module MCPClient
           # node of its own: the deadline is consulted here so a huge object
           # cannot run the walk past the budget between two nodes it visits.
           check_deadline(ctx)
-          property_errors(key.to_s, value, path, ctx,
+          property_errors(key.to_s, value, path, ctx, evaluated,
                           names: names, patterns: patterns, additional: additional, named: named)
         end
       end
 
-      # One member's errors under the property applicators.
+      # One member's errors under the property applicators. A member a
+      # pattern matched or `additionalProperties` applied to is evaluated by
+      # that keyword (its annotation); `propertyNames` evaluates the name,
+      # never the member.
       # @return [Array<String>] validation errors
-      def property_errors(name, value, path, ctx, names:, patterns:, additional:, named:)
+      def property_errors(name, value, path, ctx, evaluated, names:, patterns:, additional:, named:)
         errors = names.nil? ? [] : property_name_errors(name, names, path, ctx)
         matched = false
         patterns&.each do |pattern, sub|
           next unless schema_value?(sub) && pattern_matches?(pattern.to_s, name, ctx.deadline)
 
           matched = true
+          evaluated&.name!(name)
           errors.concat(validate_child(value, sub, "#{path}/#{name}", ctx))
         end
         return errors if matched || named.include?(name) || additional.nil?
@@ -182,6 +183,7 @@ module MCPClient
           return errors.push("#{path}: property '#{clip(name)}' is not allowed (additionalProperties is false)")
         end
 
+        evaluated&.name!(name)
         errors.concat(validate_child(value, additional, "#{path}/#{name}", ctx))
       end
 
@@ -214,8 +216,10 @@ module MCPClient
       # @param data [Array] the array
       # @param schema [Hash] string-keyed schema
       # @param path [String] location for error messages
+      # @param evaluated [Evaluated, nil] where the items the keywords
+      #   evaluate are recorded
       # @return [Array<String>] validation errors
-      def validate_array(data, schema, path, ctx, dialect = ctx.dialect)
+      def validate_array(data, schema, path, ctx, dialect = ctx.dialect, evaluated = nil)
         errors = []
         min_items = schema['minItems']
         max_items = schema['maxItems']
@@ -226,29 +230,26 @@ module MCPClient
           errors << "#{path}: expected at most #{max_items} items, got #{data.length}"
         end
         errors.concat(validate_unique_items(data, schema, path, ctx))
-        errors.concat(validate_items(data, schema, path, ctx, dialect))
-        errors.concat(validate_unevaluated_items(data, schema, path, ctx, dialect))
-        errors.concat(validate_contains(data, schema, path, ctx, dialect))
+        errors.concat(validate_items(data, schema, path, ctx, dialect, evaluated))
+        errors.concat(validate_contains(data, schema, path, ctx, dialect, evaluated))
       end
 
-      # `unevaluatedItems` (JSON Schema 2020-12 Core Section 11.2) at a node
-      # that produces every annotation it reads: the items past the ones the
-      # tuple keywords in force evaluated, which
-      # {Composition#evaluated_item_count} already counts. As with
-      # `unevaluatedProperties`, a node carrying an in-place applicator — or
-      # a `contains`, whose matches annotate the items they matched — keeps
-      # the keyword unevaluated and reported.
+      # `unevaluatedItems` (JSON Schema 2020-12 Core Section 11.2): the
+      # keyword's schema applies to every item nothing applied to the value
+      # evaluated — not the tuple keywords, not `contains`, not any
+      # applicator that passed.
+      # @param app [Evaluation::Application] the finished application
+      # @param sub [Object] the keyword's schema
       # @return [Array<String>] validation errors
-      def validate_unevaluated_items(data, schema, path, ctx, dialect)
-        sub = schema['unevaluatedItems']
-        return [] unless unevaluated_applied?(schema, 'unevaluatedItems', dialect)
-
-        covered = evaluated_item_count(schema, dialect)
-        return [] if covered == Float::INFINITY || data.length <= covered
-
+      def unevaluated_item_errors(app, sub)
+        data = app.data
+        ctx = app.ctx
+        path = app.path
         errors = []
-        (covered...data.length).each do |idx|
+        data.each_index do |idx|
           check_deadline(ctx)
+          next if app.evaluated.item?(idx)
+
           errors.concat(unevaluated_errors(data[idx], sub, "#{path}/#{idx}", ctx,
                                            "#{path}: item #{idx} is not allowed (unevaluatedItems is false)"))
         end
@@ -256,9 +257,11 @@ module MCPClient
       end
 
       # The item schemas: the positional ones first, then the schema that
-      # covers what follows them.
+      # covers what follows them. The tuple evaluates the leading items it
+      # covers and a schema for the rest evaluates every item (their
+      # annotations).
       # @return [Array<String>] validation errors
-      def validate_items(data, schema, path, ctx, dialect)
+      def validate_items(data, schema, path, ctx, dialect, evaluated = nil)
         items = schema['items']
         # 2020-12 puts positional schemas in prefixItems (items must be a
         # schema); draft-07 and 2019-09 put them in an items array and know no
@@ -276,6 +279,7 @@ module MCPClient
                end
         return [] if positional.empty? && !schema_value?(rest)
 
+        note_evaluated_items(evaluated, positional, rest, data)
         errors = []
         data.each_with_index do |item, idx|
           # As in {.validate_other_properties}: the array's length is the
@@ -296,6 +300,16 @@ module MCPClient
           errors.concat(validate_child(item, item_schema, "#{path}/#{idx}", ctx))
         end
         errors
+      end
+
+      # The tuple evaluates the leading items it covers; a schema for the
+      # rest evaluates every item (their annotations).
+      # @return [void]
+      def note_evaluated_items(evaluated, positional, rest, data)
+        return unless evaluated
+
+        evaluated.prefix!([positional.length, data.length].min)
+        evaluated.all! if schema_value?(rest)
       end
 
       # uniqueItems (JSON Schema 2020-12 Validation Section 6.4.3). Equality is
@@ -372,8 +386,10 @@ module MCPClient
       # @param schema [Hash] string-keyed schema
       # @param path [String] location for error messages
       # @param dialect [String, nil] the dialect in force
+      # @param evaluated [Evaluated, nil] where the items `contains` matched
+      #   are recorded (its annotation, 2020-12 Core Section 10.3.1.3)
       # @return [Array<String>] validation errors
-      def validate_contains(data, schema, path, ctx, dialect)
+      def validate_contains(data, schema, path, ctx, dialect, evaluated = nil)
         return [] unless keyword_known?('contains', dialect) && schema_value?(schema['contains'])
 
         min = contains_min(schema, dialect)
@@ -384,7 +400,7 @@ module MCPClient
           return ["#{path}: contains requires between #{min} and #{max} matching items, which no count satisfies"]
         end
 
-        hits, unsure = count_contains_matches(data, schema['contains'], path, ctx)
+        hits, unsure = count_contains_matches(data, schema['contains'], path, ctx, evaluated)
         errors = []
         errors << "#{path}: expected at least #{min} items matching contains, got #{hits}" if hits + unsure < min
         errors << "#{path}: expected at most #{max} items matching contains, got #{hits}" if max && hits > max
@@ -397,14 +413,17 @@ module MCPClient
       # could not evaluate is not left behind as this node's uncertainty.
       # @return [Array(Integer, Integer)] the items that matched, and those the
       #   validator could not decide
-      def count_contains_matches(data, sub, path, ctx)
+      def count_contains_matches(data, sub, path, ctx, evaluated = nil)
         hits = 0
         unsure = 0
         data.each_with_index do |item, idx|
           before = ctx.undecided
           errors = speculatively(ctx) { validate_child(item, sub, "#{path}/#{idx}", ctx) }
-          if errors.empty?
-            ctx.undecided > before ? unsure += 1 : hits += 1
+          if errors.empty? && ctx.undecided > before
+            unsure += 1
+          elsif errors.empty?
+            hits += 1
+            evaluated&.index!(idx)
           end
           ctx.undecided = before
         end

--- a/lib/mcp_client/schema_validator/instances.rb
+++ b/lib/mcp_client/schema_validator/instances.rb
@@ -400,12 +400,27 @@ module MCPClient
           return ["#{path}: contains requires between #{min} and #{max} matching items, which no count satisfies"]
         end
 
-        hits, unsure = count_contains_matches(data, schema['contains'], path, ctx, evaluated)
+        # 2020-12 Core Section 10.3.1.3 gives `contains` the item annotation
+        # `unevaluatedItems` reads; 2019-09 does not (its Section 9.3.1.3
+        # gives `unevaluatedItems` the annotations of `items` and
+        # `additionalItems` alone), so there a matched item stays unevaluated
+        # and the keyword still has to answer for it.
+        annotating = evaluated if contains_annotates?(dialect)
+        hits, unsure = count_contains_matches(data, schema['contains'], path, ctx, annotating)
         errors = []
         errors << "#{path}: expected at least #{min} items matching contains, got #{hits}" if hits + unsure < min
         errors << "#{path}: expected at most #{max} items matching contains, got #{hits}" if max && hits > max
         ctx.undecided += 1 if errors.empty? && unsure.positive? && (hits < min || (max && hits + unsure > max))
         errors
+      end
+
+      # Whether the dialect gives `contains` the item annotation that
+      # `unevaluatedItems` consumes: 2020-12 does, 2019-09 does not, and
+      # draft-07 has neither keyword.
+      # @param dialect [String, nil] the dialect in force
+      # @return [Boolean]
+      def contains_annotates?(dialect)
+        dialect != DRAFT_2019_09 && dialect != DRAFT_07
       end
 
       # Match a `contains` schema against every item. The matches are a

--- a/lib/mcp_client/schema_validator/keyword_scan.rb
+++ b/lib/mcp_client/schema_validator/keyword_scan.rb
@@ -19,26 +19,42 @@ module MCPClient
         found = []
         root = normalize_schema(schema)
         declared = dialect(root)
-        scan = { count: 0, dialect: declared && canonical_dialect(declared), walked: {}.compare_by_identity,
-                 anchors: nil }
-        collect_unsupported_keywords(root, root, found, 0, scan)
+        canonical = declared && canonical_dialect(declared)
+        scan = { count: 0, dialect: canonical, walked: {}.compare_by_identity, anchors: nil,
+                 pending: [[root, 0, canonical]] }
+        scan_positions(root, found, scan)
         found.uniq
       rescue TooLarge
         # Unusable anyway: check_schema reports it.
         found.uniq
       end
 
-      # Recursively collect unsupported keywords from a schema (keywords the
-      # dialect does not define are unknown, not unsupported). What a local
-      # `$ref` applies is scanned too, wherever it lives (a definition bag the
-      # dialect does not walk included); each object is scanned once.
+      # Read every queued position. Like the preflight walk, the scan runs on
+      # a stack of its own rather than on the interpreter's: a shallow
+      # document whose `$ref`s chain through hundreds of schemas is walked in
+      # constant stack space, so scanning one cannot overflow the thread a
+      # transport reads on.
+      # @return [void]
+      def scan_positions(root, found, scan)
+        until scan[:pending].empty?
+          schema, depth, dialect = scan[:pending].pop
+          scan_position(schema, root, found, depth, scan, dialect)
+        end
+      end
+
+      # Collect the unsupported keywords one schema position uses (keywords
+      # the dialect does not define are unknown, not unsupported) and queue
+      # what it leads to. What a local `$ref` applies is scanned too, wherever
+      # it lives (a definition bag the dialect does not walk included); each
+      # object is scanned once.
       # @param schema [Object] a (sub)schema; non-Hash values are ignored
       # @param root [Hash] the normalized root schema
       # @param found [Array<String>] accumulator
       # @param scan [Hash] :count of subschemas seen so far, the canonical
-      #   :dialect, the :walked objects and the memoized :anchors index
+      #   :dialect, the :walked objects, the memoized :anchors index and the
+      #   :pending positions
       # @return [void]
-      def collect_unsupported_keywords(schema, root, found, depth, scan, dialect = scan[:dialect])
+      def scan_position(schema, root, found, depth, scan, dialect = scan[:dialect])
         return unless schema.is_a?(Hash) && depth <= MAX_SCHEMA_DEPTH
         return if scan[:walked].key?(schema)
 
@@ -48,30 +64,36 @@ module MCPClient
 
         # An embedded resource declaring its own $schema is scanned under it.
         dialect = embedded_dialect(schema, dialect) || dialect
-        collect_referenced_keywords(schema, root, found, depth, scan, dialect) if schema['$ref'].is_a?(String)
+        referenced = referenced_position(schema, root, depth, scan, dialect) if schema['$ref'].is_a?(String)
         if dialect == DRAFT_07 && schema.key?('$ref')
           # Nothing beside the $ref is applied; the definitions stay reachable.
-          each_definition(schema, dialect) do |sub|
-            collect_unsupported_keywords(sub, root, found, depth + 1, scan, dialect)
-          end
-          return
+          return queue_scan(scan, schema, depth, dialect, referenced, :each_definition)
         end
 
         found.concat((schema.keys & UNSUPPORTED_KEYWORDS).select { |k| keyword_known?(k, dialect) })
-        each_subschema(schema, dialect) do |sub|
-          collect_unsupported_keywords(sub, root, found, depth + 1, scan, dialect)
-        end
+        queue_scan(scan, schema, depth, dialect, referenced, :each_subschema)
       end
 
-      # Scan what a local `$ref` applies (unresolvable or external references
-      # are the preflight's business).
+      # Queue the positions under a schema object (in document order, the
+      # stack being read from its end), then what its reference reaches.
+      # @param walker [Symbol] :each_subschema or :each_definition
       # @return [void]
-      def collect_referenced_keywords(schema, root, found, depth, scan, dialect)
+      def queue_scan(scan, schema, depth, dialect, referenced, walker)
+        positions = []
+        send(walker, schema, dialect) { |sub| positions << [sub, depth + 1, dialect] }
+        scan[:pending].concat(positions.reverse)
+        scan[:pending] << referenced if referenced
+      end
+
+      # The position what a local `$ref` applies is scanned at (unresolvable
+      # or external references are the preflight's business).
+      # @return [Array, nil]
+      def referenced_position(schema, root, depth, scan, dialect)
         ref = schema['$ref']
-        return if external_ref?(ref)
+        return nil if external_ref?(ref, root, scan[:dialect], scan, from: schema)
 
         target = resolve_reference(root, ref, scan[:dialect], scan, from: schema)
-        return if target.equal?(UNRESOLVED)
+        return nil if target.equal?(UNRESOLVED)
 
         # What a reference reaches is scanned under its own resource's dialect
         # and at its own lexical depth, so member order and reference fan-out
@@ -86,8 +108,7 @@ module MCPClient
                        else
                          lexical || position || (depth + 1)
                        end
-        collect_unsupported_keywords(target, root, found, target_depth, scan,
-                                     (target.is_a?(Hash) && indexed_dialect(target, scan)) || dialect)
+        [target, target_depth, (target.is_a?(Hash) && indexed_dialect(target, scan)) || dialect]
       end
     end
   end

--- a/lib/mcp_client/schema_validator/keyword_scan.rb
+++ b/lib/mcp_client/schema_validator/keyword_scan.rb
@@ -75,9 +75,11 @@ module MCPClient
 
         # What a reference reaches is scanned under its own resource's dialect
         # and at its own lexical depth, so member order and reference fan-out
-        # cannot hide its keywords.
+        # cannot hide its keywords. A target that is not a schema object has
+        # no lexical depth at all — nil, never `false`, so the depth the
+        # opaque-pointer branch compares stays a number.
         scan[:depths] ||= lexical_depths(root, scan[:dialect])
-        lexical = target.is_a?(Hash) && scan[:depths][target]
+        lexical = scan[:depths][target] if target.is_a?(Hash)
         position, opaque = pointer_position(ref, root, scan[:dialect], scan, schema)
         target_depth = if opaque
                          [position, lexical].compact.max || (depth + 1)

--- a/lib/mcp_client/schema_validator/keyword_scan.rb
+++ b/lib/mcp_client/schema_validator/keyword_scan.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module SchemaValidator
+    # The bounded scan for keywords the validator does not evaluate, so the
+    # client can say when its validation is only partial. Extended into
+    # SchemaValidator, so the methods are its own.
+    module KeywordScan
+      # List the unsupported JSON Schema keywords a schema uses (anywhere: at the
+      # top level or nested in subschemas). Property names that merely look like
+      # keywords (e.g. a property called 'not') are not reported, and
+      # data-carrying keywords (enum/const/default/examples) are not scanned.
+      # The scan stops at the same bounds as {.check_schema} (a schema beyond
+      # them is unusable anyway), so a huge server-supplied schema is never
+      # walked whole.
+      # @param schema [Object] the JSON schema (string or symbol keys)
+      # @return [Array<String>] unique unsupported keywords, in discovery order
+      def unsupported_keywords(schema)
+        found = []
+        root = normalize_schema(schema)
+        declared = dialect(root)
+        scan = { count: 0, dialect: declared && canonical_dialect(declared), walked: {}.compare_by_identity,
+                 anchors: nil }
+        collect_unsupported_keywords(root, root, found, 0, scan)
+        found.uniq
+      rescue TooLarge
+        # Unusable anyway: check_schema reports it.
+        found.uniq
+      end
+
+      # Recursively collect unsupported keywords from a schema (keywords the
+      # dialect does not define are unknown, not unsupported). What a local
+      # `$ref` applies is scanned too, wherever it lives (a definition bag the
+      # dialect does not walk included); each object is scanned once.
+      # @param schema [Object] a (sub)schema; non-Hash values are ignored
+      # @param root [Hash] the normalized root schema
+      # @param found [Array<String>] accumulator
+      # @param scan [Hash] :count of subschemas seen so far, the canonical
+      #   :dialect, the :walked objects and the memoized :anchors index
+      # @return [void]
+      def collect_unsupported_keywords(schema, root, found, depth, scan)
+        return unless schema.is_a?(Hash) && depth <= MAX_SCHEMA_DEPTH
+        return if scan[:walked].key?(schema)
+
+        scan[:walked][schema] = true
+        scan[:count] += 1
+        return if scan[:count] > MAX_SUBSCHEMAS
+
+        dialect = scan[:dialect]
+        collect_referenced_keywords(schema, root, found, depth, scan) if schema['$ref'].is_a?(String)
+        if dialect == DRAFT_07 && schema.key?('$ref')
+          # Nothing beside the $ref is applied; the definitions stay reachable.
+          each_definition(schema, dialect) { |sub| collect_unsupported_keywords(sub, root, found, depth + 1, scan) }
+          return
+        end
+
+        found.concat((schema.keys & UNSUPPORTED_KEYWORDS).select { |k| keyword_known?(k, dialect) })
+        each_subschema(schema, dialect) { |sub| collect_unsupported_keywords(sub, root, found, depth + 1, scan) }
+      end
+
+      # Scan what a local `$ref` applies (unresolvable or external references
+      # are the preflight's business).
+      # @return [void]
+      def collect_referenced_keywords(schema, root, found, depth, scan)
+        ref = schema['$ref']
+        return if external_ref?(ref)
+
+        target = resolve_reference(root, ref, scan[:dialect], scan, from: schema)
+        collect_unsupported_keywords(target, root, found, depth + 1, scan) unless target.equal?(UNRESOLVED)
+      end
+    end
+  end
+end

--- a/lib/mcp_client/schema_validator/keyword_scan.rb
+++ b/lib/mcp_client/schema_validator/keyword_scan.rb
@@ -77,7 +77,13 @@ module MCPClient
         # and at its own lexical depth, so member order and reference fan-out
         # cannot hide its keywords.
         scan[:depths] ||= lexical_depths(root, scan[:dialect])
-        target_depth = (target.is_a?(Hash) && scan[:depths][target]) || (depth + 1)
+        lexical = target.is_a?(Hash) && scan[:depths][target]
+        position, opaque = pointer_position(ref, root, scan[:dialect], scan, schema)
+        target_depth = if opaque
+                         [position, lexical].compact.max || (depth + 1)
+                       else
+                         lexical || position || (depth + 1)
+                       end
         collect_unsupported_keywords(target, root, found, target_depth, scan,
                                      (target.is_a?(Hash) && indexed_dialect(target, scan)) || dialect)
       end

--- a/lib/mcp_client/schema_validator/keyword_scan.rb
+++ b/lib/mcp_client/schema_validator/keyword_scan.rb
@@ -38,7 +38,7 @@ module MCPClient
       # @param scan [Hash] :count of subschemas seen so far, the canonical
       #   :dialect, the :walked objects and the memoized :anchors index
       # @return [void]
-      def collect_unsupported_keywords(schema, root, found, depth, scan)
+      def collect_unsupported_keywords(schema, root, found, depth, scan, dialect = scan[:dialect])
         return unless schema.is_a?(Hash) && depth <= MAX_SCHEMA_DEPTH
         return if scan[:walked].key?(schema)
 
@@ -46,27 +46,36 @@ module MCPClient
         scan[:count] += 1
         return if scan[:count] > MAX_SUBSCHEMAS
 
-        dialect = scan[:dialect]
-        collect_referenced_keywords(schema, root, found, depth, scan) if schema['$ref'].is_a?(String)
+        # An embedded resource declaring its own $schema is scanned under it.
+        dialect = embedded_dialect(schema, dialect) || dialect
+        collect_referenced_keywords(schema, root, found, depth, scan, dialect) if schema['$ref'].is_a?(String)
         if dialect == DRAFT_07 && schema.key?('$ref')
           # Nothing beside the $ref is applied; the definitions stay reachable.
-          each_definition(schema, dialect) { |sub| collect_unsupported_keywords(sub, root, found, depth + 1, scan) }
+          each_definition(schema, dialect) do |sub|
+            collect_unsupported_keywords(sub, root, found, depth + 1, scan, dialect)
+          end
           return
         end
 
         found.concat((schema.keys & UNSUPPORTED_KEYWORDS).select { |k| keyword_known?(k, dialect) })
-        each_subschema(schema, dialect) { |sub| collect_unsupported_keywords(sub, root, found, depth + 1, scan) }
+        each_subschema(schema, dialect) do |sub|
+          collect_unsupported_keywords(sub, root, found, depth + 1, scan, dialect)
+        end
       end
 
       # Scan what a local `$ref` applies (unresolvable or external references
       # are the preflight's business).
       # @return [void]
-      def collect_referenced_keywords(schema, root, found, depth, scan)
+      def collect_referenced_keywords(schema, root, found, depth, scan, dialect)
         ref = schema['$ref']
         return if external_ref?(ref)
 
         target = resolve_reference(root, ref, scan[:dialect], scan, from: schema)
-        collect_unsupported_keywords(target, root, found, depth + 1, scan) unless target.equal?(UNRESOLVED)
+        return if target.equal?(UNRESOLVED)
+
+        # What a reference reaches is scanned under its own resource's dialect.
+        collect_unsupported_keywords(target, root, found, depth + 1, scan,
+                                     (target.is_a?(Hash) && indexed_dialect(target, scan)) || dialect)
       end
     end
   end

--- a/lib/mcp_client/schema_validator/keyword_scan.rb
+++ b/lib/mcp_client/schema_validator/keyword_scan.rb
@@ -73,8 +73,12 @@ module MCPClient
         target = resolve_reference(root, ref, scan[:dialect], scan, from: schema)
         return if target.equal?(UNRESOLVED)
 
-        # What a reference reaches is scanned under its own resource's dialect.
-        collect_unsupported_keywords(target, root, found, depth + 1, scan,
+        # What a reference reaches is scanned under its own resource's dialect
+        # and at its own lexical depth, so member order and reference fan-out
+        # cannot hide its keywords.
+        scan[:depths] ||= lexical_depths(root, scan[:dialect])
+        target_depth = (target.is_a?(Hash) && scan[:depths][target]) || (depth + 1)
+        collect_unsupported_keywords(target, root, found, target_depth, scan,
                                      (target.is_a?(Hash) && indexed_dialect(target, scan)) || dialect)
       end
     end

--- a/lib/mcp_client/schema_validator/keyword_scan.rb
+++ b/lib/mcp_client/schema_validator/keyword_scan.rb
@@ -64,36 +64,43 @@ module MCPClient
 
         # An embedded resource declaring its own $schema is scanned under it.
         dialect = embedded_dialect(schema, dialect) || dialect
-        referenced = referenced_position(schema, root, depth, scan, dialect) if schema['$ref'].is_a?(String)
         if dialect == DRAFT_07 && schema.key?('$ref')
           # Nothing beside the $ref is applied; the definitions stay reachable.
+          referenced = [referenced_position(schema, root, depth, scan, dialect)].compact
           return queue_scan(scan, schema, depth, dialect, referenced, :each_definition)
         end
 
+        # A dynamic reference that names no dynamic anchor is the plain
+        # reference it resolves to: applied, and scanned like one.
+        dynamic, plain = DYNAMIC_REFERENCE_KEYWORDS.select { |k| schema.key?(k) && keyword_known?(k, dialect) }
+                                                   .partition do |k|
+          dynamic_reference?(schema, k, root, scan[:dialect], scan)
+        end
         found.concat((schema.keys & UNSUPPORTED_KEYWORDS).select do |k|
-          # A node that evaluates `unevaluatedItems` / `unevaluatedProperties`
-          # itself leaves no gap to report (see {Composition#unevaluated_applied?}).
-          keyword_known?(k, dialect) && !unevaluated_applied?(schema, k, dialect)
+          keyword_known?(k, dialect) && (!DYNAMIC_REFERENCE_KEYWORDS.include?(k) || dynamic.include?(k))
         end)
+        referenced = (['$ref'] + plain).filter_map { |k| referenced_position(schema, root, depth, scan, dialect, k) }
         queue_scan(scan, schema, depth, dialect, referenced, :each_subschema)
       end
 
       # Queue the positions under a schema object (in document order, the
-      # stack being read from its end), then what its reference reaches.
+      # stack being read from its end), then what its references reach.
       # @param walker [Symbol] :each_subschema or :each_definition
       # @return [void]
       def queue_scan(scan, schema, depth, dialect, referenced, walker)
         positions = []
         send(walker, schema, dialect) { |sub| positions << [sub, depth + 1, dialect] }
         scan[:pending].concat(positions.reverse)
-        scan[:pending] << referenced if referenced
+        scan[:pending].concat(referenced.reverse)
       end
 
-      # The position what a local `$ref` applies is scanned at (unresolvable
-      # or external references are the preflight's business).
+      # The position what a local reference applies is scanned at
+      # (unresolvable or external references are the preflight's business).
+      # @param keyword [String] `$ref`, or a dynamic reference applied as one
       # @return [Array, nil]
-      def referenced_position(schema, root, depth, scan, dialect)
-        ref = schema['$ref']
+      def referenced_position(schema, root, depth, scan, dialect, keyword = '$ref')
+        ref = schema[keyword]
+        return nil unless ref.is_a?(String)
         return nil if external_ref?(ref, root, scan[:dialect], scan, from: schema)
 
         target = resolve_reference(root, ref, scan[:dialect], scan, from: schema)

--- a/lib/mcp_client/schema_validator/keyword_scan.rb
+++ b/lib/mcp_client/schema_validator/keyword_scan.rb
@@ -70,16 +70,11 @@ module MCPClient
           return queue_scan(scan, schema, depth, dialect, referenced, :each_definition)
         end
 
-        # A dynamic reference that names no dynamic anchor is the plain
-        # reference it resolves to: applied, and scanned like one.
-        dynamic, plain = DYNAMIC_REFERENCE_KEYWORDS.select { |k| schema.key?(k) && keyword_known?(k, dialect) }
-                                                   .partition do |k|
-          dynamic_reference?(schema, k, root, scan[:dialect], scan)
-        end
-        found.concat((schema.keys & UNSUPPORTED_KEYWORDS).select do |k|
-          keyword_known?(k, dialect) && (!DYNAMIC_REFERENCE_KEYWORDS.include?(k) || dynamic.include?(k))
-        end)
-        referenced = (['$ref'] + plain).filter_map { |k| referenced_position(schema, root, depth, scan, dialect, k) }
+        # A dynamic reference is applied like a `$ref` — where it binds is
+        # decided during evaluation — so it is scanned like one.
+        dynamic = DYNAMIC_REFERENCE_KEYWORDS.select { |k| schema.key?(k) && keyword_known?(k, dialect) }
+        found.concat((schema.keys & UNSUPPORTED_KEYWORDS).select { |k| keyword_known?(k, dialect) })
+        referenced = (['$ref'] + dynamic).filter_map { |k| referenced_position(schema, root, depth, scan, dialect, k) }
         queue_scan(scan, schema, depth, dialect, referenced, :each_subschema)
       end
 

--- a/lib/mcp_client/schema_validator/keyword_scan.rb
+++ b/lib/mcp_client/schema_validator/keyword_scan.rb
@@ -70,7 +70,11 @@ module MCPClient
           return queue_scan(scan, schema, depth, dialect, referenced, :each_definition)
         end
 
-        found.concat((schema.keys & UNSUPPORTED_KEYWORDS).select { |k| keyword_known?(k, dialect) })
+        found.concat((schema.keys & UNSUPPORTED_KEYWORDS).select do |k|
+          # A node that evaluates `unevaluatedItems` / `unevaluatedProperties`
+          # itself leaves no gap to report (see {Composition#unevaluated_applied?}).
+          keyword_known?(k, dialect) && !unevaluated_applied?(schema, k, dialect)
+        end)
         queue_scan(scan, schema, depth, dialect, referenced, :each_subschema)
       end
 

--- a/lib/mcp_client/schema_validator/normalization.rb
+++ b/lib/mcp_client/schema_validator/normalization.rb
@@ -9,20 +9,22 @@ module MCPClient
       # keyword lookups and JSON pointers see one key form. Data-carrying
       # keywords (enum, const, default, examples) are left exactly as given,
       # the walk stops at the nesting bound, and — given a budget — the copy
-      # stops as soon as the document holds more structural elements (objects
-      # and array members, boolean subschemas included) than
-      # MAX_STRUCTURAL_OBJECTS, before the rest is ever read.
+      # stops as soon as the document holds more structural elements (objects,
+      # their entries and array members, boolean subschemas included) than
+      # MAX_STRUCTURAL_OBJECTS, before the rest is ever read, or as soon as
+      # the validation deadline has passed.
       # @param node [Object]
       # @param depth [Integer]
-      # @param budget [Hash, nil] :objects copied so far
+      # @param budget [Hash, nil] :objects copied so far, :deadline (optional)
       # @return [Object]
       # @raise [TooLarge] when the budget is exceeded
+      # @raise [Aborted] when the deadline passed
       def deep_stringify(node, depth = 0, budget = nil)
         return node if depth > MAX_SCHEMA_DEPTH + 1
 
         case node
         when Hash
-          charge_structure(budget, 1)
+          charge_structure(budget, node.size + 1)
           node.to_h do |key, value|
             name = key.to_s
             [name, DATA_KEYWORDS.include?(name) ? value : deep_stringify(value, depth + 1, budget)]
@@ -36,13 +38,20 @@ module MCPClient
 
       # Account for structural elements about to be copied.
       # @raise [TooLarge] when the budget is exceeded
+      # @raise [Aborted] when the deadline passed
       def charge_structure(budget, count)
         return unless budget
 
         budget[:objects] += count
-        return if budget[:objects] <= MAX_STRUCTURAL_OBJECTS
+        if budget[:objects] > MAX_STRUCTURAL_OBJECTS
+          raise TooLarge,
+                "schema has more than #{MAX_STRUCTURAL_OBJECTS} structural elements"
+        end
 
-        raise TooLarge, "schema has more than #{MAX_STRUCTURAL_OBJECTS} structural elements"
+        deadline = budget[:deadline]
+        return unless deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+        raise Aborted, 'time budget exhausted while reading the schema'
       end
     end
   end

--- a/lib/mcp_client/schema_validator/normalization.rb
+++ b/lib/mcp_client/schema_validator/normalization.rb
@@ -17,10 +17,15 @@ module MCPClient
       # @param depth [Integer]
       # @param budget [Hash, nil] :objects copied so far, :deadline (optional)
       # @return [Object]
-      # @raise [TooLarge] when the budget is exceeded
+      # @raise [TooLarge] when the budget is exceeded, or the document is
+      #   nested beyond what MAX_SCHEMA_DEPTH schema levels can hold (a
+      #   subtree is never kept unread)
       # @raise [Aborted] when the deadline passed
       def deep_stringify(node, depth = 0, budget = nil)
-        return node if depth > MAX_SCHEMA_DEPTH + 1
+        # Each schema level takes at most two document levels (a keyword map
+        # or array, then the subschema), so a deeper document holds more
+        # schema levels than the preflight walk admits.
+        raise TooLarge, "schema nesting depth exceeds #{MAX_SCHEMA_DEPTH}" if depth > (MAX_SCHEMA_DEPTH * 2) + 2
 
         case node
         when Hash

--- a/lib/mcp_client/schema_validator/normalization.rb
+++ b/lib/mcp_client/schema_validator/normalization.rb
@@ -6,22 +6,23 @@ module MCPClient
     # Extended into SchemaValidator, so the methods are its own.
     module Normalization
       # A copy of the schema with every structural Hash key as a String, so
-      # keyword lookups and JSON pointers see one key form. Data-carrying
-      # keywords (enum, const, default, examples) are left exactly as given,
-      # the walk stops at the nesting bound, and — given a budget — the copy
-      # stops as soon as the document holds more structural elements (objects,
-      # their entries and array members, boolean subschemas included) than
-      # MAX_STRUCTURAL_OBJECTS, before the rest is ever read, or as soon as
-      # the validation deadline has passed.
+      # keyword lookups and JSON pointers see one key form. The value of a
+      # data-carrying keyword (enum, const, default, examples) of a schema
+      # object is left exactly as given, the walk stops at the nesting bound,
+      # and — given a budget — the copy stops as soon as the document holds
+      # more structural elements (objects, their entries and array members,
+      # boolean subschemas included) than MAX_STRUCTURAL_OBJECTS, before the
+      # rest is ever read, or as soon as the validation deadline has passed.
       # @param node [Object]
       # @param depth [Integer]
       # @param budget [Hash, nil] :objects copied so far, :deadline (optional)
+      # @param mode [Symbol] how this position is read ({#member_mode})
       # @return [Object]
       # @raise [TooLarge] when the budget is exceeded, or the document is
       #   nested beyond what MAX_SCHEMA_DEPTH schema levels can hold (a
       #   subtree is never kept unread)
       # @raise [Aborted] when the deadline passed
-      def deep_stringify(node, depth = 0, budget = nil)
+      def deep_stringify(node, depth = 0, budget = nil, mode = :schema)
         # Each schema level takes at most two document levels (a keyword map
         # or array, then the subschema), so a deeper document holds more
         # schema levels than the preflight walk admits.
@@ -32,13 +33,53 @@ module MCPClient
           charge_structure(budget, node.size + 1)
           node.to_h do |key, value|
             name = key.to_s
-            [name, DATA_KEYWORDS.include?(name) ? value : deep_stringify(value, depth + 1, budget)]
+            [name, stringify_member(name, value, depth, budget, mode)]
           end
         when Array
           charge_structure(budget, node.length + 1)
-          node.map { |value| deep_stringify(value, depth + 1, budget) }
+          node.map.with_index do |value, idx|
+            deep_stringify(value, depth + 1, budget, member_mode(idx.to_s, value, mode))
+          end
         else node
         end
+      end
+
+      # The copy of one member: what a schema object holds under a data
+      # keyword is kept as given (its key form is the instance's, and it is
+      # compared for equality as written), everything else is copied in the
+      # mode its position implies.
+      # @return [Object]
+      def stringify_member(name, value, depth, budget, mode)
+        member = member_mode(name, value, mode)
+        return value if member == :data
+
+        deep_stringify(value, depth + 1, budget, member)
+      end
+
+      # How the member a name selects is read: :data (a data keyword of a
+      # schema object, kept as given), :list (a map or array of subschemas),
+      # :schema, or :plain (anything else — copied, never read as a schema).
+      # Only a schema object has keywords: a property, definition or pattern
+      # named `enum`, `const`, `default` or `examples` is a schema position
+      # like any other (JSON Schema 2020-12 Core Section 4.3.1), and so is
+      # everything under a keyword no dialect defines.
+      # @return [Symbol]
+      def member_mode(name, value, mode)
+        return :data if mode == :data
+        return :schema if mode == :list
+        return :plain unless mode == :schema
+        return :data if DATA_KEYWORDS.include?(name)
+        return :list if list_member?(name, value)
+
+        SUBSCHEMA_KEYWORDS.include?(name) ? :schema : :plain
+      end
+
+      # @return [Boolean] whether a keyword holds a map or array of
+      #   subschemas in the form it was written (draft-07 / 2019-09 read an
+      #   `items` array positionally)
+      def list_member?(name, value)
+        (SUBSCHEMA_MAP_KEYWORDS.include?(name) && value.is_a?(Hash)) ||
+          ((SUBSCHEMA_ARRAY_KEYWORDS.include?(name) || name == 'items') && value.is_a?(Array))
       end
 
       # Account for structural elements about to be copied.

--- a/lib/mcp_client/schema_validator/normalization.rb
+++ b/lib/mcp_client/schema_validator/normalization.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module SchemaValidator
+    # The bounded, string-keyed copy of a peer-supplied schema document.
+    # Extended into SchemaValidator, so the methods are its own.
+    module Normalization
+      # A copy of the schema with every structural Hash key as a String, so
+      # keyword lookups and JSON pointers see one key form. Data-carrying
+      # keywords (enum, const, default, examples) are left exactly as given,
+      # the walk stops at the nesting bound, and — given a budget — the copy
+      # stops as soon as the document holds more structural elements (objects
+      # and array members, boolean subschemas included) than
+      # MAX_STRUCTURAL_OBJECTS, before the rest is ever read.
+      # @param node [Object]
+      # @param depth [Integer]
+      # @param budget [Hash, nil] :objects copied so far
+      # @return [Object]
+      # @raise [TooLarge] when the budget is exceeded
+      def deep_stringify(node, depth = 0, budget = nil)
+        return node if depth > MAX_SCHEMA_DEPTH + 1
+
+        case node
+        when Hash
+          charge_structure(budget, 1)
+          node.to_h do |key, value|
+            name = key.to_s
+            [name, DATA_KEYWORDS.include?(name) ? value : deep_stringify(value, depth + 1, budget)]
+          end
+        when Array
+          charge_structure(budget, node.length + 1)
+          node.map { |value| deep_stringify(value, depth + 1, budget) }
+        else node
+        end
+      end
+
+      # Account for structural elements about to be copied.
+      # @raise [TooLarge] when the budget is exceeded
+      def charge_structure(budget, count)
+        return unless budget
+
+        budget[:objects] += count
+        return if budget[:objects] <= MAX_STRUCTURAL_OBJECTS
+
+        raise TooLarge, "schema has more than #{MAX_STRUCTURAL_OBJECTS} structural elements"
+      end
+    end
+  end
+end

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -181,6 +181,49 @@ module MCPClient
         names.select { |name| name.is_a?(String) && name.match?(ANCHOR_NAME) }
       end
 
+      # The lexical nesting depth of every schema object reachable from the
+      # root (subschema positions, definition bags of any dialect), so a
+      # referenced target is bounded by where it is written, not by where it
+      # is referenced from: neither member order nor reference fan-out can
+      # change the verdict.
+      # @return [Hash{Hash => Integer}] identity-keyed
+      def lexical_depths(root, dialect)
+        depths = {}.compare_by_identity
+        pending = [[root, 0, dialect]]
+        while (schema, depth, current = pending.shift)
+          next unless schema.is_a?(Hash) && !depths.key?(schema)
+
+          depths[schema] = depth
+          break if depths.size > MAX_SUBSCHEMAS * 2
+
+          # An embedded resource's positions follow its own dialect.
+          current = embedded_dialect(schema, current) || current
+          each_subschema(schema, current) { |sub| pending << [sub, depth + 1, current] }
+          each_foreign_definition(schema, current) { |sub| pending << [sub, depth + 1, current] }
+        end
+        depths
+      end
+
+      # The lexical depth of a value a pointer reference reaches that is not
+      # a schema object (a boolean): one below the nearest enclosing object
+      # whose depth is known, counting each array level in between.
+      # @return [Integer, nil] nil when the position cannot be placed
+      def referenced_position_depth(ref, root, dialect, counter, from)
+        return nil unless ref.start_with?('#/')
+
+        tokens = ref.delete_prefix('#').split('/', -1)[1..]
+        extra = 0
+        while tokens.length > 1
+          tokens = tokens[0...-1]
+          extra += 1
+          parent = resolve_reference(root, "##{tokens.map { |t| "/#{t}" }.join}", dialect, counter, from: from)
+          next unless parent.is_a?(Hash) && (depth = (counter[:depths] || {})[parent])
+
+          return depth + extra
+        end
+        nil
+      end
+
       # Yield the definitions held in the bag the dialect does not define
       # (`definitions` under 2019-09 / 2020-12, `$defs` under draft-07):
       # unknown to the dialect, but pointer-addressable all the same.

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -54,15 +54,26 @@ module MCPClient
       end
 
       # The decoded fragment of a reference (RFC 3986 Section 2.1), or nil
-      # when what the peer wrote does not decode to readable text: escapes
-      # that are not valid UTF-8 name nothing in this document, and reading
-      # them must never raise out of the validation.
+      # when what the peer wrote does not decode to readable text: a
+      # malformed escape ("a%ZZ") and escapes that are not valid UTF-8 name
+      # nothing in this document, and reading them must never raise out of
+      # the validation. The undecoded text is never substituted -- it would
+      # make "#/$defs/a%ZZ" resolve onto a literal "a%ZZ" member and pass a
+      # reference the peer never wrote off as valid.
       # @param ref [String] the `$ref` value
       # @return [String, nil]
       def decoded_fragment(ref)
-        fragment = ref.delete_prefix('#')
-        decoded = URI.decode_uri_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
-        decoded if decoded.valid_encoding?
+        decoded = decode_component(ref.delete_prefix('#'))
+        decoded if decoded&.valid_encoding?
+      end
+
+      # Percent-decode one component.
+      # @param component [String]
+      # @return [String, nil] nil when an escape is malformed ("a%ZZ", "a%")
+      def decode_component(component)
+        URI.decode_uri_component(component)
+      rescue ArgumentError
+        nil
       end
 
       # Resolve a JSON pointer within a schema resource, adopting on the way

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -15,13 +15,42 @@ module MCPClient
     # referencing schema belongs to — never one of an embedded resource, and
     # never one of the enclosing document from inside an embedded resource.
     module References
-      # A reference that does not point inside this document: an absolute URI
-      # (http, https, urn, file, ...), a relative document, or anything that
-      # is not a bare fragment. None of these is ever fetched.
+      # A reference that does not point inside this document, so using it
+      # would need a retrieval that never happens. A bare fragment is always
+      # local; anything else is resolved against the base URI of the
+      # resource holding it (RFC 3986 Section 5.2) and is local when the
+      # document bundles a resource whose `$id` is that URI (JSON Schema
+      # 2020-12 Core Section 9.3.1) -- the empty reference, which names the
+      # base itself, included. Without the document and its index only the
+      # syntactic answer is available, and a reference outside the fragment
+      # space is external.
       # @param ref [String]
+      # @param root [Hash, nil] the normalized root schema
+      # @param dialect [String, nil] the canonical dialect
+      # @param resolver [Hash, Context, nil] holder of the memoized index
+      # @param from [Hash, nil] the schema object holding the reference
       # @return [Boolean]
-      def external_ref?(ref)
-        !ref.start_with?('#')
+      def external_ref?(ref, root = nil, dialect = nil, resolver = nil, from: nil)
+        return false if ref.start_with?('#')
+        return true unless root.is_a?(Hash) && resolver
+
+        index = (resolver[:anchors] ||= anchor_index(root, dialect))
+        return true if from.is_a?(Hash) && !index[:resources].key?(from)
+
+        retarget_reference(index, (from && index[:resources][from]) || root, ref).first.nil?
+      end
+
+      # The bundled resource a reference outside the fragment space names,
+      # with the bare fragment left to resolve inside it.
+      # @param index [Hash] the anchor index
+      # @param resource [Hash] the resource the reference is written in
+      # @param ref [String] the `$ref` value
+      # @return [Array(Hash, String), Array(nil, nil)]
+      def retarget_reference(index, resource, ref)
+        uri, fragment = ref.split('#', 2)
+        base = merge_uri(index[:bases][resource] || '', uri.to_s)
+        target = base && index[:by_base][base]
+        target ? [target, "##{fragment}"] : [nil, nil]
       end
 
       # Resolve a local reference: a JSON pointer fragment, or a plain-name
@@ -42,13 +71,20 @@ module MCPClient
         return UNRESOLVED if from.is_a?(Hash) && !index[:resources].key?(from)
 
         resource = (from && index[:resources][from]) || root
+        # A reference outside the fragment space names a resource by URI:
+        # the document may bundle it, and then the fragment applies there.
+        unless ref.start_with?('#')
+          resource, ref = retarget_reference(index, resource, ref)
+          return UNRESOLVED unless resource
+        end
         raw = ref.delete_prefix('#')
         return resolve_adopted_pointer(resource, ref, index) if raw.empty? || raw.start_with?('/', '%2F', '%2f')
 
         # A plain-name fragment is percent-decoded like a pointer fragment
         # (RFC 3986 Section 2.1): "#foo%2Dbar" names the anchor "foo-bar".
+        # What counts as a name is the target resource's dialect's business.
         fragment = decoded_fragment(ref)
-        return UNRESOLVED unless fragment&.match?(ANCHOR_NAME)
+        return UNRESOLVED unless anchor_name?(fragment, index[:dialects][resource] || dialect)
 
         index[:anchors].fetch(resource, {}).fetch(fragment, UNRESOLVED)
       end
@@ -190,10 +226,28 @@ module MCPClient
       #   :duplicates (names declared more than once within one resource)
       def anchor_index(root, dialect)
         index = { resources: {}.compare_by_identity, anchors: {}.compare_by_identity,
-                  dialects: {}.compare_by_identity, duplicates: [], visited: 0, truncated: false }
+                  dialects: {}.compare_by_identity, bases: {}.compare_by_identity, by_base: {},
+                  duplicates: [], visited: 0, truncated: false }
         index[:dialects][root] = dialect
+        # The document's own base: the root's `$id` where it declares one,
+        # else the empty reference. Relative references resolve against each
+        # other either way, which is what a bundled document needs.
+        register_resource_base(index, root, '', declared: root.is_a?(Hash) && resource_root?(root, dialect))
         index_positions(index, [[root, root, 0, dialect, true]])
         index
+      end
+
+      # Record the base URI a schema resource establishes (RFC 3986 Section
+      # 5.1.1: an `$id` is resolved against the base in force where it is
+      # written), and the resource that base names. The first declaration of
+      # a base wins, as the first declaration of an anchor name does.
+      # @param declared [Boolean] whether the resource declares an `$id`
+      # @return [void]
+      def register_resource_base(index, resource, parent_base, declared: true)
+        id = declared && resource.is_a?(Hash) ? resource['$id'] : nil
+        base = (id.is_a?(String) ? merge_uri(parent_base, id) : parent_base) || parent_base
+        index[:bases][resource] = base
+        index[:by_base][base] ||= resource
       end
 
       # Index every schema position reachable from the pending seeds, within
@@ -214,15 +268,7 @@ module MCPClient
           (index[:truncated] = true) && next if depth > MAX_SCHEMA_DEPTH
 
           index[:visited] += 1
-          if resource_root?(schema, dialect)
-            # A resource is a schema wherever it sits: one reached through
-            # a bag the dialect does not walk names its own anchors, though
-            # nothing outside it can see them.
-            resource = schema
-            dialect = embedded_dialect(schema, dialect) || dialect
-            index[:dialects][resource] = dialect
-            named = true
-          end
+          resource, dialect, named = enter_resource(index, schema, resource, dialect, named)
           index[:resources][schema] = resource
           if named && !(dialect == DRAFT_07 && schema.key?('$ref'))
             record_anchor_names(index, resource, schema,
@@ -234,6 +280,23 @@ module MCPClient
         # Objects left unindexed at the bound would resolve and validate
         # under guesses; the index says so and the schema is unusable.
         index[:truncated] ||= pending.any? { |schema, *| schema.is_a?(Hash) && !index[:resources].key?(schema) }
+      end
+
+      # Enter the schema resource a position starts, if it starts one: a
+      # resource is a schema wherever it sits (one reached through a bag the
+      # dialect does not walk names its own anchors, though nothing outside
+      # it can see them), it may declare its own dialect, and its `$id`
+      # establishes the base its references resolve against.
+      # @return [Array(Hash, String, Boolean)] the resource in force, its
+      #   dialect, and whether the position may declare names
+      def enter_resource(index, schema, resource, dialect, named)
+        return [resource, dialect, named] unless resource_root?(schema, dialect)
+
+        parent_base = index[:bases][resource] || ''
+        dialect = embedded_dialect(schema, dialect) || dialect
+        index[:dialects][schema] = dialect
+        register_resource_base(index, schema, parent_base)
+        [schema, dialect, true]
       end
 
       # Record the plain names a schema object declares for its resource; a
@@ -309,7 +372,7 @@ module MCPClient
                 else
                   %w[$anchor $dynamicAnchor].map { |k| schema[k] if keyword_known?(k, dialect) }
                 end
-        names.select { |name| name.is_a?(String) && name.match?(ANCHOR_NAME) }
+        names.select { |name| anchor_name?(name, dialect) }
       end
 
       # The lexical nesting depth of every schema object reachable from the
@@ -433,8 +496,8 @@ module MCPClient
       end
 
       # Yield the definitions held in the bag the dialect does not define
-      # (`definitions` under 2019-09 / 2020-12, `$defs` under draft-07):
-      # unknown to the dialect, but pointer-addressable all the same.
+      # (`$defs` under draft-07, which predates it): unknown to the dialect,
+      # but pointer-addressable all the same.
       # @return [void]
       def each_foreign_definition(schema, dialect, &block)
         %w[$defs definitions].each do |keyword|

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+module MCPClient
+  module SchemaValidator
+    # Resolution of local `$ref` values: JSON pointer fragments (RFC 6901)
+    # and plain-name fragments naming an anchor. Nothing here ever fetches:
+    # a reference outside the document is reported as external. Extended
+    # into SchemaValidator, so the methods are its own.
+    module References
+      # A reference that does not point inside this document: an absolute URI
+      # (http, https, urn, file, ...), a relative document, or anything that
+      # is not a bare fragment. None of these is ever fetched.
+      # @param ref [String]
+      # @return [Boolean]
+      def external_ref?(ref)
+        !ref.start_with?('#')
+      end
+
+      # Resolve a local reference: a JSON pointer fragment, or a plain-name
+      # fragment naming an anchor.
+      # @param root [Hash] the root schema (string keys)
+      # @param ref [String] the `$ref` value
+      # @param dialect [String, nil] the canonical dialect
+      # @param resolver [Hash, Context] holder of the memoized anchor index
+      # @return [Object] the referenced value, or UNRESOLVED
+      def resolve_reference(root, ref, dialect, resolver)
+        fragment = ref.delete_prefix('#')
+        return resolve_pointer(root, ref) if fragment.empty? || fragment.start_with?('/', '%2F', '%2f')
+        return UNRESOLVED unless fragment.match?(ANCHOR_NAME)
+
+        resolver[:anchors] ||= anchor_index(root, dialect)
+        resolver[:anchors].fetch(fragment, UNRESOLVED)
+      end
+
+      # Every plain-name anchor in the document: `$anchor` (and
+      # `$dynamicAnchor`) in 2019-09 / 2020-12, `$id: "#name"` in draft-07.
+      # The walk is bounded like the preflight walk.
+      # @return [Hash{String => Object}] name => subschema (first occurrence)
+      def anchor_index(root, dialect)
+        anchors = {}
+        pending = [[root, 0]]
+        visited = 0
+        until pending.empty? || visited >= MAX_SUBSCHEMAS
+          schema, depth = pending.shift
+          next unless schema.is_a?(Hash) && depth <= MAX_SCHEMA_DEPTH
+
+          visited += 1
+          anchor_names(schema, dialect).each { |name| anchors[name] ||= schema }
+          each_subschema(schema, dialect) { |sub| pending << [sub, depth + 1] }
+        end
+        anchors
+      end
+
+      # @return [Array<String>] the plain names a schema object declares
+      def anchor_names(schema, dialect)
+        names = if dialect == DRAFT_07
+                  [schema['$id'].is_a?(String) ? schema['$id'].delete_prefix('#') : nil]
+                else
+                  %w[$anchor $dynamicAnchor].map { |k| schema[k] if keyword_known?(k, dialect) }
+                end
+        names.select { |name| name.is_a?(String) && name.match?(ANCHOR_NAME) }
+      end
+
+      # Resolve a fragment JSON pointer (`#`, `#/$defs/x`, `#/a~1b`, with
+      # percent-encoding per RFC 6901 Section 6) within the root document.
+      # @param root [Hash] the root schema (string keys)
+      # @param ref [String] the `$ref` value
+      # @return [Object] the referenced value, or UNRESOLVED
+      def resolve_pointer(root, ref)
+        fragment = ref.delete_prefix('#')
+        fragment = URI.decode_uri_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
+        return root if fragment.empty?
+        return UNRESOLVED unless fragment.start_with?('/')
+
+        fragment[1..].split('/', -1).reduce(root) do |node, token|
+          key = token.gsub('~1', '/').gsub('~0', '~')
+          case node
+          when Hash
+            return UNRESOLVED unless node.key?(key)
+
+            node[key]
+          when Array
+            return UNRESOLVED unless key.match?(/\A(0|[1-9]\d*)\z/) && key.to_i < node.length
+
+            node[key.to_i]
+          else
+            return UNRESOLVED
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -299,9 +299,13 @@ module MCPClient
       def anchor_names(schema, dialect)
         names = if dialect == DRAFT_07
                   # draft-07 Core Section 8.2.3: only an $id that is exactly a
-                  # fragment is a plain-name identifier.
+                  # fragment is a plain-name identifier. An $id is a URI
+                  # reference, so its fragment is percent-decoded (RFC 3986
+                  # Section 2.1) exactly as a $ref's is: `$id: "#foo%2Dbar"`
+                  # declares the name "foo-bar", which is what
+                  # `$ref: "#foo%2Dbar"` — decoded the same way — looks for.
                   id = schema['$id']
-                  [id.is_a?(String) && id.start_with?('#') ? id.delete_prefix('#') : nil]
+                  [id.is_a?(String) && id.start_with?('#') ? decoded_fragment(id) : nil]
                 else
                   %w[$anchor $dynamicAnchor].map { |k| schema[k] if keyword_known?(k, dialect) }
                 end

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -67,8 +67,11 @@ module MCPClient
         return target unless target.is_a?(Hash)
 
         if target.each_key.any? { |key| !key.is_a?(String) }
+          # Copied under the same structural budget as the root document: a
+          # data keyword may not hide an unbounded map behind a pointer.
           copies = (index[:normalized] ||= {}.compare_by_identity)
-          target = copies[target] ||= deep_stringify(target)
+          index[:budget] ||= { objects: 0, deadline: nil }
+          target = copies[target] ||= deep_stringify(target, 0, index[:budget])
         end
         return target if index[:resources].key?(target)
 
@@ -262,7 +265,7 @@ module MCPClient
         node = (from && index[:resources][from]) || root
         depths = counter[:depths] || {}
         walk = { index: index, depths: depths, dialect: index[:dialects][node] || dialect,
-                 depth: depths[node] || 0, mode: :schema, opaque: false }
+                 depth: depths[node] || 0, mode: :schema, opaque: false, visited: true }
         tokens.each do |token|
           child = pointer_child(node, token)
           return nil if child.equal?(UNRESOLVED)
@@ -270,7 +273,7 @@ module MCPClient
           pointer_step(walk, node, token)
           node = child
         end
-        [walk[:depth], walk[:opaque]]
+        [walk[:depth], walk[:opaque], walk[:visited]]
       end
 
       # Advance one pointer token: in schema mode the node's own dialect
@@ -290,6 +293,11 @@ module MCPClient
         end
         walk[:mode] = pointer_step_mode(node, token, walk[:dialect])
         walk[:opaque] ||= walk[:mode] == :opaque
+        # The preflight walk does not descend into an opaque keyword, nor
+        # into anything beside a draft-07 $ref but its definitions.
+        walk[:visited] &&= walk[:mode] != :opaque &&
+                           !(walk[:dialect] == DRAFT_07 && node.is_a?(Hash) && node.key?('$ref') &&
+                             token != 'definitions')
         walk[:depth] += 1 unless %i[map array].include?(walk[:mode])
       end
 

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -57,31 +57,31 @@ module MCPClient
 
       # A schema a pointer reaches outside every indexed position (inside
       # `default`, another data keyword or a vendor member) is still part of
-      # the resource it was reached from: it is indexed on arrival, so a
-      # `$ref` written in it resolves within that resource, and a document
-      # given with symbol keys is normalized there like everywhere else
-      # (data values are kept as given for equality; a target resolved as a
-      # schema gets one string-keyed copy, memoized by identity).
+      # the resource it was reached from: it (and what it holds) is indexed
+      # on arrival, so a `$ref` written anywhere in it resolves within that
+      # resource and its nested schemas follow the dialect it adopts, and
+      # the document it holds is normalized like everywhere else (data
+      # values are kept as given for equality; a target resolved as a schema
+      # gets one string-keyed copy, memoized by identity).
       # @return [Object] the target (or its normalized copy)
       def adopt_reached_target(target, resource, index)
         return target unless target.is_a?(Hash)
-
-        if target.each_key.any? { |key| !key.is_a?(String) }
-          # Copied under the same structural budget as the root document: a
-          # data keyword may not hide an unbounded map behind a pointer.
-          copies = (index[:normalized] ||= {}.compare_by_identity)
-          index[:budget] ||= { objects: 0, deadline: nil }
-          target = copies[target] ||= deep_stringify(target, 0, index[:budget])
-        end
+        # An indexed position was already walked, charged and attributed.
         return target if index[:resources].key?(target)
 
-        inherited = index[:dialects][resource]
-        if resource_root?(target, inherited)
-          index[:resources][target] = target
-          index[:dialects][target] = embedded_dialect(target, inherited) || inherited
-        else
-          index[:resources][target] = resource
-        end
+        # Copied under the same structural budget as the root document,
+        # whatever key form it arrived in (over the wire every key is a
+        # string): a data keyword may not hide an unbounded map behind a
+        # pointer.
+        copies = (index[:normalized] ||= {}.compare_by_identity)
+        index[:budget] ||= { objects: 0, deadline: nil }
+        target = copies[target] ||= deep_stringify(target, 0, index[:budget])
+        return target if index[:resources].key?(target)
+
+        # The adopted target is indexed like any schema position, so its own
+        # `$id` / `$schema` and the positions below it are seen: within the
+        # bounds the index already runs under.
+        index_positions(index, [[target, resource, 0, index[:dialects][resource], true]])
         target
       end
 
@@ -103,12 +103,21 @@ module MCPClient
       #   :duplicates (names declared more than once within one resource)
       def anchor_index(root, dialect)
         index = { resources: {}.compare_by_identity, anchors: {}.compare_by_identity,
-                  dialects: {}.compare_by_identity, duplicates: [] }
+                  dialects: {}.compare_by_identity, duplicates: [], visited: 0, truncated: false }
         index[:dialects][root] = dialect
-        pending = [[root, root, 0, dialect, true]]
-        visited = 0
-        index[:truncated] = false
-        until pending.empty? || visited >= MAX_SUBSCHEMAS
+        index_positions(index, [[root, root, 0, dialect, true]])
+        index
+      end
+
+      # Index every schema position reachable from the pending seeds, within
+      # the visit and depth bounds the whole index runs under (an adopted
+      # pointer target is seeded here too, so it shares them).
+      # @param index [Hash] the index being built
+      # @param pending [Array<Array>] seeds: schema, resource, depth,
+      #   dialect, whether the position may declare names
+      # @return [void]
+      def index_positions(index, pending)
+        until pending.empty? || index[:visited] >= MAX_SUBSCHEMAS
           schema, resource, depth, dialect, named = pending.shift
           next unless schema.is_a?(Hash)
           next if index[:resources].key?(schema)
@@ -117,7 +126,7 @@ module MCPClient
           # would otherwise resolve under guesses.
           (index[:truncated] = true) && next if depth > MAX_SCHEMA_DEPTH
 
-          visited += 1
+          index[:visited] += 1
           if resource_root?(schema, dialect)
             # A resource is a schema wherever it sits: one reached through
             # a bag the dialect does not walk names its own anchors, though
@@ -138,7 +147,6 @@ module MCPClient
         # Objects left unindexed at the bound would resolve and validate
         # under guesses; the index says so and the schema is unusable.
         index[:truncated] ||= pending.any? { |schema, *| schema.is_a?(Hash) && !index[:resources].key?(schema) }
-        index
       end
 
       # Record the plain names a schema object declares for its resource; a

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -63,10 +63,11 @@ module MCPClient
       # apart from its `definitions`.
       # @return [Hash] :resources (schema object => its resource root, by
       #   identity), :anchors (resource root => name => subschema, first
-      #   occurrence, by identity) and :dialects (resource root => dialect)
+      #   occurrence, by identity), :dialects (resource root => dialect) and
+      #   :duplicates (names declared more than once within one resource)
       def anchor_index(root, dialect)
         index = { resources: {}.compare_by_identity, anchors: {}.compare_by_identity,
-                  dialects: {}.compare_by_identity }
+                  dialects: {}.compare_by_identity, duplicates: [] }
         index[:dialects][root] = dialect
         pending = [[root, root, 0, dialect, true]]
         visited = 0
@@ -83,13 +84,25 @@ module MCPClient
           end
           index[:resources][schema] = resource
           if named && !(dialect == DRAFT_07 && schema.key?('$ref'))
-            names = (index[:anchors][resource] ||= {})
-            anchor_names(schema, dialect).each { |name| names[name] ||= schema }
+            record_anchor_names(index, resource, schema,
+                                dialect)
           end
           each_walked_position(schema, dialect) { |sub| pending << [sub, resource, depth + 1, dialect, named] }
           each_foreign_definition(schema, dialect) { |sub| pending << [sub, resource, depth + 1, dialect, false] }
         end
         index
+      end
+
+      # Record the plain names a schema object declares for its resource; a
+      # name already bound to another object of the same resource is a
+      # duplicate (anchor names are unique within a resource).
+      # @return [void]
+      def record_anchor_names(index, resource, schema, dialect)
+        names = (index[:anchors][resource] ||= {})
+        anchor_names(schema, dialect).each do |name|
+          index[:duplicates] << name if names.key?(name) && !names[name].equal?(schema)
+          names[name] ||= schema
+        end
       end
 
       # Yield the schema positions the dialect walks under a schema object:

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -204,24 +204,71 @@ module MCPClient
         depths
       end
 
-      # The lexical depth of a value a pointer reference reaches that is not
-      # a schema object (a boolean): one below the nearest enclosing object
-      # whose depth is known, counting each array level in between.
-      # @return [Integer, nil] nil when the position cannot be placed
+      # The lexical depth of the value a pointer reference reaches, counted
+      # in schema steps along the (percent-decoded) pointer from its resource
+      # root: a keyword holding one subschema is one step, a map or array of
+      # subschemas is one step per member (`#/properties/b` and `#/allOf/0`
+      # are both one below the enclosing schema), and every token under a
+      # data or unknown keyword is a step, so a document hidden inside
+      # `default`, `enum`, `const`, `examples` or a vendor keyword obeys the
+      # same bound as one written in a schema position. A schema object whose
+      # depth the lexical index knows resets the count to that depth.
+      # @return [Integer, nil] nil when the pointer cannot be followed
       def referenced_position_depth(ref, root, dialect, counter, from)
-        return nil unless ref.start_with?('#/')
+        tokens = pointer_tokens(ref)
+        return nil unless tokens
 
-        tokens = ref.delete_prefix('#').split('/', -1)[1..]
-        extra = 0
-        while tokens.length > 1
-          tokens = tokens[0...-1]
-          extra += 1
-          parent = resolve_reference(root, "##{tokens.map { |t| "/#{t}" }.join}", dialect, counter, from: from)
-          next unless parent.is_a?(Hash) && (depth = (counter[:depths] || {})[parent])
+        index = (counter[:anchors] ||= anchor_index(root, dialect))
+        node = (from && index[:resources][from]) || root
+        depths = counter[:depths] || {}
+        depth = depths[node] || 0
+        mode = :schema
+        tokens.each do |token|
+          child = pointer_child(node, token)
+          return nil if child.equal?(UNRESOLVED)
 
-          return depth + extra
+          if mode == :schema
+            depth = depths[node] if node.is_a?(Hash) && depths.key?(node)
+            mode = pointer_step_mode(node, token)
+            depth += 1 unless %i[map array].include?(mode)
+          else
+            depth += 1
+            mode = :schema if %i[map array].include?(mode)
+          end
+          node = child
         end
-        nil
+        depth
+      end
+
+      # The decoded RFC 6901 tokens of a fragment pointer.
+      # @return [Array<String>, nil] nil unless the reference is a pointer
+      def pointer_tokens(ref)
+        fragment = ref.delete_prefix('#')
+        fragment = URI.decode_uri_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
+        return nil unless fragment.start_with?('/')
+
+        fragment[1..].split('/', -1).map { |token| token.gsub('~1', '/').gsub('~0', '~') }
+      end
+
+      # @return [Object] the member a pointer token selects, or UNRESOLVED
+      def pointer_child(node, token)
+        case node
+        when Hash then node.key?(token) ? node[token] : UNRESOLVED
+        when Array then token.match?(/\A(0|[1-9]\d*)\z/) && token.to_i < node.length ? node[token.to_i] : UNRESOLVED
+        else UNRESOLVED
+        end
+      end
+
+      # How a keyword of a schema object holds what its pointer token reaches.
+      # @return [Symbol] :schema (one subschema), :map, :array, or :opaque
+      #   (data or unknown keyword: every token below is a step)
+      def pointer_step_mode(node, token)
+        return :opaque unless node.is_a?(Hash)
+        return :map if SUBSCHEMA_MAP_KEYWORDS.include?(token)
+        return :array if SUBSCHEMA_ARRAY_KEYWORDS.include?(token) || (token == 'items' && node[token].is_a?(Array))
+        return :schema if SUBSCHEMA_KEYWORDS.include?(token)
+
+        :opaque
       end
 
       # Yield the definitions held in the bag the dialect does not define

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -8,6 +8,12 @@ module MCPClient
     # and plain-name fragments naming an anchor. Nothing here ever fetches:
     # a reference outside the document is reported as external. Extended
     # into SchemaValidator, so the methods are its own.
+    #
+    # Plain names are scoped to their schema resource (JSON Schema 2020-12
+    # Core Sections 8.2.1 and 8.2.2): a subschema whose `$id` is a URI
+    # starts a new resource, and `#name` names an anchor of the resource the
+    # referencing schema belongs to — never one of an embedded resource, and
+    # never one of the enclosing document from inside an embedded resource.
     module References
       # A reference that does not point inside this document: an absolute URI
       # (http, https, urn, file, ...), a relative document, or anything that
@@ -19,13 +25,14 @@ module MCPClient
       end
 
       # Resolve a local reference: a JSON pointer fragment, or a plain-name
-      # fragment naming an anchor.
+      # fragment naming an anchor of the referencing schema's resource.
       # @param root [Hash] the root schema (string keys)
       # @param ref [String] the `$ref` value
       # @param dialect [String, nil] the canonical dialect
       # @param resolver [Hash, Context] holder of the memoized anchor index
+      # @param from [Hash, nil] the schema object holding the reference
       # @return [Object] the referenced value, or UNRESOLVED
-      def resolve_reference(root, ref, dialect, resolver)
+      def resolve_reference(root, ref, dialect, resolver, from: nil)
         fragment = ref.delete_prefix('#')
         return resolve_pointer(root, ref) if fragment.empty? || fragment.start_with?('/', '%2F', '%2f')
 
@@ -34,37 +41,79 @@ module MCPClient
         fragment = URI.decode_uri_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
         return UNRESOLVED unless fragment.match?(ANCHOR_NAME)
 
-        resolver[:anchors] ||= anchor_index(root, dialect)
-        resolver[:anchors].fetch(fragment, UNRESOLVED)
+        index = (resolver[:anchors] ||= anchor_index(root, dialect))
+        resource = (from && index[:resources][from]) || root
+        index[:anchors].fetch(resource, {}).fetch(fragment, UNRESOLVED)
       end
 
-      # Every plain-name anchor in the document: `$anchor` (and
-      # `$dynamicAnchor`) in 2019-09 / 2020-12, `$id: "#name"` in draft-07.
-      # The walk is bounded like the preflight walk.
-      # @return [Hash{String => Object}] name => subschema (first occurrence)
+      # Every plain-name anchor in the document, per schema resource:
+      # `$anchor` (and `$dynamicAnchor`) in 2019-09 / 2020-12, `$id: "#name"`
+      # in draft-07. The walk is bounded like the preflight walk. Both
+      # definition bags are walked whatever the dialect: they are reachable
+      # through JSON pointers, and an anchor's resource is lexical.
+      # @return [Hash] :resources (schema object => its resource root, by
+      #   identity) and :anchors (resource root => name => subschema, first
+      #   occurrence, by identity)
       def anchor_index(root, dialect)
-        anchors = {}
-        pending = [[root, 0]]
+        index = { resources: {}.compare_by_identity, anchors: {}.compare_by_identity }
+        pending = [[root, root, 0]]
         visited = 0
         until pending.empty? || visited >= MAX_SUBSCHEMAS
-          schema, depth = pending.shift
+          schema, resource, depth = pending.shift
           next unless schema.is_a?(Hash) && depth <= MAX_SCHEMA_DEPTH
 
           visited += 1
-          anchor_names(schema, dialect).each { |name| anchors[name] ||= schema }
-          each_subschema(schema, dialect) { |sub| pending << [sub, depth + 1] }
+          # draft-07: everything beside a $ref is ignored, identifiers
+          # included; only the definitions bag stays reachable.
+          if dialect == DRAFT_07 && schema.key?('$ref')
+            index[:resources][schema] = resource
+            each_definition(schema, nil) { |sub| pending << [sub, resource, depth + 1] }
+            next
+          end
+
+          resource = schema if resource_start?(schema)
+          index[:resources][schema] = resource
+          names = (index[:anchors][resource] ||= {})
+          anchor_names(schema, dialect).each { |name| names[name] ||= schema }
+          each_subschema(schema, dialect) { |sub| pending << [sub, resource, depth + 1] }
+          each_foreign_definition(schema, dialect) { |sub| pending << [sub, resource, depth + 1] }
         end
-        anchors
+        index
+      end
+
+      # Whether a schema object starts a new schema resource: its `$id` is a
+      # URI rather than a bare fragment (a draft-07 `$id: "#name"` is a
+      # plain-name identifier, not a base).
+      # @param schema [Hash]
+      # @return [Boolean]
+      def resource_start?(schema)
+        id = schema['$id']
+        id.is_a?(String) && !id.empty? && !id.start_with?('#')
       end
 
       # @return [Array<String>] the plain names a schema object declares
       def anchor_names(schema, dialect)
         names = if dialect == DRAFT_07
-                  [schema['$id'].is_a?(String) ? schema['$id'].delete_prefix('#') : nil]
+                  # draft-07 Core Section 8.2.3: only an $id that is exactly a
+                  # fragment is a plain-name identifier.
+                  id = schema['$id']
+                  [id.is_a?(String) && id.start_with?('#') ? id.delete_prefix('#') : nil]
                 else
                   %w[$anchor $dynamicAnchor].map { |k| schema[k] if keyword_known?(k, dialect) }
                 end
         names.select { |name| name.is_a?(String) && name.match?(ANCHOR_NAME) }
+      end
+
+      # Yield the definitions held in the bag the dialect does not define
+      # (`definitions` under 2019-09 / 2020-12, `$defs` under draft-07):
+      # unknown to the dialect, but pointer-addressable all the same.
+      # @return [void]
+      def each_foreign_definition(schema, dialect, &block)
+        %w[$defs definitions].each do |keyword|
+          next if keyword_known?(keyword, dialect)
+
+          schema[keyword].each_value(&block) if schema[keyword].is_a?(Hash)
+        end
       end
 
       # Resolve a fragment JSON pointer (`#`, `#/$defs/x`, `#/a~1b`, with

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -77,7 +77,7 @@ module MCPClient
           next if index[:resources].key?(schema)
 
           visited += 1
-          if resource_start?(schema)
+          if resource_root?(schema, dialect)
             # A resource is a schema wherever it sits: one reached through
             # a bag the dialect does not walk names its own anchors, though
             # nothing outside it can see them.
@@ -94,6 +94,9 @@ module MCPClient
           each_walked_position(schema, dialect) { |sub| pending << [sub, resource, depth + 1, dialect, named] }
           each_foreign_definition(schema, dialect) { |sub| pending << [sub, resource, depth + 1, dialect, false] }
         end
+        # Objects left unindexed at the bound would resolve and validate
+        # under guesses; the index says so and the schema is unusable.
+        index[:truncated] = pending.any? { |schema, *| schema.is_a?(Hash) && !index[:resources].key?(schema) }
         index
       end
 
@@ -144,6 +147,18 @@ module MCPClient
         id.is_a?(String) && !id.empty? && !id.start_with?('#')
       end
 
+      # {#resource_start?} in the dialect in force: under draft-07 a `$ref`
+      # replaces its whole schema object, `$id` and `$schema` included, so
+      # nothing beside it starts a resource.
+      # @param schema [Hash]
+      # @param dialect [String, nil]
+      # @return [Boolean]
+      def resource_root?(schema, dialect)
+        return false if dialect == DRAFT_07 && schema.key?('$ref')
+
+        resource_start?(schema)
+      end
+
       # @return [Array<String>] the plain names a schema object declares
       def anchor_names(schema, dialect)
         names = if dialect == DRAFT_07
@@ -181,6 +196,9 @@ module MCPClient
         return UNRESOLVED unless fragment.start_with?('/')
 
         fragment[1..].split('/', -1).reduce(root) do |node, token|
+          # RFC 6901 Section 3: "~" is only ever followed by "0" or "1".
+          return UNRESOLVED if token.match?(/~(?![01])/)
+
           key = token.gsub('~1', '/').gsub('~0', '~')
           case node
           when Hash

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -51,37 +51,70 @@ module MCPClient
 
       # Every plain-name anchor in the document, per schema resource:
       # `$anchor` (and `$dynamicAnchor`) in 2019-09 / 2020-12, `$id: "#name"`
-      # in draft-07. The walk is bounded like the preflight walk. Both
-      # definition bags are walked whatever the dialect: they are reachable
-      # through JSON pointers, and an anchor's resource is lexical.
+      # in draft-07. The walk is bounded like the preflight walk and follows
+      # the dialect of each resource (an embedded resource may declare its
+      # own `$schema`). Identifiers are taken only from schema positions the
+      # dialect walks (JSON Schema 2020-12 Core Sections 8.2.2 and 4.3.1: an
+      # identifier belongs to a schema object, and the value of a keyword
+      # the dialect does not define is not a schema): a definition bag the
+      # dialect does not define stays reachable through JSON pointers, and
+      # its objects are attributed to their lexical resource, but it is
+      # never a source of names — nor is anything beside a draft-07 `$ref`
+      # apart from its `definitions`.
       # @return [Hash] :resources (schema object => its resource root, by
-      #   identity) and :anchors (resource root => name => subschema, first
-      #   occurrence, by identity)
+      #   identity), :anchors (resource root => name => subschema, first
+      #   occurrence, by identity) and :dialects (resource root => dialect)
       def anchor_index(root, dialect)
-        index = { resources: {}.compare_by_identity, anchors: {}.compare_by_identity }
-        pending = [[root, root, 0]]
+        index = { resources: {}.compare_by_identity, anchors: {}.compare_by_identity,
+                  dialects: {}.compare_by_identity }
+        index[:dialects][root] = dialect
+        pending = [[root, root, 0, dialect, true]]
         visited = 0
         until pending.empty? || visited >= MAX_SUBSCHEMAS
-          schema, resource, depth = pending.shift
+          schema, resource, depth, dialect, named = pending.shift
           next unless schema.is_a?(Hash) && depth <= MAX_SCHEMA_DEPTH
+          next if index[:resources].key?(schema)
 
           visited += 1
-          # draft-07: everything beside a $ref is ignored, identifiers
-          # included; only the definitions bag stays reachable.
-          if dialect == DRAFT_07 && schema.key?('$ref')
-            index[:resources][schema] = resource
-            each_definition(schema, nil) { |sub| pending << [sub, resource, depth + 1] }
-            next
+          if resource_start?(schema)
+            resource = schema
+            dialect = embedded_dialect(schema, dialect) || dialect
+            index[:dialects][resource] = dialect
           end
-
-          resource = schema if resource_start?(schema)
           index[:resources][schema] = resource
-          names = (index[:anchors][resource] ||= {})
-          anchor_names(schema, dialect).each { |name| names[name] ||= schema }
-          each_subschema(schema, dialect) { |sub| pending << [sub, resource, depth + 1] }
-          each_foreign_definition(schema, dialect) { |sub| pending << [sub, resource, depth + 1] }
+          if named && !(dialect == DRAFT_07 && schema.key?('$ref'))
+            names = (index[:anchors][resource] ||= {})
+            anchor_names(schema, dialect).each { |name| names[name] ||= schema }
+          end
+          each_walked_position(schema, dialect) { |sub| pending << [sub, resource, depth + 1, dialect, named] }
+          each_foreign_definition(schema, dialect) { |sub| pending << [sub, resource, depth + 1, dialect, false] }
         end
         index
+      end
+
+      # Yield the schema positions the dialect walks under a schema object:
+      # under a draft-07 `$ref` only the `definitions` bag, else every
+      # subschema (the dialect's definition bag included).
+      # @return [void]
+      def each_walked_position(schema, dialect, &)
+        if dialect == DRAFT_07 && schema.key?('$ref')
+          each_definition(schema, dialect, &)
+        else
+          each_subschema(schema, dialect, &)
+        end
+      end
+
+      # The dialect the memoized anchor index recorded for a schema object's
+      # resource, or nil when the object was not indexed.
+      # @param schema [Hash]
+      # @param resolver [Hash, Context] holder of the memoized anchor index
+      # @return [String, nil]
+      def indexed_dialect(schema, resolver)
+        index = resolver[:anchors]
+        return nil unless index
+
+        resource = index[:resources][schema]
+        resource && index[:dialects][resource]
       end
 
       # Whether a schema object starts a new schema resource: its `$id` is a

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -25,7 +25,10 @@ module MCPClient
       end
 
       # Resolve a local reference: a JSON pointer fragment, or a plain-name
-      # fragment naming an anchor of the referencing schema's resource.
+      # fragment naming an anchor. Both are relative to the schema resource
+      # the referencing schema belongs to (JSON Schema 2020-12 Core Section
+      # 8.2.1): inside an embedded resource `#` is that resource and
+      # `#/$defs/x` its own definitions, never the enclosing document's.
       # @param root [Hash] the root schema (string keys)
       # @param ref [String] the `$ref` value
       # @param dialect [String, nil] the canonical dialect
@@ -33,16 +36,16 @@ module MCPClient
       # @param from [Hash, nil] the schema object holding the reference
       # @return [Object] the referenced value, or UNRESOLVED
       def resolve_reference(root, ref, dialect, resolver, from: nil)
+        index = (resolver[:anchors] ||= anchor_index(root, dialect))
+        resource = (from && index[:resources][from]) || root
         fragment = ref.delete_prefix('#')
-        return resolve_pointer(root, ref) if fragment.empty? || fragment.start_with?('/', '%2F', '%2f')
+        return resolve_pointer(resource, ref) if fragment.empty? || fragment.start_with?('/', '%2F', '%2f')
 
         # A plain-name fragment is percent-decoded like a pointer fragment
         # (RFC 3986 Section 2.1): "#foo%2Dbar" names the anchor "foo-bar".
         fragment = URI.decode_uri_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
         return UNRESOLVED unless fragment.match?(ANCHOR_NAME)
 
-        index = (resolver[:anchors] ||= anchor_index(root, dialect))
-        resource = (from && index[:resources][from]) || root
         index[:anchors].fetch(resource, {}).fetch(fragment, UNRESOLVED)
       end
 
@@ -117,8 +120,8 @@ module MCPClient
       end
 
       # Resolve a fragment JSON pointer (`#`, `#/$defs/x`, `#/a~1b`, with
-      # percent-encoding per RFC 6901 Section 6) within the root document.
-      # @param root [Hash] the root schema (string keys)
+      # percent-encoding per RFC 6901 Section 6) within a schema resource.
+      # @param root [Hash] the resource root (string keys)
       # @param ref [String] the `$ref` value
       # @return [Object] the referenced value, or UNRESOLVED
       def resolve_pointer(root, ref)

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -227,7 +227,7 @@ module MCPClient
       def anchor_index(root, dialect)
         index = { resources: {}.compare_by_identity, anchors: {}.compare_by_identity,
                   dialects: {}.compare_by_identity, bases: {}.compare_by_identity, by_base: {},
-                  duplicates: [], visited: 0, truncated: false }
+                  duplicates: [], duplicate_ids: [], visited: 0, truncated: false }
         index[:dialects][root] = dialect
         # The document's own base: the root's `$id` where it declares one,
         # else the empty reference. Relative references resolve against each
@@ -247,7 +247,15 @@ module MCPClient
         id = declared && resource.is_a?(Hash) ? resource['$id'] : nil
         base = (id.is_a?(String) ? merge_uri(parent_base, id) : parent_base) || parent_base
         index[:bases][resource] = base
-        index[:by_base][base] ||= resource
+        known = index[:by_base][base]
+        return index[:by_base][base] = resource if known.nil?
+
+        # Two resources answering to one URI: which one a reference lands on
+        # would depend on the order the walk met them in, so the document is
+        # unusable rather than resolved by luck (JSON Schema 2020-12 Core
+        # Section 9.1.2). Only a declared `$id` can collide; the base a
+        # resource merely inherits is its parent's, already registered.
+        index[:duplicate_ids] << base if id.is_a?(String) && !known.equal?(resource)
       end
 
       # Index every schema position reachable from the pending seeds, within
@@ -420,11 +428,13 @@ module MCPClient
       # @return [Array(Integer, Boolean), nil] the depth and whether the
       #   pointer crossed an opaque keyword; nil when it cannot be followed
       def pointer_position(ref, root, dialect, counter, from)
+        index = (counter[:anchors] ||= anchor_index(root, dialect))
+        node, ref = pointer_origin(index, root, ref, from)
+        return nil unless node
+
         tokens = pointer_tokens(ref)
         return nil unless tokens
 
-        index = (counter[:anchors] ||= anchor_index(root, dialect))
-        node = (from && index[:resources][from]) || root
         depths = counter[:depths] || {}
         walk = { index: index, depths: depths, dialect: index[:dialects][node] || dialect,
                  depth: depths[node] || 0, mode: :schema, opaque: false, visited: true }
@@ -461,6 +471,20 @@ module MCPClient
                            !(walk[:dialect] == DRAFT_07 && node.is_a?(Hash) && node.key?('$ref') &&
                              token != 'definitions')
         walk[:depth] += 1 unless %i[map array].include?(walk[:mode])
+      end
+
+      # The resource a reference's pointer is read inside, and the bare
+      # fragment that applies there. A reference written as an absolute URI
+      # into the bundled document (`urn:root#/x/y`) addresses the very
+      # position its bare spelling (`#/x/y`) does, so the pointer is followed
+      # — and the target accounted for — the same way whichever the peer
+      # wrote (JSON Schema 2020-12 Core Section 9.3.1).
+      # @return [Array(Hash, String), Array(nil, nil)]
+      def pointer_origin(index, root, ref, from)
+        resource = (from && index[:resources][from]) || root
+        return [resource, ref] if ref.start_with?('#')
+
+        retarget_reference(index, resource, ref)
       end
 
       # The decoded RFC 6901 tokens of a fragment pointer.

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -42,17 +42,78 @@ module MCPClient
         return UNRESOLVED if from.is_a?(Hash) && !index[:resources].key?(from)
 
         resource = (from && index[:resources][from]) || root
-        fragment = ref.delete_prefix('#')
-        if fragment.empty? || fragment.start_with?('/', '%2F', '%2f')
-          return adopt_reached_target(resolve_pointer(resource, ref), resource, index)
-        end
+        raw = ref.delete_prefix('#')
+        return resolve_adopted_pointer(resource, ref, index) if raw.empty? || raw.start_with?('/', '%2F', '%2f')
 
         # A plain-name fragment is percent-decoded like a pointer fragment
         # (RFC 3986 Section 2.1): "#foo%2Dbar" names the anchor "foo-bar".
-        fragment = URI.decode_uri_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
-        return UNRESOLVED unless fragment.match?(ANCHOR_NAME)
+        fragment = decoded_fragment(ref)
+        return UNRESOLVED unless fragment&.match?(ANCHOR_NAME)
 
         index[:anchors].fetch(resource, {}).fetch(fragment, UNRESOLVED)
+      end
+
+      # The decoded fragment of a reference (RFC 3986 Section 2.1), or nil
+      # when what the peer wrote does not decode to readable text: escapes
+      # that are not valid UTF-8 name nothing in this document, and reading
+      # them must never raise out of the validation.
+      # @param ref [String] the `$ref` value
+      # @return [String, nil]
+      def decoded_fragment(ref)
+        fragment = ref.delete_prefix('#')
+        decoded = URI.decode_uri_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
+        decoded if decoded.valid_encoding?
+      end
+
+      # Resolve a JSON pointer within a schema resource, adopting on the way
+      # whatever subtree the pointer enters through a data keyword (`default`
+      # and the rest): that subtree is normalized and indexed once — memoized
+      # by the identity of the object the document holds — and the remaining
+      # tokens are walked through the copy. So every pointer into it lands on
+      # the objects the index already knows, with the resource, dialect and
+      # subschema charge it gave them: a nested pointer is not a second copy
+      # attributed to the referrer (JSON Schema 2020-12 Core Sections 8.1.1
+      # and 8.2.1: a schema belongs to the resource of its nearest `$id`
+      # ancestor, wherever a reference reached it from).
+      # @param resource [Hash] the resource root the pointer starts at
+      # @param ref [String] the `$ref` value
+      # @param index [Hash] the anchor index
+      # @return [Object] the referenced value, or UNRESOLVED
+      def resolve_adopted_pointer(resource, ref, index)
+        fragment = decoded_fragment(ref)
+        return UNRESOLVED unless fragment
+        return adopt_reached_target(resource, resource, index) if fragment.empty?
+        return UNRESOLVED unless fragment.start_with?('/')
+
+        node = resource
+        mode = :schema
+        fragment[1..].split('/', -1).each do |token|
+          # RFC 6901 Section 3: "~" is only ever followed by "0" or "1".
+          return UNRESOLVED if token.match?(/~(?![01])/)
+
+          node, resource, mode = adopt_step(node, resource, index, mode)
+          token = token.gsub('~1', '/').gsub('~0', '~')
+          child = pointer_child(node, token)
+          return UNRESOLVED if child.equal?(UNRESOLVED)
+
+          mode = member_mode(token, child, mode)
+          node = child
+        end
+        adopt_reached_target(node, resource, index, raw: mode == :data)
+      end
+
+      # Adopt the object a pointer is about to step through when the document
+      # holds it as data, and follow the resource the index attributes it to.
+      # @return [Array(Object, Hash, Symbol)] the node to step through, the
+      #   resource it belongs to, and the mode it is read in
+      def adopt_step(node, resource, index, mode)
+        return [node, resource, mode] unless node.is_a?(Hash)
+
+        if mode == :data
+          node = adopt_reached_target(node, resource, index, raw: true)
+          mode = :schema
+        end
+        [node, index[:resources][node] || resource, mode]
       end
 
       # A schema a pointer reaches outside every indexed position (inside
@@ -60,29 +121,41 @@ module MCPClient
       # the resource it was reached from: it (and what it holds) is indexed
       # on arrival, so a `$ref` written anywhere in it resolves within that
       # resource and its nested schemas follow the dialect it adopts, and
-      # the document it holds is normalized like everywhere else (data
-      # values are kept as given for equality; a target resolved as a schema
-      # gets one string-keyed copy, memoized by identity).
+      # what the document holds as data is normalized like everywhere else
+      # (values are kept as given for equality; a subtree resolved as a
+      # schema gets one string-keyed copy, memoized by identity).
+      # @param raw [Boolean] whether the document holds the target as data,
+      #   so it still needs its string-keyed copy
       # @return [Object] the target (or its normalized copy)
-      def adopt_reached_target(target, resource, index)
+      def adopt_reached_target(target, resource, index, raw: false)
         return target unless target.is_a?(Hash)
-        # An indexed position was already walked, charged and attributed.
-        return target if index[:resources].key?(target)
 
         # Copied under the same structural budget as the root document,
         # whatever key form it arrived in (over the wire every key is a
         # string): a data keyword may not hide an unbounded map behind a
         # pointer.
-        copies = (index[:normalized] ||= {}.compare_by_identity)
-        index[:budget] ||= { objects: 0, deadline: nil }
-        target = copies[target] ||= deep_stringify(target, 0, index[:budget])
+        target = normalized_copy(target, index) if raw && !index[:resources].key?(target)
+        # An indexed position was already walked, charged and attributed.
         return target if index[:resources].key?(target)
 
         # The adopted target is indexed like any schema position, so its own
         # `$id` / `$schema` and the positions below it are seen: within the
-        # bounds the index already runs under.
-        index_positions(index, [[target, resource, 0, index[:dialects][resource], true]])
+        # bounds the index already runs under. It declares no names of its
+        # own — `resource_root?` turns naming on where an `$id` really starts
+        # a resource — since a data keyword is not a schema position and an
+        # `$anchor` written inside one names nothing in the document (Core
+        # Sections 8.2.2 and 4.3.1).
+        index_positions(index, [[target, resource, 0, index[:dialects][resource], false]])
         target
+      end
+
+      # The one string-keyed copy of a subtree the document holds as data,
+      # memoized by the identity of the object it holds.
+      # @return [Hash]
+      def normalized_copy(target, index)
+        copies = (index[:normalized] ||= {}.compare_by_identity)
+        index[:budget] ||= { objects: 0, deadline: nil }
+        copies[target] ||= deep_stringify(target, 0, index[:budget])
       end
 
       # Every plain-name anchor in the document, per schema resource:
@@ -312,9 +385,8 @@ module MCPClient
       # The decoded RFC 6901 tokens of a fragment pointer.
       # @return [Array<String>, nil] nil unless the reference is a pointer
       def pointer_tokens(ref)
-        fragment = ref.delete_prefix('#')
-        fragment = URI.decode_uri_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
-        return nil unless fragment.start_with?('/')
+        fragment = decoded_fragment(ref)
+        return nil unless fragment&.start_with?('/')
 
         fragment[1..].split('/', -1).map { |token| token.gsub('~1', '/').gsub('~0', '~') }
       end
@@ -351,37 +423,6 @@ module MCPClient
           next if keyword_known?(keyword, dialect)
 
           schema[keyword].each_value(&block) if schema[keyword].is_a?(Hash)
-        end
-      end
-
-      # Resolve a fragment JSON pointer (`#`, `#/$defs/x`, `#/a~1b`, with
-      # percent-encoding per RFC 6901 Section 6) within a schema resource.
-      # @param root [Hash] the resource root (string keys)
-      # @param ref [String] the `$ref` value
-      # @return [Object] the referenced value, or UNRESOLVED
-      def resolve_pointer(root, ref)
-        fragment = ref.delete_prefix('#')
-        fragment = URI.decode_uri_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
-        return root if fragment.empty?
-        return UNRESOLVED unless fragment.start_with?('/')
-
-        fragment[1..].split('/', -1).reduce(root) do |node, token|
-          # RFC 6901 Section 3: "~" is only ever followed by "0" or "1".
-          return UNRESOLVED if token.match?(/~(?![01])/)
-
-          key = token.gsub('~1', '/').gsub('~0', '~')
-          case node
-          when Hash
-            return UNRESOLVED unless node.key?(key)
-
-            node[key]
-          when Array
-            return UNRESOLVED unless key.match?(/\A(0|[1-9]\d*)\z/) && key.to_i < node.length
-
-            node[key.to_i]
-          else
-            return UNRESOLVED
-          end
         end
       end
     end

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -87,7 +87,10 @@ module MCPClient
 
         node = resource
         mode = :schema
-        fragment[1..].split('/', -1).each do |token|
+        # RFC 6901 Section 5: the pointer "/" is the member named "", so the
+        # leading separator is dropped rather than split off ("" splits to no
+        # tokens at all, which would read "#/" as the whole document).
+        fragment.split('/', -1).drop(1).each do |token|
           # RFC 6901 Section 3: "~" is only ever followed by "0" or "1".
           return UNRESOLVED if token.match?(/~(?![01])/)
 
@@ -388,7 +391,7 @@ module MCPClient
         fragment = decoded_fragment(ref)
         return nil unless fragment&.start_with?('/')
 
-        fragment[1..].split('/', -1).map { |token| token.gsub('~1', '/').gsub('~0', '~') }
+        fragment.split('/', -1).drop(1).map { |token| token.gsub('~1', '/').gsub('~0', '~') }
       end
 
       # @return [Object] the member a pointer token selects, or UNRESOLVED

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -43,7 +43,9 @@ module MCPClient
 
         resource = (from && index[:resources][from]) || root
         fragment = ref.delete_prefix('#')
-        return resolve_pointer(resource, ref) if fragment.empty? || fragment.start_with?('/', '%2F', '%2f')
+        if fragment.empty? || fragment.start_with?('/', '%2F', '%2f')
+          return adopt_reached_target(resolve_pointer(resource, ref), resource, index)
+        end
 
         # A plain-name fragment is percent-decoded like a pointer fragment
         # (RFC 3986 Section 2.1): "#foo%2Dbar" names the anchor "foo-bar".
@@ -51,6 +53,33 @@ module MCPClient
         return UNRESOLVED unless fragment.match?(ANCHOR_NAME)
 
         index[:anchors].fetch(resource, {}).fetch(fragment, UNRESOLVED)
+      end
+
+      # A schema a pointer reaches outside every indexed position (inside
+      # `default`, another data keyword or a vendor member) is still part of
+      # the resource it was reached from: it is indexed on arrival, so a
+      # `$ref` written in it resolves within that resource, and a document
+      # given with symbol keys is normalized there like everywhere else
+      # (data values are kept as given for equality; a target resolved as a
+      # schema gets one string-keyed copy, memoized by identity).
+      # @return [Object] the target (or its normalized copy)
+      def adopt_reached_target(target, resource, index)
+        return target unless target.is_a?(Hash)
+
+        if target.each_key.any? { |key| !key.is_a?(String) }
+          copies = (index[:normalized] ||= {}.compare_by_identity)
+          target = copies[target] ||= deep_stringify(target)
+        end
+        return target if index[:resources].key?(target)
+
+        inherited = index[:dialects][resource]
+        if resource_root?(target, inherited)
+          index[:resources][target] = target
+          index[:dialects][target] = embedded_dialect(target, inherited) || inherited
+        else
+          index[:resources][target] = resource
+        end
+        target
       end
 
       # Every plain-name anchor in the document, per schema resource:
@@ -211,33 +240,57 @@ module MCPClient
       # are both one below the enclosing schema), and every token under a
       # data or unknown keyword is a step, so a document hidden inside
       # `default`, `enum`, `const`, `examples` or a vendor keyword obeys the
-      # same bound as one written in a schema position. A schema object whose
-      # depth the lexical index knows resets the count to that depth.
+      # same bound as one written in a schema position. Keywords are
+      # classified by the dialect in force at each node (an embedded
+      # resource's own `$schema` takes over when the pointer enters it). A
+      # schema object whose depth the lexical index knows resets the count
+      # to that depth — unless the pointer already passed through an opaque
+      # keyword, after which every token counts (the index placed such an
+      # object under another dialect's grammar).
       # @return [Integer, nil] nil when the pointer cannot be followed
       def referenced_position_depth(ref, root, dialect, counter, from)
+        pointer_position(ref, root, dialect, counter, from)&.first
+      end
+
+      # @return [Array(Integer, Boolean), nil] the depth and whether the
+      #   pointer crossed an opaque keyword; nil when it cannot be followed
+      def pointer_position(ref, root, dialect, counter, from)
         tokens = pointer_tokens(ref)
         return nil unless tokens
 
         index = (counter[:anchors] ||= anchor_index(root, dialect))
         node = (from && index[:resources][from]) || root
         depths = counter[:depths] || {}
-        depth = depths[node] || 0
-        mode = :schema
+        walk = { index: index, depths: depths, dialect: index[:dialects][node] || dialect,
+                 depth: depths[node] || 0, mode: :schema, opaque: false }
         tokens.each do |token|
           child = pointer_child(node, token)
           return nil if child.equal?(UNRESOLVED)
 
-          if mode == :schema
-            depth = depths[node] if node.is_a?(Hash) && depths.key?(node)
-            mode = pointer_step_mode(node, token, dialect)
-            depth += 1 unless %i[map array].include?(mode)
-          else
-            depth += 1
-            mode = :schema if %i[map array].include?(mode)
-          end
+          pointer_step(walk, node, token)
           node = child
         end
-        depth
+        [walk[:depth], walk[:opaque]]
+      end
+
+      # Advance one pointer token: in schema mode the node's own dialect
+      # and known depth apply and the keyword decides how the next token
+      # counts; inside a map or array keyword the member is the step;
+      # under an opaque keyword every token is a step.
+      # @return [void]
+      def pointer_step(walk, node, token)
+        unless walk[:mode] == :schema
+          walk[:depth] += 1
+          walk[:mode] = :schema if %i[map array].include?(walk[:mode])
+          return
+        end
+        if node.is_a?(Hash)
+          walk[:depth] = walk[:depths][node] if !walk[:opaque] && walk[:depths].key?(node)
+          walk[:dialect] = walk[:index][:dialects][node] || embedded_dialect(node, walk[:dialect]) || walk[:dialect]
+        end
+        walk[:mode] = pointer_step_mode(node, token, walk[:dialect])
+        walk[:opaque] ||= walk[:mode] == :opaque
+        walk[:depth] += 1 unless %i[map array].include?(walk[:mode])
       end
 
       # The decoded RFC 6901 tokens of a fragment pointer.

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -37,6 +37,10 @@ module MCPClient
       # @return [Object] the referenced value, or UNRESOLVED
       def resolve_reference(root, ref, dialect, resolver, from: nil)
         index = (resolver[:anchors] ||= anchor_index(root, dialect))
+        # A referring schema the index never reached has no known resource:
+        # resolving against the document root would apply the wrong `#`.
+        return UNRESOLVED if from.is_a?(Hash) && !index[:resources].key?(from)
+
         resource = (from && index[:resources][from]) || root
         fragment = ref.delete_prefix('#')
         return resolve_pointer(resource, ref) if fragment.empty? || fragment.start_with?('/', '%2F', '%2f')
@@ -71,10 +75,15 @@ module MCPClient
         index[:dialects][root] = dialect
         pending = [[root, root, 0, dialect, true]]
         visited = 0
+        index[:truncated] = false
         until pending.empty? || visited >= MAX_SUBSCHEMAS
           schema, resource, depth, dialect, named = pending.shift
-          next unless schema.is_a?(Hash) && depth <= MAX_SCHEMA_DEPTH
+          next unless schema.is_a?(Hash)
           next if index[:resources].key?(schema)
+          # A schema below the depth bound is left unindexed just like one
+          # beyond the visit bound: a reference from it (or an `$id` there)
+          # would otherwise resolve under guesses.
+          (index[:truncated] = true) && next if depth > MAX_SCHEMA_DEPTH
 
           visited += 1
           if resource_root?(schema, dialect)
@@ -96,7 +105,7 @@ module MCPClient
         end
         # Objects left unindexed at the bound would resolve and validate
         # under guesses; the index says so and the schema is unusable.
-        index[:truncated] = pending.any? { |schema, *| schema.is_a?(Hash) && !index[:resources].key?(schema) }
+        index[:truncated] ||= pending.any? { |schema, *| schema.is_a?(Hash) && !index[:resources].key?(schema) }
         index
       end
 

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -229,7 +229,7 @@ module MCPClient
 
           if mode == :schema
             depth = depths[node] if node.is_a?(Hash) && depths.key?(node)
-            mode = pointer_step_mode(node, token)
+            mode = pointer_step_mode(node, token, dialect)
             depth += 1 unless %i[map array].include?(mode)
           else
             depth += 1
@@ -262,8 +262,10 @@ module MCPClient
       # How a keyword of a schema object holds what its pointer token reaches.
       # @return [Symbol] :schema (one subschema), :map, :array, or :opaque
       #   (data or unknown keyword: every token below is a step)
-      def pointer_step_mode(node, token)
-        return :opaque unless node.is_a?(Hash)
+      # A keyword the dialect in force does not define (`prefixItems` under
+      # draft-07, `additionalItems` under 2020-12) is opaque data there.
+      def pointer_step_mode(node, token, dialect)
+        return :opaque unless node.is_a?(Hash) && keyword_known?(token, dialect)
         return :map if SUBSCHEMA_MAP_KEYWORDS.include?(token)
         return :array if SUBSCHEMA_ARRAY_KEYWORDS.include?(token) || (token == 'items' && node[token].is_a?(Array))
         return :schema if SUBSCHEMA_KEYWORDS.include?(token)

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -28,6 +28,10 @@ module MCPClient
       def resolve_reference(root, ref, dialect, resolver)
         fragment = ref.delete_prefix('#')
         return resolve_pointer(root, ref) if fragment.empty? || fragment.start_with?('/', '%2F', '%2f')
+
+        # A plain-name fragment is percent-decoded like a pointer fragment
+        # (RFC 3986 Section 2.1): "#foo%2Dbar" names the anchor "foo-bar".
+        fragment = URI.decode_uri_component(fragment) rescue fragment # rubocop:disable Style/RescueModifier
         return UNRESOLVED unless fragment.match?(ANCHOR_NAME)
 
         resolver[:anchors] ||= anchor_index(root, dialect)

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -78,9 +78,13 @@ module MCPClient
 
           visited += 1
           if resource_start?(schema)
+            # A resource is a schema wherever it sits: one reached through
+            # a bag the dialect does not walk names its own anchors, though
+            # nothing outside it can see them.
             resource = schema
             dialect = embedded_dialect(schema, dialect) || dialect
             index[:dialects][resource] = dialect
+            named = true
           end
           index[:resources][schema] = resource
           if named && !(dialect == DRAFT_07 && schema.key?('$ref'))

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -366,6 +366,34 @@ module MCPClient
         resource_start?(schema)
       end
 
+      # Whether a dynamic reference is dynamic at all. A `$dynamicRef` whose
+      # initial target — resolved exactly as a `$ref` is — declares a
+      # `$dynamicAnchor` of the name the fragment carries may be re-bound by
+      # the dynamic scope a validation was entered through (2020-12 Core
+      # Section 8.2.3.2); one naming a pointer, or a plain `$anchor`, is the
+      # `$ref` it resolves to. A `$recursiveRef` is dynamic where its target
+      # carries `$recursiveAnchor: true` (2019-09 Core Section 8.2.4.2.2).
+      # A reference that resolves to nothing usable is taken as dynamic: it
+      # is not shown to be a plain one, and the preflight reports it.
+      # @param schema [Hash] the schema object holding the reference
+      # @param keyword [String] `$dynamicRef` or `$recursiveRef`
+      # @param root [Hash] the normalized root schema
+      # @param dialect [String, nil] the canonical root dialect
+      # @param resolver [Hash, Context] holder of the memoized anchor index
+      # @return [Boolean]
+      def dynamic_reference?(schema, keyword, root, dialect, resolver)
+        ref = schema[keyword]
+        return true unless ref.is_a?(String) && !external_ref?(ref, root, dialect, resolver, from: schema)
+
+        target = resolve_reference(root, ref, dialect, resolver, from: schema)
+        return true if target.equal?(UNRESOLVED)
+        return false unless target.is_a?(Hash)
+        return target['$recursiveAnchor'] == true if keyword == '$recursiveRef'
+
+        fragment = ref.include?('#') ? decoded_fragment(ref[ref.index('#')..]) : nil
+        !fragment.nil? && !fragment.start_with?('/') && !fragment.empty? && target['$dynamicAnchor'] == fragment
+      end
+
       # @return [Array<String>] the plain names a schema object declares
       def anchor_names(schema, dialect)
         names = if dialect == DRAFT_07

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -366,83 +366,79 @@ module MCPClient
         resource_start?(schema)
       end
 
-      # Whether a dynamic reference is one this validator leaves unevaluated:
-      # one the dynamic scope would have to choose a binding for.
-      # @return [Boolean]
-      def dynamic_reference?(schema, keyword, root, dialect, resolver)
-        dynamic_binding(schema, keyword, root, dialect, resolver).first == :ambiguous
-      end
-
       # How a dynamic reference binds (JSON Schema 2020-12 Core Section
       # 8.2.3.2; 2019-09 Section 8.2.4.2.2). A reference whose initial
       # target declares no matching dynamic anchor is the plain reference it
-      # resolves to (`:plain`). One that does re-binds to the OUTERMOST
-      # dynamic scope declaring that anchor: the dynamic scope always starts
-      # at the root resource of the schema being applied, so where the root
-      # declares the anchor the binding is the root's, wherever the
-      # reference is met; and where exactly one resource declares it, that
-      # resource is the target the reference named (`:bound`, with the
-      # target). Only several non-root resources declaring the same dynamic
-      # anchor would need the evaluation path to choose (`:ambiguous`) — the
-      # one case left unevaluated, and reported as such.
+      # resolves to (`:plain`). One that does re-binds to the declaration in
+      # the OUTERMOST resource of the dynamic scope — the resources the
+      # evaluation entered on its way here, which {SchemaValidator.enter_scope}
+      # records as they are entered (`:bound`, with the target). What the
+      # document holds elsewhere decides nothing: a resource the instance
+      # never entered is not in the scope, so a duplicate anchor there is
+      # neither ambiguity nor a reason to leave the reference unevaluated.
+      # Outside a validation there is no scope to read, and every reference
+      # is the plain one it resolves to — which is what the preflight, whose
+      # job is that the reference resolves at all, needs.
       # @param schema [Hash] the schema object holding the reference
       # @param keyword [String] "$dynamicRef" or "$recursiveRef"
       # @param root [Hash] the root schema
       # @param dialect [String, nil] the canonical root dialect
-      # @param resolver [Hash, Context] holder of the memoized anchor index
-      # @return [Array] [:plain], [:bound, target] or [:ambiguous]
+      # @param resolver [Hash, Context] holder of the memoized anchor index,
+      #   and — during a validation — of the dynamic scope
+      # @return [Array] [:plain] or [:bound, target]
       def dynamic_binding(schema, keyword, root, dialect, resolver)
         ref = schema[keyword]
-        return [:ambiguous] unless ref.is_a?(String) && !external_ref?(ref, root, dialect, resolver, from: schema)
+        return [:plain] unless ref.is_a?(String) && !external_ref?(ref, root, dialect, resolver, from: schema)
 
         target = resolve_reference(root, ref, dialect, resolver, from: schema)
-        return [:ambiguous] if target.equal?(UNRESOLVED)
+        return [:plain] if target.equal?(UNRESOLVED)
         return [:plain] unless target.is_a?(Hash)
 
         index = resolver[:anchors]
-        candidates = if keyword == '$recursiveRef'
-                       return [:plain] unless target['$recursiveAnchor'] == true
+        scope = resolver[:scope]
+        bound = if keyword == '$recursiveRef'
+                  return [:plain] unless target['$recursiveAnchor'] == true
 
-                       recursive_anchor_resources(index, root, dialect)
-                     else
-                       fragment = ref.include?('#') ? decoded_fragment(ref[ref.index('#')..]) : nil
-                       return [:plain] if fragment.nil? || fragment.empty? || fragment.start_with?('/')
-                       return [:plain] unless target['$dynamicAnchor'] == fragment
+                  outermost_recursive_anchor(index, scope, dialect)
+                else
+                  fragment = ref.include?('#') ? decoded_fragment(ref[ref.index('#')..]) : nil
+                  return [:plain] if fragment.nil? || fragment.empty? || fragment.start_with?('/')
+                  return [:plain] unless target['$dynamicAnchor'] == fragment
 
-                       dynamic_anchor_declarations(index, fragment)
-                     end
-        bind_outermost(candidates, root)
+                  outermost_dynamic_anchor(index, scope, fragment)
+                end
+        bound ? [:bound, bound] : [:plain]
       end
 
-      # The resource roots whose `$recursiveAnchor` is true, as
-      # [resource, target] pairs (the target of a `$recursiveRef` is the
-      # resource root itself).
-      # @return [Array<Array(Hash, Hash)>]
-      def recursive_anchor_resources(index, root, dialect)
-        roots = ([root] + index[:by_base].values).uniq(&:object_id)
-        roots.select { |resource| resource.is_a?(Hash) && resource['$recursiveAnchor'] == true }
-             .reject { |resource| (index[:dialects][resource] || dialect) == DRAFT_07 }
-             .map { |resource| [resource, resource] }
-      end
-
-      # The resources declaring `$dynamicAnchor: name`, as [resource,
-      # declaring schema] pairs, in index order.
-      # @return [Array<Array(Hash, Hash)>]
-      def dynamic_anchor_declarations(index, name)
-        index[:anchors].filter_map do |resource, names|
-          declaring = names[name]
-          [resource, declaring] if declaring.is_a?(Hash) && declaring['$dynamicAnchor'] == name
+      # The schema declaring `$dynamicAnchor: name` in the outermost resource
+      # of the dynamic scope that declares it — the scope being the resources
+      # the evaluation actually entered, outermost first. A resource the
+      # instance never entered declares nothing for this reference, however
+      # many of them the document holds; and where no entered resource
+      # declares the name, the caller keeps the target the reference resolved
+      # to on its own, which is what the specification's "otherwise behave as
+      # $ref" says.
+      # @param index [Hash] the anchor index
+      # @param scope [Array<Hash>, nil] the dynamic scope, outermost first
+      # @param name [String] the anchor name
+      # @return [Hash, nil]
+      def outermost_dynamic_anchor(index, scope, name)
+        Array(scope).each do |resource|
+          declaring = index[:anchors][resource]&.[](name)
+          return declaring if declaring.is_a?(Hash) && declaring['$dynamicAnchor'] == name
         end
+        nil
       end
 
-      # @param candidates [Array<Array(Hash, Hash)>] [resource, target] pairs
-      # @return [Array] [:bound, target] or [:ambiguous]
-      def bind_outermost(candidates, root)
-        at_root = candidates.find { |resource, _| resource.equal?(root) }
-        return [:bound, at_root.last] if at_root
-        return [:bound, candidates.first.last] if candidates.size == 1
-
-        [:ambiguous]
+      # The outermost resource of the dynamic scope whose `$recursiveAnchor`
+      # is true (2019-09 Core Section 8.2.4.2.2); the target of a
+      # `$recursiveRef` is the resource root itself.
+      # @return [Hash, nil]
+      def outermost_recursive_anchor(index, scope, dialect)
+        Array(scope).find do |resource|
+          resource.is_a?(Hash) && resource['$recursiveAnchor'] == true &&
+            (index[:dialects][resource] || dialect) != DRAFT_07
+        end
       end
 
       # @return [Array<String>] the plain names a schema object declares

--- a/lib/mcp_client/schema_validator/references.rb
+++ b/lib/mcp_client/schema_validator/references.rb
@@ -366,32 +366,83 @@ module MCPClient
         resource_start?(schema)
       end
 
-      # Whether a dynamic reference is dynamic at all. A `$dynamicRef` whose
-      # initial target — resolved exactly as a `$ref` is — declares a
-      # `$dynamicAnchor` of the name the fragment carries may be re-bound by
-      # the dynamic scope a validation was entered through (2020-12 Core
-      # Section 8.2.3.2); one naming a pointer, or a plain `$anchor`, is the
-      # `$ref` it resolves to. A `$recursiveRef` is dynamic where its target
-      # carries `$recursiveAnchor: true` (2019-09 Core Section 8.2.4.2.2).
-      # A reference that resolves to nothing usable is taken as dynamic: it
-      # is not shown to be a plain one, and the preflight reports it.
-      # @param schema [Hash] the schema object holding the reference
-      # @param keyword [String] `$dynamicRef` or `$recursiveRef`
-      # @param root [Hash] the normalized root schema
-      # @param dialect [String, nil] the canonical root dialect
-      # @param resolver [Hash, Context] holder of the memoized anchor index
+      # Whether a dynamic reference is one this validator leaves unevaluated:
+      # one the dynamic scope would have to choose a binding for.
       # @return [Boolean]
       def dynamic_reference?(schema, keyword, root, dialect, resolver)
+        dynamic_binding(schema, keyword, root, dialect, resolver).first == :ambiguous
+      end
+
+      # How a dynamic reference binds (JSON Schema 2020-12 Core Section
+      # 8.2.3.2; 2019-09 Section 8.2.4.2.2). A reference whose initial
+      # target declares no matching dynamic anchor is the plain reference it
+      # resolves to (`:plain`). One that does re-binds to the OUTERMOST
+      # dynamic scope declaring that anchor: the dynamic scope always starts
+      # at the root resource of the schema being applied, so where the root
+      # declares the anchor the binding is the root's, wherever the
+      # reference is met; and where exactly one resource declares it, that
+      # resource is the target the reference named (`:bound`, with the
+      # target). Only several non-root resources declaring the same dynamic
+      # anchor would need the evaluation path to choose (`:ambiguous`) — the
+      # one case left unevaluated, and reported as such.
+      # @param schema [Hash] the schema object holding the reference
+      # @param keyword [String] "$dynamicRef" or "$recursiveRef"
+      # @param root [Hash] the root schema
+      # @param dialect [String, nil] the canonical root dialect
+      # @param resolver [Hash, Context] holder of the memoized anchor index
+      # @return [Array] [:plain], [:bound, target] or [:ambiguous]
+      def dynamic_binding(schema, keyword, root, dialect, resolver)
         ref = schema[keyword]
-        return true unless ref.is_a?(String) && !external_ref?(ref, root, dialect, resolver, from: schema)
+        return [:ambiguous] unless ref.is_a?(String) && !external_ref?(ref, root, dialect, resolver, from: schema)
 
         target = resolve_reference(root, ref, dialect, resolver, from: schema)
-        return true if target.equal?(UNRESOLVED)
-        return false unless target.is_a?(Hash)
-        return target['$recursiveAnchor'] == true if keyword == '$recursiveRef'
+        return [:ambiguous] if target.equal?(UNRESOLVED)
+        return [:plain] unless target.is_a?(Hash)
 
-        fragment = ref.include?('#') ? decoded_fragment(ref[ref.index('#')..]) : nil
-        !fragment.nil? && !fragment.start_with?('/') && !fragment.empty? && target['$dynamicAnchor'] == fragment
+        index = resolver[:anchors]
+        candidates = if keyword == '$recursiveRef'
+                       return [:plain] unless target['$recursiveAnchor'] == true
+
+                       recursive_anchor_resources(index, root, dialect)
+                     else
+                       fragment = ref.include?('#') ? decoded_fragment(ref[ref.index('#')..]) : nil
+                       return [:plain] if fragment.nil? || fragment.empty? || fragment.start_with?('/')
+                       return [:plain] unless target['$dynamicAnchor'] == fragment
+
+                       dynamic_anchor_declarations(index, fragment)
+                     end
+        bind_outermost(candidates, root)
+      end
+
+      # The resource roots whose `$recursiveAnchor` is true, as
+      # [resource, target] pairs (the target of a `$recursiveRef` is the
+      # resource root itself).
+      # @return [Array<Array(Hash, Hash)>]
+      def recursive_anchor_resources(index, root, dialect)
+        roots = ([root] + index[:by_base].values).uniq(&:object_id)
+        roots.select { |resource| resource.is_a?(Hash) && resource['$recursiveAnchor'] == true }
+             .reject { |resource| (index[:dialects][resource] || dialect) == DRAFT_07 }
+             .map { |resource| [resource, resource] }
+      end
+
+      # The resources declaring `$dynamicAnchor: name`, as [resource,
+      # declaring schema] pairs, in index order.
+      # @return [Array<Array(Hash, Hash)>]
+      def dynamic_anchor_declarations(index, name)
+        index[:anchors].filter_map do |resource, names|
+          declaring = names[name]
+          [resource, declaring] if declaring.is_a?(Hash) && declaring['$dynamicAnchor'] == name
+        end
+      end
+
+      # @param candidates [Array<Array(Hash, Hash)>] [resource, target] pairs
+      # @return [Array] [:bound, target] or [:ambiguous]
+      def bind_outermost(candidates, root)
+        at_root = candidates.find { |resource, _| resource.equal?(root) }
+        return [:bound, at_root.last] if at_root
+        return [:bound, candidates.first.last] if candidates.size == 1
+
+        [:ambiguous]
       end
 
       # @return [Array<String>] the plain names a schema object declares

--- a/lib/mcp_client/schema_validator/scalars.rb
+++ b/lib/mcp_client/schema_validator/scalars.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module SchemaValidator
+    # The string and number keywords, and the budget a peer-supplied pattern
+    # is matched under. Both a pattern and the values it runs against come
+    # from the remote peer, so matching is bounded by the validation-wide
+    # deadline. Extended into SchemaValidator, so the methods are its own.
+    module Scalars
+      # Validate a string against minLength/maxLength/pattern.
+      # @param data [String] the string
+      # @param schema [Hash] string-keyed schema
+      # @param path [String] location for error messages
+      # @return [Array<String>] validation errors
+      def validate_string(data, schema, path, deadline = nil)
+        errors = []
+        min_length = schema['minLength']
+        max_length = schema['maxLength']
+        if min_length.is_a?(Numeric) && data.length < min_length
+          errors << "#{path}: string is shorter than minLength #{min_length}"
+        end
+        if max_length.is_a?(Numeric) && data.length > max_length
+          errors << "#{path}: string is longer than maxLength #{max_length}"
+        end
+        errors.concat(validate_pattern(data, schema['pattern'], path, deadline))
+        errors
+      end
+
+      # Validate a string against a regular-expression pattern.
+      # Invalid patterns are not enforced.
+      #
+      # The pattern comes from the tool's outputSchema, i.e. from the remote
+      # server, so matching runs against the validation-wide deadline: neither a
+      # single expensive expression nor many cheap-looking ones can pin the
+      # calling thread. A match that exceeds the budget aborts the validation
+      # rather than silently accepting the value — the value was never shown
+      # to satisfy the schema.
+      # @param data [String] the string
+      # @param pattern [Object] the pattern keyword value
+      # @param path [String] location for error messages
+      # @param deadline [Float, nil] monotonic deadline for the whole validation
+      # @return [Array<String>] validation errors
+      # @raise [Aborted] when the budget is exhausted
+      def validate_pattern(data, pattern, path, deadline = nil)
+        return [] unless pattern.is_a?(String)
+
+        remaining = pattern_budget_remaining(deadline)
+        raise Aborted, "validation time budget exhausted before pattern #{clip(pattern.inspect)}" if remaining.zero?
+
+        return [] if data.match?(Regexp.new(pattern, timeout: remaining))
+
+        ["#{path}: string does not match pattern #{clip(pattern.inspect)}"]
+      rescue Regexp::TimeoutError
+        raise Aborted, "pattern #{clip(pattern.inspect)} exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"
+      rescue RegexpError
+        []
+      end
+
+      # Time left in the validation-wide budget.
+      # @param deadline [Float, nil] monotonic deadline, or nil for a lone match
+      # @return [Float] seconds available; 0.0 when exhausted
+      def pattern_budget_remaining(deadline)
+        return PATTERN_MATCH_TIMEOUT unless deadline
+
+        remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        return 0.0 if remaining <= 0
+
+        [remaining, MIN_PATTERN_MATCH_TIMEOUT].max
+      end
+
+      # Validate a number against its bounds. `minimum` / `maximum` and
+      # `exclusiveMinimum` / `exclusiveMaximum` are four independent numeric
+      # assertions in every supported dialect (draft-07 validation Sections
+      # 6.2.2-6.2.5); each present one is applied.
+      # @param data [Numeric] the number
+      # @param schema [Hash] string-keyed schema
+      # @param path [String] location for error messages
+      # @return [Array<String>] validation errors
+      def validate_number(data, schema, path, _dialect = nil)
+        errors = []
+        minimum = schema['minimum']
+        maximum = schema['maximum']
+        exclusive_min = schema['exclusiveMinimum']
+        exclusive_max = schema['exclusiveMaximum']
+        shown = clip_value(data)
+        if minimum.is_a?(Numeric) && data < minimum
+          errors << "#{path}: value #{shown} is less than minimum #{clip_value(minimum)}"
+        end
+        if maximum.is_a?(Numeric) && data > maximum
+          errors << "#{path}: value #{shown} is greater than maximum #{clip_value(maximum)}"
+        end
+        if exclusive_min.is_a?(Numeric) && data <= exclusive_min
+          errors << "#{path}: value #{shown} must be greater than exclusiveMinimum #{clip_value(exclusive_min)}"
+        end
+        if exclusive_max.is_a?(Numeric) && data >= exclusive_max
+          errors << "#{path}: value #{shown} must be less than exclusiveMaximum #{clip_value(exclusive_max)}"
+        end
+        errors
+      end
+    end
+  end
+end

--- a/lib/mcp_client/schema_validator/scalars.rb
+++ b/lib/mcp_client/schema_validator/scalars.rb
@@ -47,13 +47,67 @@ module MCPClient
         remaining = pattern_budget_remaining(deadline)
         raise Aborted, "validation time budget exhausted before pattern #{clip(pattern.inspect)}" if remaining.zero?
 
-        return [] if data.match?(Regexp.new(pattern, timeout: remaining))
+        return [] if data.match?(ecma_regexp(pattern, remaining))
 
         ["#{path}: string does not match pattern #{clip(pattern.inspect)}"]
       rescue Regexp::TimeoutError
         raise Aborted, "pattern #{clip(pattern.inspect)} exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"
       rescue RegexpError
         []
+      end
+
+      # A `pattern` compiled with ECMAScript's anchor semantics. JSON Schema
+      # 2020-12 Core Section 4.3 requires patterns to be interpreted as
+      # ECMA-262 regular expressions, where `^` and `$` match only at the
+      # ends of the subject; Ruby's match at every line boundary, so "a\nb"
+      # satisfied "^a$" here and not there — accepting a string the schema
+      # rejects, and (through `not`) rejecting one it accepts.
+      # @param pattern [String] the peer's pattern
+      # @param timeout [Float] seconds the match may take
+      # @return [Regexp]
+      # @raise [RegexpError] when the pattern is not a usable expression
+      def ecma_regexp(pattern, timeout)
+        Regexp.new(ecma_anchors(pattern), timeout: timeout)
+      end
+
+      # Rewrite the anchors of an ECMA-262 pattern to Ruby's absolute ones,
+      # leaving every escaped `^` / `$` and every one inside a character
+      # class as written.
+      # @param pattern [String]
+      # @return [String]
+      def ecma_anchors(pattern)
+        rewritten = +''
+        in_class = false
+        escaped = false
+        pattern.each_char do |char|
+          if escaped
+            escaped = false
+            next rewritten << char
+          end
+
+          in_class = ecma_anchor_char(char, rewritten, in_class)
+          escaped = char == '\\'
+        end
+        rewritten
+      end
+
+      # What each ECMA-262 anchor means in Ruby: the ends of the subject,
+      # never a line boundary.
+      ECMA_ANCHORS = { '^' => '\\A', '$' => '\\z' }.freeze
+
+      # Copy one character of a pattern, translating an anchor outside a
+      # character class.
+      # @return [Boolean] whether the scan is inside a character class after it
+      def ecma_anchor_char(char, rewritten, in_class)
+        case char
+        when '[' then in_class = true
+        when ']' then in_class = false
+        when '^', '$'
+          rewritten << (in_class ? char : ECMA_ANCHORS[char])
+          return in_class
+        end
+        rewritten << char
+        in_class
       end
 
       # Time left in the validation-wide budget.
@@ -95,7 +149,28 @@ module MCPClient
         if exclusive_max.is_a?(Numeric) && data >= exclusive_max
           errors << "#{path}: value #{shown} must be less than exclusiveMaximum #{clip_value(exclusive_max)}"
         end
+        factor = schema['multipleOf']
+        if factor.is_a?(Numeric) && factor.positive? && !multiple_of?(data, factor)
+          errors << "#{path}: value #{shown} is not a multiple of #{clip_value(factor)}"
+        end
         errors
+      end
+
+      # Whether dividing the value by the factor gives an integer (JSON
+      # Schema 2020-12 Validation Section 6.2.1). The division is exact:
+      # 0.0075 is a multiple of 0.0001, which binary floating point says it
+      # is not, so the decimal each number was written as decides.
+      # @param data [Numeric] the instance
+      # @param factor [Numeric] the multipleOf value
+      # @return [Boolean]
+      def multiple_of?(data, factor)
+        return (data % factor).zero? if data.is_a?(Integer) && factor.is_a?(Integer)
+
+        (Rational(data.to_s) / Rational(factor.to_s)).denominator == 1
+      rescue ArgumentError, ZeroDivisionError, FloatDomainError, TypeError
+        # A value no decimal describes (an infinity a Ruby caller passed in;
+        # JSON carries none) falls back to the floating-point remainder.
+        (data % factor).zero?
       end
     end
   end

--- a/lib/mcp_client/schema_validator/scalars.rb
+++ b/lib/mcp_client/schema_validator/scalars.rb
@@ -56,58 +56,150 @@ module MCPClient
         []
       end
 
-      # A `pattern` compiled with ECMAScript's anchor semantics. JSON Schema
+      # A `pattern` compiled with ECMAScript's semantics. JSON Schema
       # 2020-12 Core Section 4.3 requires patterns to be interpreted as
-      # ECMA-262 regular expressions, where `^` and `$` match only at the
-      # ends of the subject; Ruby's match at every line boundary, so "a\nb"
-      # satisfied "^a$" here and not there — accepting a string the schema
-      # rejects, and (through `not`) rejecting one it accepts.
+      # ECMA-262 regular expressions, and Ruby's differ from them in both
+      # directions: what Ruby accepts that ECMAScript rejects makes the
+      # validator accept a value the schema refuses, and the converse
+      # rejects a conforming one (and, through `not` or
+      # `additionalProperties: false`, flips both).
       # @param pattern [String] the peer's pattern
       # @param timeout [Float] seconds the match may take
       # @return [Regexp]
       # @raise [RegexpError] when the pattern is not a usable expression
       def ecma_regexp(pattern, timeout)
-        Regexp.new(ecma_anchors(pattern), timeout: timeout)
-      end
-
-      # Rewrite the anchors of an ECMA-262 pattern to Ruby's absolute ones,
-      # leaving every escaped `^` / `$` and every one inside a character
-      # class as written.
-      # @param pattern [String]
-      # @return [String]
-      def ecma_anchors(pattern)
-        rewritten = +''
-        in_class = false
-        escaped = false
-        pattern.each_char do |char|
-          if escaped
-            escaped = false
-            next rewritten << char
-          end
-
-          in_class = ecma_anchor_char(char, rewritten, in_class)
-          escaped = char == '\\'
-        end
-        rewritten
+        Regexp.new(ecma_source(pattern), timeout: timeout)
       end
 
       # What each ECMA-262 anchor means in Ruby: the ends of the subject,
       # never a line boundary.
       ECMA_ANCHORS = { '^' => '\\A', '$' => '\\z' }.freeze
 
-      # Copy one character of a pattern, translating an anchor outside a
-      # character class.
-      # @return [Boolean] whether the scan is inside a character class after it
-      def ecma_anchor_char(char, rewritten, in_class)
-        case char
-        when '[' then in_class = true
-        when ']' then in_class = false
-        when '^', '$'
-          rewritten << (in_class ? char : ECMA_ANCHORS[char])
-          return in_class
+      # ECMA-262 `.` matches every character except the four line
+      # terminators; Ruby's excludes only "\n".
+      ECMA_DOT = '[^\\n\\r\\u2028\\u2029]'
+
+      # The members of ECMA-262's `\s` (WhiteSpace plus LineTerminator):
+      # Ruby's is `[ \t\r\n\f\v]` and knows none of the Unicode spaces, so a
+      # non-breaking space failed a pattern ECMAScript satisfies.
+      ECMA_SPACE_MEMBERS = '\\t\\n\\v\\f\\r \\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff'
+
+      # A character class matching nothing, which is what ECMA-262 makes of
+      # `[]` — Ruby cannot compile that at all, so the pattern used to be
+      # dropped and every string satisfied it.
+      ECMA_EMPTY_CLASS = '[^\\s\\S]'
+
+      # Its complement: ECMA-262 `[^]` matches any character, line
+      # terminators included.
+      ECMA_ANY_CLASS = '[\\s\\S]'
+
+      # The escapes ECMA-262 defines, which Ruby reads the same way:
+      # the class escapes, the assertions, the control escapes, a hex,
+      # Unicode or control-letter escape, a named back-reference, a Unicode
+      # property, and the numeric back-references. `\s` / `\S` are defined
+      # by both but over different sets, so they are rewritten rather than
+      # kept.
+      ECMA_KEPT_ESCAPES = 'bBdDwWfnrtv0123456789xuckpP'
+
+      # Rewrite an ECMA-262 pattern as the Ruby expression that means the
+      # same thing. Everything ECMA-262 defines is kept; what only Ruby
+      # defines is read the way ECMA-262 reads it — an escape ECMA-262 does
+      # not define is an identity escape there (Annex B.1.2), so `\A` is a
+      # literal "A" and not the start of the subject.
+      # @param pattern [String] the peer's pattern
+      # @return [String] Ruby regexp source
+      def ecma_source(pattern)
+        out = +''
+        index = 0
+        while index < pattern.length
+          index = if pattern[index] == '['
+                    copy_character_class(pattern, index, out)
+                  else
+                    copy_ecma_token(pattern, index, out)
+                  end
         end
-        rewritten << char
-        in_class
+        out
+      end
+
+      # Copy one token from outside a character class.
+      # @return [Integer] the index the scan continues at
+      def copy_ecma_token(pattern, index, out)
+        char = pattern[index]
+        if char == '\\'
+          out << ecma_escape(pattern[index + 1], in_class: false)
+          return index + 2
+        end
+
+        out << (ECMA_ANCHORS[char] || (char == '.' ? ECMA_DOT : char))
+        index + 1
+      end
+
+      # One escape sequence's Ruby spelling. An escape ECMA-262 leaves
+      # undefined is an identity escape: the character itself.
+      # @param char [String, nil] what followed the backslash
+      # @param in_class [Boolean] whether the escape sits in a character class
+      # @return [String]
+      def ecma_escape(char, in_class:)
+        # A trailing backslash is no expression in either dialect; Ruby says so.
+        return '\\' if char.nil?
+        return in_class ? ECMA_SPACE_MEMBERS : "[#{ECMA_SPACE_MEMBERS}]" if char == 's'
+        # Inside a class Ruby reads the nested one as a union, which is
+        # what a member set complement means there.
+        return "[^#{ECMA_SPACE_MEMBERS}]" if char == 'S'
+        # `\B` asserts outside a class and is an identity escape inside one.
+        return 'B' if in_class && char == 'B'
+        return "\\#{char}" if ECMA_KEPT_ESCAPES.include?(char)
+
+        # An identity escape: a letter stands for itself, and punctuation
+        # keeps the backslash (which means the same in both dialects).
+        char.match?(/[A-Za-z]/) ? char : "\\#{char}"
+      end
+
+      # Copy a character class, which ECMA-262 and Ruby read differently: an
+      # empty class is legal there and matches nothing, and `[` and `&`
+      # inside a class are literals rather than the openers of Ruby's nested
+      # classes and set intersection.
+      # @param index [Integer] the index of the opening bracket
+      # @return [Integer] the index the scan continues at
+      def copy_character_class(pattern, index, out)
+        negated = pattern[index + 1] == '^'
+        body = +''
+        cursor = index + (negated ? 2 : 1)
+        while cursor < pattern.length && pattern[cursor] != ']'
+          if pattern[cursor] == '\\'
+            body << ecma_escape(pattern[cursor + 1], in_class: true)
+            cursor += 2
+            next
+          end
+
+          body << class_member(pattern[cursor])
+          cursor += 1
+        end
+        # Unterminated: no expression in either dialect, so it is copied as
+        # written and Ruby refuses it.
+        if cursor >= pattern.length
+          out << pattern[index..]
+          return pattern.length
+        end
+
+        out << class_source(body, negated)
+        cursor + 1
+      end
+
+      # @return [String] the Ruby spelling of one unescaped class member
+      def class_member(char)
+        # Ruby reads a nested `[` as another class and `&&` as intersection;
+        # ECMA-262 has neither, so both are literals there.
+        ['[', '&'].include?(char) ? "\\#{char}" : char
+      end
+
+      # @param body [String] the translated members
+      # @param negated [Boolean] whether the class was written with a `^`
+      # @return [String] the Ruby character class
+      def class_source(body, negated)
+        return negated ? ECMA_ANY_CLASS : ECMA_EMPTY_CLASS if body.empty?
+
+        negated ? "[^#{body}]" : "[#{body}]"
       end
 
       # Time left in the validation-wide budget.

--- a/lib/mcp_client/schema_validator/scalars.rb
+++ b/lib/mcp_client/schema_validator/scalars.rb
@@ -53,6 +53,8 @@ module MCPClient
         ["#{path}: string does not match pattern #{clip(pattern.inspect)}"]
       rescue Regexp::TimeoutError
         raise Aborted, "pattern #{clip(pattern.inspect)} exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"
+      rescue EcmaPatterns::Untranslatable => e
+        ["#{path}: pattern #{clip(pattern.inspect)} cannot be evaluated faithfully (#{clip(e.message)})"]
       rescue RegexpError => e
         ["#{path}: pattern #{clip(pattern.inspect)} is not an ECMA-262 regular expression (#{clip(e.message)})"]
       end

--- a/lib/mcp_client/schema_validator/scalars.rb
+++ b/lib/mcp_client/schema_validator/scalars.rb
@@ -26,8 +26,9 @@ module MCPClient
         errors
       end
 
-      # Validate a string against a regular-expression pattern.
-      # Invalid patterns are not enforced.
+      # Validate a string against a regular-expression pattern. A pattern
+      # that is no ECMA-262 expression is a malformed keyword the preflight
+      # refuses; should one reach here it is an error, never a pass.
       #
       # The pattern comes from the tool's outputSchema, i.e. from the remote
       # server, so matching runs against the validation-wide deadline: neither a
@@ -47,159 +48,13 @@ module MCPClient
         remaining = pattern_budget_remaining(deadline)
         raise Aborted, "validation time budget exhausted before pattern #{clip(pattern.inspect)}" if remaining.zero?
 
-        return [] if data.match?(ecma_regexp(pattern, remaining))
+        return [] if data.match?(ecma_regexp(pattern, remaining, deadline))
 
         ["#{path}: string does not match pattern #{clip(pattern.inspect)}"]
       rescue Regexp::TimeoutError
         raise Aborted, "pattern #{clip(pattern.inspect)} exceeded the #{PATTERN_MATCH_TIMEOUT}s matching budget"
-      rescue RegexpError
-        []
-      end
-
-      # A `pattern` compiled with ECMAScript's semantics. JSON Schema
-      # 2020-12 Core Section 4.3 requires patterns to be interpreted as
-      # ECMA-262 regular expressions, and Ruby's differ from them in both
-      # directions: what Ruby accepts that ECMAScript rejects makes the
-      # validator accept a value the schema refuses, and the converse
-      # rejects a conforming one (and, through `not` or
-      # `additionalProperties: false`, flips both).
-      # @param pattern [String] the peer's pattern
-      # @param timeout [Float] seconds the match may take
-      # @return [Regexp]
-      # @raise [RegexpError] when the pattern is not a usable expression
-      def ecma_regexp(pattern, timeout)
-        Regexp.new(ecma_source(pattern), timeout: timeout)
-      end
-
-      # What each ECMA-262 anchor means in Ruby: the ends of the subject,
-      # never a line boundary.
-      ECMA_ANCHORS = { '^' => '\\A', '$' => '\\z' }.freeze
-
-      # ECMA-262 `.` matches every character except the four line
-      # terminators; Ruby's excludes only "\n".
-      ECMA_DOT = '[^\\n\\r\\u2028\\u2029]'
-
-      # The members of ECMA-262's `\s` (WhiteSpace plus LineTerminator):
-      # Ruby's is `[ \t\r\n\f\v]` and knows none of the Unicode spaces, so a
-      # non-breaking space failed a pattern ECMAScript satisfies.
-      ECMA_SPACE_MEMBERS = '\\t\\n\\v\\f\\r \\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff'
-
-      # A character class matching nothing, which is what ECMA-262 makes of
-      # `[]` — Ruby cannot compile that at all, so the pattern used to be
-      # dropped and every string satisfied it.
-      ECMA_EMPTY_CLASS = '[^\\s\\S]'
-
-      # Its complement: ECMA-262 `[^]` matches any character, line
-      # terminators included.
-      ECMA_ANY_CLASS = '[\\s\\S]'
-
-      # The escapes ECMA-262 defines, which Ruby reads the same way:
-      # the class escapes, the assertions, the control escapes, a hex,
-      # Unicode or control-letter escape, a named back-reference, a Unicode
-      # property, and the numeric back-references. `\s` / `\S` are defined
-      # by both but over different sets, so they are rewritten rather than
-      # kept.
-      ECMA_KEPT_ESCAPES = 'bBdDwWfnrtv0123456789xuckpP'
-
-      # Rewrite an ECMA-262 pattern as the Ruby expression that means the
-      # same thing. Everything ECMA-262 defines is kept; what only Ruby
-      # defines is read the way ECMA-262 reads it — an escape ECMA-262 does
-      # not define is an identity escape there (Annex B.1.2), so `\A` is a
-      # literal "A" and not the start of the subject.
-      # @param pattern [String] the peer's pattern
-      # @return [String] Ruby regexp source
-      def ecma_source(pattern)
-        out = +''
-        index = 0
-        while index < pattern.length
-          index = if pattern[index] == '['
-                    copy_character_class(pattern, index, out)
-                  else
-                    copy_ecma_token(pattern, index, out)
-                  end
-        end
-        out
-      end
-
-      # Copy one token from outside a character class.
-      # @return [Integer] the index the scan continues at
-      def copy_ecma_token(pattern, index, out)
-        char = pattern[index]
-        if char == '\\'
-          out << ecma_escape(pattern[index + 1], in_class: false)
-          return index + 2
-        end
-
-        out << (ECMA_ANCHORS[char] || (char == '.' ? ECMA_DOT : char))
-        index + 1
-      end
-
-      # One escape sequence's Ruby spelling. An escape ECMA-262 leaves
-      # undefined is an identity escape: the character itself.
-      # @param char [String, nil] what followed the backslash
-      # @param in_class [Boolean] whether the escape sits in a character class
-      # @return [String]
-      def ecma_escape(char, in_class:)
-        # A trailing backslash is no expression in either dialect; Ruby says so.
-        return '\\' if char.nil?
-        return in_class ? ECMA_SPACE_MEMBERS : "[#{ECMA_SPACE_MEMBERS}]" if char == 's'
-        # Inside a class Ruby reads the nested one as a union, which is
-        # what a member set complement means there.
-        return "[^#{ECMA_SPACE_MEMBERS}]" if char == 'S'
-        # `\B` asserts outside a class and is an identity escape inside one.
-        return 'B' if in_class && char == 'B'
-        return "\\#{char}" if ECMA_KEPT_ESCAPES.include?(char)
-
-        # An identity escape: a letter stands for itself, and punctuation
-        # keeps the backslash (which means the same in both dialects).
-        char.match?(/[A-Za-z]/) ? char : "\\#{char}"
-      end
-
-      # Copy a character class, which ECMA-262 and Ruby read differently: an
-      # empty class is legal there and matches nothing, and `[` and `&`
-      # inside a class are literals rather than the openers of Ruby's nested
-      # classes and set intersection.
-      # @param index [Integer] the index of the opening bracket
-      # @return [Integer] the index the scan continues at
-      def copy_character_class(pattern, index, out)
-        negated = pattern[index + 1] == '^'
-        body = +''
-        cursor = index + (negated ? 2 : 1)
-        while cursor < pattern.length && pattern[cursor] != ']'
-          if pattern[cursor] == '\\'
-            body << ecma_escape(pattern[cursor + 1], in_class: true)
-            cursor += 2
-            next
-          end
-
-          body << class_member(pattern[cursor])
-          cursor += 1
-        end
-        # Unterminated: no expression in either dialect, so it is copied as
-        # written and Ruby refuses it.
-        if cursor >= pattern.length
-          out << pattern[index..]
-          return pattern.length
-        end
-
-        out << class_source(body, negated)
-        cursor + 1
-      end
-
-      # @return [String] the Ruby spelling of one unescaped class member
-      def class_member(char)
-        # Ruby reads a nested `[` as another class and `&&` as intersection;
-        # ECMA-262 has neither, so both are literals there.
-        ['[', '&'].include?(char) ? "\\#{char}" : char
-      end
-
-      # @param body [String] the translated members
-      # @param negated [Boolean] whether the class was written with a `^`
-      # @return [String] the Ruby character class
-      def class_source(body, negated)
-        return negated ? ECMA_ANY_CLASS : ECMA_EMPTY_CLASS if body.empty?
-
-        negated ? "[^#{body}]" : "[#{body}]"
+      rescue RegexpError => e
+        ["#{path}: pattern #{clip(pattern.inspect)} is not an ECMA-262 regular expression (#{clip(e.message)})"]
       end
 
       # Time left in the validation-wide budget.

--- a/lib/mcp_client/schema_validator/shapes.rb
+++ b/lib/mcp_client/schema_validator/shapes.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module SchemaValidator
+    # The shape every keyword value must have before a schema can be used:
+    # an applicator must hold schemas, and an assertion this validator reads
+    # must hold what its keyword is defined to hold. A value of the wrong
+    # shape is neither ignored (that would turn an assertion into a pass)
+    # nor read as written (that would fail every instance): the schema is
+    # unusable, and the preflight says which keyword is at fault. Extended
+    # into SchemaValidator, so the methods are its own.
+    module Shapes
+      # Every applicator value must be a schema (object or boolean), an array
+      # of schemas or a map of schemas; anything else is not silently read as
+      # "true". Keywords the dialect does not define are ignored.
+      # @return [void]
+      def check_applicator_shapes(schema, dialect, problems)
+        schema.each do |keyword, value|
+          next unless keyword_known?(keyword, dialect)
+
+          problem = applicator_shape_problem(keyword, value)
+          problems << problem if problem
+        end
+      end
+
+      # @return [String, nil] why an applicator value is malformed
+      def applicator_shape_problem(keyword, value)
+        if SUBSCHEMA_KEYWORDS.include?(keyword)
+          tuple = keyword == 'items' && all_schemas?(value)
+          "#{keyword} must be a schema" unless schema_value?(value) || tuple
+        elsif keyword == 'dependencies'
+          dependencies_shape_problem(value)
+        elsif SUBSCHEMA_MAP_KEYWORDS.include?(keyword)
+          # A definition bag holds reusable schemas, whatever a reference ends
+          # up pointing at (JSON Schema 2020-12 Core Section 8.2.4).
+          "#{keyword} must be an object of schemas" unless value.is_a?(Hash) && all_schemas?(value.values)
+        elsif SUBSCHEMA_ARRAY_KEYWORDS.include?(keyword)
+          # allOf / anyOf / oneOf / prefixItems: "MUST be a non-empty array".
+          "#{keyword} must be a non-empty array of schemas" unless all_schemas?(value) && !value.empty?
+        end
+      end
+
+      # Assertion keywords whose value shape this validator reads, with what
+      # each must be. A malformed value is not silently ignored (that would
+      # turn an assertion into a pass) nor read as data (that would fail every
+      # instance): the schema is unusable, and the caller is told why.
+      ASSERTION_SHAPES = {
+        'type' => :type_names, 'enum' => :array, 'required' => :property_names, 'pattern' => :string,
+        'minLength' => :non_negative_integer, 'maxLength' => :non_negative_integer,
+        'minItems' => :non_negative_integer, 'maxItems' => :non_negative_integer,
+        'minimum' => :number, 'maximum' => :number
+      }.freeze
+
+      # The JSON Schema type names (2020-12 Validation Section 6.1.1).
+      JSON_TYPE_NAMES = %w[array boolean integer null number object string].freeze
+
+      # Check the assertion keyword values a schema object carries. Every one
+      # of these keywords exists in all supported dialects, so no dialect test
+      # is needed.
+      # @return [void]
+      def check_assertion_shapes(schema, problems)
+        schema.each do |keyword, value|
+          problem = assertion_shape_problem(keyword, value)
+          problems << problem if problem
+        end
+      end
+
+      # @return [String, nil] why an assertion value is malformed
+      def assertion_shape_problem(keyword, value)
+        case ASSERTION_SHAPES[keyword]
+        when :type_names then type_shape_problem(value)
+        when :array then "#{keyword} must be an array" unless value.is_a?(Array)
+        when :property_names then "#{keyword} must be an array of property names" unless property_names?(value)
+        when :string then "#{keyword} must be a string" unless value.is_a?(String)
+        when :non_negative_integer
+          "#{keyword} must be a non-negative integer" unless integer?(value) && !value.negative?
+        when :number then "#{keyword} must be a number" unless value.is_a?(Numeric)
+        end
+      end
+
+      # @return [String, nil] why a `type` value is malformed
+      def type_shape_problem(value)
+        names = value.is_a?(Array) ? value : [value]
+        known = !names.empty? && names.all? do |name|
+          (name.is_a?(String) || name.is_a?(Symbol)) && JSON_TYPE_NAMES.include?(name.to_s)
+        end
+        return nil if known && (!value.is_a?(Array) || names.uniq.size == names.size)
+
+        "type must be one of #{JSON_TYPE_NAMES.join(', ')}, or a non-empty array of distinct such names"
+      end
+
+      # draft-07: each dependencies entry is a schema or an array of property
+      # names.
+      # @return [String, nil]
+      def dependencies_shape_problem(value)
+        return if value.is_a?(Hash) && value.each_value.all? { |v| schema_value?(v) || property_names?(v) }
+
+        'dependencies entries must be schemas or arrays of property names'
+      end
+
+      # @param value [Object]
+      # @return [Boolean] whether value is an array of property names
+      def property_names?(value)
+        value.is_a?(Array) && value.all?(String)
+      end
+
+      # exclusiveMinimum / exclusiveMaximum are numbers in every supported
+      # dialect (draft-07 validation Sections 6.2.3 and 6.2.5, kept by 2019-09
+      # and 2020-12); the boolean modifier form belongs to draft-04, which is
+      # not supported, and is not silently ignored (it would turn a bound
+      # into a pass).
+      # @return [void]
+      def check_exclusive_bounds(schema, _dialect, problems)
+        %w[exclusiveMinimum exclusiveMaximum].each do |keyword|
+          next if !schema.key?(keyword) || schema[keyword].is_a?(Numeric)
+
+          problems << "#{keyword} must be a number (the draft-04 boolean form is not supported)"
+        end
+      end
+
+      # @param values [Object]
+      # @return [Boolean] whether values is an array of schemas
+      def all_schemas?(values)
+        values.is_a?(Array) && values.all? { |v| schema_value?(v) }
+      end
+    end
+  end
+end

--- a/lib/mcp_client/schema_validator/shapes.rb
+++ b/lib/mcp_client/schema_validator/shapes.rb
@@ -48,18 +48,24 @@ module MCPClient
         'type' => :type_names, 'enum' => :array, 'required' => :property_names, 'pattern' => :string,
         'minLength' => :non_negative_integer, 'maxLength' => :non_negative_integer,
         'minItems' => :non_negative_integer, 'maxItems' => :non_negative_integer,
-        'minimum' => :number, 'maximum' => :number
+        'minimum' => :number, 'maximum' => :number,
+        'multipleOf' => :positive_number, 'uniqueItems' => :boolean,
+        'minContains' => :non_negative_integer, 'maxContains' => :non_negative_integer,
+        'minProperties' => :non_negative_integer, 'maxProperties' => :non_negative_integer,
+        'dependentRequired' => :dependent_required
       }.freeze
 
       # The JSON Schema type names (2020-12 Validation Section 6.1.1).
       JSON_TYPE_NAMES = %w[array boolean integer null number object string].freeze
 
-      # Check the assertion keyword values a schema object carries. Every one
-      # of these keywords exists in all supported dialects, so no dialect test
-      # is needed.
+      # Check the assertion keyword values a schema object carries. A keyword
+      # the dialect does not define (`minContains` under draft-07) is an
+      # unknown one there: ignored, never malformed.
       # @return [void]
-      def check_assertion_shapes(schema, problems)
+      def check_assertion_shapes(schema, dialect, problems)
         schema.each do |keyword, value|
+          next unless keyword_known?(keyword, dialect)
+
           problem = assertion_shape_problem(keyword, value)
           problems << problem if problem
         end
@@ -67,15 +73,70 @@ module MCPClient
 
       # @return [String, nil] why an assertion value is malformed
       def assertion_shape_problem(keyword, value)
-        case ASSERTION_SHAPES[keyword]
-        when :type_names then type_shape_problem(value)
-        when :array then "#{keyword} must be an array" unless value.is_a?(Array)
-        when :property_names then "#{keyword} must be an array of property names" unless property_names?(value)
-        when :string then "#{keyword} must be a string" unless value.is_a?(String)
-        when :non_negative_integer
-          "#{keyword} must be a non-negative integer" unless integer?(value) && !value.negative?
-        when :number then "#{keyword} must be a number" unless value.is_a?(Numeric)
-        end
+        shape = ASSERTION_SHAPES[keyword]
+        return nil unless shape
+        return type_shape_problem(value) if shape == :type_names
+        return dependent_required_shape_problem(keyword, value) if shape == :dependent_required
+
+        requirement = shape_requirement(shape, value)
+        "#{keyword} must be #{requirement}" if requirement
+      end
+
+      # Each simple assertion shape: the predicate that admits a value, and
+      # how the requirement reads in a problem.
+      VALUE_SHAPES = {
+        array: [:array_value?, 'an array'],
+        property_names: [:property_names?, 'an array of distinct property names'],
+        string: [:string_value?, 'a string'],
+        non_negative_integer: [:non_negative_integer?, 'a non-negative integer'],
+        number: [:number_value?, 'a number'],
+        positive_number: [:positive_number?, 'a number greater than zero'],
+        boolean: [:boolean_value?, 'a boolean']
+      }.freeze
+
+      # @return [String, nil] what a malformed value should have been
+      def shape_requirement(shape, value)
+        predicate, requirement = VALUE_SHAPES[shape]
+        requirement unless predicate.nil? || send(predicate, value)
+      end
+
+      # @return [Boolean]
+      def array_value?(value)
+        value.is_a?(Array)
+      end
+
+      # @return [Boolean]
+      def string_value?(value)
+        value.is_a?(String)
+      end
+
+      # @return [Boolean]
+      def number_value?(value)
+        value.is_a?(Numeric)
+      end
+
+      # @return [Boolean]
+      def positive_number?(value)
+        value.is_a?(Numeric) && value.positive?
+      end
+
+      # @return [Boolean]
+      def non_negative_integer?(value)
+        integer?(value) && !value.negative?
+      end
+
+      # @return [Boolean]
+      def boolean_value?(value)
+        [true, false].include?(value)
+      end
+
+      # `dependentRequired` maps a property name to the names it requires
+      # (JSON Schema 2020-12 Validation Section 6.5.4).
+      # @return [String, nil]
+      def dependent_required_shape_problem(keyword, value)
+        return if value.is_a?(Hash) && value.each_value.all? { |v| property_names?(v) }
+
+        "#{keyword} must be an object of arrays of distinct property names"
       end
 
       # @return [String, nil] why a `type` value is malformed
@@ -98,10 +159,45 @@ module MCPClient
         'dependencies entries must be schemas or arrays of property names'
       end
 
+      # JSON Schema 2020-12 Validation Sections 6.5.3 and 6.5.4: the elements
+      # of `required` (and of a `dependentRequired` entry) are strings, and
+      # they MUST be unique — a name written twice is a malformed keyword,
+      # not the same assertion made again.
       # @param value [Object]
-      # @return [Boolean] whether value is an array of property names
+      # @return [Boolean] whether value is an array of distinct property names
       def property_names?(value)
-        value.is_a?(Array) && value.all?(String)
+        value.is_a?(Array) && value.all?(String) && value.uniq.size == value.size
+      end
+
+      # An identifier must have the shape its dialect defines: `$id` is a URI
+      # reference without a non-empty fragment (JSON Schema 2020-12 Core
+      # Section 8.2.1) — draft-07 additionally spells a plain-name identifier
+      # as a bare fragment (Core Section 8.2.3) — and `$anchor` /
+      # `$dynamicAnchor` hold a plain name (Core Section 8.2.2). An
+      # identifier the validator cannot read names nothing, so a reference
+      # written to it would silently resolve elsewhere.
+      # @return [void]
+      def check_identifier_shapes(schema, dialect, problems)
+        id_problem = id_shape_problem(schema['$id'], dialect) if schema.key?('$id')
+        problems << id_problem if id_problem
+        %w[$anchor $dynamicAnchor].each do |keyword|
+          next unless schema.key?(keyword) && keyword_known?(keyword, dialect)
+
+          problems << "#{keyword} must be a plain name" unless anchor_name?(schema[keyword], dialect)
+        end
+      end
+
+      # @return [String, nil] why an `$id` is malformed
+      def id_shape_problem(id, dialect)
+        return '$id must be a non-empty string' unless id.is_a?(String) && !id.empty?
+        # draft-07 Core Section 8.2.3: an $id that is exactly a fragment
+        # declares a plain name rather than a base URI.
+        return nil if dialect == DRAFT_07 && id.start_with?('#')
+
+        fragment = id.split('#', 2)[1]
+        return nil if fragment.nil? || fragment.empty?
+
+        "$id #{clip(id.inspect)} must not contain a non-empty fragment"
       end
 
       # exclusiveMinimum / exclusiveMaximum are numbers in every supported

--- a/lib/mcp_client/schema_validator/shapes.rb
+++ b/lib/mcp_client/schema_validator/shapes.rb
@@ -55,6 +55,21 @@ module MCPClient
         'dependentRequired' => :dependent_required
       }.freeze
 
+      # The standard keywords that only annotate, with the type JSON Schema
+      # 2020-12 Validation Section 9 (and Section 8 for the content
+      # keywords) gives each. Annotating rather than asserting does not
+      # exempt a keyword from being written correctly: a schema that spells
+      # one wrong is a malformed document, and reading it as usable let
+      # :strict check results against a schema no validator could read.
+      ANNOTATION_SHAPES = {
+        'title' => :string, 'description' => :string, '$comment' => :string, 'format' => :string,
+        'contentEncoding' => :string, 'contentMediaType' => :string,
+        'readOnly' => :boolean, 'writeOnly' => :boolean, 'deprecated' => :boolean, 'examples' => :array
+      }.freeze
+
+      # Every keyword whose value shape the preflight reads.
+      KEYWORD_SHAPES = ASSERTION_SHAPES.merge(ANNOTATION_SHAPES).freeze
+
       # The JSON Schema type names (2020-12 Validation Section 6.1.1).
       JSON_TYPE_NAMES = %w[array boolean integer null number object string].freeze
 
@@ -71,9 +86,9 @@ module MCPClient
         end
       end
 
-      # @return [String, nil] why an assertion value is malformed
+      # @return [String, nil] why an assertion or annotation value is malformed
       def assertion_shape_problem(keyword, value)
-        shape = ASSERTION_SHAPES[keyword]
+        shape = KEYWORD_SHAPES[keyword]
         return nil unless shape
         return type_shape_problem(value) if shape == :type_names
         return dependent_required_shape_problem(keyword, value) if shape == :dependent_required

--- a/lib/mcp_client/schema_validator/shapes.rb
+++ b/lib/mcp_client/schema_validator/shapes.rb
@@ -205,6 +205,10 @@ module MCPClient
       # @return [String, nil] why an `$id` is malformed
       def id_shape_problem(id, dialect)
         return '$id must be a non-empty string' unless id.is_a?(String) && !id.empty?
+        # JSON Schema 2020-12 Core Section 8.2.1: the value is a URI
+        # reference. One that is not (a space in it, say) names no resource,
+        # and a reference written to it would resolve elsewhere or nowhere.
+        return "$id #{clip(id.inspect)} must be a URI reference" unless uri_reference?(id)
         # draft-07 Core Section 8.2.3: an $id that is exactly a fragment
         # declares a plain name rather than a base URI.
         return nil if dialect == DRAFT_07 && id.start_with?('#')
@@ -213,6 +217,64 @@ module MCPClient
         return nil if fragment.nil? || fragment.empty?
 
         "$id #{clip(id.inspect)} must not contain a non-empty fragment"
+      end
+
+      # @return [Boolean] whether a string parses as an RFC 3986 URI reference
+      def uri_reference?(value)
+        URI::RFC3986_PARSER.parse(value)
+        true
+      rescue URI::InvalidURIError
+        false
+      end
+
+      # The core keywords with a fixed shape beyond the identifiers:
+      # `$vocabulary` is an object mapping vocabulary URIs to booleans (Core
+      # Section 8.1.2) and 2019-09's `$recursiveAnchor` is a boolean (2019-09
+      # Core Section 8.2.4.2.2). A keyword the dialect does not define is
+      # unknown there, never malformed.
+      # @return [void]
+      def check_core_keyword_shapes(schema, dialect, problems)
+        if schema.key?('$vocabulary') && keyword_known?('$vocabulary',
+                                                        dialect) && !vocabulary_map?(schema['$vocabulary'])
+          problems << '$vocabulary must be an object of booleans keyed by URI'
+        end
+        return unless schema.key?('$recursiveAnchor') && keyword_known?('$recursiveAnchor', dialect)
+
+        problems << '$recursiveAnchor must be a boolean' unless boolean_value?(schema['$recursiveAnchor'])
+      end
+
+      # @return [Boolean]
+      def vocabulary_map?(value)
+        value.is_a?(Hash) && value.all? { |uri, required| uri_reference?(uri.to_s) && boolean_value?(required) }
+      end
+
+      # A `pattern`, and every `patternProperties` key, must be an ECMA-262
+      # regular expression the validator can read (JSON Schema 2020-12 Core
+      # Section 4.3) within the length bound. One that is not is a malformed
+      # keyword: the schema is unusable, not a schema without the pattern
+      # (which admitted every string).
+      # @return [void]
+      def check_pattern_shapes(schema, dialect, problems)
+        pattern = schema['pattern']
+        problem = pattern_shape_problem('pattern', pattern) if pattern.is_a?(String)
+        problems << problem if problem
+        patterns = schema['patternProperties'] if keyword_known?('patternProperties', dialect)
+        return unless patterns.is_a?(Hash)
+
+        patterns.each_key do |key|
+          problem = pattern_shape_problem('patternProperties pattern', key.to_s)
+          problems << problem if problem
+        end
+      end
+
+      # @return [String, nil] why a pattern cannot be used
+      def pattern_shape_problem(keyword, pattern)
+        return "#{keyword} is longer than #{MAX_PATTERN_LENGTH} characters" if pattern.length > MAX_PATTERN_LENGTH
+
+        ecma_regexp(pattern, PATTERN_MATCH_TIMEOUT)
+        nil
+      rescue RegexpError => e
+        "#{keyword} #{clip(pattern.inspect)} is not an ECMA-262 regular expression (#{clip(e.message)})"
       end
 
       # exclusiveMinimum / exclusiveMaximum are numbers in every supported

--- a/lib/mcp_client/schema_validator/shapes.rb
+++ b/lib/mcp_client/schema_validator/shapes.rb
@@ -287,6 +287,8 @@ module MCPClient
 
         ecma_regexp(pattern, PATTERN_MATCH_TIMEOUT, deadline)
         nil
+      rescue EcmaPatterns::Untranslatable => e
+        "#{keyword} #{clip(pattern.inspect)} cannot be evaluated faithfully (#{clip(e.message)})"
       rescue RegexpError => e
         "#{keyword} #{clip(pattern.inspect)} is not an ECMA-262 regular expression (#{clip(e.message)})"
       rescue Aborted => e

--- a/lib/mcp_client/schema_validator/shapes.rb
+++ b/lib/mcp_client/schema_validator/shapes.rb
@@ -243,9 +243,18 @@ module MCPClient
         problems << '$recursiveAnchor must be a boolean' unless boolean_value?(schema['$recursiveAnchor'])
       end
 
+      # A vocabulary is identified by a URI (Core Section 8.1.2), never by a
+      # relative reference.
       # @return [Boolean]
       def vocabulary_map?(value)
-        value.is_a?(Hash) && value.all? { |uri, required| uri_reference?(uri.to_s) && boolean_value?(required) }
+        value.is_a?(Hash) && value.all? { |uri, required| absolute_uri?(uri.to_s) && boolean_value?(required) }
+      end
+
+      # @return [Boolean] whether the value is a URI with a scheme
+      def absolute_uri?(value)
+        !URI::RFC3986_PARSER.parse(value).scheme.nil?
+      rescue URI::InvalidURIError
+        false
       end
 
       # A `pattern`, and every `patternProperties` key, must be an ECMA-262
@@ -253,28 +262,35 @@ module MCPClient
       # Section 4.3) within the length bound. One that is not is a malformed
       # keyword: the schema is unusable, not a schema without the pattern
       # (which admitted every string).
+      # @param deadline [Float, nil] monotonic deadline the check runs under
       # @return [void]
-      def check_pattern_shapes(schema, dialect, problems)
+      def check_pattern_shapes(schema, dialect, problems, deadline = nil)
         pattern = schema['pattern']
-        problem = pattern_shape_problem('pattern', pattern) if pattern.is_a?(String)
+        problem = pattern_shape_problem('pattern', pattern, deadline) if pattern.is_a?(String)
         problems << problem if problem
         patterns = schema['patternProperties'] if keyword_known?('patternProperties', dialect)
         return unless patterns.is_a?(Hash)
 
         patterns.each_key do |key|
-          problem = pattern_shape_problem('patternProperties pattern', key.to_s)
+          break unless problems.empty?
+
+          problem = pattern_shape_problem('patternProperties pattern', key.to_s, deadline)
           problems << problem if problem
         end
       end
 
       # @return [String, nil] why a pattern cannot be used
-      def pattern_shape_problem(keyword, pattern)
+      def pattern_shape_problem(keyword, pattern, deadline = nil)
         return "#{keyword} is longer than #{MAX_PATTERN_LENGTH} characters" if pattern.length > MAX_PATTERN_LENGTH
+        return 'validation aborted: validation time budget exhausted during the schema check' if
+          budget_exhausted?(deadline)
 
-        ecma_regexp(pattern, PATTERN_MATCH_TIMEOUT)
+        ecma_regexp(pattern, PATTERN_MATCH_TIMEOUT, deadline)
         nil
       rescue RegexpError => e
         "#{keyword} #{clip(pattern.inspect)} is not an ECMA-262 regular expression (#{clip(e.message)})"
+      rescue Aborted => e
+        "validation aborted: #{e.message}"
       end
 
       # exclusiveMinimum / exclusiveMaximum are numbers in every supported

--- a/lib/mcp_client/schema_validator/uri_references.rb
+++ b/lib/mcp_client/schema_validator/uri_references.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+module MCPClient
+  module SchemaValidator
+    # URI reference resolution (RFC 3986 Section 5), used to decide which
+    # schema resource a `$ref` names. A JSON Schema document may bundle the
+    # resources it uses (JSON Schema 2020-12 Core Section 9.3.1): a reference
+    # written as an absolute URI, as a URI relative to the base an enclosing
+    # `$id` established, or as the empty reference then names a resource the
+    # document already carries, and resolving it needs no retrieval. Nothing
+    # here fetches or normalizes anything beyond what RFC 3986 defines, and
+    # nothing here raises: a reference a peer wrote that cannot be parsed
+    # simply names no local resource. Extended into SchemaValidator, so the
+    # methods are its own.
+    module UriReferences
+      # RFC 3986 Appendix B: the components of a URI reference.
+      URI_REFERENCE = %r{
+        \A
+        (?:(?<scheme>[A-Za-z][A-Za-z0-9+\-.]*):)?
+        (?://(?<authority>[^/?\#]*))?
+        (?<path>[^?\#]*)
+        (?:\?(?<query>[^\#]*))?
+        (?:\#(?<fragment>.*))?
+        \z
+      }mx
+
+      # Resolve a URI reference against a base URI (RFC 3986 Section 5.2.2),
+      # dropping the fragment: what comes back identifies a resource, which
+      # is what an `$id` declares and what a `$ref` selects before its
+      # fragment is applied.
+      # @param base [String] the base URI (may be empty when the document
+      #   declares none: relative references still resolve consistently
+      #   against each other)
+      # @param ref [String] the reference to resolve
+      # @return [String, nil] nil when either side is not a URI reference
+      def merge_uri(base, ref)
+        target = parse_uri_reference(ref)
+        origin = parse_uri_reference(base)
+        return nil unless target && origin
+        return merge_relative_uri(origin, target) unless target[:scheme]
+
+        compose_uri(target[:scheme], target[:authority], remove_dot_segments(target[:path]), target[:query])
+      end
+
+      # The RFC 3986 Section 5.2.2 branches for a reference without a scheme.
+      # @param origin [Hash] the parsed base URI
+      # @param target [Hash] the parsed reference
+      # @return [String]
+      def merge_relative_uri(origin, target)
+        if target[:authority]
+          compose_uri(origin[:scheme], target[:authority], remove_dot_segments(target[:path]), target[:query])
+        elsif target[:path].empty?
+          compose_uri(origin[:scheme], origin[:authority], origin[:path], target[:query] || origin[:query])
+        elsif target[:path].start_with?('/')
+          compose_uri(origin[:scheme], origin[:authority], remove_dot_segments(target[:path]), target[:query])
+        else
+          path = remove_dot_segments(merge_paths(origin, target[:path]))
+          compose_uri(origin[:scheme], origin[:authority], path, target[:query])
+        end
+      end
+
+      # @param uri [String]
+      # @return [Hash, nil] :scheme, :authority, :query (each String or nil)
+      #   and :path (always a String); nil when the text is not a URI
+      #   reference (or is not readable text at all)
+      def parse_uri_reference(uri)
+        return nil unless uri.is_a?(String)
+
+        match = URI_REFERENCE.match(uri)
+        return nil unless match
+
+        # A scheme is case-insensitive (RFC 3986 Section 3.1), so two
+        # spellings of one resource identify the same one.
+        { scheme: match[:scheme]&.downcase, authority: match[:authority], path: match[:path].to_s,
+          query: match[:query] }
+      rescue ArgumentError
+        nil
+      end
+
+      # RFC 3986 Section 5.3.
+      # @return [String]
+      def compose_uri(scheme, authority, path, query)
+        composed = +''
+        composed << "#{scheme}:" if scheme
+        composed << "//#{authority}" if authority
+        composed << path
+        composed << "?#{query}" if query
+        composed
+      end
+
+      # RFC 3986 Section 5.2.3: a relative path is merged onto the base's.
+      # @param origin [Hash] the parsed base URI
+      # @param path [String] the reference's relative path
+      # @return [String]
+      def merge_paths(origin, path)
+        return "/#{path}" if origin[:authority] && origin[:path].empty?
+
+        "#{origin[:path].sub(%r{[^/]*\z}, '')}#{path}"
+      end
+
+      # RFC 3986 Section 5.2.4.
+      # @param path [String]
+      # @return [String]
+      def remove_dot_segments(path)
+        input = path
+        output = []
+        until input.empty?
+          stripped = strip_leading_dots(input)
+          unless stripped.equal?(input)
+            input = stripped
+            next
+          end
+
+          stepped = dot_segment_step(input, output)
+          if stepped
+            input = stepped
+            next
+          end
+
+          segment = input[%r{\A/?[^/]*}]
+          output << segment
+          input = input[segment.length..]
+        end
+        output.join
+      end
+
+      # The RFC 3986 Section 5.2.4 A and B prefixes, which are simply dropped.
+      # @return [String] the input itself when neither applies
+      def strip_leading_dots(input)
+        return input.sub(%r{\A\.\.?/}, '') if input.start_with?('../', './')
+        return '' if ['.', '..'].include?(input)
+
+        input
+      end
+
+      # The RFC 3986 Section 5.2.4 C and D prefixes, which also pop an
+      # already-emitted segment for "..".
+      # @return [String, false] the remaining input, or false when the
+      #   prefix does not apply
+      def dot_segment_step(input, output)
+        return "/#{input[3..]}" if input.start_with?('/./')
+        return '/' if input == '/.'
+
+        if input.start_with?('/../') || input == '/..'
+          output.pop
+          return input == '/..' ? '/' : "/#{input[4..]}"
+        end
+
+        false
+      end
+    end
+  end
+end

--- a/lib/mcp_client/tool.rb
+++ b/lib/mcp_client/tool.rb
@@ -31,6 +31,13 @@ module MCPClient
     attr_reader :name, :title, :description, :schema, :output_schema, :annotations, :server, :task_support,
                 :icons, :meta
 
+    # @!attribute [r] schema_identity
+    #   @return [Object] a token naming this tool definition: every copy the
+    #     client cache hands out carries the same one, and a definition
+    #     fetched again carries a new one, so once-per-definition checks of
+    #     its schemas can be keyed without hashing a peer-supplied document
+    attr_reader :schema_identity
+
     # Initialize a new Tool
     # @param name [String] the name of the tool
     # @param description [String] the description of the tool
@@ -54,6 +61,9 @@ module MCPClient
       @task_support = task_support
       @icons = icons
       @meta = meta
+      # A frozen object is copied by reference by DeepCopy, so the token
+      # survives every copy of this definition.
+      @schema_identity = Object.new.freeze
     end
 
     # Create a Tool instance from JSON data

--- a/lib/mcp_client/tool.rb
+++ b/lib/mcp_client/tool.rb
@@ -64,7 +64,9 @@ module MCPClient
       # Some servers (Playwright MCP CLI) use 'inputSchema' instead of 'schema'
       # Handle both string and symbol keys
       schema = data['inputSchema'] || data[:inputSchema] || data['schema'] || data[:schema]
-      output_schema = data['outputSchema'] || data[:outputSchema]
+      # By key presence: a boolean false schema is a schema (one that
+      # accepts nothing), not an absent one.
+      output_schema = data.key?('outputSchema') ? data['outputSchema'] : data[:outputSchema]
       annotations = data['annotations'] || data[:annotations]
       title = data['title'] || data[:title]
       execution = data['execution'] || data[:execution]

--- a/lib/mcp_client/tool.rb
+++ b/lib/mcp_client/tool.rb
@@ -183,7 +183,11 @@ module MCPClient
     # Check if the tool supports structured outputs (MCP 2025-06-18)
     # @return [Boolean] true if the tool has an output schema defined
     def structured_output?
-      !@output_schema.nil? && !@output_schema.empty?
+      return false if @output_schema.nil?
+      # A boolean schema (true: any value; false: none) is a schema too.
+      return true unless @output_schema.respond_to?(:empty?)
+
+      !@output_schema.empty?
     end
 
     # Whether task-augmented execution is allowed for this tool (MCP 2025-11-25).

--- a/lib/mcp_client/tool.rb
+++ b/lib/mcp_client/tool.rb
@@ -185,11 +185,10 @@ module MCPClient
     # Check if the tool supports structured outputs (MCP 2025-06-18)
     # @return [Boolean] true if the tool has an output schema defined
     def structured_output?
-      return false if @output_schema.nil?
-      # A boolean schema (true: any value; false: none) is a schema too.
-      return true unless @output_schema.respond_to?(:empty?)
-
-      !@output_schema.empty?
+      # Any provided schema counts: a boolean schema (true: any value;
+      # false: none) and the empty schema `{}` (any value) included. Only
+      # the absence of outputSchema means no structured output.
+      !@output_schema.nil?
     end
 
     # Whether task-augmented execution is allowed for this tool (MCP 2025-11-25).

--- a/lib/mcp_client/tool.rb
+++ b/lib/mcp_client/tool.rb
@@ -49,13 +49,18 @@ module MCPClient
     # @param task_support [String, nil] execution.taskSupport value (MCP 2025-11-25)
     # @param icons [Array<Hash>, nil] optional icons for display in user interfaces (MCP 2025-11-25)
     # @param meta [Hash, nil] optional `_meta` metadata attached to the tool (MCP 2025-11-25)
+    # @param output_schema_declared [Boolean, nil] whether the definition carried
+    #   an outputSchema member at all; nil means "whenever a schema was given"
     def initialize(name:, description:, schema:, title: nil, output_schema: nil, annotations: nil, server: nil,
-                   task_support: nil, icons: nil, meta: nil)
+                   task_support: nil, icons: nil, meta: nil, output_schema_declared: nil)
       @name = name
       @title = title
       @description = description
       @schema = schema
       @output_schema = output_schema
+      # An explicit `"outputSchema": null` declares a schema — an unusable
+      # one — and is not the same as leaving the member out.
+      @output_schema_declared = output_schema_declared.nil? ? !output_schema.nil? : output_schema_declared
       @annotations = annotations
       @server = server
       @task_support = task_support
@@ -75,7 +80,9 @@ module MCPClient
       # Handle both string and symbol keys
       schema = data['inputSchema'] || data[:inputSchema] || data['schema'] || data[:schema]
       # By key presence: a boolean false schema is a schema (one that
-      # accepts nothing), not an absent one.
+      # accepts nothing), not an absent one, and neither is an explicit null
+      # (an unusable schema root, like any other non-schema value).
+      output_schema_declared = data.key?('outputSchema') || data.key?(:outputSchema)
       output_schema = data.key?('outputSchema') ? data['outputSchema'] : data[:outputSchema]
       annotations = data['annotations'] || data[:annotations]
       title = data['title'] || data[:title]
@@ -89,6 +96,7 @@ module MCPClient
         schema: schema,
         title: title,
         output_schema: output_schema,
+        output_schema_declared: output_schema_declared,
         annotations: annotations,
         server: server,
         task_support: task_support,
@@ -195,10 +203,11 @@ module MCPClient
     # Check if the tool supports structured outputs (MCP 2025-06-18)
     # @return [Boolean] true if the tool has an output schema defined
     def structured_output?
-      # Any provided schema counts: a boolean schema (true: any value;
-      # false: none) and the empty schema `{}` (any value) included. Only
-      # the absence of outputSchema means no structured output.
-      !@output_schema.nil?
+      # Any declared schema counts: a boolean schema (true: any value;
+      # false: none), the empty schema `{}` (any value) and an explicit null
+      # (a schema root the validator rejects) included. Only the absence of
+      # outputSchema means no structured output.
+      @output_schema_declared
     end
 
     # Whether task-augmented execution is allowed for this tool (MCP 2025-11-25).

--- a/spec/lib/mcp_client/cacheable_results_2026_round31_spec.rb
+++ b/spec/lib/mcp_client/cacheable_results_2026_round31_spec.rb
@@ -140,6 +140,9 @@ RSpec.describe 'MCP 2026-07-28 cacheable results — round 31' do
       end
       server.send(:note_request_params, { 'a' => 1 })
       server.send(:mark_round_trip_result, true)
+      # Round 30 of the JSON Schema work: the definition a HeaderMismatch
+      # retry was checked against is pinned on the thread for the send.
+      server.send(:pin_retry_definition, 'greet', nil) if server.respond_to?(:pin_retry_definition, true)
       Thread.current[server.send(:recorded_entries_key)] = { tools: Object.new }
       Thread.current[server.send(:served_entries_key)] = { tools: [Object.new, nil] }
       Thread.current[server.send(:response_received_key)] = 1.0

--- a/spec/lib/mcp_client/client_spec.rb
+++ b/spec/lib/mcp_client/client_spec.rb
@@ -731,6 +731,10 @@ RSpec.describe MCPClient::Client do
       end
 
       before do
+        # The client asks the transport about optional hooks while it wraps
+        # the stream; anything not stubbed below it simply does not have.
+        allow(mock_server).to receive(:respond_to?).and_return(false)
+        allow(mock_server2).to receive(:respond_to?).and_return(false)
         # Make sure mock_server responds to call_tool_streaming
         allow(mock_server).to receive(:call_tool_streaming).and_return(Enumerator.new { |y|
           [1, 2, 3].each do |i|
@@ -763,7 +767,10 @@ RSpec.describe MCPClient::Client do
       it 'streams from the specified server by name' do
         enum = multi_client.call_tool_streaming('test_tool', {}, server: 'server2')
         expect(mock_server2).to have_received(:call_tool_streaming).with('test_tool', {})
-        expect(enum).to eq(server2_stream)
+        # The client wraps the transport's stream (every chunk is checked
+        # against the tool's outputSchema), so the chunks are what identify
+        # the server that was streamed from, not the enumerator object.
+        expect(enum.to_a).to eq([4, 5, 6])
       end
     end
   end

--- a/spec/lib/mcp_client/client_spec.rb
+++ b/spec/lib/mcp_client/client_spec.rb
@@ -767,9 +767,11 @@ RSpec.describe MCPClient::Client do
       it 'streams from the specified server by name' do
         enum = multi_client.call_tool_streaming('test_tool', {}, server: 'server2')
         expect(mock_server2).to have_received(:call_tool_streaming).with('test_tool', {})
-        # The client wraps the transport's stream (every chunk is checked
-        # against the tool's outputSchema), so the chunks are what identify
-        # the server that was streamed from, not the enumerator object.
+        # The client wraps the transport's stream (a complete result chunk
+        # is checked against the tool's outputSchema — see the JSON Schema
+        # round 29 examples; this tool declares none and streams scalars),
+        # so the chunks are what identify the server that was streamed from,
+        # not the enumerator object.
         expect(enum.to_a).to eq([4, 5, 6])
       end
     end

--- a/spec/lib/mcp_client/json_schema_2026_round10_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round10_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, tenth review round: a `$ref` chain
+# that crosses into an embedded resource is followed by where each hop
+# lands, not by the text of its fragment, and an anchor declared twice in
+# one schema resource makes the schema unusable.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 10' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+
+  describe 'reference chains across resources' do
+    let(:schema) do
+      {
+        'properties' => { 'a' => { '$ref' => '#/$defs/x' } },
+        '$defs' => {
+          'x' => {
+            '$id' => 'https://example.com/inner',
+            '$ref' => '#/$defs/x',
+            '$defs' => { 'x' => { 'type' => 'string' } }
+          }
+        }
+      }
+    end
+
+    it 'follows the same fragment text into an embedded resource without calling it a cycle' do
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => 'ok' }, schema)).to be_empty
+      expect(validator.validate({ 'a' => 1 }, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+
+    it 'still reports a chain that returns to a schema it visited' do
+      cyclic = { 'properties' => { 'a' => { '$ref' => '#/$defs/x' } },
+                 '$defs' => { 'x' => { '$ref' => '#/$defs/y' }, 'y' => { '$ref' => '#/$defs/x' } } }
+      expect(validator.check_schema(cyclic)).to contain_exactly(a_string_matching(/cycles/))
+    end
+  end
+
+  describe 'duplicate anchors' do
+    it 'rejects an $anchor declared twice in one resource' do
+      schema = {
+        'properties' => { 'a' => { '$ref' => '#node' } },
+        '$defs' => { 'x' => { '$anchor' => 'node', 'type' => 'string' },
+                     'y' => { '$anchor' => 'node', 'type' => 'integer' } }
+      }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/anchor "node".*more than once/))
+      expect(validator.validate({ 'a' => 'ok' }, schema)).to contain_exactly(a_string_matching(/anchor "node"/))
+    end
+
+    it 'rejects a $dynamicAnchor colliding with an $anchor' do
+      schema = { '$defs' => { 'x' => { '$anchor' => 'node' }, 'y' => { '$dynamicAnchor' => 'node' } } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/anchor "node".*more than once/))
+    end
+
+    it 'rejects a draft-07 fragment $id declared twice' do
+      schema = { '$schema' => draft7,
+                 'definitions' => { 'x' => { '$id' => '#node' }, 'y' => { '$id' => '#node' } } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/anchor "node".*more than once/))
+    end
+
+    it 'allows the same name in different resources' do
+      schema = {
+        'properties' => { 'a' => { '$ref' => '#node' } },
+        '$defs' => { 'x' => { '$anchor' => 'node', 'type' => 'string' },
+                     'y' => { '$id' => 'https://example.com/other', '$anchor' => 'node', 'type' => 'integer' } }
+      }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => 1 }, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round10_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round10_spec.rb
@@ -40,8 +40,10 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 10' do
   describe 'names of a resource reached through a foreign bag' do
     let(:schema) do
       {
-        'properties' => { 'a' => { '$ref' => '#/definitions/x' } },
-        'definitions' => {
+        'properties' => { 'a' => { '$ref' => '#/x-defs/x' } },
+        # A vendor bag no dialect defines, so nothing walks it: the resource
+        # is reached only by following the pointer.
+        'x-defs' => {
           'x' => { '$id' => 'https://example.com/x', '$anchor' => 'trap', 'type' => 'object',
                    'properties' => { 'v' => { '$ref' => '#trap' } } }
         }

--- a/spec/lib/mcp_client/json_schema_2026_round10_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round10_spec.rb
@@ -37,6 +37,48 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 10' do
     end
   end
 
+  describe 'names of a resource reached through a foreign bag' do
+    let(:schema) do
+      {
+        'properties' => { 'a' => { '$ref' => '#/definitions/x' } },
+        'definitions' => {
+          'x' => { '$id' => 'https://example.com/x', '$anchor' => 'trap', 'type' => 'object',
+                   'properties' => { 'v' => { '$ref' => '#trap' } } }
+        }
+      }
+    end
+
+    it 'resolves the resource\'s own anchor even when the resource sits in a bag the dialect does not walk' do
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => { 'v' => {} } }, schema)).to be_empty
+      expect(validator.validate({ 'a' => { 'v' => 1 } },
+                                schema)).to contain_exactly(a_string_matching(/expected type object/))
+    end
+
+    it 'still hides that name from the enclosing resource' do
+      schema['properties']['b'] = { '$ref' => '#trap' }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable local \$ref "#trap"/))
+    end
+  end
+
+  describe 'wide leaf maps' do
+    it 'rejects a wide map of leaf values before copying it' do
+      huge = {}
+      (validator::MAX_STRUCTURAL_OBJECTS + 10).times { |i| huge["k#{i}"] = i }
+      schema = { 'type' => 'integer', 'x-huge' => huge }
+      allow(huge).to receive(:to_h).and_raise('the map must not be copied whole')
+      allow(huge).to receive(:each).and_raise('the map must not be copied whole')
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/structural elements/))
+      expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/structural elements/))
+    end
+
+    it 'runs the normalization under the validation deadline' do
+      schema = { 'type' => 'integer', 'x-slow' => { 'k' => 1 } }
+      past = Process.clock_gettime(Process::CLOCK_MONOTONIC) - 1
+      expect(validator.validate(1, schema, deadline: past)).to contain_exactly(a_string_matching(/aborted|time/))
+    end
+  end
+
   describe 'duplicate anchors' do
     it 'rejects an $anchor declared twice in one resource' do
       schema = {

--- a/spec/lib/mcp_client/json_schema_2026_round11_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round11_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, eleventh review round: a branch the
+# validator can only partly evaluate is no verdict for not / oneOf / if,
+# the structural bound covers deep subtrees, the client never hashes a
+# peer schema whole, a draft-07 `$id` beside a `$ref` is ignored, a
+# truncated anchor index makes the schema unusable, and malformed JSON
+# Pointer escapes are unresolvable.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 11' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+
+  describe 'partially evaluated branches' do
+    it 'does not reject a value because a not branch it cannot decide seemed to match' do
+      expect(validator.validate(3, { 'not' => { 'multipleOf' => 2 } })).to be_empty
+      expect(validator.validate(4, { 'not' => { 'multipleOf' => 2 } })).to be_empty
+      # A decided branch still asserts.
+      expect(validator.validate('x', { 'not' => { 'type' => 'string' } })).to contain_exactly(a_string_matching(/not/))
+      # A branch that fails on a supported keyword is decided even when it
+      # also carries an unsupported one.
+      undecided_then_failing = { 'not' => { 'allOf' => [{ 'multipleOf' => 2 }, { 'type' => 'string' }] } }
+      expect(validator.validate(3, undecided_then_failing)).to be_empty
+      expect(validator.validate('x', undecided_then_failing)).to be_empty
+    end
+
+    it 'does not count an undecided oneOf branch as a match' do
+      schema = { 'oneOf' => [{ 'multipleOf' => 2 }, { 'type' => 'integer' }] }
+      expect(validator.validate(3, schema)).to be_empty
+      decided = { 'oneOf' => [{ 'type' => 'number' }, { 'type' => 'integer' }] }
+      expect(validator.validate(3, decided)).to contain_exactly(a_string_matching(/oneOf/))
+    end
+
+    it 'skips a conditional whose if it cannot decide' do
+      schema = { 'if' => { 'multipleOf' => 2 }, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'string' } }
+      expect(validator.validate(3, schema)).to be_empty
+      decided = { 'if' => { 'type' => 'integer' }, 'then' => { 'type' => 'string' } }
+      expect(validator.validate(3, decided)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+
+    it 'keeps treating a partial pass as a pass where that is the permissive direction' do
+      expect(validator.validate(3, { 'anyOf' => [{ 'multipleOf' => 2 }] })).to be_empty
+      expect(validator.validate(3, { 'allOf' => [{ 'multipleOf' => 2 }] })).to be_empty
+    end
+  end
+
+  describe 'deep subtrees' do
+    def nested(levels, leaf)
+      levels.times.reduce(leaf) { |inner, _| { 'type' => 'object', 'properties' => { 'a' => inner } } }
+    end
+
+    it 'normalizes and charges a subtree below the nesting bound' do
+      schema = nested(40, { type: 'integer' })
+      data = 40.times.reduce('x') { |inner, _| { 'a' => inner } }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(data, schema)).to contain_exactly(a_string_matching(/expected type integer/))
+
+      wide = {}
+      (validator::MAX_STRUCTURAL_OBJECTS + 10).times { |i| wide["p#{i}"] = true }
+      expect(validator.check_schema(nested(40, { 'type' => 'object', 'properties' => wide })))
+        .to contain_exactly(a_string_matching(/structural elements/))
+    end
+
+    it 'reports a document nested beyond the bound instead of keeping the rest raw' do
+      deep = nested(validator::MAX_SCHEMA_DEPTH + 10, { 'type' => 'integer' })
+      expect(validator.check_schema(deep)).to contain_exactly(a_string_matching(/depth/))
+    end
+  end
+
+  describe 'draft-07 $id beside $ref' do
+    it 'ignores a URI $id next to a $ref like every other sibling' do
+      schema = { '$schema' => draft7,
+                 'properties' => { 'a' => { '$ref' => '#/definitions/int', '$id' => 'https://example.com/ignored' } },
+                 'definitions' => { 'int' => { 'type' => 'integer' } } }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => 1 }, schema)).to be_empty
+      expect(validator.validate({ 'a' => 'x' }, schema)).to contain_exactly(a_string_matching(/expected type integer/))
+    end
+  end
+
+  describe 'anchor index bound' do
+    it 'makes a document whose anchors cannot be fully indexed unusable' do
+      bag = {}
+      validator::MAX_SUBSCHEMAS.times { |i| bag["d#{i}"] = { 'type' => 'string' } }
+      schema = {
+        'properties' => { 'a' => { '$ref' => '#/$defs/holder/$defs/t' } },
+        '$defs' => { 'holder' => { '$defs' => { 't' => { '$id' => 'https://example.com/t', '$schema' => draft7,
+                                                         'items' => [{ 'type' => 'integer' }] } } } },
+        'definitions' => bag
+      }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/index/))
+      expect(validator.validate({ 'a' => ['x'] }, schema)).to contain_exactly(a_string_matching(/index/))
+    end
+  end
+
+  describe 'JSON Pointer escapes' do
+    it 'treats a tilde not followed by 0 or 1 as an unresolvable reference' do
+      schema = { 'properties' => { 'a' => { '$ref' => '#/$defs/bad~2key' } },
+                 '$defs' => { 'bad~2key' => { 'type' => 'string' } } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable/))
+      good = { 'properties' => { 'a' => { '$ref' => '#/$defs/a~0b~1c' } },
+               '$defs' => { 'a~b/c' => { 'type' => 'string' } } }
+      expect(validator.check_schema(good)).to be_empty
+    end
+  end
+
+  describe 'through MCPClient::Client' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+
+    def client_with(tools)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+      allow(mock_server).to receive(:on_notification)
+      allow(mock_server).to receive(:list_tools).and_return(tools)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger)
+    end
+
+    it 'never hashes a peer schema whole before the bounded check' do
+      deep = { 'type' => 'object' }
+      100_000.times { deep = { 'properties' => { 'a' => deep } } }
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: deep, output_schema: deep,
+                                 server: mock_server)
+      client = client_with([tool])
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => {} })
+
+      expect { client.send(:warn_unusable_input_schema, tool) }.not_to raise_error
+      expect { client.call_tool('t', {}) }.not_to raise_error
+      expect(log_output.string).to include('not usable')
+    end
+
+    it 'checks a schema again only when the tool carries a different one' do
+      schema = { 'type' => 'object', 'format' => 'custom' }
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: schema, output_schema: schema,
+                                 server: mock_server)
+      client = client_with([tool])
+      allow(validator).to receive(:check_schema).and_call_original
+
+      2.times { client.send(:warn_unusable_input_schema, tool) }
+      expect(validator).to have_received(:check_schema).once
+
+      refreshed = MCPClient::Tool.new(name: 't', description: 'd', schema: schema.dup, server: mock_server)
+      client.send(:warn_unusable_input_schema, refreshed)
+      expect(validator).to have_received(:check_schema).twice
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round11_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round11_spec.rb
@@ -34,8 +34,12 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 11' do
       expect(validator.validate(3, decided)).to contain_exactly(a_string_matching(/oneOf/))
     end
 
-    it 'skips a conditional whose if it cannot decide' do
-      schema = { 'if' => { 'multipleOf' => 2 }, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'string' } }
+    it 'skips a conditional whose if it cannot decide, unless the branches agree' do
+      # Neither branch can be selected, but both reject the value, so the
+      # instance is rejected whichever way the condition goes.
+      agreed = { 'if' => { 'multipleOf' => 2 }, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'string' } }
+      expect(validator.validate(3, agreed)).to contain_exactly(a_string_matching(/expected type string/))
+      schema = { 'if' => { 'multipleOf' => 2 }, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'integer' } }
       expect(validator.validate(3, schema)).to be_empty
       decided = { 'if' => { 'type' => 'integer' }, 'then' => { 'type' => 'string' } }
       expect(validator.validate(3, decided)).to contain_exactly(a_string_matching(/expected type string/))
@@ -85,11 +89,14 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 11' do
     it 'makes a document whose anchors cannot be fully indexed unusable' do
       bag = {}
       validator::MAX_SUBSCHEMAS.times { |i| bag["d#{i}"] = { 'type' => 'string' } }
+      # The bag sits under the container this dialect does not define, so
+      # the preflight walk never reads it while the index still must.
       schema = {
-        'properties' => { 'a' => { '$ref' => '#/$defs/holder/$defs/t' } },
-        '$defs' => { 'holder' => { '$defs' => { 't' => { '$id' => 'https://example.com/t', '$schema' => draft7,
-                                                         'items' => [{ 'type' => 'integer' }] } } } },
-        'definitions' => bag
+        '$schema' => draft7,
+        'properties' => { 'a' => { '$ref' => '#/definitions/holder/definitions/t' } },
+        'definitions' => { 'holder' => { 'definitions' => { 't' => { '$id' => 'https://example.com/t',
+                                                                     'items' => [{ 'type' => 'integer' }] } } } },
+        '$defs' => bag
       }
       expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/index/))
       expect(validator.validate({ 'a' => ['x'] }, schema)).to contain_exactly(a_string_matching(/index/))
@@ -127,7 +134,7 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 11' do
       client = client_with([tool])
       allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => {} })
 
-      expect { client.send(:warn_unusable_input_schema, tool) }.not_to raise_error
+      expect { client.send(:input_schema_state, tool) }.not_to raise_error
       expect { client.call_tool('t', {}) }.not_to raise_error
       expect(log_output.string).to include('not usable')
     end
@@ -139,11 +146,11 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 11' do
       client = client_with([tool])
       allow(validator).to receive(:check_schema).and_call_original
 
-      2.times { client.send(:warn_unusable_input_schema, tool) }
+      2.times { client.send(:input_schema_state, tool) }
       expect(validator).to have_received(:check_schema).once
 
       refreshed = MCPClient::Tool.new(name: 't', description: 'd', schema: schema.dup, server: mock_server)
-      client.send(:warn_unusable_input_schema, refreshed)
+      client.send(:input_schema_state, refreshed)
       expect(validator).to have_received(:check_schema).twice
     end
   end

--- a/spec/lib/mcp_client/json_schema_2026_round11_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round11_spec.rb
@@ -14,22 +14,23 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 11' do
 
   describe 'partially evaluated branches' do
     it 'does not reject a value because a not branch it cannot decide seemed to match' do
-      expect(validator.validate(3, { 'not' => { 'multipleOf' => 2 } })).to be_empty
-      expect(validator.validate(4, { 'not' => { 'multipleOf' => 2 } })).to be_empty
+      # `unevaluatedItems` needs the annotations a whole composition produces,
+      # so a branch carrying one is a verdict this validator cannot reach.
+      expect(validator.validate([1], { 'not' => { 'unevaluatedItems' => false } })).to be_empty
       # A decided branch still asserts.
       expect(validator.validate('x', { 'not' => { 'type' => 'string' } })).to contain_exactly(a_string_matching(/not/))
-      # A branch that fails on a supported keyword is decided even when it
-      # also carries an unsupported one.
-      undecided_then_failing = { 'not' => { 'allOf' => [{ 'multipleOf' => 2 }, { 'type' => 'string' }] } }
-      expect(validator.validate(3, undecided_then_failing)).to be_empty
-      # multipleOf does not apply to a string, so that branch is decided by
-      # its type alone and matches: not rejects the string.
+      # A branch that fails on an evaluated keyword is decided even when it
+      # also carries an unevaluated one.
+      undecided_then_failing = { 'not' => { 'allOf' => [{ 'unevaluatedItems' => false }, { 'type' => 'string' }] } }
+      expect(validator.validate([1], undecided_then_failing)).to be_empty
+      # unevaluatedItems does not apply to a string, so that branch is decided
+      # by its type alone and matches: not rejects the string.
       expect(validator.validate('x', undecided_then_failing)).to contain_exactly(a_string_matching(/not/))
     end
 
     it 'does not count an undecided oneOf branch as a match' do
-      schema = { 'oneOf' => [{ 'multipleOf' => 2 }, { 'type' => 'integer' }] }
-      expect(validator.validate(3, schema)).to be_empty
+      schema = { 'oneOf' => [{ 'unevaluatedItems' => false }, { 'type' => 'array' }] }
+      expect(validator.validate([1], schema)).to be_empty
       decided = { 'oneOf' => [{ 'type' => 'number' }, { 'type' => 'integer' }] }
       expect(validator.validate(3, decided)).to contain_exactly(a_string_matching(/oneOf/))
     end
@@ -37,17 +38,25 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 11' do
     it 'skips a conditional whose if it cannot decide, unless the branches agree' do
       # Neither branch can be selected, but both reject the value, so the
       # instance is rejected whichever way the condition goes.
-      agreed = { 'if' => { 'multipleOf' => 2 }, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'string' } }
-      expect(validator.validate(3, agreed)).to contain_exactly(a_string_matching(/expected type string/))
-      schema = { 'if' => { 'multipleOf' => 2 }, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'integer' } }
-      expect(validator.validate(3, schema)).to be_empty
+      condition = { 'unevaluatedItems' => false }
+      agreed = { 'if' => condition, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'string' } }
+      expect(validator.validate([1], agreed)).to contain_exactly(a_string_matching(/expected type string/))
+      schema = { 'if' => condition, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'array' } }
+      expect(validator.validate([1], schema)).to be_empty
       decided = { 'if' => { 'type' => 'integer' }, 'then' => { 'type' => 'string' } }
       expect(validator.validate(3, decided)).to contain_exactly(a_string_matching(/expected type string/))
     end
 
     it 'keeps treating a partial pass as a pass where that is the permissive direction' do
-      expect(validator.validate(3, { 'anyOf' => [{ 'multipleOf' => 2 }] })).to be_empty
-      expect(validator.validate(3, { 'allOf' => [{ 'multipleOf' => 2 }] })).to be_empty
+      expect(validator.validate([1], { 'anyOf' => [{ 'unevaluatedItems' => false }] })).to be_empty
+      expect(validator.validate([1], { 'allOf' => [{ 'unevaluatedItems' => false }] })).to be_empty
+      # An assertion this validator does evaluate decides those compositions
+      # rather than passing them: an unevaluated one is not a licence to
+      # accept what the schema rejects.
+      expect(validator.validate(4, { 'anyOf' => [{ 'multipleOf' => 3 }] }))
+        .to contain_exactly(a_string_matching(/anyOf/))
+      expect(validator.validate(4, { 'allOf' => [{ 'multipleOf' => 3 }] }))
+        .to contain_exactly(a_string_matching(%r{allOf/0}))
     end
   end
 

--- a/spec/lib/mcp_client/json_schema_2026_round11_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round11_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 11' do
       # also carries an unsupported one.
       undecided_then_failing = { 'not' => { 'allOf' => [{ 'multipleOf' => 2 }, { 'type' => 'string' }] } }
       expect(validator.validate(3, undecided_then_failing)).to be_empty
-      expect(validator.validate('x', undecided_then_failing)).to be_empty
+      # multipleOf does not apply to a string, so that branch is decided by
+      # its type alone and matches: not rejects the string.
+      expect(validator.validate('x', undecided_then_failing)).to contain_exactly(a_string_matching(/not/))
     end
 
     it 'does not count an undecided oneOf branch as a match' do

--- a/spec/lib/mcp_client/json_schema_2026_round11_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round11_spec.rb
@@ -38,7 +38,10 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 11' do
     it 'skips a conditional whose if it cannot decide, unless the branches agree' do
       # Neither branch can be selected, but both reject the value, so the
       # instance is rejected whichever way the condition goes.
-      condition = { 'unevaluatedItems' => false }
+      # A `$dynamicRef` needs the dynamic scope a validation was entered
+      # through, which this validator does not track: a condition carrying
+      # one is genuinely undecidable.
+      condition = { '$dynamicRef' => '#node' }
       agreed = { 'if' => condition, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'string' } }
       expect(validator.validate([1], agreed)).to contain_exactly(a_string_matching(/expected type string/))
       schema = { 'if' => condition, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'array' } }
@@ -48,8 +51,8 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 11' do
     end
 
     it 'keeps treating a partial pass as a pass where that is the permissive direction' do
-      expect(validator.validate([1], { 'anyOf' => [{ 'unevaluatedItems' => false }] })).to be_empty
-      expect(validator.validate([1], { 'allOf' => [{ 'unevaluatedItems' => false }] })).to be_empty
+      expect(validator.validate([1], { 'anyOf' => [{ '$dynamicRef' => '#node' }] })).to be_empty
+      expect(validator.validate([1], { 'allOf' => [{ '$dynamicRef' => '#node' }] })).to be_empty
       # An assertion this validator does evaluate decides those compositions
       # rather than passing them: an unevaluated one is not a licence to
       # accept what the schema rejects.

--- a/spec/lib/mcp_client/json_schema_2026_round11_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round11_spec.rb
@@ -38,21 +38,24 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 11' do
     it 'skips a conditional whose if it cannot decide, unless the branches agree' do
       # Neither branch can be selected, but both reject the value, so the
       # instance is rejected whichever way the condition goes.
-      # A `$dynamicRef` needs the dynamic scope a validation was entered
-      # through, which this validator does not track: a condition carrying
-      # one is genuinely undecidable.
-      condition = { '$dynamicRef' => '#node' }
-      agreed = { 'if' => condition, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'string' } }
-      expect(validator.validate([1], agreed)).to contain_exactly(a_string_matching(/expected type string/))
-      schema = { 'if' => condition, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'array' } }
-      expect(validator.validate([1], schema)).to be_empty
+      # draft-07 `format` asserts and formats are not evaluated: a string
+      # branch carrying one is genuinely undecidable.
+      draft7 = MCPClient::SchemaValidator::DRAFT_07
+      condition = { 'format' => 'email' }
+      agreed = { '$schema' => draft7, 'if' => condition, 'then' => { 'type' => 'integer' },
+                 'else' => { 'type' => 'integer' } }
+      expect(validator.validate('x', agreed)).to contain_exactly(a_string_matching(/expected type integer/))
+      schema = { '$schema' => draft7, 'if' => condition, 'then' => { 'type' => 'integer' },
+                 'else' => { 'type' => 'string' } }
+      expect(validator.validate('x', schema)).to be_empty
       decided = { 'if' => { 'type' => 'integer' }, 'then' => { 'type' => 'string' } }
       expect(validator.validate(3, decided)).to contain_exactly(a_string_matching(/expected type string/))
     end
 
     it 'keeps treating a partial pass as a pass where that is the permissive direction' do
-      expect(validator.validate([1], { 'anyOf' => [{ '$dynamicRef' => '#node' }] })).to be_empty
-      expect(validator.validate([1], { 'allOf' => [{ '$dynamicRef' => '#node' }] })).to be_empty
+      draft7 = MCPClient::SchemaValidator::DRAFT_07
+      expect(validator.validate('x', { '$schema' => draft7, 'anyOf' => [{ 'format' => 'email' }] })).to be_empty
+      expect(validator.validate('x', { '$schema' => draft7, 'allOf' => [{ 'format' => 'email' }] })).to be_empty
       # An assertion this validator does evaluate decides those compositions
       # rather than passing them: an unevaluated one is not a licence to
       # accept what the schema rejects.

--- a/spec/lib/mcp_client/json_schema_2026_round12_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round12_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 12' do
     end
 
     it 'makes the schema unusable instead of resolving # against the document root' do
-      expect(validator.check_schema(schema)).to include(a_string_matching(/anchors|unresolvable/))
+      # Since round 14 the target is bounded by its own (too deep) position.
+      expect(validator.check_schema(schema)).to include(a_string_matching(/anchors|unresolvable|depth/))
       expect(validator.validate({ 'a' => { 'v' => 'nope' } }, schema)).not_to be_empty
     end
 

--- a/spec/lib/mcp_client/json_schema_2026_round12_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round12_spec.rb
@@ -49,18 +49,26 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 12' do
     end
 
     it 'ignores an unevaluated assertion that does not apply to the instance' do
-      expect(validator.validate('x', { 'not' => { 'multipleOf' => 2 } })).to contain_exactly(a_string_matching(/not/))
-      expect(validator.validate('x', { 'not' => { 'additionalProperties' => false } }))
+      expect(validator.validate('x', { 'not' => { 'unevaluatedProperties' => false } }))
         .to contain_exactly(a_string_matching(/not/))
-      expect(validator.validate(3, { 'not' => { 'uniqueItems' => true } })).to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate(3, { 'not' => { 'unevaluatedItems' => false } }))
+        .to contain_exactly(a_string_matching(/not/))
     end
 
     it 'stays undecided for an unevaluated assertion that applies to the instance' do
-      expect(validator.validate(3, { 'not' => { 'multipleOf' => 2 } })).to be_empty
-      expect(validator.validate({ 'a' => 1 }, { 'not' => { 'additionalProperties' => false } })).to be_empty
-      expect(validator.validate([1, 1], { 'not' => { 'uniqueItems' => true } })).to be_empty
-      expect(validator.validate([1], { 'oneOf' => [{ 'type' => 'array' }, { 'contains' => { 'type' => 'integer' } }] }))
+      expect(validator.validate({ 'a' => 1 }, { 'not' => { 'unevaluatedProperties' => false } })).to be_empty
+      expect(validator.validate([1], { 'not' => { 'unevaluatedItems' => false } })).to be_empty
+      expect(validator.validate([1], { 'oneOf' => [{ 'type' => 'array' }, { 'unevaluatedItems' => false }] }))
         .to be_empty
+    end
+
+    it 'decides a branch whose only assertion the validator now evaluates' do
+      expect(validator.validate([1, 1], { 'not' => { 'uniqueItems' => true } })).to be_empty
+      expect(validator.validate([1, 2], { 'not' => { 'uniqueItems' => true } }))
+        .to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate({ 'a' => 1 }, { 'not' => { 'additionalProperties' => false } })).to be_empty
+      expect(validator.validate({}, { 'not' => { 'additionalProperties' => false } }))
+        .to contain_exactly(a_string_matching(/not/))
     end
   end
 end

--- a/spec/lib/mcp_client/json_schema_2026_round12_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round12_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, twelfth review round: a `$id`
+# resource the anchor index could not reach is truncation, a reference from
+# an unindexed schema never falls back to the document root, and a branch
+# is undecided only while an unevaluated assertion that applies to the
+# instance remains (annotations such as `format` decide nothing).
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 12' do
+  let(:validator) { MCPClient::SchemaValidator }
+
+  describe 'resources beyond the index depth' do
+    let(:schema) do
+      inner = { '$id' => 'https://example.com/deep', 'type' => 'object',
+                'properties' => { 'v' => { '$ref' => '#' } } }
+      (validator::MAX_SCHEMA_DEPTH + 1).times { inner = { 'not' => inner } }
+      { 'properties' => { 'a' => { '$ref' => "#/definitions/x#{'/not' * (validator::MAX_SCHEMA_DEPTH + 1)}" } },
+        'definitions' => { 'x' => inner } }
+    end
+
+    it 'makes the schema unusable instead of resolving # against the document root' do
+      expect(validator.check_schema(schema)).to include(a_string_matching(/anchors|unresolvable/))
+      expect(validator.validate({ 'a' => { 'v' => 'nope' } }, schema)).not_to be_empty
+    end
+
+    it 'never resolves a reference from a schema the index does not know' do
+      index = validator.anchor_index({ 'type' => 'object' }, validator::DEFAULT_DIALECT)
+      stranger = { '$ref' => '#' }
+      resolved = validator.resolve_reference({ 'type' => 'object' }, '#', validator::DEFAULT_DIALECT,
+                                             { anchors: index }, from: stranger)
+      expect(resolved).to equal(validator::UNRESOLVED)
+    end
+  end
+
+  describe 'undecided branches' do
+    it 'treats format as an annotation that decides nothing' do
+      expect(validator.validate(1, { 'not' => { 'format' => 'email' } })).to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate(1, { 'not' => { 'type' => 'integer', 'format' => 'int32' } }))
+        .to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate('x', { 'if' => { 'format' => 'email' }, 'then' => false }))
+        .to contain_exactly(a_string_matching(/false/))
+    end
+
+    it 'counts a branch decided by its evaluated keywords in oneOf' do
+      schema = { 'oneOf' => [{ 'type' => 'integer' }, { 'type' => 'integer', 'format' => 'int32' }] }
+      expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/oneOf/))
+    end
+
+    it 'ignores an unevaluated assertion that does not apply to the instance' do
+      expect(validator.validate('x', { 'not' => { 'multipleOf' => 2 } })).to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate('x', { 'not' => { 'additionalProperties' => false } }))
+        .to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate(3, { 'not' => { 'uniqueItems' => true } })).to contain_exactly(a_string_matching(/not/))
+    end
+
+    it 'stays undecided for an unevaluated assertion that applies to the instance' do
+      expect(validator.validate(3, { 'not' => { 'multipleOf' => 2 } })).to be_empty
+      expect(validator.validate({ 'a' => 1 }, { 'not' => { 'additionalProperties' => false } })).to be_empty
+      expect(validator.validate([1, 1], { 'not' => { 'uniqueItems' => true } })).to be_empty
+      expect(validator.validate([1], { 'oneOf' => [{ 'type' => 'array' }, { 'contains' => { 'type' => 'integer' } }] }))
+        .to be_empty
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round13_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round13_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, thirteenth review round: a definite
+# verdict is never weakened by uncertainty inside a branch that was decided
+# anyway — a failing branch leaves no uncertainty behind, anyOf passes once
+# any branch definitely passes, and oneOf fails once two branches do.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 13' do
+  let(:validator) { MCPClient::SchemaValidator }
+
+  it 'discards the uncertainty of a branch that definitely fails' do
+    schema = { 'not' => { 'not' => { 'minimum' => 10, 'multipleOf' => 2 } } }
+    expect(validator.validate(3, schema)).to contain_exactly(a_string_matching(/not/))
+    expect(validator.validate(12, schema)).to be_empty
+  end
+
+  it 'lets anyOf pass on a later definite branch, whatever the order' do
+    expect(validator.validate(3, { 'not' => { 'anyOf' => [{ 'multipleOf' => 2 }, true] } }))
+      .to contain_exactly(a_string_matching(/not/))
+    expect(validator.validate(3, { 'not' => { 'anyOf' => [true, { 'multipleOf' => 2 }] } }))
+      .to contain_exactly(a_string_matching(/not/))
+    expect(validator.validate(3, { 'not' => { 'anyOf' => [{ 'multipleOf' => 2 }, { 'type' => 'string' }] } }))
+      .to be_empty
+  end
+
+  it 'rejects oneOf once two branches definitely pass' do
+    expect(validator.validate(3, { 'oneOf' => [true, true, { 'multipleOf' => 2 }] }))
+      .to contain_exactly(a_string_matching(/oneOf/))
+    expect(validator.validate(3, { 'oneOf' => [true, { 'type' => 'string' }, { 'multipleOf' => 2 }] })).to be_empty
+    expect(validator.validate(3, { 'not' => { 'oneOf' => [true, true, { 'multipleOf' => 2 }] } })).to be_empty
+  end
+
+  it 'keeps a genuinely undecided branch undecided' do
+    expect(validator.validate(3, { 'not' => { 'multipleOf' => 2 } })).to be_empty
+    expect(validator.validate(3, { 'not' => { 'anyOf' => [{ 'multipleOf' => 2 }, { 'type' => 'string' }] } }))
+      .to be_empty
+    expect(validator.validate(3, { 'oneOf' => [true, { 'multipleOf' => 2 }] })).to be_empty
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round13_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round13_spec.rb
@@ -10,8 +10,13 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 13' do
   let(:validator) { MCPClient::SchemaValidator }
 
   it 'discards the uncertainty of a branch that definitely fails' do
-    schema = { 'not' => { 'not' => { 'minimum' => 10, 'multipleOf' => 2 } } }
+    # The branch holds a keyword this validator cannot decide (`$dynamicRef`
+    # needs a dynamic scope) beside one it can: the definite failure decides
+    # the branch, and the uncertainty is not carried out of it.
+    schema = { 'not' => { 'not' => { 'minimum' => 10, '$dynamicRef' => '#x' } } }
     expect(validator.validate(3, schema)).to contain_exactly(a_string_matching(/not/))
+    # Without the definite failure the same branch is genuinely undecided,
+    # and the uncertainty does reach the outer negation.
     expect(validator.validate(12, schema)).to be_empty
   end
 
@@ -32,9 +37,13 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 13' do
   end
 
   it 'keeps a genuinely undecided branch undecided' do
-    expect(validator.validate(3, { 'not' => { 'multipleOf' => 2 } })).to be_empty
-    expect(validator.validate(3, { 'not' => { 'anyOf' => [{ 'multipleOf' => 2 }, { 'type' => 'string' }] } }))
-      .to be_empty
-    expect(validator.validate(3, { 'oneOf' => [true, { 'multipleOf' => 2 }] })).to be_empty
+    # `multipleOf` is evaluated and decides its branch outright, so what is
+    # left undecided here is a keyword no verdict can be reached for.
+    undecidable = { '$dynamicRef' => '#x' }
+    expect(validator.validate(3, { 'not' => undecidable })).to be_empty
+    expect(validator.validate(3, { 'not' => { 'anyOf' => [undecidable, { 'type' => 'string' }] } })).to be_empty
+    expect(validator.validate(3, { 'oneOf' => [true, undecidable] })).to be_empty
+    # And a branch the validator can decide is decided: `not` reports it.
+    expect(validator.validate(3, { 'not' => { 'multipleOf' => 3 } })).to contain_exactly(a_string_matching(/not/))
   end
 end

--- a/spec/lib/mcp_client/json_schema_2026_round13_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round13_spec.rb
@@ -8,16 +8,18 @@ require 'spec_helper'
 # any branch definitely passes, and oneOf fails once two branches do.
 RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 13' do
   let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { MCPClient::SchemaValidator::DRAFT_07 }
 
   it 'discards the uncertainty of a branch that definitely fails' do
-    # The branch holds a keyword this validator cannot decide (`$dynamicRef`
-    # needs a dynamic scope) beside one it can: the definite failure decides
-    # the branch, and the uncertainty is not carried out of it.
-    schema = { 'not' => { 'not' => { 'minimum' => 10, '$dynamicRef' => '#x' } } }
-    expect(validator.validate(3, schema)).to contain_exactly(a_string_matching(/not/))
+    # The branch holds a keyword this validator cannot decide (draft-07
+    # `format` asserts, and formats are not evaluated) beside one it can: the
+    # definite failure decides the branch, and the uncertainty is not carried
+    # out of it.
+    schema = { '$schema' => draft7, 'not' => { 'not' => { 'minLength' => 10, 'format' => 'email' } } }
+    expect(validator.validate('short', schema)).to contain_exactly(a_string_matching(/not/))
     # Without the definite failure the same branch is genuinely undecided,
     # and the uncertainty does reach the outer negation.
-    expect(validator.validate(12, schema)).to be_empty
+    expect(validator.validate('long enough to pass', schema)).to be_empty
   end
 
   it 'lets anyOf pass on a later definite branch, whatever the order' do
@@ -37,13 +39,16 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 13' do
   end
 
   it 'keeps a genuinely undecided branch undecided' do
-    # `multipleOf` is evaluated and decides its branch outright, so what is
-    # left undecided here is a keyword no verdict can be reached for.
-    undecidable = { '$dynamicRef' => '#x' }
-    expect(validator.validate(3, { 'not' => undecidable })).to be_empty
-    expect(validator.validate(3, { 'not' => { 'anyOf' => [undecidable, { 'type' => 'string' }] } })).to be_empty
-    expect(validator.validate(3, { 'oneOf' => [true, undecidable] })).to be_empty
+    # `minLength` is evaluated and decides its branch outright, so what is
+    # left undecided here is a keyword no verdict can be reached for: a
+    # draft-07 `format`, which asserts there and is not evaluated.
+    undecidable = { 'format' => 'email' }
+    expect(validator.validate('x', { '$schema' => draft7, 'not' => undecidable })).to be_empty
+    expect(validator.validate('x', { '$schema' => draft7,
+                                     'not' => { 'anyOf' => [undecidable, { 'type' => 'integer' }] } })).to be_empty
+    expect(validator.validate('x', { '$schema' => draft7, 'oneOf' => [true, undecidable] })).to be_empty
     # And a branch the validator can decide is decided: `not` reports it.
-    expect(validator.validate(3, { 'not' => { 'multipleOf' => 3 } })).to contain_exactly(a_string_matching(/not/))
+    expect(validator.validate('x', { '$schema' => draft7, 'not' => { 'minLength' => 1 } }))
+      .to contain_exactly(a_string_matching(/not/))
   end
 end

--- a/spec/lib/mcp_client/json_schema_2026_round14_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round14_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, fourteenth review round: a decided
+# composition stops evaluating branches, only an assertion that can still
+# change the result is uncertainty, referenced targets are bounded by their
+# own position, and boolean subschemas obey the depth bound.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 14' do
+  let(:validator) { MCPClient::SchemaValidator }
+
+  it 'stops a composition once its outcome is definite' do
+    expect(validator.validate(1, { 'anyOf' => [true, { '$ref' => '#' }] })).to be_empty
+    expect(validator.validate(1, { 'not' => { 'oneOf' => [true, true, { '$ref' => '#' }] } })).to be_empty
+    expect(validator.validate(1, { 'not' => { 'allOf' => [false, { '$ref' => '#' }] } })).to be_empty
+    huge = Array.new(validator::MAX_NODE_VISITS + 10, 1)
+    expect(validator.validate(huge, { 'anyOf' => [true, { 'items' => true }] })).to be_empty
+  end
+
+  it 'counts only an assertion that can still change the result as uncertainty' do
+    expect(validator.validate([], { 'not' => { 'minContains' => 1 } })).to contain_exactly(a_string_matching(/not/))
+    expect(validator.validate([1], { 'if' => { 'maxContains' => 0 }, 'then' => false })).not_to be_empty
+    expect(validator.validate([], { 'oneOf' => [{ 'minContains' => 1 }, { 'type' => 'array' }] }))
+      .to contain_exactly(a_string_matching(/oneOf/))
+    draft7 = { '$schema' => 'http://json-schema.org/draft-07/schema#',
+               'not' => { 'additionalItems' => false, 'items' => { 'type' => 'number' } } }
+    expect(validator.validate([1, 2], draft7)).to contain_exactly(a_string_matching(/not/))
+    expect(validator.validate({}, { 'not' => { 'additionalProperties' => true } }))
+      .to contain_exactly(a_string_matching(/not/))
+    expect(validator.validate([1, 1],
+                              { 'not' => { 'uniqueItems' => false } })).to contain_exactly(a_string_matching(/not/))
+    expect(validator.validate({}, { 'oneOf' => [{ 'type' => 'object' }, { 'additionalProperties' => true }] }))
+      .to contain_exactly(a_string_matching(/oneOf/))
+    # Still genuinely undecided.
+    expect(validator.validate([1],
+                              { 'not' => { 'contains' => { 'type' => 'integer' }, 'minContains' => 2 } })).to be_empty
+    expect(validator.validate({ 'a' => 1 }, { 'not' => { 'additionalProperties' => false } })).to be_empty
+    expect(validator.validate([1, 1], { 'not' => { 'uniqueItems' => true } })).to be_empty
+  end
+
+  it 'bounds a referenced target by its own position, whatever the key order' do
+    leaf = { '$ref' => '#/$defs/x' }
+    nested = leaf
+    (validator::MAX_SCHEMA_DEPTH - 1).times { nested = { 'type' => 'object', 'properties' => { 'a' => nested } } }
+    defs_last = { 'type' => 'object', 'properties' => { 'a' => nested }, '$defs' => { 'x' => { 'type' => 'string' } } }
+    defs_first = { '$defs' => { 'x' => { 'type' => 'string' } }, 'type' => 'object', 'properties' => { 'a' => nested } }
+    expect(validator.check_schema(defs_first)).to eq(validator.check_schema(defs_last))
+    expect(validator.check_schema(defs_last)).to be_empty
+  end
+
+  it 'charges a boolean target once, not per reference' do
+    props = {}
+    1500.times { |i| props["p#{i}"] = { '$ref' => '#/$defs/t' } }
+    schema = { 'type' => 'object', 'properties' => props, '$defs' => { 't' => true } }
+    expect(validator.check_schema(schema)).to be_empty
+  end
+
+  it 'applies the depth bound to boolean subschemas' do
+    ending_true = true
+    ending_object = {}
+    (validator::MAX_SCHEMA_DEPTH + 1).times do
+      ending_true = { 'not' => ending_true }
+      ending_object = { 'not' => ending_object }
+    end
+    expect(validator.check_schema(ending_object)).to contain_exactly(a_string_matching(/depth/))
+    expect(validator.check_schema(ending_true)).to contain_exactly(a_string_matching(/depth/))
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round15_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round15_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, fifteenth review round: lexical
+# depths follow each resource's dialect, the keyword scan and boolean
+# reference targets are bounded by their own position, an unusable input
+# schema asserts nothing, and a tautological additionalItems is decided.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 15' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+  let(:modern) { 'https://json-schema.org/draft/2020-12/schema' }
+
+  def nested_properties(depth, leaf)
+    (1..depth).reduce(leaf) { |inner, _| { 'properties' => { 'a' => inner } } }
+  end
+
+  def nested_not(depth, leaf)
+    (1..depth).reduce(leaf) { |inner, _| { 'not' => inner } }
+  end
+
+  it 'bounds a boolean reference target by its own lexical depth' do
+    deep_bool = nested_not(validator::MAX_SCHEMA_DEPTH + 1, true)
+    pointer = "#/definitions/n#{'/not' * (validator::MAX_SCHEMA_DEPTH + 1)}"
+    schema = { 'properties' => { 'a' => { '$ref' => pointer } }, 'definitions' => { 'n' => deep_bool } }
+    expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/depth/))
+
+    shallow = { 'properties' => { 'a' => { '$ref' => '#/definitions/n/not' } },
+                'definitions' => { 'n' => { 'not' => true } } }
+    expect(validator.check_schema(shallow)).to be_empty
+  end
+
+  it 'follows each resource dialect when computing lexical depths, whatever the key order' do
+    target = { '$id' => 'https://example.com/r', '$schema' => modern,
+               'prefixItems' => [{ 'type' => 'integer' }] }
+    chain = nested_properties(validator::MAX_SCHEMA_DEPTH, { '$ref' => '#/definitions/r/prefixItems/0' })
+    ref_first = { '$schema' => draft7 }.merge(chain).merge('definitions' => { 'r' => target })
+    resource_first = { '$schema' => draft7, 'definitions' => { 'r' => target } }.merge(chain)
+
+    expect(validator.check_schema(ref_first)).to be_empty
+    expect(validator.check_schema(resource_first)).to be_empty
+  end
+
+  it 'scans a referenced target for unsupported keywords at its own lexical depth' do
+    chain = nested_properties(validator::MAX_SCHEMA_DEPTH - 1, { '$ref' => '#/$defs/t' })
+    schema = chain.merge('$defs' => { 't' => { 'items' => { 'uniqueItems' => true } } })
+    expect(validator.check_schema(schema)).to be_empty
+    expect(validator.unsupported_keywords(schema)).to include('uniqueItems')
+  end
+
+  it 'treats a tautological additionalItems beside a tuple as decided' do
+    schema = { '$schema' => draft7, 'not' => { 'items' => [true], 'additionalItems' => true } }
+    expect(validator.validate([1], schema)).to contain_exactly(a_string_matching(/not/))
+    empty_schema = { '$schema' => draft7, 'not' => { 'items' => [true], 'additionalItems' => {} } }
+    expect(validator.validate([1], empty_schema)).to contain_exactly(a_string_matching(/not/))
+    real = { '$schema' => draft7, 'not' => { 'items' => [true], 'additionalItems' => false } }
+    expect(validator.validate([1, 2], real)).to be_empty
+  end
+
+  describe 'through MCPClient::Client' do
+    let(:logger) { Logger.new(StringIO.new) }
+    let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+
+    it 'sends the call when the input schema is unusable, whatever it claims to require' do
+      schema = { '$schema' => 'urn:unknown-dialect', 'type' => 'object', 'required' => ['x'] }
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: schema, server: mock_server)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+      allow(mock_server).to receive(:on_notification)
+      allow(mock_server).to receive(:list_tools).and_return([tool])
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [] })
+      client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger)
+
+      expect { client.call_tool('t', {}) }.not_to raise_error
+      expect { client.call_tool('t', {}) }.not_to raise_error
+      expect(mock_server).to have_received(:call_tool).twice
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round15_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round15_spec.rb
@@ -49,10 +49,12 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 15' do
   end
 
   it 'treats a tautological additionalItems beside a tuple as decided' do
+    # Two items against a one-schema tuple, so `additionalItems` really does
+    # apply to the second: a tautological one still decides the branch.
     schema = { '$schema' => draft7, 'not' => { 'items' => [true], 'additionalItems' => true } }
-    expect(validator.validate([1], schema)).to contain_exactly(a_string_matching(/not/))
+    expect(validator.validate([1, 2], schema)).to contain_exactly(a_string_matching(/not/))
     empty_schema = { '$schema' => draft7, 'not' => { 'items' => [true], 'additionalItems' => {} } }
-    expect(validator.validate([1], empty_schema)).to contain_exactly(a_string_matching(/not/))
+    expect(validator.validate([1, 2], empty_schema)).to contain_exactly(a_string_matching(/not/))
     real = { '$schema' => draft7, 'not' => { 'items' => [true], 'additionalItems' => false } }
     expect(validator.validate([1, 2], real)).to be_empty
   end
@@ -62,7 +64,12 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 15' do
     let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
 
     it 'sends the call when the input schema is unusable, whatever it claims to require' do
-      schema = { '$schema' => 'urn:unknown-dialect', 'type' => 'object', 'required' => ['x'] }
+      # An unusable schema asserts nothing, so the server judges the
+      # arguments; an unsupported *dialect* is an error instead (MCP
+      # 2026-07-28 "Implementation Requirements"), covered in the
+      # verification round.
+      schema = { 'type' => 'object', 'required' => ['x'],
+                 'properties' => { 'x' => { '$ref' => 'https://example.com/x' } } }
       tool = MCPClient::Tool.new(name: 't', description: 'd', schema: schema, server: mock_server)
       allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
       allow(mock_server).to receive(:on_notification)

--- a/spec/lib/mcp_client/json_schema_2026_round15_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round15_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 15' do
 
   it 'scans a referenced target for unsupported keywords at its own lexical depth' do
     chain = nested_properties(validator::MAX_SCHEMA_DEPTH - 1, { '$ref' => '#/$defs/t' })
-    schema = chain.merge('$defs' => { 't' => { 'items' => { 'uniqueItems' => true } } })
+    schema = chain.merge('$defs' => { 't' => { 'items' => { 'unevaluatedItems' => false } } })
     expect(validator.check_schema(schema)).to be_empty
-    expect(validator.unsupported_keywords(schema)).to include('uniqueItems')
+    expect(validator.unsupported_keywords(schema)).to include('unevaluatedItems')
   end
 
   it 'treats a tautological additionalItems beside a tuple as decided' do

--- a/spec/lib/mcp_client/json_schema_2026_round15_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round15_spec.rb
@@ -43,11 +43,10 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 15' do
 
   it 'scans a referenced target for unsupported keywords at its own lexical depth' do
     chain = nested_properties(validator::MAX_SCHEMA_DEPTH - 1, { '$ref' => '#/$defs/t' })
-    # Beside an in-place applicator, whose annotations this validator does
-    # not collect, `unevaluatedItems` is still unevaluated (and reported).
-    schema = chain.merge('$defs' => { 't' => { 'items' => { 'allOf' => [true], 'unevaluatedItems' => false } } })
+    # `format` only annotates in 2020-12, and is reported as such.
+    schema = chain.merge('$defs' => { 't' => { 'items' => { 'format' => 'uuid' } } })
     expect(validator.check_schema(schema)).to be_empty
-    expect(validator.unsupported_keywords(schema)).to include('unevaluatedItems')
+    expect(validator.unsupported_keywords(schema)).to include('format')
   end
 
   it 'treats a tautological additionalItems beside a tuple as decided' do

--- a/spec/lib/mcp_client/json_schema_2026_round15_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round15_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 15' do
 
   it 'scans a referenced target for unsupported keywords at its own lexical depth' do
     chain = nested_properties(validator::MAX_SCHEMA_DEPTH - 1, { '$ref' => '#/$defs/t' })
-    schema = chain.merge('$defs' => { 't' => { 'items' => { 'unevaluatedItems' => false } } })
+    # Beside an in-place applicator, whose annotations this validator does
+    # not collect, `unevaluatedItems` is still unevaluated (and reported).
+    schema = chain.merge('$defs' => { 't' => { 'items' => { 'allOf' => [true], 'unevaluatedItems' => false } } })
     expect(validator.check_schema(schema)).to be_empty
     expect(validator.unsupported_keywords(schema)).to include('unevaluatedItems')
   end

--- a/spec/lib/mcp_client/json_schema_2026_round16_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round16_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, sixteenth review round: a pointer
+# target's depth counts schema steps, positions under data or unknown
+# keywords are bounded too, and an assertion is uncertainty only when it
+# can still change this instance.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 16' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+  let(:max) { validator::MAX_SCHEMA_DEPTH }
+
+  def nested_properties(depth, leaf)
+    (1..depth).reduce(leaf) { |inner, _| { 'properties' => { 'a' => inner } } }
+  end
+
+  def nested_not(depth, leaf)
+    (1..depth).reduce(leaf) { |inner, _| { 'not' => inner } }
+  end
+
+  it 'counts schema steps, not tokens, for a boolean under a map or array keyword' do
+    base = nested_properties(max - 1, { 'properties' => { 'b' => true } })
+    expect(validator.check_schema(base)).to be_empty
+
+    pointer = "##{'/properties/a' * (max - 1)}/properties/b"
+    expect(validator.check_schema(base.merge('allOf' => [{ '$ref' => pointer }]))).to be_empty
+
+    defs = { '$defs' => { 't' => nested_not(max - 1, true) },
+             'allOf' => [{ '$ref' => "#/$defs/t#{'/not' * (max - 1)}" }] }
+    expect(validator.check_schema(defs)).to be_empty
+
+    tuple = { 'prefixItems' => [nested_not(max - 1, true)],
+              'not' => { '$ref' => "#/prefixItems/0#{'/not' * (max - 1)}" } }
+    expect(validator.check_schema(tuple)).to be_empty
+
+    composed = { 'allOf' => [nested_not(max - 1, true)], 'not' => { '$ref' => "#/allOf/0#{'/not' * (max - 1)}" } }
+    expect(validator.check_schema(composed)).to be_empty
+
+    too_deep = { '$defs' => { 't' => nested_not(max, true) }, 'allOf' => [{ '$ref' => "#/$defs/t#{'/not' * max}" }] }
+    expect(validator.check_schema(too_deep)).to contain_exactly(a_string_matching(/depth/))
+  end
+
+  it 'bounds a reference into a data or unknown keyword by its position' do
+    deep = nested_not(max + 5, true)
+    %w[default enum const examples x-custom].each do |keyword|
+      holder = %w[enum examples].include?(keyword) ? [deep] : deep
+      prefix = %w[enum examples].include?(keyword) ? "#/#{keyword}/0" : "#/#{keyword}"
+      schema = { 'properties' => { 'a' => { '$ref' => "#{prefix}#{'/not' * (max + 5)}" } }, keyword => holder }
+      expect(validator.check_schema(schema)).to include(a_string_matching(/depth|unresolvable/)), keyword
+      expect(validator.validate({ 'a' => 1 }, schema)).not_to be_empty, keyword
+    end
+
+    deep_object = nested_not(max + 5, {})
+    schema = { 'properties' => { 'a' => { '$ref' => "#/default#{'/not' * (max + 5)}" } }, 'default' => deep_object }
+    expect(validator.check_schema(schema)).to include(a_string_matching(/depth|unresolvable/))
+  end
+
+  it 'decodes a percent-encoded pointer before placing its target' do
+    deep = nested_not(max + 5, true)
+    schema = { 'properties' => { 'a' => { '$ref' => "#%2Fdefault#{'%2Fnot' * (max + 5)}" } }, 'default' => deep }
+    expect(validator.check_schema(schema)).to include(a_string_matching(/depth|unresolvable/))
+
+    fine = { 'properties' => { 'a' => { '$ref' => '#%2F$defs%2Ft' } }, '$defs' => { 't' => { 'type' => 'integer' } } }
+    expect(validator.check_schema(fine)).to be_empty
+    expect(validator.validate({ 'a' => 'x' }, fine)).not_to be_empty
+  end
+
+  it 'treats additionalItems false as decided when the tuple covers the instance' do
+    schema = { '$schema' => draft7, 'not' => { 'items' => [true], 'additionalItems' => false } }
+    expect(validator.validate([1], schema)).to contain_exactly(a_string_matching(/not/))
+    expect(validator.validate([1, 2], schema)).to be_empty
+    expect(validator.validate([], schema)).to contain_exactly(a_string_matching(/not/))
+  end
+
+  it 'treats contains as decided when minContains is 0' do
+    schema = { 'not' => { 'contains' => true, 'minContains' => 0 } }
+    expect(validator.validate([], schema)).to contain_exactly(a_string_matching(/not/))
+    expect(validator.validate([1], schema)).to contain_exactly(a_string_matching(/not/))
+
+    one_of = { 'oneOf' => [{ 'type' => 'array' }, { 'contains' => true, 'minContains' => 0 }] }
+    expect(validator.validate([1], one_of)).to contain_exactly(a_string_matching(/oneOf/))
+
+    conditional = { 'if' => { 'contains' => true, 'minContains' => 0 }, 'then' => false }
+    expect(validator.validate([], conditional)).not_to be_empty
+
+    still_open = { 'not' => { 'contains' => { 'type' => 'string' } } }
+    expect(validator.validate([1], still_open)).to be_empty
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round17_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round17_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, seventeenth review round: pointer
+# steps are classified by the dialect in force, every distinct boolean a
+# reference reaches is charged once, draft-07 `format` is an unevaluated
+# assertion, and a companion keyword the dialect does not define changes
+# nothing.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 17' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+  let(:max) { validator::MAX_SCHEMA_DEPTH }
+
+  def nested_not(depth, leaf)
+    (1..depth).reduce(leaf) { |inner, _| { 'not' => inner } }
+  end
+
+  it 'treats a keyword the dialect does not define as opaque data when counting pointer steps' do
+    pointer = "#/prefixItems/0#{'/not' * (max - 1)}"
+    modern = { 'prefixItems' => [nested_not(max - 1, true)], 'not' => { '$ref' => pointer } }
+    expect(validator.check_schema(modern)).to be_empty
+
+    legacy = modern.merge('$schema' => draft7)
+    expect(validator.check_schema(legacy)).to contain_exactly(a_string_matching(/nesting depth exceeds/))
+  end
+
+  it 'charges every distinct boolean a reference reaches toward the subschema bound' do
+    count = (validator::MAX_SUBSCHEMAS / 2) + 100
+    bools = (0...count).to_h { |i| ["b#{i}", true] }
+    props = (0...count).to_h { |i| ["p#{i}", { '$ref' => "#/x-bools/b#{i}" }] }
+    schema = { 'type' => 'object', 'properties' => props, 'x-bools' => bools }
+
+    expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/more than \d+ subschemas/))
+
+    few = { 'type' => 'object', 'x-bools' => { 'b' => true },
+            'properties' => { 'p' => { '$ref' => '#/x-bools/b' }, 'q' => { '$ref' => '#/x-bools/b' } } }
+    expect(validator.check_schema(few)).to be_empty
+  end
+
+  it 'leaves a draft-07 branch carrying format undecided while 2020-12 treats it as an annotation' do
+    expect(validator.validate('abc', { 'not' => { 'format' => 'email' } })).not_to be_empty
+    expect(validator.validate('abc', { '$schema' => draft7, 'not' => { 'format' => 'email' } })).to be_empty
+    expect(validator.validate(1, { '$schema' => draft7, 'not' => { 'format' => 'email' } })).not_to be_empty
+  end
+
+  it 'ignores a companion keyword the dialect does not define' do
+    modern = { 'not' => { 'contains' => true, 'minContains' => 0 } }
+    expect(validator.validate([], modern)).not_to be_empty
+
+    # draft-07 does not define minContains: contains keeps its one-match
+    # requirement, so [] fails the inner schema and the not passes.
+    legacy = { '$schema' => draft7, 'not' => { 'contains' => true, 'minContains' => 0 } }
+    expect(validator.validate([], legacy)).to be_empty
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round18_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round18_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, eighteenth review round: pointer
+# depth follows the dialect in force at each node (switching inside an
+# embedded resource) and an opaque count is never overridden by a lexical
+# depth; an unevaluated assertion that cannot change this instance decides
+# nothing; a boolean the walk already admitted is not charged again.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 18' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+  let(:modern) { 'https://json-schema.org/draft/2020-12/schema' }
+  let(:max) { validator::MAX_SCHEMA_DEPTH }
+
+  def nested_not(depth, leaf)
+    (1..depth).reduce(leaf) { |inner, _| { 'not' => inner } }
+  end
+
+  describe 'pointer depth by the dialect in force' do
+    it 'accepts a boolean legal at the bound inside a 2020-12 resource embedded in a draft-07 document' do
+      n = max - 2
+      emb = { '$id' => 'https://example.com/emb', '$schema' => modern,
+              'prefixItems' => [nested_not(n, true)],
+              'allOf' => [{ '$ref' => "#/prefixItems/0#{'/not' * n}" }] }
+      schema = { '$schema' => draft7, 'definitions' => { 'emb' => emb } }
+
+      expect(validator.check_schema(schema)).to be_empty
+    end
+
+    it 'counts every token under a keyword the embedded dialect does not define' do
+      node = true
+      40.times { node = { 'prefixItems' => [node] } }
+      schema = { '$defs' => { 'emb' => { '$id' => 'https://example.com/e', '$schema' => draft7,
+                                         'prefixItems' => [node] } },
+                 'allOf' => [{ '$ref' => "#/$defs/emb#{'/prefixItems/0' * 41}" }] }
+
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/nesting depth exceeds/))
+      expect(validator.validate(123, schema)).to contain_exactly(a_string_matching(/nesting depth exceeds/))
+    end
+
+    it 'lets the opaque count win over a lexical depth for an object leaf too' do
+      pointer = "#/$defs/t#{'/not' * (max - 1)}"
+      schema = { '$schema' => draft7, '$defs' => { 't' => nested_not(max - 1, {}) },
+                 'allOf' => [{ '$ref' => pointer }] }
+
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/nesting depth exceeds/))
+    end
+  end
+
+  describe 'assertions that cannot change the instance' do
+    it 'decides not / oneOf when the unevaluated keyword is a no-op for the value' do
+      expect(validator.validate([1], { 'not' => { 'prefixItems' => [true], 'unevaluatedItems' => false } }))
+        .to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate([1, 2], { 'not' => { 'items' => true, 'unevaluatedItems' => false } }))
+        .to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate([1], { 'not' => { 'uniqueItems' => true } }))
+        .to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate([1], { 'oneOf' => [{ 'type' => 'array' }, { 'uniqueItems' => true }] }))
+        .to contain_exactly(a_string_matching(/oneOf/))
+      expect(validator.validate({}, { 'not' => { 'additionalProperties' => false } }))
+        .to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate([], { 'not' => { 'contains' => true, 'minContains' => 0, 'maxContains' => 0 } }))
+        .to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate({ 'a' => 1 }, { 'not' => { 'properties' => { 'a' => true },
+                                                           'unevaluatedProperties' => false } }))
+        .to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate({ 'a' => 1 }, { 'not' => { 'minProperties' => 1, 'maxProperties' => 1 } }))
+        .to contain_exactly(a_string_matching(/not/))
+    end
+
+    it 'stays undecided while the keyword can still change the value' do
+      expect(validator.validate([1, 2], { 'not' => { 'prefixItems' => [true], 'unevaluatedItems' => false } }))
+        .to be_empty
+      expect(validator.validate([1, 1], { 'not' => { 'uniqueItems' => true } })).to be_empty
+      expect(validator.validate({ 'a' => 1 }, { 'not' => { 'additionalProperties' => false } })).to be_empty
+      expect(validator.validate([1], { 'not' => { 'contains' => true, 'minContains' => 0, 'maxContains' => 0 } }))
+        .to be_empty
+    end
+  end
+
+  it 'resolves a reference written in a schema that was reached through a data keyword' do
+    schema = { '$ref' => '#/default', 'default' => { '$ref' => '#/$defs/x' },
+               '$defs' => { 'x' => { 'type' => 'string' } } }
+
+    expect(validator.check_schema(schema)).to be_empty
+    expect(validator.validate('ok', schema)).to be_empty
+    expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/expected type string/))
+  end
+
+  it 'normalizes a symbol-keyed schema reached through a data keyword' do
+    schema = { '$ref': '#/default', default: { type: 'string' } }
+
+    expect(validator.check_schema(schema)).to be_empty
+    expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    expect(validator.validate('ok', schema)).to be_empty
+  end
+
+  it 'does not charge a boolean the walk already admitted when a reference reaches it' do
+    count = 700
+    bools = (0...count).to_h { |i| ["b#{i}", true] }
+    props = (0...count).to_h { |i| ["p#{i}", { '$ref' => "#/$defs/b#{i}" }] }
+    schema = { 'type' => 'object', 'properties' => props, '$defs' => bools }
+
+    expect(validator.check_schema(schema)).to be_empty
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round19_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round19_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, nineteenth round: the once-per-schema
+# checks are keyed by a tool identity that survives the copies the client
+# cache hands out, and a refreshed definition is checked again.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 19' do
+  let(:log_output) { StringIO.new }
+  let(:logger) { Logger.new(log_output) }
+  let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+
+  def tool(input, output = nil)
+    MCPClient::Tool.new(name: 'tool', description: 'd', schema: input, output_schema: output, server: mock_server)
+  end
+
+  def client_with(tools)
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+    allow(mock_server).to receive(:on_notification)
+    allow(mock_server).to receive(:list_tools).and_return(tools)
+    MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger)
+  end
+
+  it 'keeps the identity of a tool definition across copies and changes it for a new definition' do
+    original = tool({ 'type' => 'object' })
+    copy = MCPClient::DeepCopy.copy(original)
+
+    expect(copy).not_to equal(original)
+    expect(copy.schema).not_to equal(original.schema)
+    expect(copy.schema_identity).to eq(original.schema_identity)
+    expect(tool({ 'type' => 'object' }).schema_identity).not_to eq(original.schema_identity)
+  end
+
+  it 'warns once about an unusable input schema across cache hits handing out copies' do
+    client = client_with([tool({ '$ref' => 'https://example.com/in.json' })])
+    allow(mock_server).to receive(:call_tool).and_return({ 'content' => [] })
+    allow(MCPClient::SchemaValidator).to receive(:check_schema).and_call_original
+
+    first = client.list_tools.first
+    second = client.list_tools.first
+    expect(second).not_to equal(first)
+    2.times { client.call_tool('tool', {}) }
+
+    expect(log_output.string.scan(/input schema.*external \$ref/).size).to eq(1)
+    expect(MCPClient::SchemaValidator).to have_received(:check_schema).once
+  end
+
+  it 'scans the output schema once per definition across copies and again for a refreshed one' do
+    partial = { 'type' => 'object', 'format' => 'custom' }
+    client = client_with([tool({ 'type' => 'object' }, partial)])
+    allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => {} })
+    allow(MCPClient::SchemaValidator).to receive(:unsupported_keywords).and_call_original
+
+    3.times { client.call_tool('tool', {}) }
+    expect(MCPClient::SchemaValidator).to have_received(:unsupported_keywords).once
+
+    allow(mock_server).to receive(:list_tools).and_return([tool({ 'type' => 'object' }, partial.dup)])
+    client.clear_cache
+    client.call_tool('tool', {})
+    expect(MCPClient::SchemaValidator).to have_received(:unsupported_keywords).twice
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round20_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round20_spec.rb
@@ -67,10 +67,10 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 20' do
   it 'scans a data-keyword $ref target at its own position even from a referrer at the depth bound' do
     leaf = nested('properties', 0, { '$ref' => '#/default' })
     validator::MAX_SCHEMA_DEPTH.times { leaf = { 'properties' => { 'a' => leaf } } }
-    schema = leaf.merge('default' => { 'type' => 'array', 'uniqueItems' => true })
+    schema = leaf.merge('default' => { 'type' => 'array', 'unevaluatedItems' => false })
 
     expect(validator.check_schema(schema)).to be_empty
-    expect(validator.unsupported_keywords(schema)).to eq(['uniqueItems'])
+    expect(validator.unsupported_keywords(schema)).to eq(['unevaluatedItems'])
   end
 
   it 'copies a symbol-keyed target adopted from a data keyword within the structural budget' do

--- a/spec/lib/mcp_client/json_schema_2026_round20_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round20_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, twentieth round: more unevaluated
+# assertions that cannot change the instance decide nothing under not /
+# oneOf / if, a boolean in a position the walk never visits is charged when
+# a reference reaches it, the keyword scan follows a pointer into a data
+# keyword at the target's own position, and a symbol-keyed target adopted
+# from a data keyword is copied within the structural budget.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 20' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+
+  def nested(keyword, count, leaf)
+    count.times.reduce(leaf) { |inner, _| { keyword => inner } }
+  end
+
+  describe 'inert unevaluated assertions' do
+    it 'treats contains true or {} on an array that satisfies minContains as decided' do
+      expect(validator.validate([1], { 'not' => { 'contains' => true } })).not_to be_empty
+      expect(validator.validate([1], { 'not' => { 'contains' => {} } })).not_to be_empty
+      expect(validator.validate([1], { 'oneOf' => [{ 'type' => 'array' }, { 'contains' => true }] })).not_to be_empty
+      expect(validator.validate([1], { 'if' => { 'contains' => true }, 'then' => false })).not_to be_empty
+      # An empty array fails contains true (default minContains 1): a real assertion.
+      expect(validator.validate([], { 'not' => { 'contains' => true } })).to be_empty
+      # A contains schema the validator cannot evaluate stays undecided.
+      expect(validator.validate([1], { 'not' => { 'contains' => { 'type' => 'string' } } })).to be_empty
+    end
+
+    it 'treats unevaluatedItems as inert once contains evaluated every item' do
+      expect(validator.validate([1], { 'not' => { 'contains' => true, 'unevaluatedItems' => false } })).not_to be_empty
+      schema = { 'not' => { 'contains' => true, 'minContains' => 0, 'unevaluatedItems' => false } }
+      expect(validator.validate([1], schema)).not_to be_empty
+    end
+
+    it 'treats patternProperties matching nothing or only tautologies as inert' do
+      inert = { 'not' => { 'patternProperties' => { '^z' => { 'type' => 'string' } } } }
+      expect(validator.validate({ 'a' => 1 }, inert)).not_to be_empty
+      schema = { 'not' => { 'patternProperties' => { '.*' => true }, 'additionalProperties' => false } }
+      expect(validator.validate({ 'a' => 1 }, schema)).not_to be_empty
+      # A matching pattern with a real schema still leaves the branch undecided.
+      live = { 'not' => { 'patternProperties' => { '^a' => { 'type' => 'string' } } } }
+      expect(validator.validate({ 'a' => 1 }, live)).to be_empty
+    end
+
+    it 'treats dependencies whose present trigger cannot fail as inert' do
+      expect(validator.validate({ 'a' => 1 }, { 'not' => { 'dependentRequired' => { 'a' => [] } } })).not_to be_empty
+      expect(validator.validate({ 'a' => 1 }, { 'not' => { 'dependentSchemas' => { 'a' => true } } })).not_to be_empty
+      draft = { '$schema' => draft7, 'not' => { 'dependencies' => { 'a' => {} } } }
+      expect(validator.validate({ 'a' => 1 }, draft)).not_to be_empty
+      expect(validator.validate({ 'a' => 1 }, { 'not' => { 'dependentRequired' => { 'a' => ['b'] } } })).to be_empty
+    end
+  end
+
+  it 'charges booleans beside a draft-07 $ref (a position the walk never visits) toward the subschema bound' do
+    count = validator::MAX_SUBSCHEMAS - 200
+    props = (0...count).to_h { |i| ["p#{i}", { '$ref' => "#/definitions/hidden/allOf/#{i}" }] }
+    schema = { '$schema' => draft7, 'type' => 'object', 'properties' => props,
+               'definitions' => { 'hidden' => { '$ref' => '#/definitions/x', 'allOf' => Array.new(count, true) },
+                                  'x' => { 'type' => 'integer' } } }
+
+    expect(validator.check_schema(schema))
+      .to contain_exactly(a_string_matching(/more than #{validator::MAX_SUBSCHEMAS}/))
+  end
+
+  it 'scans a data-keyword $ref target at its own position even from a referrer at the depth bound' do
+    leaf = nested('properties', 0, { '$ref' => '#/default' })
+    validator::MAX_SCHEMA_DEPTH.times { leaf = { 'properties' => { 'a' => leaf } } }
+    schema = leaf.merge('default' => { 'type' => 'array', 'uniqueItems' => true })
+
+    expect(validator.check_schema(schema)).to be_empty
+    expect(validator.unsupported_keywords(schema)).to eq(['uniqueItems'])
+  end
+
+  it 'copies a symbol-keyed target adopted from a data keyword within the structural budget' do
+    huge = {}
+    (validator::MAX_STRUCTURAL_OBJECTS + 50).times { |i| huge[:"k#{i}"] = i }
+
+    expect(validator.check_schema({ '$ref': '#/default', default: huge }))
+      .to contain_exactly(a_string_matching(/structural elements/))
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round20_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round20_spec.rb
@@ -67,10 +67,10 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 20' do
   it 'scans a data-keyword $ref target at its own position even from a referrer at the depth bound' do
     leaf = nested('properties', 0, { '$ref' => '#/default' })
     validator::MAX_SCHEMA_DEPTH.times { leaf = { 'properties' => { 'a' => leaf } } }
-    schema = leaf.merge('default' => { 'type' => 'array', 'allOf' => [true], 'unevaluatedItems' => false })
+    schema = leaf.merge('default' => { 'type' => 'array', 'items' => { 'format' => 'uuid' } })
 
     expect(validator.check_schema(schema)).to be_empty
-    expect(validator.unsupported_keywords(schema)).to eq(['unevaluatedItems'])
+    expect(validator.unsupported_keywords(schema)).to eq(['format'])
   end
 
   it 'copies a symbol-keyed target adopted from a data keyword within the structural budget' do

--- a/spec/lib/mcp_client/json_schema_2026_round20_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round20_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 20' do
   it 'scans a data-keyword $ref target at its own position even from a referrer at the depth bound' do
     leaf = nested('properties', 0, { '$ref' => '#/default' })
     validator::MAX_SCHEMA_DEPTH.times { leaf = { 'properties' => { 'a' => leaf } } }
-    schema = leaf.merge('default' => { 'type' => 'array', 'unevaluatedItems' => false })
+    schema = leaf.merge('default' => { 'type' => 'array', 'allOf' => [true], 'unevaluatedItems' => false })
 
     expect(validator.check_schema(schema)).to be_empty
     expect(validator.unsupported_keywords(schema)).to eq(['unevaluatedItems'])

--- a/spec/lib/mcp_client/json_schema_2026_round21_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round21_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, twenty-first round: the pattern
+# matching behind the property-coverage checks runs under the validation
+# deadline and the regexp timeout, every adopted pointer target is charged
+# against the structural bound and indexed with its descendants, dependency
+# triggers are looked up in both key forms, and an explicit null
+# outputSchema is a declaration, not an absent field.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 21' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+  # Backtracking Ruby's regexp cache cannot flatten (the backreference
+  # disables the memoization): a server-controlled expression like this one
+  # must not be able to hold the calling thread past the deadline.
+  let(:evil_pattern) { '^(a*)*\1$' }
+  let(:evil_name) { "#{'a' * 17}!" }
+
+  def timed
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = yield
+    [result, Process.clock_gettime(Process::CLOCK_MONOTONIC) - started]
+  end
+
+  describe 'pattern matching behind the property-coverage checks' do
+    it 'matches patternProperties patterns under the validation deadline' do
+      schema = { 'not' => { 'patternProperties' => { evil_pattern => { 'type' => 'string' } } } }
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 0.05
+      errors, elapsed = timed { validator.validate({ evil_name => 1 }, schema, deadline: deadline) }
+
+      expect(elapsed).to be < 2
+      expect(errors).to contain_exactly(a_string_matching(/aborted/))
+    end
+
+    it 'matches additionalProperties coverage patterns under the validation deadline' do
+      schema = { 'not' => { 'additionalProperties' => false, 'patternProperties' => { evil_pattern => true } } }
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 0.05
+      errors, elapsed = timed { validator.validate({ evil_name => 1 }, schema, deadline: deadline) }
+
+      expect(elapsed).to be < 2
+      expect(errors).to contain_exactly(a_string_matching(/aborted/))
+    end
+
+    it 'still reads a cheap pattern within the budget' do
+      inert = { 'not' => { 'patternProperties' => { '^z' => { 'type' => 'string' } } } }
+      expect(validator.validate({ 'a' => 1 }, inert)).not_to be_empty
+      live = { 'not' => { 'patternProperties' => { '^a' => { 'type' => 'string' } } } }
+      expect(validator.validate({ 'a' => 1 }, live)).to be_empty
+    end
+  end
+
+  describe 'adopted pointer targets' do
+    it 'charges a string-keyed target against the structural bound' do
+      huge = {}
+      (validator::MAX_STRUCTURAL_OBJECTS + 50).times { |i| huge["k#{i}"] = i }
+
+      expect(validator.check_schema({ '$ref' => '#/default', 'default' => huge }))
+        .to contain_exactly(a_string_matching(/structural elements/))
+    end
+
+    it 'resolves a $ref written inside an adopted target' do
+      schema = { 'type' => 'object',
+                 'properties' => { 'a' => { '$ref' => '#/default' } },
+                 'default' => { '$defs' => { 'i' => { 'type' => 'integer' } },
+                                'properties' => { 'b' => { '$ref' => '#/default/$defs/i' } } } }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => { 'b' => 1 } }, schema)).to be_empty
+      expect(validator.validate({ 'a' => { 'b' => 'x' } }, schema))
+        .to contain_exactly(a_string_matching(%r{#/a/b: expected type integer}))
+    end
+
+    it 'keeps the adopted resource dialect for the schemas nested inside it' do
+      schema = { 'properties' => { 'a' => { '$ref' => '#/default' } },
+                 'default' => { '$id' => 'https://example.com/embedded', '$schema' => draft7,
+                                'properties' => { 'b' => { 'items' => [{ 'type' => 'integer' }] } } } }
+
+      expect(validator.check_schema(schema)).to be_empty
+      # draft-07 reads an items array positionally; under the root's 2020-12
+      # the same array would apply nothing at all.
+      expect(validator.validate({ 'a' => { 'b' => ['x'] } }, schema))
+        .to contain_exactly(a_string_matching(%r{#/a/b/0: expected type integer}))
+    end
+  end
+
+  describe 'dependency triggers' do
+    let(:schema) { { 'not' => { 'dependentRequired' => { 'a' => ['b'] } } } }
+
+    it 'is looked up in both key forms' do
+      expect(validator.validate({ 'a' => 1 }, schema)).to be_empty
+      expect(validator.validate({ a: 1 }, schema)).to be_empty
+      draft = { '$schema' => draft7, 'not' => { 'dependencies' => { 'a' => { 'type' => 'string' } } } }
+      expect(validator.validate({ a: 1 }, draft)).to be_empty
+    end
+
+    it 'decides the branch when the trigger is present in neither form' do
+      expect(validator.validate({ 'c' => 1 }, schema)).not_to be_empty
+      expect(validator.validate({ c: 1 }, schema)).not_to be_empty
+    end
+  end
+
+  describe 'an explicit null outputSchema' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+
+    def tool_json(**extra)
+      MCPClient::Tool.from_json({ 'name' => 'tool', 'description' => 'd', 'inputSchema' => { 'type' => 'object' } }
+                                 .merge(extra), server: mock_server)
+    end
+
+    def client_with(tools, **opts)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+      allow(mock_server).to receive(:on_notification)
+      allow(mock_server).to receive(:list_tools).and_return(tools)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger, **opts)
+    end
+
+    it 'is a declared schema, not an absent field' do
+      expect(tool_json('outputSchema' => nil).structured_output?).to be(true)
+      expect(MCPClient::Tool.from_json({ 'name' => 't', 'description' => 'd',
+                                         inputSchema: {}, outputSchema: nil }).structured_output?).to be(true)
+      expect(tool_json.structured_output?).to be(false)
+      expect(tool_json('outputSchema' => nil).output_schema).to be_nil
+    end
+
+    it 'survives a copy of the tool definition' do
+      expect(tool_json('outputSchema' => nil).dup.structured_output?).to be(true)
+      expect(tool_json.dup.structured_output?).to be(false)
+    end
+
+    it 'still requires structuredContent in a successful result' do
+      client = client_with([tool_json('outputSchema' => nil)], validate_structured_content: :strict)
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [] })
+
+      expect { client.call_tool('tool', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /no structuredContent/)
+    end
+
+    it 'reports the null schema as unusable rather than as a permissive pass' do
+      client = client_with([tool_json('outputSchema' => nil)], validate_structured_content: :strict)
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => { 'a' => 1 } })
+
+      expect { client.call_tool('tool', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /must be an object or a boolean/)
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round21_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round21_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 21' do
   # Backtracking Ruby's regexp cache cannot flatten (the backreference
   # disables the memoization): a server-controlled expression like this one
   # must not be able to hold the calling thread past the deadline.
-  let(:evil_pattern) { '^(a*)*\1$' }
+  # The back-reference is to a group `?` quantifies, which repeats at most
+  # once, so it is a pattern this validator translates — and one Ruby's
+  # optimizer cannot flatten, so matching it burns the whole budget.
+  let(:evil_pattern) { '^(x?)(a*)*\1$' }
   let(:evil_name) { "#{'a' * 17}!" }
 
   def timed

--- a/spec/lib/mcp_client/json_schema_2026_round22_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round22_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, twenty-second round: a subtree a
+# pointer reaches through a data keyword is adopted once and every pointer
+# into it lands on the indexed objects (their own resource, dialect and
+# subschema charge), the identifiers such a subtree declares are never the
+# document's, a reference whose percent-encoding is not readable resolves to
+# nothing instead of raising, a property named like a data keyword is a
+# schema position, and a branch that already failed a supported assertion is
+# not measured for the keywords it does not evaluate.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 22' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+
+  describe 'a pointer into an adopted subtree' do
+    it 'keeps the dialect of the resource the pointer entered' do
+      schema = { 'allOf' => [{ '$ref' => '#/default/$defs/i' }],
+                 'default' => { '$id' => 'https://example.com/emb', '$schema' => draft7,
+                                '$defs' => { 'i' => { 'items' => [{ 'type' => 'integer' }] } } } }
+
+      expect(validator.check_schema(schema)).to be_empty
+      # draft-07 reads the items array positionally; 2020-12 would reject it.
+      expect(validator.validate(['x'], schema))
+        .to contain_exactly(a_string_matching(%r{#/0: expected type integer}))
+    end
+
+    it 'does not declare the anchors of the adopted subtree twice' do
+      schema = { 'properties' => { 'a' => { '$ref' => '#/default' } },
+                 'default' => { '$defs' => { 'i' => { '$anchor' => 'int', 'type' => 'integer' } },
+                                'properties' => { 'b' => { '$ref' => '#/default/$defs/i' } } } }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => { 'b' => 'x' } }, schema))
+        .to contain_exactly(a_string_matching(%r{#/a/b: expected type integer}))
+    end
+
+    it 'charges the adopted subtree against the subschema bound once' do
+      big = { 'allOf' => Array.new(1200) { { 'type' => 'integer' } } }
+      schema = { 'allOf' => [{ '$ref' => '#/default' }, { '$ref' => '#/default/$defs/i' }],
+                 'default' => { '$defs' => { 'i' => big } } }
+
+      expect(validator.check_schema(schema)).to be_empty
+    end
+  end
+
+  describe 'identifiers written inside a data keyword' do
+    it 'are not the document\'s anchors' do
+      schema = { '$defs' => { 'x' => { '$anchor' => 'foo', 'type' => 'string' } },
+                 'properties' => { 'a' => { '$ref' => '#/default' } },
+                 'default' => { '$anchor' => 'foo', 'type' => 'integer' },
+                 'allOf' => [{ '$ref' => '#foo' }] }
+
+      expect(validator.check_schema(schema)).to be_empty
+      # "#foo" is the one the document declares, whatever the data keyword holds.
+      expect(validator.validate('x', schema)).to be_empty
+      expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+
+    it 'resolves a plain name the same way whatever the member order' do
+      props_first = { 'properties' => { 'a' => { '$ref' => '#/default' } },
+                      'default' => { '$anchor' => 'foo', 'type' => 'integer' },
+                      'allOf' => [{ '$ref' => '#foo' }] }
+      allof_first = { 'allOf' => [{ '$ref' => '#foo' }],
+                      'properties' => { 'a' => { '$ref' => '#/default' } },
+                      'default' => { '$anchor' => 'foo', 'type' => 'integer' } }
+
+      expect(validator.check_schema(props_first))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref "#foo"/))
+      expect(validator.check_schema(allof_first)).to eq(validator.check_schema(props_first))
+    end
+
+    it 'validates the same way whatever the instance' do
+      schema = { 'properties' => { 'a' => { '$ref' => '#/default' } },
+                 'default' => { '$anchor' => 'foo', 'type' => 'integer' },
+                 'allOf' => [{ '$ref' => '#foo' }] }
+
+      expect(validator.validate('x', schema)).to eq(validator.validate({ 'a' => 1 }, schema))
+      expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+  end
+
+  describe 'a reference whose percent-encoding is not readable' do
+    it 'resolves to nothing rather than raising' do
+      expect { validator.check_schema({ '$ref' => '#%FF' }) }.not_to raise_error
+      expect(validator.check_schema({ '$ref' => '#%FF' }))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+      expect(validator.check_schema({ '$ref' => '#/%FF' }))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+      expect(validator.validate(1, { '$ref' => '#/%FF' }))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+
+    it 'still reads a readable escape' do
+      schema = { '$ref' => '#/$defs/a%2Db', '$defs' => { 'a-b' => { 'type' => 'integer' } } }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/expected type integer/))
+    end
+  end
+
+  describe 'a property named like a data keyword' do
+    it 'is a schema position, not data' do
+      schema = { properties: { enum: { type: 'string' } } }
+
+      expect(validator.validate({ 'enum' => 123 }, schema))
+        .to contain_exactly(a_string_matching(%r{#/enum: expected type string}))
+      expect(validator.validate({ 'enum' => 'ok' }, schema)).to be_empty
+    end
+
+    it 'still keeps a real data keyword as it was given' do
+      schema = { type: 'object', properties: { a: { const: { b: 1 } } } }
+
+      expect(validator.validate({ 'a' => { b: 1 } }, schema)).to be_empty
+      expect(validator.validate({ 'a' => { 'c' => 1 } }, schema)).not_to be_empty
+    end
+  end
+
+  describe 'a branch that already failed a supported assertion' do
+    # Backtracking Ruby's regexp cache cannot flatten: matching it would
+    # burn the whole validation budget.
+    let(:evil_pattern) { '^(a*)*\1$' }
+    let(:evil_name) { "#{'a' * 17}!" }
+
+    it 'is not measured for the keywords the validator does not evaluate' do
+      schema = { 'not' => { 'type' => 'string', 'patternProperties' => { evil_pattern => false } } }
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      errors = validator.validate({ evil_name => 1 }, schema)
+
+      expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).to be < 0.5
+      expect(errors).to be_empty
+    end
+
+    it 'still measures a branch its supported assertions accept' do
+      schema = { 'not' => { 'type' => 'object', 'patternProperties' => { '^a' => { 'type' => 'string' } } } }
+      expect(validator.validate({ 'ab' => 1 }, schema)).to be_empty
+    end
+  end
+
+  describe 'the once-per-definition schema checks' do
+    let(:logger) { Logger.new(StringIO.new) }
+    let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+
+    def tool(name)
+      MCPClient::Tool.from_json({ 'name' => name, 'description' => 'd',
+                                  'inputSchema' => { 'type' => 'object' },
+                                  'outputSchema' => { 'type' => 'object', 'minProperties' => 1 } },
+                                server: mock_server)
+    end
+
+    def client_with(tools)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+      allow(mock_server).to receive(:on_notification)
+      allow(mock_server).to receive(:list_tools).and_return(tools)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger)
+    end
+
+    it 'forgets the tools a refreshed list no longer carries' do
+      client = client_with([tool('old')])
+      client.send(:warn_unusable_input_schema, tool('old'))
+      client.send(:warn_partial_schema_coverage, tool('old'))
+      expect(client.instance_variable_get(:@input_schema_warnings)).not_to be_empty
+
+      allow(mock_server).to receive(:list_tools).and_return([tool('new')])
+      client.list_tools(cache: false)
+
+      expect(client.instance_variable_get(:@input_schema_warnings)).to be_empty
+      expect(client.instance_variable_get(:@output_schema_coverage)).to be_empty
+    end
+
+    it 'forgets them when the whole cache is cleared' do
+      client = client_with([tool('old')])
+      client.send(:warn_unusable_input_schema, tool('old'))
+      client.send(:warn_partial_schema_coverage, tool('old'))
+
+      client.clear_cache
+
+      expect(client.instance_variable_get(:@input_schema_warnings)).to be_empty
+      expect(client.instance_variable_get(:@output_schema_coverage)).to be_empty
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round22_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round22_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 22' do
 
     it 'forgets the tools a refreshed list no longer carries' do
       client = client_with([tool('old')])
-      client.send(:warn_unusable_input_schema, tool('old'))
+      client.send(:input_schema_state, tool('old'))
       client.send(:warn_partial_schema_coverage, tool('old'))
       expect(client.instance_variable_get(:@input_schema_warnings)).not_to be_empty
 
@@ -170,7 +170,7 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 22' do
 
     it 'forgets them when the whole cache is cleared' do
       client = client_with([tool('old')])
-      client.send(:warn_unusable_input_schema, tool('old'))
+      client.send(:input_schema_state, tool('old'))
       client.send(:warn_partial_schema_coverage, tool('old'))
 
       client.clear_cache

--- a/spec/lib/mcp_client/json_schema_2026_round22_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round22_spec.rb
@@ -116,13 +116,13 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 22' do
     end
   end
 
-  describe 'a branch that already failed a supported assertion' do
+  describe 'a node whose own type already rejected the value' do
     # Backtracking Ruby's regexp cache cannot flatten: matching it would
     # burn the whole validation budget.
     let(:evil_pattern) { '^(a*)*\1$' }
     let(:evil_name) { "#{'a' * 17}!" }
 
-    it 'is not measured for the keywords the validator does not evaluate' do
+    it 'spends nothing more on the keywords for the type it does not have' do
       schema = { 'not' => { 'type' => 'string', 'patternProperties' => { evil_pattern => false } } }
       started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       errors = validator.validate({ evil_name => 1 }, schema)
@@ -131,9 +131,10 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 22' do
       expect(errors).to be_empty
     end
 
-    it 'still measures a branch its supported assertions accept' do
+    it 'still applies them when the type accepts the value' do
       schema = { 'not' => { 'type' => 'object', 'patternProperties' => { '^a' => { 'type' => 'string' } } } }
       expect(validator.validate({ 'ab' => 1 }, schema)).to be_empty
+      expect(validator.validate({ 'ab' => 'x' }, schema)).to contain_exactly(a_string_matching(/not/))
     end
   end
 
@@ -166,6 +167,49 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 22' do
 
       expect(client.instance_variable_get(:@input_schema_warnings)).to be_empty
       expect(client.instance_variable_get(:@output_schema_coverage)).to be_empty
+    end
+
+    # An emptied memo hash is only the mechanism; what matters is that the
+    # next call decides on the definition the server is now serving.
+    it 'decides the next call on the refreshed definition, warning about it again' do
+      log = StringIO.new
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+      allow(mock_server).to receive(:on_notification)
+      partial = MCPClient::Tool.from_json({ 'name' => 't', 'description' => 'd',
+                                            'inputSchema' => { 'type' => 'object' },
+                                            'outputSchema' => { 'type' => 'object', 'format' => 'x' } },
+                                          server: mock_server)
+      allow(mock_server).to receive(:list_tools).and_return([partial])
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => { 'a' => 1 } })
+      client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }],
+                                     logger: Logger.new(log))
+
+      2.times { client.call_tool('t', {}) }
+      expect(log.string.scan('validation is partial').size).to eq(1)
+
+      # A refreshed definition the notification announces: the coverage
+      # warning is made again, and it names what the new schema uses.
+      refreshed = MCPClient::Tool.from_json(
+        { 'name' => 't', 'description' => 'd', 'inputSchema' => { 'type' => 'object' },
+          'outputSchema' => { 'type' => 'object', 'unevaluatedProperties' => false } }, server: mock_server
+      )
+      allow(mock_server).to receive(:list_tools).and_return([refreshed])
+      client.send(:invalidate_caches_for_notification, mock_server, 'notifications/tools/list_changed')
+
+      client.call_tool('t', {})
+      expect(log.string.scan('validation is partial').size).to eq(2)
+      expect(log.string).to include('unevaluatedProperties')
+
+      # And a refreshed dialect is refused, rather than read from the memo
+      # the first definition filled in.
+      unusable = MCPClient::Tool.from_json(
+        { 'name' => 't', 'description' => 'd',
+          'inputSchema' => { '$schema' => 'urn:unknown', 'type' => 'object' } }, server: mock_server
+      )
+      allow(mock_server).to receive(:list_tools).and_return([unusable])
+      client.send(:invalidate_caches_for_notification, mock_server, 'notifications/tools/list_changed')
+
+      expect { client.call_tool('t', {}) }.to raise_error(MCPClient::Errors::ValidationError, /urn:unknown/)
     end
 
     it 'forgets them when the whole cache is cleared' do

--- a/spec/lib/mcp_client/json_schema_2026_round22_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round22_spec.rb
@@ -197,15 +197,15 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 22' do
       # warning is made again, and it names what the new schema uses.
       refreshed = MCPClient::Tool.from_json(
         { 'name' => 't', 'description' => 'd', 'inputSchema' => { 'type' => 'object' },
-          'outputSchema' => { 'type' => 'object', 'allOf' => [true],
-                              'unevaluatedProperties' => false } }, server: mock_server
+          'outputSchema' => { 'type' => 'object', 'properties' => { 'a' => { 'contentSchema' => true } } } },
+        server: mock_server
       )
       allow(mock_server).to receive(:list_tools).and_return([refreshed])
       client.send(:invalidate_caches_for_notification, mock_server, 'notifications/tools/list_changed')
 
       client.call_tool('t', {})
       expect(log.string.scan('validation is partial').size).to eq(2)
-      expect(log.string).to include('unevaluatedProperties')
+      expect(log.string).to include('contentSchema')
 
       # And a refreshed dialect is refused, rather than read from the memo
       # the first definition filled in.

--- a/spec/lib/mcp_client/json_schema_2026_round22_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round22_spec.rb
@@ -160,13 +160,19 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 22' do
       client = client_with([tool('old')])
       client.send(:input_schema_state, tool('old'))
       client.send(:warn_partial_schema_coverage, tool('old'))
+      client.send(:output_schema_state, tool('old'))
       expect(client.instance_variable_get(:@input_schema_warnings)).not_to be_empty
+      expect(client.instance_variable_get(:@output_schema_dialects)).not_to be_empty
 
       allow(mock_server).to receive(:list_tools).and_return([tool('new')])
       client.list_tools(cache: false)
 
       expect(client.instance_variable_get(:@input_schema_warnings)).to be_empty
       expect(client.instance_variable_get(:@output_schema_coverage)).to be_empty
+      # The output-dialect memo is keyed by a tool definition too, so it is
+      # forgotten with the rest: a server that keeps renaming its tools must
+      # not grow it without bound.
+      expect(client.instance_variable_get(:@output_schema_dialects)).to be_empty
     end
 
     # An emptied memo hash is only the mechanism; what matters is that the
@@ -191,7 +197,8 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 22' do
       # warning is made again, and it names what the new schema uses.
       refreshed = MCPClient::Tool.from_json(
         { 'name' => 't', 'description' => 'd', 'inputSchema' => { 'type' => 'object' },
-          'outputSchema' => { 'type' => 'object', 'unevaluatedProperties' => false } }, server: mock_server
+          'outputSchema' => { 'type' => 'object', 'allOf' => [true],
+                              'unevaluatedProperties' => false } }, server: mock_server
       )
       allow(mock_server).to receive(:list_tools).and_return([refreshed])
       client.send(:invalidate_caches_for_notification, mock_server, 'notifications/tools/list_changed')

--- a/spec/lib/mcp_client/json_schema_2026_round22_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round22_spec.rb
@@ -117,9 +117,11 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 22' do
   end
 
   describe 'a node whose own type already rejected the value' do
-    # Backtracking Ruby's regexp cache cannot flatten: matching it would
-    # burn the whole validation budget.
-    let(:evil_pattern) { '^(a*)*\1$' }
+    # Backtracking Ruby's regexp cache cannot flatten: matching it would burn
+    # the whole validation budget. The back-reference is to a group `?`
+    # quantifies, which repeats at most once, so it stays a pattern this
+    # validator translates.
+    let(:evil_pattern) { '^(x?)(a*)*\1$' }
     let(:evil_name) { "#{'a' * 17}!" }
 
     it 'spends nothing more on the keywords for the type it does not have' do

--- a/spec/lib/mcp_client/json_schema_2026_round23_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round23_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, twenty-third round: the JSON pointer
+# "/" addresses the member named "" and not the whole document, a
+# tautological `contains` is an assertion this validator decides rather than
+# a keyword that leaves a branch undecided, and a `dependentRequired` (or
+# draft-07 `dependencies`) list whose names the instance already carries
+# cannot fail.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 23' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+
+  describe 'the pointer to the empty-named member' do
+    it 'resolves "#/" to the member named "" (RFC 6901 Section 5)' do
+      schema = { '$ref' => '#/', '' => { 'type' => 'string', 'minLength' => 2 } }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate('ab', schema)).to be_empty
+      expect(validator.validate('a', schema))
+        .to contain_exactly(a_string_matching(/string is shorter than minLength 2/))
+    end
+
+    it 'resolves the percent-encoded form "#%2F" the same way' do
+      schema = { '$ref' => '#%2F', '' => { 'type' => 'integer' } }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(1, schema)).to be_empty
+      expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/expected type integer/))
+    end
+
+    it 'reports "#/" without an empty-named member as unresolvable, not as a cycle' do
+      expect(validator.check_schema({ '$ref' => '#/' }))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+
+    it 'still reads the empty pointer "#" as the whole document' do
+      expect(validator.check_schema({ '$ref' => '#' })).to contain_exactly(a_string_matching(/cycles/))
+    end
+
+    it 'walks on past an empty token to the members below it' do
+      schema = { '$ref' => '#//x', '' => { 'x' => { 'type' => 'boolean' } } }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(true, schema)).to be_empty
+      expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/expected type boolean/))
+    end
+
+    it 'keeps reading a trailing empty token as the empty-named member' do
+      schema = { '$ref' => '#/$defs/', '$defs' => { '' => { 'type' => 'null' } } }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(nil, schema)).to be_empty
+      expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/expected type null/))
+    end
+
+    it 'reaches a boolean schema held by the empty-named member' do
+      schema = { '$ref' => '#/', '' => false }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/schema false accepts no value/))
+    end
+  end
+
+  describe 'a tautological contains' do
+    it 'fails an array that holds fewer items than minContains requires' do
+      expect(validator.validate([], { 'contains' => true }))
+        .to contain_exactly(a_string_matching(/at least 1 items matching contains/))
+      expect(validator.validate([1], { 'contains' => true })).to be_empty
+      expect(validator.validate([1, 2, 3], { 'contains' => {}, 'minContains' => 5 }))
+        .to contain_exactly(a_string_matching(/at least 5 items matching contains/))
+    end
+
+    it 'fails an array that holds more items than maxContains allows' do
+      expect(validator.validate([1, 2, 3], { 'contains' => true, 'maxContains' => 2 }))
+        .to contain_exactly(a_string_matching(/at most 2 items matching contains/))
+      expect(validator.validate([1, 2], { 'contains' => true, 'maxContains' => 2 })).to be_empty
+    end
+
+    it 'asserts nothing once minContains switches it off' do
+      expect(validator.validate([], { 'contains' => true, 'minContains' => 0 })).to be_empty
+    end
+
+    it 'takes the default minContains under a dialect without the companion' do
+      schema = { '$schema' => draft7, 'contains' => true, 'minContains' => 0 }
+
+      # draft-07 knows no minContains, so the default of 1 stands.
+      expect(validator.validate([], schema)).to contain_exactly(a_string_matching(/at least 1 items matching contains/))
+    end
+
+    it 'decides the branches that never treat an undecided verdict as a match' do
+      expect(validator.validate([], { 'if' => { 'contains' => true }, 'then' => true, 'else' => false }))
+        .to contain_exactly(a_string_matching(/schema false accepts no value/))
+      expect(validator.validate([], { 'oneOf' => [{ 'type' => 'null' }, { 'contains' => true }] }))
+        .to contain_exactly(a_string_matching(/satisfies 0 schemas in oneOf/))
+      expect(validator.validate([], { 'anyOf' => [{ 'contains' => true }] }))
+        .to contain_exactly(a_string_matching(/does not satisfy any schema in anyOf/))
+      expect(validator.validate([1], { 'not' => { 'contains' => true } }))
+        .to contain_exactly(a_string_matching(/value satisfies the schema in not/))
+    end
+
+    it 'leaves a contains schema it does not evaluate undecided' do
+      # A real contains schema is still unevaluated: not must not fail here.
+      expect(validator.validate([1], { 'not' => { 'contains' => { 'type' => 'string' } } })).to be_empty
+    end
+  end
+
+  describe 'a dependency whose required names are already present' do
+    it 'cannot fail, so not and if decide the branch' do
+      instance = { 'a' => 1, 'b' => 2 }
+
+      expect(validator.validate(instance, { 'not' => { 'dependentRequired' => { 'a' => %w[b] } } }))
+        .to contain_exactly(a_string_matching(/value satisfies the schema in not/))
+      expect(validator.validate(instance, { 'if' => { 'dependentRequired' => { 'a' => %w[b] } }, 'then' => false }))
+        .to contain_exactly(a_string_matching(/schema false accepts no value/))
+    end
+
+    it 'reads a draft-07 dependencies list the same way' do
+      instance = { 'a' => 1, 'b' => 2 }
+      schema = { '$schema' => draft7, 'not' => { 'dependencies' => { 'a' => %w[b] } } }
+
+      expect(validator.validate(instance, schema))
+        .to contain_exactly(a_string_matching(/value satisfies the schema in not/))
+    end
+
+    it 'still leaves the branch undecided while a required name is absent' do
+      expect(validator.validate({ 'a' => 1 }, { 'not' => { 'dependentRequired' => { 'a' => %w[b] } } })).to be_empty
+      expect(validator.validate({ 'a' => 1, 'b' => 2 },
+                                { 'not' => { 'dependentRequired' => { 'a' => %w[b c] } } })).to be_empty
+    end
+
+    it 'reads the symbol key form of the instance as present' do
+      expect(validator.validate({ a: 1, b: 2 }, { 'not' => { 'dependentRequired' => { 'a' => %w[b] } } }))
+        .to contain_exactly(a_string_matching(/value satisfies the schema in not/))
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round23_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round23_spec.rb
@@ -100,9 +100,16 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 23' do
         .to contain_exactly(a_string_matching(/value satisfies the schema in not/))
     end
 
-    it 'leaves a contains schema it does not evaluate undecided' do
-      # A real contains schema is still unevaluated: not must not fail here.
-      expect(validator.validate([1], { 'not' => { 'contains' => { 'type' => 'string' } } })).to be_empty
+    it 'leaves a contains whose items it cannot decide undecided' do
+      # An item the validator cannot decide is neither a match nor a
+      # non-match, so the count never settles and `not` must not fail here.
+      undecidable = { 'contains' => { '$dynamicRef' => '#x' } }
+      expect(validator.validate([1], { 'not' => undecidable })).to be_empty
+      # A contains schema it can evaluate decides the branch outright.
+      expect(validator.validate([1], { 'not' => { 'contains' => { 'type' => 'integer' } } }))
+        .to contain_exactly(a_string_matching(/value satisfies the schema in not/))
+      expect(validator.validate([1], { 'if' => { 'contains' => { 'type' => 'string' } }, 'else' => false }))
+        .to contain_exactly(a_string_matching(/schema false accepts no value/))
     end
   end
 
@@ -124,10 +131,17 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 23' do
         .to contain_exactly(a_string_matching(/value satisfies the schema in not/))
     end
 
-    it 'still leaves the branch undecided while a required name is absent' do
-      expect(validator.validate({ 'a' => 1 }, { 'not' => { 'dependentRequired' => { 'a' => %w[b] } } })).to be_empty
+    it 'fails the branch outright while a required name is absent' do
+      # `dependentRequired` is evaluated, so a missing name is a definite
+      # failure rather than an unreachable verdict — which `if`/`else` shows
+      # and a bare `not` (empty either way) cannot.
+      absent = { 'dependentRequired' => { 'a' => %w[b] } }
+      expect(validator.validate({ 'a' => 1 }, { 'not' => absent })).to be_empty
+      expect(validator.validate({ 'a' => 1 }, { 'if' => absent, 'else' => false }))
+        .to contain_exactly(a_string_matching(/schema false accepts no value/))
       expect(validator.validate({ 'a' => 1, 'b' => 2 },
-                                { 'not' => { 'dependentRequired' => { 'a' => %w[b c] } } })).to be_empty
+                                { 'if' => { 'dependentRequired' => { 'a' => %w[b c] } }, 'else' => false }))
+        .to contain_exactly(a_string_matching(/schema false accepts no value/))
     end
 
     it 'reads the symbol key form of the instance as present' do

--- a/spec/lib/mcp_client/json_schema_2026_round23_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round23_spec.rb
@@ -103,8 +103,9 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 23' do
     it 'leaves a contains whose items it cannot decide undecided' do
       # An item the validator cannot decide is neither a match nor a
       # non-match, so the count never settles and `not` must not fail here.
-      undecidable = { 'contains' => { '$dynamicRef' => '#x' } }
-      expect(validator.validate([1], { 'not' => undecidable })).to be_empty
+      undecidable = { 'contains' => { 'format' => 'email' } }
+      expect(validator.validate(['x'], { '$schema' => MCPClient::SchemaValidator::DRAFT_07,
+                                         'not' => undecidable })).to be_empty
       # A contains schema it can evaluate decides the branch outright.
       expect(validator.validate([1], { 'not' => { 'contains' => { 'type' => 'integer' } } }))
         .to contain_exactly(a_string_matching(/value satisfies the schema in not/))

--- a/spec/lib/mcp_client/json_schema_2026_round24_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round24_spec.rb
@@ -107,7 +107,11 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 24' do
 
     it 'still leaves a contains the length cannot settle unevaluated' do
       expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' } })).to be_empty
-      expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' }, 'maxContains' => 0 })).to be_empty
+      # `maxContains: 0` alone is unsatisfiable beside the default
+      # `minContains: 1` (round 25); with the lower bound switched off, how
+      # many items match is still the item schema's business.
+      expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' },
+                                          'minContains' => 0, 'maxContains' => 0 })).to be_empty
     end
   end
 

--- a/spec/lib/mcp_client/json_schema_2026_round24_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round24_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, twenty-fourth round: a fragment whose
+# percent escapes are malformed decodes to nothing, so the reference holding
+# it is unresolvable rather than a pointer to whatever literal member happens
+# to spell the undecoded text (RFC 3986 Section 2.1); the number of items a
+# `contains` can match is bounded by the array's length whatever its item
+# schema says, so the bounds that length alone settles are decided instead of
+# left open; and the `$ref` hop budget counts hops taken at one instance
+# value, so a recursive schema still describes arbitrarily deep data.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 24' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+
+  describe 'a reference whose fragment has a malformed percent escape' do
+    it 'does not resolve "#/$defs/a%ZZ" onto a literal "a%ZZ" member' do
+      schema = { '$ref' => '#/$defs/a%ZZ', '$defs' => { 'a%ZZ' => { 'type' => 'string' } } }
+
+      expect(validator.check_schema(schema))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+
+    it 'reports "#/$defs/a%ZZ" as unresolvable when no such member exists either' do
+      schema = { '$ref' => '#/$defs/a%ZZ', '$defs' => { 'a' => { 'type' => 'string' } } }
+
+      expect(validator.check_schema(schema))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+
+    it 'leaves a schema built on such a reference unusable rather than silently applied' do
+      schema = { '$ref' => '#/$defs/a%ZZ', '$defs' => { 'a%ZZ' => { 'type' => 'string' } } }
+
+      expect(validator.validate('x', schema))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+
+    it 'does not resolve a truncated escape "#/$defs/a%" onto a literal "a%" member' do
+      schema = { '$ref' => '#/$defs/a%', '$defs' => { 'a%' => { 'type' => 'integer' } } }
+
+      expect(validator.check_schema(schema))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+
+    it 'reports a plain-name fragment with a bad escape as unresolvable' do
+      schema = { '$ref' => '#a%ZZ', '$defs' => { 'x' => { '$anchor' => 'aZZ', 'type' => 'string' } } }
+
+      expect(validator.check_schema(schema))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+
+    it 'still resolves a well-formed escape naming the same member' do
+      schema = { '$ref' => '#/$defs/a%2Db', '$defs' => { 'a-b' => { 'type' => 'string' } } }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate('x', schema)).to be_empty
+      expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+  end
+
+  describe 'the contains bounds the array length alone settles' do
+    it 'rejects an empty array against a contains that must match an item' do
+      expect(validator.validate([], { 'contains' => { 'type' => 'string' } }))
+        .to contain_exactly(a_string_matching(/expected at least 1 items matching contains/))
+    end
+
+    it 'rejects an array shorter than minContains' do
+      schema = { 'contains' => { 'type' => 'string' }, 'minContains' => 5 }
+
+      expect(validator.validate([1, 2], schema))
+        .to contain_exactly(a_string_matching(/expected at least 5 items matching contains/))
+    end
+
+    it 'rejects any array against a contains that matches nothing' do
+      expect(validator.validate([1], { 'contains' => false }))
+        .to contain_exactly(a_string_matching(/expected at least 1 items matching contains/))
+    end
+
+    it 'accepts a contains matching nothing when minContains switches it off' do
+      expect(validator.validate([1], { 'contains' => false, 'minContains' => 0 })).to be_empty
+    end
+
+    it 'decides such a contains outright, so `not` can reject it' do
+      expect(validator.validate([1], { 'not' => { 'contains' => false, 'minContains' => 0 } }))
+        .to contain_exactly(a_string_matching(/satisfies the schema in not/))
+    end
+
+    it 'ignores minContains under draft-07, which does not define it' do
+      schema = { '$schema' => draft7, 'contains' => false, 'minContains' => 0 }
+
+      expect(validator.validate([1], schema))
+        .to contain_exactly(a_string_matching(/expected at least 1 items matching contains/))
+    end
+
+    it 'does not let an anyOf branch pass on a contains its length already fails' do
+      expect(validator.validate([], { 'anyOf' => [{ 'contains' => { 'type' => 'string' } }] }))
+        .not_to be_empty
+    end
+
+    it 'takes the else branch when the if branch fails on length alone' do
+      schema = { 'if' => { 'contains' => { 'type' => 'string' } }, 'then' => true, 'else' => false }
+
+      expect(validator.validate([], schema)).to contain_exactly(a_string_matching(/schema false accepts no value/))
+      expect(validator.validate(['x'], schema)).to be_empty
+    end
+
+    it 'still leaves a contains the length cannot settle unevaluated' do
+      expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' } })).to be_empty
+      expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' }, 'maxContains' => 0 })).to be_empty
+    end
+  end
+
+  describe 'the $ref hop budget against recursive data' do
+    it 'validates a self-recursive array schema against deeply nested data' do
+      schema = { 'type' => 'array', 'items' => { '$ref' => '#' } }
+      data = (1..40).reduce([]) { |nested, _| [nested] }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(data, schema)).to be_empty
+    end
+
+    it 'still reports a violation deep inside such data' do
+      schema = { 'type' => 'array', 'items' => { '$ref' => '#' } }
+      data = (1..40).reduce(['x']) { |nested, _| [nested] }
+
+      expect(validator.validate(data, schema))
+        .to contain_exactly(a_string_matching(/expected type array, got string/))
+    end
+
+    it 'validates a self-recursive object schema against deeply nested data' do
+      schema = { 'type' => 'object', 'properties' => { 'child' => { '$ref' => '#' } } }
+      data = (1..40).reduce({}) { |nested, _| { 'child' => nested } }
+
+      expect(validator.validate(data, schema)).to be_empty
+    end
+
+    it 'still rejects a $ref cycle that consumes no instance' do
+      schema = { '$ref' => '#/$defs/a', '$defs' => { 'a' => { '$ref' => '#/$defs/a' } } }
+
+      expect(validator.validate([], schema)).not_to be_empty
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round24_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round24_spec.rb
@@ -105,8 +105,10 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 24' do
       expect(validator.validate(['x'], schema)).to be_empty
     end
 
-    it 'still leaves a contains the length cannot settle unevaluated' do
-      expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' } })).to be_empty
+    it 'matches item by item where the length cannot settle contains' do
+      expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' } }))
+        .to contain_exactly(a_string_matching(/at least 1 items matching contains/))
+      expect(validator.validate([1, 'x'], { 'contains' => { 'type' => 'string' } })).to be_empty
       # `maxContains: 0` alone is unsatisfiable beside the default
       # `minContains: 1` (round 25); with the lower bound switched off, how
       # many items match is still the item schema's business.

--- a/spec/lib/mcp_client/json_schema_2026_round25_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round25_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 25' do
 
     it 'still reports the keywords a reference to a schema object reaches' do
       schema = { 'definitions' => {}, 'x' => 1.5, '$ref' => '#/y',
-                 'y' => { 'type' => 'array', 'uniqueItems' => true } }
+                 'y' => { 'type' => 'array', 'unevaluatedItems' => false } }
 
-      expect(validator.unsupported_keywords(schema)).to contain_exactly('uniqueItems')
+      expect(validator.unsupported_keywords(schema)).to contain_exactly('unevaluatedItems')
     end
   end
 
@@ -87,8 +87,12 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 25' do
                                           '$defs' => { 'any' => true } })).to be_empty
     end
 
-    it 'still leaves bounds the array length cannot settle unevaluated' do
-      expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' } })).to be_empty
+    it 'matches the items themselves where the bounds leave the count open' do
+      expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' } }))
+        .to contain_exactly(a_string_matching(/at least 1 items matching contains/))
+      expect(validator.validate([1, 'x'], { 'contains' => { 'type' => 'string' } })).to be_empty
+      # `minContains: 0` switches the lower bound off, and a `maxContains` no
+      # count can exceed asserts nothing either.
       expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' },
                                           'minContains' => 0, 'maxContains' => 0 })).to be_empty
     end
@@ -97,7 +101,11 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 25' do
       schema = { '$schema' => 'http://json-schema.org/draft-07/schema#',
                  'contains' => { 'type' => 'string' }, 'maxContains' => 0 }
 
-      expect(validator.validate([1, 2], schema)).to be_empty
+      # The unknown upper bound makes nothing unsatisfiable: draft-07
+      # `contains` asks only for one matching item, and never for at most none.
+      expect(validator.validate([1, 2], schema))
+        .to contain_exactly(a_string_matching(/at least 1 items matching contains/))
+      expect(validator.validate([1, 'x', 'y'], schema)).to be_empty
     end
   end
 

--- a/spec/lib/mcp_client/json_schema_2026_round25_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round25_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, twenty-fifth round: the keyword scan
+# survives a local `$ref` that points at a non-schema-object member, so an
+# accepted schema never turns a successful call into an exception; `contains`
+# bounds that no count can satisfy fail on the bounds alone, before any appeal
+# to an item schema the validator cannot decide, so a non-monotonic
+# composition does not fail open on them; and the walk over an instance is
+# depth-bounded, so data nested deeper than the interpreter's stack allows
+# aborts with one validation error instead of a SystemStackError.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 25' do
+  let(:validator) { MCPClient::SchemaValidator }
+
+  describe 'the keyword scan over a $ref to a non-object member' do
+    it 'scans a reference to a number beside a definition bag without raising' do
+      schema = { 'definitions' => {}, 'x' => 1.5, '$ref' => '#/x' }
+
+      expect { validator.unsupported_keywords(schema) }.not_to raise_error
+      expect(validator.unsupported_keywords(schema)).to be_empty
+    end
+
+    it 'scans a reference to a boolean vendor member without raising' do
+      schema = { '$ref' => '#/x', 'x' => true }
+
+      expect { validator.unsupported_keywords(schema) }.not_to raise_error
+      expect(validator.unsupported_keywords(schema)).to be_empty
+    end
+
+    it 'leaves such a schema usable end to end' do
+      schema = { '$ref' => '#/x', 'x' => true }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(1, schema)).to be_empty
+    end
+
+    it 'still reports the keywords a reference to a schema object reaches' do
+      schema = { 'definitions' => {}, 'x' => 1.5, '$ref' => '#/y',
+                 'y' => { 'type' => 'array', 'uniqueItems' => true } }
+
+      expect(validator.unsupported_keywords(schema)).to contain_exactly('uniqueItems')
+    end
+  end
+
+  describe 'contains bounds no count can satisfy' do
+    it 'fails a contains whose minContains default exceeds its maxContains' do
+      schema = { 'contains' => { 'type' => 'string' }, 'maxContains' => 0 }
+
+      expect(validator.validate([1, 2], schema))
+        .to contain_exactly(a_string_matching(/matching items/))
+    end
+
+    it 'fails such a contains whatever the item schema is' do
+      schema = { 'contains' => { 'not' => false }, 'minContains' => 3, 'maxContains' => 2 }
+
+      expect(validator.validate([1, 2, 3, 4], schema))
+        .to contain_exactly(a_string_matching(/matching items/))
+    end
+
+    it 'does not let an anyOf branch pass on bounds that cannot overlap' do
+      schema = { 'anyOf' => [{ 'contains' => { 'type' => 'string' }, 'maxContains' => 0 }] }
+
+      expect(validator.validate([1, 2], schema))
+        .to contain_exactly(a_string_matching(/does not satisfy any schema in anyOf/))
+    end
+
+    it 'takes the else branch when the if branch is unsatisfiable on its bounds' do
+      schema = { 'if' => { 'contains' => { 'type' => 'string' }, 'maxContains' => 0 },
+                 'then' => true, 'else' => false }
+
+      expect(validator.validate([1, 2], schema))
+        .to contain_exactly(a_string_matching(/schema false accepts no value/))
+    end
+
+    it 'counts such a oneOf branch as no match rather than as undecided' do
+      schema = { 'oneOf' => [{ 'contains' => { 'type' => 'string' }, 'maxContains' => 0 },
+                             { 'type' => 'string' }] }
+
+      expect(validator.validate([1, 2], schema))
+        .to contain_exactly(a_string_matching(/satisfies 0 schemas in oneOf/))
+    end
+
+    it 'keeps a tautological non-literal contains bounded by the array length' do
+      expect(validator.validate([1, 2], { 'contains' => { 'not' => false } })).to be_empty
+      expect(validator.validate([1, 2], { 'contains' => { '$ref' => '#/$defs/any' },
+                                          '$defs' => { 'any' => true } })).to be_empty
+    end
+
+    it 'still leaves bounds the array length cannot settle unevaluated' do
+      expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' } })).to be_empty
+      expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' },
+                                          'minContains' => 0, 'maxContains' => 0 })).to be_empty
+    end
+
+    it 'leaves a draft-07 maxContains alone, the dialect not defining it' do
+      schema = { '$schema' => 'http://json-schema.org/draft-07/schema#',
+                 'contains' => { 'type' => 'string' }, 'maxContains' => 0 }
+
+      expect(validator.validate([1, 2], schema)).to be_empty
+    end
+  end
+
+  describe 'an instance nested deeper than the walk can follow' do
+    let(:recursive) { { 'type' => 'array', 'items' => { '$ref' => '#' } } }
+
+    def nest(depth, seed = [])
+      (1..depth).reduce(seed) { |nested, _| [nested] }
+    end
+
+    it 'aborts with a single validation error instead of a SystemStackError' do
+      expect(validator.validate(nest(5000), recursive))
+        .to contain_exactly(a_string_matching(/validation aborted/))
+    end
+
+    it 'aborts on a thread with a smaller stack too' do
+      result = Thread.new { validator.validate(nest(5000), recursive) }.value
+
+      expect(result).to contain_exactly(a_string_matching(/validation aborted/))
+    end
+
+    it 'still accepts data nested as deeply as the wire allows' do
+      data = nest(99)
+
+      expect(JSON.parse(JSON.generate(data))).to eq(data)
+      expect(validator.validate(data, recursive)).to be_empty
+    end
+
+    it 'still validates and reports at ordinary depths' do
+      expect(validator.validate(nest(40), recursive)).to be_empty
+      expect(validator.validate(nest(40, ['x']), recursive))
+        .to contain_exactly(a_string_matching(/expected type array, got string/))
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round25_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round25_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 25' do
 
     it 'still reports the keywords a reference to a schema object reaches' do
       schema = { 'definitions' => {}, 'x' => 1.5, '$ref' => '#/y',
-                 'y' => { 'type' => 'array', 'allOf' => [true], 'unevaluatedItems' => false } }
+                 'y' => { 'type' => 'array', 'items' => { 'format' => 'uuid' } } }
 
-      expect(validator.unsupported_keywords(schema)).to contain_exactly('unevaluatedItems')
+      expect(validator.unsupported_keywords(schema)).to contain_exactly('format')
     end
   end
 

--- a/spec/lib/mcp_client/json_schema_2026_round25_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round25_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 25' do
 
     it 'still reports the keywords a reference to a schema object reaches' do
       schema = { 'definitions' => {}, 'x' => 1.5, '$ref' => '#/y',
-                 'y' => { 'type' => 'array', 'unevaluatedItems' => false } }
+                 'y' => { 'type' => 'array', 'allOf' => [true], 'unevaluatedItems' => false } }
 
       expect(validator.unsupported_keywords(schema)).to contain_exactly('unevaluatedItems')
     end

--- a/spec/lib/mcp_client/json_schema_2026_round26_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round26_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, twenty-sixth round: the depth bound the
+# walk applies counts descents into a child instance value, not every frame of
+# the walk. A recursive schema composed through a few `$defs` mixins applies
+# several subschemas to each instance level — `$ref` hops, allOf/anyOf/if
+# branches — and counting those made the frame count a multiple of the
+# instance depth, so JSON that `JSON.parse` accepts (its default max_nesting
+# is 100) aborted as "nested too deep". Same-instance recursion stays bounded
+# by the `$ref` hop budget and the node-visit cap, as before, and an instance
+# that really does nest past the bound still aborts with one validation error
+# rather than a SystemStackError.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 26' do
+  let(:validator) { MCPClient::SchemaValidator }
+
+  # A recursive schema whose every level is assembled from several `$defs`
+  # mixins and composition branches, all applied to the same instance value.
+  let(:composed) do
+    {
+      '$ref' => '#/$defs/node',
+      '$defs' => {
+        'named' => { 'type' => 'object', 'required' => ['name'] },
+        'tagged' => { 'anyOf' => [{ '$ref' => '#/$defs/named' }, { 'type' => 'object' }] },
+        # The recursion runs through the mixins, so every instance level is
+        # reached through a handful of frames applied to the same value.
+        'nested' => { 'properties' => { 'child' => { '$ref' => '#/$defs/node' } } },
+        'section' => { 'allOf' => [{ '$ref' => '#/$defs/nested' }] },
+        'body' => { 'allOf' => [{ '$ref' => '#/$defs/tagged' }, { '$ref' => '#/$defs/section' }] },
+        'node' => {
+          'type' => 'object',
+          'allOf' => [{ '$ref' => '#/$defs/named' }, { '$ref' => '#/$defs/body' }],
+          'anyOf' => [{ '$ref' => '#/$defs/tagged' }],
+          'if' => { '$ref' => '#/$defs/named' },
+          'then' => { '$ref' => '#/$defs/tagged' }
+        }
+      }
+    }
+  end
+
+  # An instance `depth` levels deep, each level a node the schema above
+  # describes.
+  def chain(depth)
+    (1...depth).reduce({ 'name' => 'leaf' }) { |inner, i| { 'name' => "n#{i}", 'child' => inner } }
+  end
+
+  describe 'a recursive schema composed through several mixins' do
+    it 'accepts an instance as deep as the wire allows' do
+      data = chain(99)
+
+      expect(JSON.parse(JSON.generate(data))).to eq(data)
+      expect(validator.validate(data, composed)).to be_empty
+    end
+
+    it 'still reports a mismatch at that depth rather than aborting' do
+      data = chain(99)
+      deepest = data
+      deepest = deepest['child'] while deepest['child']
+      deepest.delete('name')
+
+      errors = validator.validate(data, composed)
+
+      expect(errors).not_to be_empty
+      expect(errors).to all(satisfy { |e| !e.include?('validation aborted') })
+    end
+
+    it 'accepts an instance at ordinary depths' do
+      expect(validator.validate(chain(20), composed)).to be_empty
+    end
+  end
+
+  describe 'an instance that really does nest past the bound' do
+    let(:recursive) { { 'type' => 'array', 'items' => { '$ref' => '#' } } }
+
+    def nest(depth, seed = [])
+      (1..depth).reduce(seed) { |nested, _| [nested] }
+    end
+
+    it 'aborts on the counted descent, with a single validation error' do
+      expect(validator.validate(nest(5000), recursive))
+        .to contain_exactly(a_string_matching(/validation aborted: instance nested deeper than 256/))
+    end
+
+    it 'aborts the same way on a thread, whose stack is smaller' do
+      result = Thread.new { validator.validate(nest(5000), recursive) }.value
+
+      expect(result).to contain_exactly(a_string_matching(/validation aborted: instance nested deeper than 256/))
+    end
+
+    # The depth bound counts instance levels, not what one level costs on the
+    # stack, and a composed schema spends several frames per level. A stack
+    # that runs out before the count does still ends as one validation error.
+    it 'aborts on the composed schema on a thread rather than raising SystemStackError' do
+      result = Thread.new { validator.validate(chain(5000), composed) }.value
+
+      expect(result).to contain_exactly(a_string_matching(/validation aborted/))
+    end
+  end
+
+  describe 'a schema that recurses on the same instance value forever' do
+    it 'is still stopped by the $ref hop budget' do
+      schema = { '$ref' => '#/$defs/a', '$defs' => { 'a' => { 'allOf' => [{ '$ref' => '#/$defs/a' }] } } }
+
+      hops = /validation aborted: \$ref chain exceeds #{validator::MAX_REF_DEPTH} hops/
+
+      expect(validator.validate({ 'x' => 1 }, schema)).to contain_exactly(a_string_matching(hops))
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round27_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round27_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, twenty-seventh round.
+#
+# Round 26 stopped counting the frames a schema spends on one instance value
+# against the depth bound, but those frames still sat on the Ruby call stack:
+# a recursive schema composed through N `$defs` mixins spent N of them per
+# instance level, so the stack grew with the product of instance depth and
+# mixin count and a conforming `structuredContent` aborted with
+# "schema too deeply recursive for this stack". The same-instance
+# applications — a `$ref` hop, an allOf/anyOf/oneOf/not/if branch, a
+# then/else — are now applied iteratively, so a frame is spent only on a step
+# into a child value and MAX_NODE_DEPTH genuinely bounds the stack.
+#
+# Also: a draft-07 `$id` is a URI reference, so its fragment is
+# percent-decoded when the plain name it declares is read, exactly as a
+# `$ref`'s fragment is.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 27' do
+  let(:validator) { MCPClient::SchemaValidator }
+
+  # A recursive schema whose every instance level is reached through `count`
+  # mixins applied to the same value: the innermost one carries the descent
+  # into the array's items, the rest only wrap it in one more same-instance
+  # application. The mixin count is the dimension round 26's spec never
+  # varied — it is what multiplies the frames one instance level costs.
+  def mixin_schema(count, keyword)
+    defs = { 'leaf' => { 'type' => 'array', 'items' => { '$ref' => '#' } } }
+    (0...count).each do |i|
+      inner = { '$ref' => i + 1 < count ? "#/$defs/n#{i + 1}" : '#/$defs/leaf' }
+      defs["n#{i}"] = case keyword
+                      when 'if' then { 'if' => { 'type' => 'array' }, 'then' => inner }
+                      when '$ref' then inner
+                      else { keyword => [inner] }
+                      end
+    end
+    { '$ref' => '#/$defs/n0', '$defs' => defs }
+  end
+
+  # An array nested `depth` levels deep — data every JSON parser accepts
+  # (`JSON.parse`'s default max_nesting is 100).
+  def nest(depth)
+    (1..depth).reduce([]) { |nested, _| [nested] }
+  end
+
+  # The deepest instance the schema validates without an abort, searched
+  # between 1 and MAX_NODE_DEPTH.
+  def deepest_accepted(schema, on_thread: false)
+    low = 0
+    high = validator::MAX_NODE_DEPTH
+    while low < high
+      mid = ((low + high) / 2) + 1
+      run = -> { validator.validate(nest(mid), schema) }
+      if (on_thread ? Thread.new(&run).value : run.call).empty?
+        low = mid
+      else
+        high = mid - 1
+      end
+    end
+    low
+  end
+
+  describe 'a recursive schema composed through a varying number of mixins' do
+    # 16 mixins keep the per-level `$ref` chain inside MAX_REF_DEPTH, which
+    # is the budget that is meant to bound same-instance recursion.
+    mixin_counts = [1, 2, 4, 8, 16]
+
+    %w[allOf anyOf oneOf if $ref].each do |keyword|
+      mixin_counts.each do |count|
+        context "with #{count} #{keyword} mixins" do
+          let(:schema) { mixin_schema(count, keyword) }
+
+          it 'is a usable schema' do
+            expect(validator.check_schema(schema)).to be_empty
+          end
+
+          it 'validates an instance as deep as the wire allows' do
+            data = nest(99)
+
+            expect(JSON.parse(JSON.generate(data))).to eq(data)
+            expect(validator.validate(data, schema)).to be_empty
+          end
+
+          # A transport's reader thread has a smaller stack than the main
+          # one, and that is where a tool result is actually validated.
+          it 'validates that instance on a thread too' do
+            expect(Thread.new { validator.validate(nest(99), schema) }.value).to be_empty
+          end
+
+          # The bound the validator names is the bound it applies: the mixin
+          # count no longer eats into it.
+          it 'accepts the instance depth its bound promises, on either stack' do
+            expect(deepest_accepted(schema)).to eq(validator::MAX_NODE_DEPTH)
+            expect(deepest_accepted(schema, on_thread: true)).to eq(validator::MAX_NODE_DEPTH)
+          end
+        end
+      end
+    end
+  end
+
+  describe 'an instance nested past the bound, under a composed schema' do
+    let(:schema) { mixin_schema(8, 'allOf') }
+
+    it 'aborts on the counted descent rather than on the stack' do
+      expect(validator.validate(nest(validator::MAX_NODE_DEPTH + 1), schema))
+        .to contain_exactly(a_string_matching(/aborted: instance nested deeper than #{validator::MAX_NODE_DEPTH}/))
+    end
+
+    it 'aborts the same way on a thread' do
+      result = Thread.new { validator.validate(nest(validator::MAX_NODE_DEPTH + 1), schema) }.value
+
+      expect(result)
+        .to contain_exactly(a_string_matching(/aborted: instance nested deeper than #{validator::MAX_NODE_DEPTH}/))
+    end
+  end
+
+  describe 'a schema that recurses on the same instance value forever' do
+    it 'is still stopped by the $ref hop budget, not by the stack' do
+      schema = { '$ref' => '#/$defs/a', '$defs' => { 'a' => { 'allOf' => [{ '$ref' => '#/$defs/a' }] } } }
+      hops = /validation aborted: \$ref chain exceeds #{validator::MAX_REF_DEPTH} hops/
+
+      expect(validator.validate({ 'x' => 1 }, schema)).to contain_exactly(a_string_matching(hops))
+    end
+
+    it 'is stopped the same way on a thread' do
+      schema = { '$ref' => '#/$defs/a', '$defs' => { 'a' => { 'anyOf' => [{ '$ref' => '#/$defs/a' }] } } }
+      result = Thread.new { validator.validate({ 'x' => 1 }, schema) }.value
+
+      expect(result).to contain_exactly(a_string_matching(/validation aborted: \$ref chain exceeds/))
+    end
+  end
+
+  describe 'a draft-07 $id whose fragment is percent-encoded' do
+    let(:schema) do
+      {
+        '$schema' => 'http://json-schema.org/draft-07/schema#',
+        '$ref' => '#foo%2Dbar',
+        'definitions' => { 'target' => { '$id' => '#foo%2Dbar', 'type' => 'integer' } }
+      }
+    end
+
+    it 'declares the decoded plain name, so the matching $ref resolves' do
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(7, schema)).to be_empty
+    end
+
+    it 'still applies the target it names' do
+      expect(validator.validate('seven', schema))
+        .to contain_exactly(a_string_matching(/expected type integer, got string/))
+    end
+
+    it 'resolves an undecoded $ref against the decoded name it declares' do
+      undecoded = {
+        '$schema' => 'http://json-schema.org/draft-07/schema#',
+        '$ref' => '#foo-bar',
+        'definitions' => { 'target' => { '$id' => '#foo%2Dbar', 'type' => 'integer' } }
+      }
+
+      expect(validator.check_schema(undecoded)).to be_empty
+      expect(validator.validate('seven', undecoded))
+        .to contain_exactly(a_string_matching(/expected type integer, got string/))
+    end
+
+    it 'names nothing when the escape is malformed' do
+      malformed = {
+        '$schema' => 'http://json-schema.org/draft-07/schema#',
+        '$ref' => '#a%ZZ',
+        'definitions' => { 'target' => { '$id' => '#a%ZZ', 'type' => 'integer' } }
+      }
+
+      expect(validator.check_schema(malformed))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round28_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round28_spec.rb
@@ -1,0 +1,545 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 JSON Schema handling, twenty-eighth round.
+#
+# MCP 2026-07-28 basic "Implementation Requirements" makes 2020-12 support
+# mandatory, and a validator that leaves a standard assertion unevaluated
+# does not merely report less: it accepts instances the schema rejects.
+# `{"allOf": [{"multipleOf": 3}]}` admitted 4, `{"not": {"multipleOf": 2}}`
+# admitted 4, `uniqueItems` admitted `[1, 1]` and `contains` was decided by
+# the array's length alone. The assertions and applicators whose verdict does
+# not depend on annotations collected across a composition are now evaluated,
+# and only the annotation-driven ones (`unevaluatedItems`,
+# `unevaluatedProperties`), the dynamic references and `format` are left to
+# the partial-coverage report.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 28' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+  let(:draft2019) { 'https://json-schema.org/draft/2019-09/schema' }
+
+  describe 'multipleOf' do
+    it 'asserts on its own and inside every composition' do
+      expect(validator.validate(4, { 'multipleOf' => 3 })).to contain_exactly(a_string_matching(/multiple of 3/))
+      expect(validator.validate(6, { 'multipleOf' => 3 })).to be_empty
+      expect(validator.validate(4, { 'allOf' => [{ 'multipleOf' => 3 }] }))
+        .to contain_exactly(a_string_matching(%r{allOf/0}))
+      expect(validator.validate(4, { 'anyOf' => [{ 'multipleOf' => 3 }] }))
+        .to contain_exactly(a_string_matching(/anyOf/))
+      expect(validator.validate(4, { 'not' => { 'multipleOf' => 2 } }))
+        .to contain_exactly(a_string_matching(/not/))
+      # The condition is decided now, so `then` is applied rather than skipped.
+      conditional = { 'if' => { 'multipleOf' => 2 }, 'then' => { 'type' => 'string' },
+                      'else' => { 'type' => 'integer' } }
+      expect(validator.validate(4, conditional)).to contain_exactly(a_string_matching(/expected type string/))
+      expect(validator.validate(3, conditional)).to be_empty
+    end
+
+    it 'divides exactly rather than in binary floating point' do
+      expect(validator.validate(0.0075, { 'multipleOf' => 0.0001 })).to be_empty
+      expect(validator.validate(1.5, { 'multipleOf' => 0.5 })).to be_empty
+      expect(validator.validate(1.6, { 'multipleOf' => 0.5 })).to contain_exactly(a_string_matching(/multiple of/))
+      # Applies to numbers only.
+      expect(validator.validate('4', { 'multipleOf' => 3 })).to be_empty
+    end
+
+    it 'refuses a schema whose multipleOf is not a positive number' do
+      expect(validator.check_schema({ 'multipleOf' => 0 })).to contain_exactly(a_string_matching(/multipleOf/))
+      expect(validator.check_schema({ 'multipleOf' => -2 })).to contain_exactly(a_string_matching(/multipleOf/))
+      expect(validator.check_schema({ 'multipleOf' => 'two' })).to contain_exactly(a_string_matching(/multipleOf/))
+      expect(validator.check_schema({ 'multipleOf' => 0.5 })).to be_empty
+    end
+  end
+
+  describe 'uniqueItems' do
+    it 'rejects equal items, comparing JSON values rather than Ruby objects' do
+      expect(validator.validate([1, 1], { 'uniqueItems' => true })).to contain_exactly(a_string_matching(/unique/))
+      # JSON Schema equality: 1 and 1.0 are the same number.
+      expect(validator.validate([1, 1.0], { 'uniqueItems' => true })).to contain_exactly(a_string_matching(/unique/))
+      expect(validator.validate([{ 'a' => 1, 'b' => 2 }, { 'b' => 2, 'a' => 1 }], { 'uniqueItems' => true }))
+        .to contain_exactly(a_string_matching(/unique/))
+      expect(validator.validate([1, true], { 'uniqueItems' => true })).to be_empty
+      expect(validator.validate([1, 2], { 'uniqueItems' => true })).to be_empty
+      expect(validator.validate([1, 1], { 'uniqueItems' => false })).to be_empty
+    end
+
+    it 'decides a not branch that only uniqueItems can settle' do
+      expect(validator.validate([1, 1], { 'not' => { 'uniqueItems' => true } })).to be_empty
+      expect(validator.validate([1, 2], { 'not' => { 'uniqueItems' => true } }))
+        .to contain_exactly(a_string_matching(/not/))
+    end
+  end
+
+  describe 'contains' do
+    it 'matches item by item instead of reading the array length alone' do
+      expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' } }))
+        .to contain_exactly(a_string_matching(/at least 1 items matching contains/))
+      expect(validator.validate([1, 'x'], { 'contains' => { 'type' => 'string' } })).to be_empty
+      expect(validator.validate([1, 'x', 'y'], { 'contains' => { 'type' => 'string' }, 'maxContains' => 1 }))
+        .to contain_exactly(a_string_matching(/at most 1 items matching contains/))
+      expect(validator.validate(%w[x y], { 'contains' => { 'type' => 'string' }, 'minContains' => 3 }))
+        .to contain_exactly(a_string_matching(/at least 3 items matching contains/))
+      # minContains 0 switches the lower bound off entirely.
+      expect(validator.validate([1, 2], { 'contains' => { 'type' => 'string' }, 'minContains' => 0 })).to be_empty
+    end
+
+    it 'decides a composition that turns on contains' do
+      expect(validator.validate([1, 2], { 'not' => { 'contains' => { 'type' => 'integer' } } }))
+        .to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate([1, 2], { 'not' => { 'contains' => { 'type' => 'string' } } })).to be_empty
+    end
+
+    it 'refuses a schema whose contains bounds are not non-negative integers' do
+      expect(validator.check_schema({ 'contains' => true, 'minContains' => -1 }))
+        .to contain_exactly(a_string_matching(/minContains/))
+      expect(validator.check_schema({ 'contains' => true, 'maxContains' => 1.5 }))
+        .to contain_exactly(a_string_matching(/maxContains/))
+      # draft-07 does not define the bounds, so nothing there is malformed.
+      expect(validator.check_schema({ '$schema' => draft7, 'contains' => true, 'minContains' => -1 })).to be_empty
+    end
+  end
+
+  describe 'object assertions' do
+    it 'applies property counts and dependent requirements' do
+      expect(validator.validate({}, { 'minProperties' => 1 })).to contain_exactly(a_string_matching(/minProperties/))
+      expect(validator.validate({ 'a' => 1, 'b' => 2 }, { 'maxProperties' => 1 }))
+        .to contain_exactly(a_string_matching(/maxProperties/))
+      dependent = { 'dependentRequired' => { 'card' => ['billing'] } }
+      expect(validator.validate({ 'card' => 1 }, dependent)).to contain_exactly(a_string_matching(/billing/))
+      expect(validator.validate({ 'card' => 1, 'billing' => 2 }, dependent)).to be_empty
+      expect(validator.validate({ 'billing' => 2 }, dependent)).to be_empty
+      # draft-07 spells the same assertion `dependencies`.
+      legacy = { '$schema' => draft7, 'dependencies' => { 'card' => ['billing'] } }
+      expect(validator.validate({ 'card' => 1 }, legacy)).to contain_exactly(a_string_matching(/billing/))
+    end
+
+    it 'applies patternProperties, additionalProperties and propertyNames' do
+      schema = { 'properties' => { 'a' => { 'type' => 'integer' } },
+                 'patternProperties' => { '\Ax' => { 'type' => 'string' } },
+                 'additionalProperties' => false }
+      expect(validator.validate({ 'a' => 1, 'xy' => 'ok' }, schema)).to be_empty
+      expect(validator.validate({ 'xy' => 3 }, schema)).to contain_exactly(a_string_matching(/expected type string/))
+      expect(validator.validate({ 'zz' => 1 }, schema)).to contain_exactly(a_string_matching(/not allowed/))
+
+      typed = { 'additionalProperties' => { 'type' => 'integer' } }
+      expect(validator.validate({ 'z' => 'x' }, typed)).to contain_exactly(a_string_matching(/expected type integer/))
+      names = { 'propertyNames' => { 'maxLength' => 2 } }
+      expect(validator.validate({ 'ab' => 1 }, names)).to be_empty
+      expect(validator.validate({ 'abc' => 1 }, names)).to contain_exactly(a_string_matching(/propertyNames/))
+    end
+
+    it 'applies the schema form of a dependency to the same instance' do
+      schema = { 'dependentSchemas' => { 'card' => { 'required' => ['billing'] } } }
+      expect(validator.validate({ 'card' => 1 }, schema)).to contain_exactly(a_string_matching(/billing/))
+      expect(validator.validate({ 'card' => 1, 'billing' => 2 }, schema)).to be_empty
+      expect(validator.validate({ 'other' => 1 }, schema)).to be_empty
+      legacy = { '$schema' => draft7, 'dependencies' => { 'card' => { 'required' => ['billing'] } } }
+      expect(validator.validate({ 'card' => 1 }, legacy)).to contain_exactly(a_string_matching(/billing/))
+    end
+
+    it 'refuses malformed property-count and dependency values' do
+      expect(validator.check_schema({ 'minProperties' => -1 }))
+        .to contain_exactly(a_string_matching(/minProperties/))
+      expect(validator.check_schema({ 'maxProperties' => 'lots' }))
+        .to contain_exactly(a_string_matching(/maxProperties/))
+      expect(validator.check_schema({ 'uniqueItems' => 'yes' })).to contain_exactly(a_string_matching(/uniqueItems/))
+      expect(validator.check_schema({ 'dependentRequired' => { 'a' => 'b' } }))
+        .to contain_exactly(a_string_matching(/dependentRequired/))
+    end
+  end
+
+  describe 'draft-07 additionalItems' do
+    it 'applies the tuple tail schema' do
+      schema = { '$schema' => draft7, 'items' => [{ 'type' => 'integer' }], 'additionalItems' => false }
+      expect(validator.validate([1], schema)).to be_empty
+      expect(validator.validate([1, 2], schema)).to contain_exactly(a_string_matching(/not allowed/))
+      typed = { '$schema' => draft2019, 'items' => [{ 'type' => 'integer' }],
+                'additionalItems' => { 'type' => 'string' } }
+      expect(validator.validate([1, 'x'], typed)).to be_empty
+      expect(validator.validate([1, 2], typed)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+  end
+
+  describe 'identifier collisions' do
+    it 'refuses a document whose resources declare the same URI' do
+      schema = { '$ref' => 'urn:s',
+                 '$defs' => { 'a' => { '$id' => 'urn:s', 'type' => 'string' },
+                              'b' => { '$id' => 'urn:s', 'type' => 'integer' } } }
+      # Which declaration a reference lands on would otherwise depend on the
+      # order the walk met them in.
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/urn:s.*more than once/))
+      expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/urn:s.*more than once/))
+      distinct = { '$ref' => 'urn:s',
+                   '$defs' => { 'a' => { '$id' => 'urn:s', 'type' => 'string' },
+                                'b' => { '$id' => 'urn:t', 'type' => 'integer' } } }
+      expect(validator.check_schema(distinct)).to be_empty
+    end
+
+    it 'refuses an $id carrying a non-empty fragment, and a malformed anchor' do
+      expect(validator.check_schema({ '$id' => 'urn:root#bad', 'type' => 'integer' }))
+        .to contain_exactly(a_string_matching(/\$id.*fragment/))
+      expect(validator.check_schema({ '$id' => 'urn:root#', 'type' => 'integer' })).to be_empty
+      expect(validator.check_schema({ '$anchor' => 'not a name' }))
+        .to contain_exactly(a_string_matching(/\$anchor must be a plain name/))
+      # draft-07 spells a plain-name identifier as a bare fragment.
+      expect(validator.check_schema({ '$schema' => draft7, '$id' => '#name', 'type' => 'integer' })).to be_empty
+      expect(validator.check_schema({ '$id' => 5 })).to contain_exactly(a_string_matching(/\$id/))
+    end
+
+    it 'refuses duplicate names in required and dependentRequired' do
+      expect(validator.check_schema({ 'required' => %w[a a] })).to contain_exactly(a_string_matching(/required/))
+      expect(validator.check_schema({ 'dependentRequired' => { 'a' => %w[b b] } }))
+        .to contain_exactly(a_string_matching(/dependentRequired/))
+    end
+  end
+
+  describe 'references written as absolute URIs into the bundled document' do
+    def bool_bag(spelling)
+      bools = {}
+      props = {}
+      1100.times do |i|
+        bools["b#{i}"] = true
+        props["p#{i}"] = { '$ref' => format(spelling, i) }
+      end
+      { '$id' => 'urn:root', 'x-bools' => bools, 'properties' => props }
+    end
+
+    it 'charges a boolean target reached through an absolute reference' do
+      # The same targets, spelled two ways: the accounting must not depend on
+      # which spelling the peer chose.
+      expect(validator.check_schema(bool_bag('#/x-bools/b%d')))
+        .to contain_exactly(a_string_matching(/more than #{validator::MAX_SUBSCHEMAS} subschemas/))
+      expect(validator.check_schema(bool_bag('urn:root#/x-bools/b%d')))
+        .to contain_exactly(a_string_matching(/more than #{validator::MAX_SUBSCHEMAS} subschemas/))
+    end
+
+    it 'tells two bundled resources apart by the query of their URIs' do
+      schema = { '$id' => 'urn:x',
+                 'properties' => { 'a' => { '$ref' => 'https://example.com/s?v=1' },
+                                   'b' => { '$ref' => 'https://example.com/s?v=2' } },
+                 '$defs' => { 'one' => { '$id' => 'https://example.com/s?v=1', 'type' => 'string' },
+                              'two' => { '$id' => 'https://example.com/s?v=2', 'type' => 'integer' } } }
+
+      # Dropping the query would merge the two resources into one URI, so
+      # neither reference could name the resource its author wrote.
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => 'x', 'b' => 1 }, schema)).to be_empty
+      expect(validator.validate({ 'a' => 1, 'b' => 'x' }, schema))
+        .to contain_exactly(a_string_matching(%r{#/a: expected type string}),
+                            a_string_matching(%r{#/b: expected type integer}))
+    end
+
+    it 'resolves a query-only reference against the base in force' do
+      # RFC 3986 Section 5.2.2: an empty path keeps the base's, and the
+      # reference's own query replaces it — which is the only thing telling
+      # this resource from the document root.
+      schema = { '$id' => 'https://example.com/root', 'type' => 'object',
+                 'properties' => { 'a' => { '$ref' => '?v=2' } },
+                 '$defs' => { 'two' => { '$id' => '?v=2', 'type' => 'integer' } } }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => 'x' }, schema))
+        .to contain_exactly(a_string_matching(/expected type integer/))
+      expect(validator.validate({ 'a' => 1 }, schema)).to be_empty
+    end
+
+    it 'removes the dot segments of a relative reference' do
+      schema = { '$id' => 'https://example.com/a/b/root',
+                 'properties' => { 'a' => { '$ref' => '../c/s' } },
+                 '$defs' => { 's' => { '$id' => 'https://example.com/a/c/s', 'type' => 'string' } } }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => 1 }, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+
+    it 'still resolves an absolute reference to a schema in the bundle' do
+      schema = { '$id' => 'urn:root', 'properties' => { 'a' => { '$ref' => 'urn:root#/$defs/s' } },
+                 '$defs' => { 's' => { 'type' => 'string' } } }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => 1 }, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+  end
+
+  describe 'an output schema whose dialect this client does not implement' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+    let(:output_schema) { { '$schema' => 'urn:unknown', 'type' => 'object' } }
+    let(:tool) do
+      MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
+                          output_schema: output_schema, server: mock_server)
+    end
+
+    def client_with(mode)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+      allow(mock_server).to receive(:on_notification)
+      allow(mock_server).to receive(:list_tools).and_return([tool])
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => {} })
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger,
+                            validate_structured_content: mode)
+    end
+
+    # MCP 2026-07-28 basic "Implementation Requirements": a client MUST
+    # return an error saying the dialect is not supported. That is not a
+    # structured-content mismatch the host may choose to only log — the
+    # client cannot read the schema at all — so it is raised in both modes,
+    # exactly as an unsupported input dialect is.
+    it 'raises in the default mode as well as in :strict' do
+      expect { client_with(:warn).call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown.*not supported/m)
+      expect { client_with(:strict).call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown.*not supported/m)
+    end
+
+    it 'still only logs an output schema that is unusable for another reason' do
+      allow(tool).to receive(:output_schema).and_return({ '$ref' => 'https://example.com/x' })
+      result = client_with(:warn).call_tool('t', {})
+
+      expect(result).to eq({ 'content' => [], 'structuredContent' => {} })
+      expect(log_output.string).to include('external $ref')
+    end
+  end
+
+  describe 'schema checks across tools and entry points' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+
+    def stub_server(name, tools)
+      srv = instance_double(MCPClient::ServerBase, name: name)
+      allow(srv).to receive(:on_notification)
+      allow(srv).to receive(:list_tools).and_return(tools)
+      allow(srv).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => {} })
+      allow(srv).to receive(:call_tool_streaming) do |*|
+        Enumerator.new { |y| y << { 'content' => [], 'structuredContent' => {} } }
+      end
+      srv
+    end
+
+    def client_over(servers, **opts)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(*servers)
+      MCPClient::Client.new(mcp_server_configs: Array.new(servers.length) { { type: 'stdio', command: 'test' } },
+                            logger: logger, **opts)
+    end
+
+    it 'checks two servers exposing the same tool name independently' do
+      good = stub_server('good', [])
+      bad = stub_server('bad', [])
+      allow(good).to receive(:list_tools).and_return(
+        [MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' }, server: good)]
+      )
+      allow(bad).to receive(:list_tools).and_return(
+        [MCPClient::Tool.new(name: 't', description: 'd',
+                             schema: { '$schema' => 'urn:unknown', 'type' => 'object' }, server: bad)]
+      )
+      client = client_over([good, bad])
+
+      expect(client.call_tool('t', {}, server: 'good')).to eq({ 'content' => [], 'structuredContent' => {} })
+      expect { client.call_tool('t', {}, server: 'bad') }
+        .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown/)
+      # And the first server's memo is untouched by the second's verdict.
+      expect(client.call_tool('t', {}, server: 'good')).to eq({ 'content' => [], 'structuredContent' => {} })
+    end
+
+    it 'refuses an unsupported input dialect at the streaming entry point too' do
+      srv = stub_server('s', [])
+      allow(srv).to receive(:list_tools).and_return(
+        [MCPClient::Tool.new(name: 't', description: 'd',
+                             schema: { '$schema' => 'urn:unknown', 'type' => 'object' }, server: srv)]
+      )
+      client = client_over([srv])
+
+      expect { client.call_tool_streaming('t', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown/)
+      expect(srv).not_to have_received(:call_tool_streaming)
+    end
+
+    # A boolean or null outputSchema is a declared schema, so a result must
+    # be validated against it — and the copies the client cache hands out
+    # must carry that as the parsed definition did.
+    [[false, /schema false accepts no value/], [nil, /must be an object or a boolean/]].each do |schema, message|
+      it "validates a result against a parsed #{schema.inspect} outputSchema" do
+        srv = stub_server('s', [])
+        parsed = MCPClient::Tool.from_json({ 'name' => 't', 'inputSchema' => { 'type' => 'object' },
+                                             'outputSchema' => schema }, server: srv)
+        allow(srv).to receive(:list_tools).and_return([parsed])
+        client = client_over([srv], validate_structured_content: :strict)
+
+        expect(client.list_tools.first.structured_output?).to be true
+        expect { client.call_tool('t', {}) }.to raise_error(MCPClient::Errors::ValidationError, message)
+      end
+    end
+  end
+
+  describe 'through the wire' do
+    let(:base_url) { 'https://example.com' }
+    let(:endpoint) { '/mcp' }
+    let(:url) { "#{base_url}#{endpoint}" }
+
+    def json_response(id, result)
+      { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result),
+        headers: { 'Content-Type' => 'application/json' } }
+    end
+
+    def modern_client(mode: :strict)
+      MCPClient::Client.new(
+        mcp_server_configs: [MCPClient.streamable_http_config(base_url: base_url, endpoint: endpoint, retries: 0)],
+        validate_structured_content: mode
+      )
+    end
+
+    # The transport's HeaderMismatch recovery re-derives the call's
+    # Mcp-Param-* headers from a refreshed tools/list, so the attempt that is
+    # answered may have gone out under a definition this client never
+    # resolved -- and the dialect check must cover that one too.
+    it 'refuses a call answered under a refreshed input schema of an unsupported dialect' do
+      listed = { 'name' => 'execute_sql',
+                 'inputSchema' => { 'type' => 'object',
+                                    'properties' => { 'region' => { 'type' => 'string',
+                                                                    'x-mcp-header' => 'Region' } } } }
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'server/discover'
+          json_response(body['id'],
+                        { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+                          'capabilities' => { 'tools' => {} } })
+        when 'tools/list' then json_response(body['id'], { 'tools' => [listed] })
+        when 'tools/call'
+          next json_response(body['id'], { 'content' => [] }) if request.headers['Mcp-Param-Zone']
+
+          listed = { 'name' => 'execute_sql',
+                     'inputSchema' => { '$schema' => 'urn:unknown-dialect', 'type' => 'object',
+                                        'properties' => { 'region' => { 'type' => 'string',
+                                                                        'x-mcp-header' => 'Zone' } } } }
+          { status: 400, headers: { 'Content-Type' => 'application/json' },
+            body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'],
+                                'error' => { 'code' => -32_020, 'message' => 'Mcp-Param-Zone missing' }) }
+        end
+      end
+      client = modern_client
+
+      expect { client.call_tool('execute_sql', { 'region' => 'eu' }) }
+        .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown-dialect.*not supported/m)
+      client.cleanup
+    end
+
+    # MCP 2025-11-25 server/tools: structured content is an object there, and
+    # an outputSchema describes one. The widening to "any JSON value" is a
+    # 2026-07-28 rule and does not reach back to a session negotiated legacy.
+    it 'still treats a null structuredContent as missing on a legacy session' do
+      tool = { 'name' => 'execute_sql', 'inputSchema' => { 'type' => 'object' },
+               'outputSchema' => { 'type' => 'null' } }
+      stub_request(:get, url).to_return(status: 405, body: '')
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'initialize'
+          json_response(body['id'], { 'protocolVersion' => '2025-11-25', 'capabilities' => { 'tools' => {} },
+                                      'serverInfo' => { 'name' => 'legacy', 'version' => '1' } })
+        when 'notifications/initialized' then { status: 202, body: '' }
+        when 'tools/list' then json_response(body['id'], { 'tools' => [tool] })
+        when 'tools/call' then json_response(body['id'], { 'content' => [], 'structuredContent' => nil })
+        end
+      end
+      client = MCPClient::Client.new(
+        mcp_server_configs: [MCPClient.streamable_http_config(base_url: base_url, endpoint: endpoint, retries: 0,
+                                                              protocol: :legacy)],
+        validate_structured_content: :strict
+      )
+
+      expect { client.call_tool('execute_sql', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /carries no structuredContent/)
+      client.cleanup
+    end
+  end
+
+  describe 'a leaf deep under a chain of same-instance applications' do
+    it 'reports it, and reports a negation of it, through the trampoline' do
+      # Twenty mixins applied to each value, so every instance level is
+      # reached through twenty same-instance applications.
+      defs = { 'leaf' => { 'type' => 'object', 'properties' => { 'next' => { '$ref' => '#/$defs/n0' } },
+                           'additionalProperties' => { 'type' => 'integer' } } }
+      20.times do |i|
+        defs["n#{i}"] = { '$ref' => i + 1 < 20 ? "#/$defs/n#{i + 1}" : '#/$defs/leaf' }
+      end
+      schema = { '$ref' => '#/$defs/n0', '$defs' => defs }
+      deep = (1..30).reduce({ 'v' => 1 }) { |inner, _| { 'next' => inner } }
+      bad = (1..30).reduce({ 'v' => 'x' }) { |inner, _| { 'next' => inner } }
+
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(deep, schema)).to be_empty
+      expect(validator.validate(bad, schema)).to contain_exactly(a_string_matching(/expected type integer/))
+      # The same descent inside a negation: the leaf decides it.
+      negated = { 'not' => { '$ref' => '#/$defs/n0' }, '$defs' => defs }
+      expect(validator.validate(bad, negated)).to be_empty
+      expect(validator.validate(deep, negated)).to contain_exactly(a_string_matching(/not/))
+    end
+  end
+
+  describe 'ECMAScript pattern semantics' do
+    # JSON Schema 2020-12 Core Section 4.3: a `pattern` is an ECMA-262
+    # regular expression, where `^` and `$` match only at the ends of the
+    # subject. Ruby's match at every line boundary, so a value carrying a
+    # newline satisfied a pattern ECMAScript rejects — and, through `not`,
+    # was rejected although ECMAScript accepts it.
+    it 'anchors a pattern to the whole string, not to each line' do
+      expect(validator.validate("a\nb", { 'pattern' => '^a$' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+      expect(validator.validate('a', { 'pattern' => '^a$' })).to be_empty
+      expect(validator.validate("a\nb", { 'not' => { 'pattern' => '^a$' } })).to be_empty
+      # An anchor inside a character class or escaped is a literal.
+      expect(validator.validate('a^b$c', { 'pattern' => '[$^]' })).to be_empty
+      expect(validator.validate('a$b', { 'pattern' => '\\$' })).to be_empty
+      expect(validator.validate('ab', { 'pattern' => '[^x]b' })).to be_empty
+    end
+
+    it 'anchors a property-name pattern the same way' do
+      schema = { 'patternProperties' => { '^a$' => { 'type' => 'integer' } }, 'additionalProperties' => false }
+      expect(validator.validate({ 'a' => 1 }, schema)).to be_empty
+      expect(validator.validate({ "a\nb" => 1 }, schema)).to contain_exactly(a_string_matching(/not allowed/))
+    end
+
+    it 'matches non-ASCII text as written' do
+      expect(validator.validate('héllo', { 'pattern' => '^héllo$' })).to be_empty
+      expect(validator.validate("héllo\nx", { 'pattern' => '^héllo$' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+    end
+  end
+
+  describe 'the dynamic references this validator does not evaluate' do
+    it 'reports them and never lets one decide a non-monotonic composition' do
+      schema = { '$dynamicRef' => '#node', '$defs' => { 'n' => { '$dynamicAnchor' => 'node', 'type' => 'string' } } }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.unsupported_keywords(schema)).to contain_exactly('$dynamicRef')
+      # Not applied, so it decides nothing — and a `not` around it cannot
+      # read the pass as a match.
+      expect(validator.validate(1, schema)).to be_empty
+      expect(validator.validate(1, { 'not' => schema })).to be_empty
+    end
+
+    it 'refuses a dynamic reference that is not a string' do
+      expect(validator.check_schema({ '$dynamicRef' => 5 }))
+        .to contain_exactly(a_string_matching(/\$dynamicRef must be a string/))
+      expect(validator.check_schema({ '$schema' => draft2019, '$recursiveRef' => [] }))
+        .to contain_exactly(a_string_matching(/\$recursiveRef must be a string/))
+      # A dialect that does not define the keyword has nothing to refuse.
+      expect(validator.check_schema({ '$schema' => draft7, '$dynamicRef' => 5 })).to be_empty
+    end
+  end
+
+  describe 'the partial-coverage report' do
+    it 'keeps only the keywords whose verdict this validator still cannot reach' do
+      supported = { 'multipleOf' => 2, 'uniqueItems' => true, 'contains' => true, 'minContains' => 1,
+                    'maxContains' => 2, 'minProperties' => 1, 'maxProperties' => 2,
+                    'additionalProperties' => false, 'patternProperties' => {}, 'propertyNames' => true,
+                    'dependentRequired' => {}, 'dependentSchemas' => {} }
+      expect(validator.unsupported_keywords(supported)).to be_empty
+      partial = { 'unevaluatedProperties' => false, 'format' => 'email', '$dynamicRef' => '#a',
+                  '$dynamicAnchor' => 'a' }
+      expect(validator.unsupported_keywords(partial))
+        .to contain_exactly('$dynamicRef', 'unevaluatedProperties', 'format')
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round28_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round28_spec.rb
@@ -510,13 +510,19 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 28' do
 
   describe 'the dynamic references this validator does not evaluate' do
     it 'reports them and never lets one decide a non-monotonic composition' do
-      schema = { '$dynamicRef' => '#node', '$defs' => { 'n' => { '$dynamicAnchor' => 'node', 'type' => 'string' } } }
+      # Several non-root resources declare the anchor: only the evaluation
+      # path could choose the binding, which this validator does not track.
+      schema = { '$ref' => 'https://example.com/a',
+                 '$defs' => { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node',
+                                       'type' => 'object', 'properties' => { 'v' => { '$dynamicRef' => '#node' } } },
+                              'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node',
+                                       'type' => 'string' } } }
       expect(validator.check_schema(schema)).to be_empty
       expect(validator.unsupported_keywords(schema)).to contain_exactly('$dynamicRef')
       # Not applied, so it decides nothing — and a `not` around it cannot
       # read the pass as a match.
-      expect(validator.validate(1, schema)).to be_empty
-      expect(validator.validate(1, { 'not' => schema })).to be_empty
+      expect(validator.validate({ 'v' => 1 }, schema)).to be_empty
+      expect(validator.validate({ 'v' => 1 }, { 'not' => schema })).to be_empty
     end
 
     it 'refuses a dynamic reference that is not a string' do
@@ -537,7 +543,10 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 28' do
                     'dependentRequired' => {}, 'dependentSchemas' => {},
                     'allOf' => [true], 'unevaluatedProperties' => false, 'unevaluatedItems' => false }
       expect(validator.unsupported_keywords(supported)).to be_empty
-      partial = { 'format' => 'email', '$dynamicRef' => '#a', '$dynamicAnchor' => 'a' }
+      partial = { 'format' => 'email', '$ref' => 'https://example.com/a',
+                  '$defs' => { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node',
+                                        'properties' => { 'v' => { '$dynamicRef' => '#node' } } },
+                               'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node' } } }
       expect(validator.unsupported_keywords(partial)).to contain_exactly('$dynamicRef', 'format')
     end
   end

--- a/spec/lib/mcp_client/json_schema_2026_round28_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round28_spec.rb
@@ -508,20 +508,18 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 28' do
     end
   end
 
-  describe 'the dynamic references this validator does not evaluate' do
-    it 'reports them and never lets one decide a non-monotonic composition' do
-      # Several non-root resources declare the anchor: only the evaluation
-      # path could choose the binding, which this validator does not track.
+  describe 'the dynamic references' do
+    it 'evaluates them, so one decides a non-monotonic composition like any other' do
+      # The binding is the outermost resource of the dynamic scope declaring
+      # the anchor; a resource the instance never entered is not in it.
       schema = { '$ref' => 'https://example.com/a',
                  '$defs' => { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node',
                                        'type' => 'object', 'properties' => { 'v' => { '$dynamicRef' => '#node' } } },
                               'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node',
                                        'type' => 'string' } } }
       expect(validator.check_schema(schema)).to be_empty
-      expect(validator.unsupported_keywords(schema)).to contain_exactly('$dynamicRef')
-      # Not applied, so it decides nothing — and a `not` around it cannot
-      # read the pass as a match.
-      expect(validator.validate({ 'v' => 1 }, schema)).to be_empty
+      expect(validator.unsupported_keywords(schema)).to be_empty
+      expect(validator.validate({ 'v' => 1 }, schema)).not_to be_empty
       expect(validator.validate({ 'v' => 1 }, { 'not' => schema })).to be_empty
     end
 
@@ -543,11 +541,15 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 28' do
                     'dependentRequired' => {}, 'dependentSchemas' => {},
                     'allOf' => [true], 'unevaluatedProperties' => false, 'unevaluatedItems' => false }
       expect(validator.unsupported_keywords(supported)).to be_empty
-      partial = { 'format' => 'email', '$ref' => 'https://example.com/a',
+      # A dynamic reference is evaluated and reports nothing; `format` and
+      # `contentSchema`, which this validator only ever annotates with, are
+      # what is left.
+      partial = { 'format' => 'email', 'contentSchema' => { 'type' => 'object' },
+                  '$ref' => 'https://example.com/a',
                   '$defs' => { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node',
                                         'properties' => { 'v' => { '$dynamicRef' => '#node' } } },
                                'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node' } } }
-      expect(validator.unsupported_keywords(partial)).to contain_exactly('$dynamicRef', 'format')
+      expect(validator.unsupported_keywords(partial)).to contain_exactly('contentSchema', 'format')
     end
   end
 end

--- a/spec/lib/mcp_client/json_schema_2026_round28_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round28_spec.rb
@@ -534,12 +534,11 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 28' do
       supported = { 'multipleOf' => 2, 'uniqueItems' => true, 'contains' => true, 'minContains' => 1,
                     'maxContains' => 2, 'minProperties' => 1, 'maxProperties' => 2,
                     'additionalProperties' => false, 'patternProperties' => {}, 'propertyNames' => true,
-                    'dependentRequired' => {}, 'dependentSchemas' => {} }
+                    'dependentRequired' => {}, 'dependentSchemas' => {},
+                    'allOf' => [true], 'unevaluatedProperties' => false, 'unevaluatedItems' => false }
       expect(validator.unsupported_keywords(supported)).to be_empty
-      partial = { 'unevaluatedProperties' => false, 'format' => 'email', '$dynamicRef' => '#a',
-                  '$dynamicAnchor' => 'a' }
-      expect(validator.unsupported_keywords(partial))
-        .to contain_exactly('$dynamicRef', 'unevaluatedProperties', 'format')
+      partial = { 'format' => 'email', '$dynamicRef' => '#a', '$dynamicAnchor' => 'a' }
+      expect(validator.unsupported_keywords(partial)).to contain_exactly('$dynamicRef', 'format')
     end
   end
 end

--- a/spec/lib/mcp_client/json_schema_2026_round28_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round28_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 28' do
 
     it 'applies patternProperties, additionalProperties and propertyNames' do
       schema = { 'properties' => { 'a' => { 'type' => 'integer' } },
-                 'patternProperties' => { '\Ax' => { 'type' => 'string' } },
+                 'patternProperties' => { '^x' => { 'type' => 'string' } },
                  'additionalProperties' => false }
       expect(validator.validate({ 'a' => 1, 'xy' => 'ok' }, schema)).to be_empty
       expect(validator.validate({ 'xy' => 3 }, schema)).to contain_exactly(a_string_matching(/expected type string/))

--- a/spec/lib/mcp_client/json_schema_2026_round29_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round29_spec.rb
@@ -259,25 +259,27 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 29' do
       expect(validator.unsupported_keywords({ 'prefixItems' => [true], 'unevaluatedItems' => false })).to be_empty
     end
 
-    it 'still defers the keyword where a composition produces the annotations' do
-      # An in-place applicator contributes annotations this validator does not
-      # collect, so the keyword stays unevaluated — reported, never guessed.
+    it 'evaluates the keyword where a composition produces the annotations' do
+      # An in-place applicator's annotations are collected (round 31), so the
+      # keyword is evaluated there too — and decides a `not` like any other.
       composed = { 'allOf' => [{ 'properties' => { 'a' => true } }], 'unevaluatedProperties' => false }
-      expect(validator.unsupported_keywords(composed)).to contain_exactly('unevaluatedProperties')
+      expect(validator.unsupported_keywords(composed)).to be_empty
       expect(validator.validate({ 'a' => 1 }, composed)).to be_empty
-      # ... and never decides a non-monotonic composition on that guess.
-      expect(validator.validate({ 'a' => 1 }, { 'not' => composed })).to be_empty
+      expect(validator.validate({ 'a' => 1, 'b' => 2 }, composed)).to contain_exactly(a_string_matching(/'b'/))
+      expect(validator.validate({ 'a' => 1 }, { 'not' => composed })).not_to be_empty
 
       referenced = { '$ref' => '#/$defs/p', 'unevaluatedProperties' => false,
                      '$defs' => { 'p' => { 'properties' => { 'a' => true } } } }
-      expect(validator.unsupported_keywords(referenced)).to contain_exactly('unevaluatedProperties')
+      expect(validator.unsupported_keywords(referenced)).to be_empty
       expect(validator.validate({ 'a' => 1 }, referenced)).to be_empty
+      expect(validator.validate({ 'a' => 1, 'b' => 2 }, referenced)).not_to be_empty
     end
 
-    it 'still defers unevaluatedItems beside contains, whose matches annotate' do
+    it 'evaluates unevaluatedItems beside contains, whose matches annotate' do
       schema = { 'contains' => { 'type' => 'string' }, 'unevaluatedItems' => false }
-      expect(validator.unsupported_keywords(schema)).to contain_exactly('unevaluatedItems')
-      expect(validator.validate(['x', 1], schema)).to be_empty
+      expect(validator.unsupported_keywords(schema)).to be_empty
+      expect(validator.validate(['x'], schema)).to be_empty
+      expect(validator.validate(['x', 1], schema)).to contain_exactly(a_string_matching(/item 1/))
     end
 
     it 'leaves the keyword alone in a dialect that does not define it' do

--- a/spec/lib/mcp_client/json_schema_2026_round29_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round29_spec.rb
@@ -1,0 +1,656 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 JSON Schema handling, twenty-ninth round.
+#
+# Round 28 evaluated the standard assertions; this round fixes the verdicts
+# some of them reached. `uniqueItems` canonicalized an object into an array
+# of member pairs, so `[{}, []]` — two distinct JSON values — read as equal
+# and :strict rejected a conforming result. A `pattern` was compiled as a
+# Ruby expression with only its anchors rewritten, so `\A` meant
+# start-of-string where ECMA-262 means a literal `A`, `.` matched a carriage
+# return ECMA-262 excludes, `\s` missed the Unicode spaces it includes and an
+# empty character class was not an expression at all (so the pattern was
+# skipped, and every string passed it). The wide instance loops spent
+# unbounded work before the deadline was consulted. The annotation-driven
+# keywords are now evaluated wherever a node's own applicators produce every
+# annotation they read.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 29' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+  let(:draft2019) { 'https://json-schema.org/draft/2019-09/schema' }
+
+  describe 'uniqueItems compares JSON values, not their Ruby encodings' do
+    it 'never reads an object as equal to an array' do
+      # JSON Schema 2020-12 Validation Section 6.4.3 equality is JSON's: an
+      # object is never equal to an array, whatever members either holds.
+      expect(validator.validate([{}, []], { 'uniqueItems' => true })).to be_empty
+      expect(validator.validate([{ 'a' => 1 }, [['a', 1]]], { 'uniqueItems' => true })).to be_empty
+      expect(validator.validate([{ 'a' => 1 }, { 'a' => 1 }], { 'uniqueItems' => true }))
+        .to contain_exactly(a_string_matching(/unique/))
+      expect(validator.validate([[1, 2], [1, 2]], { 'uniqueItems' => true }))
+        .to contain_exactly(a_string_matching(/unique/))
+      expect(validator.validate([[1, 2], [2, 1]], { 'uniqueItems' => true })).to be_empty
+    end
+
+    it 'tells a string apart from the number and the boolean written like it' do
+      expect(validator.validate(['1', 1], { 'uniqueItems' => true })).to be_empty
+      expect(validator.validate([true, 1], { 'uniqueItems' => true })).to be_empty
+      expect(validator.validate([nil, false], { 'uniqueItems' => true })).to be_empty
+      expect(validator.validate([{ 'a' => nil }, {}], { 'uniqueItems' => true })).to be_empty
+    end
+
+    it 'reads the same verdict through a negation' do
+      # The mistake flipped here: `not` ACCEPTED a conforming array.
+      expect(validator.validate([{}, []], { 'not' => { 'uniqueItems' => true } }))
+        .to contain_exactly(a_string_matching(/not/))
+      expect(validator.validate([{}, {}], { 'not' => { 'uniqueItems' => true } })).to be_empty
+    end
+  end
+
+  describe 'the validation budget inside the wide instance loops' do
+    # A schema keyword's cost is bounded by the schema; a loop over the
+    # instance is bounded by what the peer sent. Walking every property of a
+    # 100k-member object (or canonicalizing a deep one for uniqueItems)
+    # without consulting the deadline let a peer hold the calling thread well
+    # past the budget the client advertises, and — under `not` — report the
+    # work as a pass.
+    def with_clock(step)
+      now = 0.0
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { now += step }
+      yield
+    end
+
+    it 'aborts a wide additionalProperties sweep instead of running it out' do
+      data = (1..500).to_h { |i| ["p#{i}", i] }
+      errors = with_clock(0.05) { validator.validate(data, { 'not' => { 'additionalProperties' => false } }) }
+      expect(errors).to contain_exactly(a_string_matching(/aborted/))
+    end
+
+    it 'aborts a wide tuple tail instead of naming every item past it' do
+      # Inside `not` the tail's errors are a verdict, so MAX_ERRORS never
+      # stops the sweep: only the deadline can.
+      data = Array.new(500, 'x')
+      tail = { 'items' => [{ 'type' => 'string' }], 'additionalItems' => false }
+      schema = { '$schema' => draft2019, 'not' => tail }
+      errors = with_clock(0.05) { validator.validate(data, schema) }
+      expect(errors).to contain_exactly(a_string_matching(/aborted/))
+    end
+
+    it 'aborts canonicalizing a deep instance for uniqueItems' do
+      # Three items, so the per-item checkpoint is never reached: the cost is
+      # in canonicalizing what each of them holds.
+      data = Array.new(3) { |i| { 'k' => Array.new(50) { |j| { 'n' => (i * 50) + j } } } }
+      errors = with_clock(0.05) { validator.validate(data, { 'uniqueItems' => true }) }
+      expect(errors).to contain_exactly(a_string_matching(/aborted/))
+    end
+  end
+
+  describe 'ECMA-262 pattern semantics beyond the anchors' do
+    # JSON Schema 2020-12 Core Section 4.3: a `pattern` is an ECMA-262
+    # regular expression. Round 28 rewrote `^` and `$`; everything else was
+    # still read as Ruby, and the two dialects disagree about more than the
+    # anchors — in both directions, so a pattern accepted the wrong strings
+    # and (through `not` or `additionalProperties: false`) rejected the right
+    # ones.
+    it 'reads a Ruby-only escape as the literal character ECMA-262 makes it' do
+      # `\A` anchors in Ruby; in ECMA-262 it is an identity escape for "A".
+      expect(validator.validate('xy', { 'pattern' => '\\Ax' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+      expect(validator.validate('Ax', { 'pattern' => '\\Ax' })).to be_empty
+      # The same for the other Ruby anchors and escapes ECMA-262 does not define.
+      expect(validator.validate('xz', { 'pattern' => 'x\\z' })).to be_empty
+      expect(validator.validate('x', { 'pattern' => 'x\\z' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+      expect(validator.validate('hG', { 'pattern' => '\\h\\G' })).to be_empty
+      # The escapes ECMA-262 does define keep their meaning.
+      expect(validator.validate('a1 ', { 'pattern' => '^\\w\\d\\s$' })).to be_empty
+      expect(validator.validate('a\\A', { 'pattern' => 'a\\\\A' })).to be_empty
+    end
+
+    it 'excludes the line terminators ECMA-262 excludes from a dot' do
+      expect(validator.validate("\r", { 'pattern' => '^.$' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+      expect(validator.validate("\u2028", { 'pattern' => '^.$' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+      expect(validator.validate('x', { 'pattern' => '^.$' })).to be_empty
+      # An escaped dot, and a dot inside a character class, are literals.
+      expect(validator.validate('.', { 'pattern' => '^\\.$' })).to be_empty
+      expect(validator.validate('x', { 'pattern' => '^\\.$' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+      expect(validator.validate('.', { 'pattern' => '^[.]$' })).to be_empty
+    end
+
+    it 'counts the Unicode spaces ECMA-262 counts as whitespace' do
+      expect(validator.validate("\u00a0", { 'pattern' => '^\\s$' })).to be_empty
+      expect(validator.validate("\u3000", { 'pattern' => '^[\\s]$' })).to be_empty
+      expect(validator.validate("\u00a0", { 'pattern' => '^\\S$' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+      expect(validator.validate('x', { 'pattern' => '^[a-z\\S]$' })).to be_empty
+      expect(validator.validate(' ', { 'pattern' => '^\\s$' })).to be_empty
+    end
+
+    it 'matches nothing with an empty character class rather than skipping the keyword' do
+      # Ruby cannot compile `[]` at all, so the pattern was dropped and every
+      # string satisfied it; in ECMA-262 an empty class matches no character.
+      expect(validator.validate('x', { 'pattern' => '[]' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+      expect(validator.validate('', { 'pattern' => '[]*' })).to be_empty
+      # `[^]` is its complement: any character at all, line terminators included.
+      expect(validator.validate("\n", { 'pattern' => '^[^]$' })).to be_empty
+    end
+
+    it 'leaves a character class the peer wrote alone' do
+      expect(validator.validate('b', { 'pattern' => '^[a-c]$' })).to be_empty
+      expect(validator.validate('d', { 'pattern' => '^[a-c]$' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+      expect(validator.validate(']', { 'pattern' => '^[\\]]$' })).to be_empty
+      expect(validator.validate('-', { 'pattern' => '^[-a]$' })).to be_empty
+      expect(validator.validate('^', { 'pattern' => '^[x^]$' })).to be_empty
+      expect(validator.validate('aa', { 'pattern' => '^(a)\\1$' })).to be_empty
+    end
+
+    it 'reads a property-name pattern in the same dialect' do
+      schema = { 'patternProperties' => { '\\Ax' => { 'type' => 'string' } }, 'additionalProperties' => false }
+      # "xy" is not a member in ECMA-262: `\Ax` needs a literal "Ax".
+      expect(validator.validate({ 'xy' => 'ok' }, schema)).to contain_exactly(a_string_matching(/not allowed/))
+      expect(validator.validate({ 'Axe' => 'ok' }, schema)).to be_empty
+      expect(validator.validate({ 'Axe' => 3 }, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+
+    it 'reads the same dialect through a negation' do
+      expect(validator.validate('xy', { 'not' => { 'pattern' => '\\Ax' } })).to be_empty
+      expect(validator.validate('Ax', { 'not' => { 'pattern' => '\\Ax' } }))
+        .to contain_exactly(a_string_matching(/not/))
+    end
+  end
+
+  describe 'the shape of the standard keywords that only annotate' do
+    # JSON Schema 2020-12 Validation Section 9 gives each metadata keyword a
+    # type. A schema that writes one of them wrong is malformed, exactly as a
+    # malformed assertion is: the preflight said such a document was usable,
+    # so :strict checked results against a schema no validator could read.
+    it 'refuses a metadata keyword whose value is not what its type says' do
+      expect(validator.check_schema({ 'readOnly' => 'no' })).to contain_exactly(a_string_matching(/readOnly/))
+      expect(validator.check_schema({ 'writeOnly' => 1 })).to contain_exactly(a_string_matching(/writeOnly/))
+      expect(validator.check_schema({ 'title' => 5 })).to contain_exactly(a_string_matching(/title/))
+      expect(validator.check_schema({ 'description' => [] })).to contain_exactly(a_string_matching(/description/))
+      expect(validator.check_schema({ '$comment' => 5 })).to contain_exactly(a_string_matching(/\$comment/))
+      expect(validator.check_schema({ 'format' => 3 })).to contain_exactly(a_string_matching(/format/))
+      expect(validator.check_schema({ 'contentMediaType' => 3 }))
+        .to contain_exactly(a_string_matching(/contentMediaType/))
+      expect(validator.check_schema({ 'contentEncoding' => {} }))
+        .to contain_exactly(a_string_matching(/contentEncoding/))
+      expect(validator.check_schema({ 'examples' => { 'a' => 1 } })).to contain_exactly(a_string_matching(/examples/))
+      expect(validator.check_schema({ 'deprecated' => 'yes' })).to contain_exactly(a_string_matching(/deprecated/))
+    end
+
+    it 'accepts the same keywords written as their type' do
+      well_formed = { 'title' => 't', 'description' => 'd', '$comment' => 'c', 'format' => 'email',
+                      'contentMediaType' => 'application/json', 'contentEncoding' => 'base64',
+                      'readOnly' => true, 'writeOnly' => false, 'deprecated' => true, 'examples' => [1],
+                      'default' => { 'anything' => true } }
+      expect(validator.check_schema(well_formed)).to be_empty
+    end
+
+    it 'leaves a keyword the dialect does not define alone' do
+      # `deprecated` arrived in 2019-09: under draft-07 it is an unknown
+      # keyword, and an unknown keyword is never malformed.
+      expect(validator.check_schema({ '$schema' => draft7, 'deprecated' => 'yes' })).to be_empty
+      expect(validator.check_schema({ '$schema' => draft2019, 'deprecated' => 'yes' }))
+        .to contain_exactly(a_string_matching(/deprecated/))
+    end
+
+    it 'refuses a malformed metadata keyword nested in a subschema' do
+      expect(validator.check_schema({ 'properties' => { 'a' => { 'title' => 5 } } }))
+        .to contain_exactly(a_string_matching(/title/))
+      # And an unusable schema is a violation, never a permissive pass.
+      expect(validator.validate({ 'a' => 1 }, { 'properties' => { 'a' => { 'title' => 5 } } }))
+        .to contain_exactly(a_string_matching(/title/))
+    end
+  end
+
+  describe 'unevaluatedProperties and unevaluatedItems where the annotations are local' do
+    # These two are decided by the annotations a whole composition produces,
+    # which is why they were left out. But where a node carries no in-place
+    # applicator, every annotation they read is produced by that node's own
+    # applicators — and there they are simply `additionalProperties` /
+    # `additionalItems` over what the node did not name. Leaving even those
+    # unevaluated made :strict accept instances a 2020-12 validator rejects.
+    it 'rejects an item past the tuple the node itself evaluates' do
+      schema = { 'prefixItems' => [{ 'type' => 'number' }], 'unevaluatedItems' => false }
+      expect(validator.validate([1, 'x'], schema)).to contain_exactly(a_string_matching(/unevaluatedItems/))
+      expect(validator.validate([1], schema)).to be_empty
+      expect(validator.validate([], schema)).to be_empty
+      typed = { 'prefixItems' => [{ 'type' => 'number' }], 'unevaluatedItems' => { 'type' => 'string' } }
+      expect(validator.validate([1, 'x'], typed)).to be_empty
+      expect(validator.validate([1, 2], typed)).to contain_exactly(a_string_matching(/expected type string/))
+      # An `items` schema evaluates every item, so nothing is left over.
+      expect(validator.validate([1, 'x'], { 'items' => true, 'unevaluatedItems' => false })).to be_empty
+    end
+
+    it 'rejects a property the node itself leaves unevaluated' do
+      expect(validator.validate({ 'extra' => 1 }, { 'unevaluatedProperties' => false }))
+        .to contain_exactly(a_string_matching(/unevaluatedProperties/))
+      expect(validator.validate({}, { 'unevaluatedProperties' => false })).to be_empty
+      covered = { 'properties' => { 'a' => true }, 'patternProperties' => { '^x' => true },
+                  'unevaluatedProperties' => false }
+      expect(validator.validate({ 'a' => 1, 'xy' => 2 }, covered)).to be_empty
+      expect(validator.validate({ 'a' => 1, 'zz' => 2 }, covered))
+        .to contain_exactly(a_string_matching(/unevaluatedProperties/))
+      typed = { 'properties' => { 'a' => true }, 'unevaluatedProperties' => { 'type' => 'string' } }
+      expect(validator.validate({ 'a' => 1, 'b' => 2 }, typed))
+        .to contain_exactly(a_string_matching(/expected type string/))
+      # additionalProperties already evaluates every member the node did not name.
+      expect(validator.validate({ 'b' => 2 }, { 'additionalProperties' => true,
+                                                'unevaluatedProperties' => false })).to be_empty
+    end
+
+    it 'settles a negation the keyword alone decides' do
+      expect(validator.validate({ 'extra' => 1 }, { 'not' => { 'unevaluatedProperties' => false } })).to be_empty
+      expect(validator.validate({}, { 'not' => { 'unevaluatedProperties' => false } }))
+        .to contain_exactly(a_string_matching(/not/))
+    end
+
+    it 'stops reporting partial coverage for a node it now evaluates' do
+      expect(validator.unsupported_keywords({ 'unevaluatedProperties' => false })).to be_empty
+      expect(validator.unsupported_keywords({ 'prefixItems' => [true], 'unevaluatedItems' => false })).to be_empty
+    end
+
+    it 'still defers the keyword where a composition produces the annotations' do
+      # An in-place applicator contributes annotations this validator does not
+      # collect, so the keyword stays unevaluated — reported, never guessed.
+      composed = { 'allOf' => [{ 'properties' => { 'a' => true } }], 'unevaluatedProperties' => false }
+      expect(validator.unsupported_keywords(composed)).to contain_exactly('unevaluatedProperties')
+      expect(validator.validate({ 'a' => 1 }, composed)).to be_empty
+      # ... and never decides a non-monotonic composition on that guess.
+      expect(validator.validate({ 'a' => 1 }, { 'not' => composed })).to be_empty
+
+      referenced = { '$ref' => '#/$defs/p', 'unevaluatedProperties' => false,
+                     '$defs' => { 'p' => { 'properties' => { 'a' => true } } } }
+      expect(validator.unsupported_keywords(referenced)).to contain_exactly('unevaluatedProperties')
+      expect(validator.validate({ 'a' => 1 }, referenced)).to be_empty
+    end
+
+    it 'still defers unevaluatedItems beside contains, whose matches annotate' do
+      schema = { 'contains' => { 'type' => 'string' }, 'unevaluatedItems' => false }
+      expect(validator.unsupported_keywords(schema)).to contain_exactly('unevaluatedItems')
+      expect(validator.validate(['x', 1], schema)).to be_empty
+    end
+
+    it 'leaves the keyword alone in a dialect that does not define it' do
+      legacy = { '$schema' => draft7, 'unevaluatedProperties' => false }
+      expect(validator.unsupported_keywords(legacy)).to be_empty
+      expect(validator.validate({ 'a' => 1 }, legacy)).to be_empty
+      modern = { '$schema' => draft2019, 'unevaluatedProperties' => false }
+      expect(validator.validate({ 'a' => 1 }, modern))
+        .to contain_exactly(a_string_matching(/unevaluatedProperties/))
+    end
+
+    it 'keeps the dynamic references deferred, and says so' do
+      # A `$dynamicRef` needs the dynamic scope a validation was entered
+      # through, which this validator does not track. It stays unevaluated,
+      # is reported, and never decides a non-monotonic composition.
+      schema = { '$dynamicRef' => '#node', '$defs' => { 'n' => { '$dynamicAnchor' => 'node', 'type' => 'string' } } }
+      expect(validator.unsupported_keywords(schema)).to contain_exactly('$dynamicRef')
+      expect(validator.validate(1, schema)).to be_empty
+      expect(validator.validate(1, { 'not' => schema })).to be_empty
+    end
+  end
+
+  describe 'the client entry points a result reaches' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:chunk) { { 'resultType' => 'complete', 'content' => [], 'structuredContent' => {} } }
+
+    def stub_server(output_schema, chunk, input_schema: { 'type' => 'object' })
+      srv = instance_double(MCPClient::ServerBase, name: 's')
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: input_schema,
+                                 output_schema: output_schema, server: srv)
+      allow(srv).to receive(:on_notification)
+      allow(srv).to receive(:list_tools).and_return([tool])
+      allow(srv).to receive(:call_tool).and_return(chunk)
+      allow(srv).to receive(:call_tool_streaming) { |*| Enumerator.new { |y| y << chunk } }
+      srv
+    end
+
+    def client_over(srv, mode)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(srv)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger,
+                            validate_structured_content: mode)
+    end
+
+    # The tools spec's "Clients SHOULD validate structured results against
+    # this schema" is about a result, not about the method that fetched it:
+    # a stream handed the chunk back unchecked, so the very payload
+    # #call_tool refuses came through #call_tool_streaming silently — the
+    # unsupported output dialect this PR must refuse included.
+    it 'validates an ordinary streamed result against the output schema' do
+      srv = stub_server({ 'type' => 'object', 'required' => ['n'] }, chunk)
+      client = client_over(srv, :strict)
+
+      expect { client.call_tool_streaming('t', {}).to_a }
+        .to raise_error(MCPClient::Errors::ValidationError, /does not match its output schema/)
+    end
+
+    it 'refuses an unsupported output dialect on the streaming path, in both modes' do
+      %i[warn strict].each do |mode|
+        srv = stub_server({ '$schema' => 'urn:unknown', 'type' => 'object' }, chunk)
+        expect { client_over(srv, mode).call_tool_streaming('t', {}).to_a }
+          .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown.*not supported/m)
+      end
+    end
+
+    it 'reports missing structured content on the streaming path' do
+      srv = stub_server({ 'type' => 'object' }, { 'resultType' => 'complete', 'content' => [] })
+      client = client_over(srv, :strict)
+
+      expect { client.call_tool_streaming('t', {}).to_a }
+        .to raise_error(MCPClient::Errors::ValidationError, /carries no structuredContent/)
+    end
+
+    it 'hands a conforming streamed result through unchanged' do
+      srv = stub_server({ 'type' => 'object', 'required' => ['n'] },
+                        { 'resultType' => 'complete', 'content' => [], 'structuredContent' => { 'n' => 1 } })
+      client = client_over(srv, :strict)
+
+      expect(client.call_tool_streaming('t', {}).to_a)
+        .to eq([{ 'resultType' => 'complete', 'content' => [], 'structuredContent' => { 'n' => 1 } }])
+    end
+
+    it 'leaves a chunk that is not a complete result to the host' do
+      # A transport may stream progress; only a complete CallToolResult is a
+      # result to check against the output schema.
+      partial = { 'resultType' => 'io.modelcontextprotocol/partial', 'content' => [] }
+      srv = stub_server({ 'type' => 'object', 'required' => ['n'] }, partial)
+      client = client_over(srv, :strict)
+
+      expect(client.call_tool_streaming('t', {}).to_a).to eq([partial])
+    end
+
+    # The two task-result methods this PR moved onto #validate_called_result!
+    # differ from the structured-content check by exactly one thing: they
+    # also refuse the input dialect of the definition the answered request
+    # went out under (which a HeaderMismatch refresh may have replaced).
+    describe 'the results a task delivers' do
+      let(:unreadable) do
+        MCPClient::Tool.new(name: 't', description: 'd',
+                            schema: { '$schema' => 'urn:unknown', 'type' => 'object' },
+                            output_schema: { 'type' => 'object' }, server: nil)
+      end
+      let(:readable) do
+        MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
+                            output_schema: { 'type' => 'object', 'required' => ['n'] }, server: nil)
+      end
+      let(:client) { client_over(stub_server({ 'type' => 'object' }, chunk), :strict) }
+
+      it 'refuses a synchronous task answer under an unreadable input dialect' do
+        expect { client.send(:validated_sync_result, chunk, unreadable) }
+          .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown.*not supported/m)
+      end
+
+      it 'refuses a delivered task result under an unreadable input dialect' do
+        handle = MCPClient::Task.completed_locally(chunk, server: nil).with_called_tool(unreadable)
+        expect { client.send(:validated_task_result, handle, chunk) }
+          .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown.*not supported/m)
+      end
+
+      it 'still checks the structured content of a readable definition' do
+        expect { client.send(:validated_sync_result, chunk, readable) }
+          .to raise_error(MCPClient::Errors::ValidationError, /does not match its output schema/)
+        good = { 'resultType' => 'complete', 'content' => [], 'structuredContent' => { 'n' => 1 } }
+        expect(client.send(:validated_sync_result, good, readable)).to eq(good)
+      end
+    end
+  end
+
+  describe 'the era a structuredContent value belongs to, on the wire' do
+    let(:base_url) { 'https://example.com' }
+    let(:endpoint) { '/mcp' }
+    let(:url) { "#{base_url}#{endpoint}" }
+    # An open schema: valid in either era, and it accepts any JSON value, so
+    # what the client makes of the value is what the example measures.
+    let(:tool) { { 'name' => 't', 'inputSchema' => { 'type' => 'object' }, 'outputSchema' => {} } }
+
+    def json_response(id, result)
+      { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result),
+        headers: { 'Content-Type' => 'application/json' } }
+    end
+
+    def legacy_session(structured)
+      stub_request(:get, url).to_return(status: 405, body: '')
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'initialize'
+          json_response(body['id'], { 'protocolVersion' => '2025-11-25', 'capabilities' => { 'tools' => {} },
+                                      'serverInfo' => { 'name' => 'legacy', 'version' => '1' } })
+        when 'notifications/initialized' then { status: 202, body: '' }
+        when 'tools/list' then json_response(body['id'], { 'tools' => [tool] })
+        when 'tools/call' then json_response(body['id'], { 'content' => [], 'structuredContent' => structured })
+        end
+      end
+      MCPClient::Client.new(
+        mcp_server_configs: [MCPClient.streamable_http_config(base_url: base_url, endpoint: endpoint, retries: 0,
+                                                              protocol: :legacy)],
+        validate_structured_content: :strict
+      )
+    end
+
+    def modern_session(structured)
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'server/discover'
+          json_response(body['id'],
+                        { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+                          'capabilities' => { 'tools' => {} } })
+        when 'tools/list' then json_response(body['id'], { 'tools' => [tool] })
+        when 'tools/call'
+          json_response(body['id'],
+                        { 'resultType' => 'complete', 'content' => [], 'structuredContent' => structured })
+        end
+      end
+      MCPClient::Client.new(
+        mcp_server_configs: [MCPClient.streamable_http_config(base_url: base_url, endpoint: endpoint, retries: 0)],
+        validate_structured_content: :strict
+      )
+    end
+
+    # MCP 2025-11-25 server/tools types structuredContent as an object. The
+    # widening to "any JSON value" is a 2026-07-28 rule, and a session
+    # negotiated to the older revision does not get it: an array or a scalar
+    # there is no more structured content than a null is.
+    [[[1, 2], 'an array'], ['x', 'a string'], [true, 'a boolean'], [42, 'a number']].each do |value, described|
+      it "treats #{described} structuredContent as missing on a legacy session" do
+        client = legacy_session(value)
+
+        expect { client.call_tool('t', {}) }
+          .to raise_error(MCPClient::Errors::ValidationError, /carries no structuredContent/)
+        client.cleanup
+      end
+    end
+
+    it 'keeps an object structuredContent on a legacy session' do
+      client = legacy_session({ 'a' => 1 })
+
+      expect(client.call_tool('t', {}))
+        .to eq({ 'content' => [], 'structuredContent' => { 'a' => 1 } })
+      client.cleanup
+    end
+
+    it 'accepts any JSON value on a 2026-07-28 session' do
+      [[1, 2], 'x', true, 42, nil].each do |value|
+        client = modern_session(value)
+
+        expect(client.call_tool('t', {}))
+          .to eq({ 'resultType' => 'complete', 'content' => [], 'structuredContent' => value })
+        client.cleanup
+      end
+    end
+  end
+
+  describe 'the HeaderMismatch retry' do
+    let(:base_url) { 'https://example.com' }
+    let(:endpoint) { '/mcp' }
+    let(:url) { "#{base_url}#{endpoint}" }
+
+    def json_response(id, result)
+      { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result),
+        headers: { 'Content-Type' => 'application/json' } }
+    end
+
+    # MCP 2026-07-28 "Custom Headers from Tool Parameters": a HeaderMismatch
+    # means the server rejected the request BEFORE executing it, and the
+    # client re-fetches tools/list and retries once. That retry is the send
+    # that runs the tool — so if the refreshed inputSchema declares a dialect
+    # this client cannot read, refusing only the answer is too late: the tool
+    # has already run. The dialect is checked before the retry goes out.
+    it 'is not sent under a refreshed input schema of an unsupported dialect' do
+      listed = { 'name' => 'execute_sql',
+                 'inputSchema' => { 'type' => 'object',
+                                    'properties' => { 'region' => { 'type' => 'string',
+                                                                    'x-mcp-header' => 'Region' } } } }
+      calls = []
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'server/discover'
+          json_response(body['id'],
+                        { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+                          'capabilities' => { 'tools' => {} } })
+        when 'tools/list' then json_response(body['id'], { 'tools' => [listed] })
+        when 'tools/call'
+          calls << request.headers.slice('Mcp-Param-Region', 'Mcp-Param-Zone')
+          next json_response(body['id'], { 'resultType' => 'complete', 'content' => [] }) if
+            request.headers['Mcp-Param-Zone']
+
+          listed = { 'name' => 'execute_sql',
+                     'inputSchema' => { '$schema' => 'urn:unknown-dialect', 'type' => 'object',
+                                        'properties' => { 'region' => { 'type' => 'string',
+                                                                        'x-mcp-header' => 'Zone' } } } }
+          { status: 400, headers: { 'Content-Type' => 'application/json' },
+            body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'],
+                                'error' => { 'code' => -32_020, 'message' => 'Mcp-Param-Zone missing' }) }
+        end
+      end
+      client = MCPClient::Client.new(
+        mcp_server_configs: [MCPClient.streamable_http_config(base_url: base_url, endpoint: endpoint, retries: 0)],
+        validate_structured_content: :strict
+      )
+
+      expect { client.call_tool('execute_sql', { 'region' => 'eu' }) }
+        .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown-dialect.*not supported/m)
+      # The rejected attempt did not run the tool; the retry would have.
+      expect(calls.length).to eq(1)
+      client.cleanup
+    end
+  end
+
+  describe 'the reference resolver, at the shapes a document can write' do
+    # RFC 3986 Section 5.2.2 has a branch per reference form, and a schema
+    # document may bundle the resources it names (JSON Schema 2020-12 Core
+    # Section 9.3.1), so each of those branches decides which bundled
+    # resource a `$ref` lands on.
+    {
+      'a network-path reference' => ['https://example.com/root', '//other.example/s', 'https://other.example/s'],
+      'an absolute-path reference' => ['https://example.com/a/root', '/s', 'https://example.com/s'],
+      'a same-directory reference' => ['https://example.com/a/root', './s', 'https://example.com/a/s'],
+      'a parent-directory reference' => ['https://example.com/a/root', '../s', 'https://example.com/s']
+    }.each do |described, (base, ref, id)|
+      it "resolves #{described} against the base in force" do
+        schema = { '$id' => base, '$ref' => ref, '$defs' => { 's' => { '$id' => id, 'type' => 'integer' } } }
+
+        expect(validator.check_schema(schema)).to be_empty
+        expect(validator.validate(1, schema)).to be_empty
+        expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/expected type integer/))
+      end
+    end
+
+    it 'refuses a pointer that names nothing' do
+      # A JSON pointer either resolves to a schema or it resolves to nothing;
+      # an index past the end, a negative or a "-" index, and a step through a
+      # scalar all name nothing, and none of them is a permissive pass.
+      ['#/prefixItems/5', '#/prefixItems/-1', '#/prefixItems/-'].each do |ref|
+        expect(validator.check_schema({ 'prefixItems' => [true], '$ref' => ref }))
+          .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+      end
+      expect(validator.check_schema({ 'title' => 'x', '$ref' => '#/title/a' }))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+      expect(validator.validate(1, { 'prefixItems' => [true], '$ref' => '#/prefixItems/5' }))
+        .to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+
+    it 'refuses a reference that is not a string, and a local chain that leaves the document' do
+      expect(validator.check_schema({ '$ref' => 5 }))
+        .to contain_exactly(a_string_matching(/\$ref must be a string, got integer/))
+      chain = { '$ref' => '#/$defs/a',
+                '$defs' => { 'a' => { '$ref' => '#/$defs/b' }, 'b' => { '$ref' => 'https://example.com/x' } } }
+      expect(validator.check_schema(chain))
+        .to contain_exactly(a_string_matching(%r{external \$ref "https://example.com/x"}))
+      expect(validator.validate(1, chain)).to contain_exactly(a_string_matching(/external \$ref/))
+    end
+  end
+
+  describe 'the dialect an output schema declares, through the client' do
+    let(:logger) { Logger.new(StringIO.new) }
+    let(:srv) { instance_double(MCPClient::ServerBase, name: 's') }
+
+    def client_for(output_schema, structured, mode: :strict)
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
+                                 output_schema: output_schema, server: srv)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(srv)
+      allow(srv).to receive(:on_notification)
+      allow(srv).to receive(:list_tools).and_return([tool])
+      allow(srv).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => structured })
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger,
+                            validate_structured_content: mode)
+    end
+
+    # The declared dialect travels with the schema: a client that dropped it
+    # would read a draft-07 tuple as a 2020-12 `items`, which is not a schema
+    # there — so the document would be unusable rather than applied.
+    it 'reads an output schema with the grammar its own dialect defines' do
+      tuple = { '$schema' => draft7, 'items' => [{ 'type' => 'string' }], 'additionalItems' => false }
+
+      expect { client_for(tuple, %w[a b]).call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /additionalItems is false/)
+      expect(client_for(tuple, ['a']).call_tool('t', {}))
+        .to eq({ 'content' => [], 'structuredContent' => ['a'] })
+    end
+
+    it 'refuses an unsupported dialect an embedded output resource declares, in both modes' do
+      embedded = { 'type' => 'object',
+                   'properties' => { 'a' => { '$id' => 'https://example.com/r', '$schema' => 'urn:unknown' } } }
+
+      %i[warn strict].each do |mode|
+        expect { client_for(embedded, {}, mode: mode).call_tool('t', {}) }
+          .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown.*not supported/m)
+      end
+    end
+
+    it 'decides on the refreshed output dialect, in both directions' do
+      good = { 'type' => 'object' }
+      bad = { '$schema' => 'urn:unknown', 'type' => 'object' }
+      client = client_for(good, {})
+      expect(client.call_tool('t', {})).to eq({ 'content' => [], 'structuredContent' => {} })
+
+      refreshed = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
+                                      output_schema: bad, server: srv)
+      allow(srv).to receive(:list_tools).and_return([refreshed])
+      client.send(:invalidate_caches_for_notification, srv, 'notifications/tools/list_changed')
+      expect { client.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown/)
+
+      # ... and back: a definition that is readable again is not refused from
+      # the memo the unusable one filled in.
+      restored = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
+                                     output_schema: good, server: srv)
+      allow(srv).to receive(:list_tools).and_return([restored])
+      client.send(:invalidate_caches_for_notification, srv, 'notifications/tools/list_changed')
+      expect(client.call_tool('t', {})).to eq({ 'content' => [], 'structuredContent' => {} })
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round29_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round29_spec.rb
@@ -291,19 +291,19 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 29' do
         .to contain_exactly(a_string_matching(/unevaluatedProperties/))
     end
 
-    it 'keeps the dynamic reference only the evaluation path could bind deferred, and says so' do
-      # A `$dynamicRef` binds to the outermost dynamic scope declaring its
-      # anchor; where several non-root resources declare it, only the path a
-      # validation was entered through could choose, which this validator
-      # does not track. That one stays unevaluated, is reported, and never
-      # decides a non-monotonic composition.
+    it 'binds the dynamic reference by the path the evaluation took' do
+      # A `$dynamicRef` binds to the outermost resource of the dynamic scope
+      # declaring its anchor — the resources the evaluation entered. A
+      # resource it never entered declares nothing for it, so the reference
+      # is evaluated and decides its composition like any other.
       schema = { '$ref' => 'https://example.com/a',
                  '$defs' => { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node',
                                        'type' => 'object', 'properties' => { 'v' => { '$dynamicRef' => '#node' } } },
                               'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node',
                                        'type' => 'string' } } }
-      expect(validator.unsupported_keywords(schema)).to contain_exactly('$dynamicRef')
-      expect(validator.validate({ 'v' => 1 }, schema)).to be_empty
+      expect(validator.unsupported_keywords(schema)).to be_empty
+      expect(validator.validate({ 'v' => 1 }, schema)).not_to be_empty
+      expect(validator.validate({ 'v' => {} }, schema)).to be_empty
       expect(validator.validate({ 'v' => 1 }, { 'not' => schema })).to be_empty
     end
   end

--- a/spec/lib/mcp_client/json_schema_2026_round29_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round29_spec.rb
@@ -291,14 +291,20 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 29' do
         .to contain_exactly(a_string_matching(/unevaluatedProperties/))
     end
 
-    it 'keeps the dynamic references deferred, and says so' do
-      # A `$dynamicRef` needs the dynamic scope a validation was entered
-      # through, which this validator does not track. It stays unevaluated,
-      # is reported, and never decides a non-monotonic composition.
-      schema = { '$dynamicRef' => '#node', '$defs' => { 'n' => { '$dynamicAnchor' => 'node', 'type' => 'string' } } }
+    it 'keeps the dynamic reference only the evaluation path could bind deferred, and says so' do
+      # A `$dynamicRef` binds to the outermost dynamic scope declaring its
+      # anchor; where several non-root resources declare it, only the path a
+      # validation was entered through could choose, which this validator
+      # does not track. That one stays unevaluated, is reported, and never
+      # decides a non-monotonic composition.
+      schema = { '$ref' => 'https://example.com/a',
+                 '$defs' => { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node',
+                                       'type' => 'object', 'properties' => { 'v' => { '$dynamicRef' => '#node' } } },
+                              'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node',
+                                       'type' => 'string' } } }
       expect(validator.unsupported_keywords(schema)).to contain_exactly('$dynamicRef')
-      expect(validator.validate(1, schema)).to be_empty
-      expect(validator.validate(1, { 'not' => schema })).to be_empty
+      expect(validator.validate({ 'v' => 1 }, schema)).to be_empty
+      expect(validator.validate({ 'v' => 1 }, { 'not' => schema })).to be_empty
     end
   end
 

--- a/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
@@ -147,9 +147,9 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
 
   describe 'JSON pointers' do
     it 'keeps literal plus signs and rejects indexes with leading zeros' do
-      schema = { '$defs' => { 'a+b' => { 'type' => 'integer' } }, 'items' => [{ 'type' => 'string' }],
-                 'properties' => { 'p' => { '$ref' => '#/$defs/a+b' }, 'q' => { '$ref' => '#/items/00' } } }
-      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(%r{unresolvable.*#/items/00}))
+      schema = { '$defs' => { 'a+b' => { 'type' => 'integer' } }, 'prefixItems' => [{ 'type' => 'string' }],
+                 'properties' => { 'p' => { '$ref' => '#/$defs/a+b' }, 'q' => { '$ref' => '#/prefixItems/00' } } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(%r{unresolvable.*#/prefixItems/00}))
       expect(validator.validate({ 'p' => 'x' }, { '$defs' => { 'a+b' => { 'type' => 'integer' } },
                                                   'properties' => { 'p' => { '$ref' => '#/$defs/a+b' } } }))
         .to contain_exactly(a_string_matching(%r{#/p: expected type integer}))

--- a/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
 
       errors = validator.validate(1, schema)
 
+      # The schema recurses without bound on one value, so the walk must end
+      # in an abort rather than in silence: a validator that produced nothing
+      # would satisfy the size assertions too.
+      expect(errors).to contain_exactly(a_string_matching(/aborted|hops|nodes visited|budget/))
       expect(errors.size).to be <= validator::MAX_ERRORS
       expect(errors.sum(&:bytesize)).to be < 20_000
     end
@@ -134,11 +138,15 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
 
     it 'reports draft-specific keywords it does not evaluate under the dialect that defines them' do
       draft7 = 'http://json-schema.org/draft-07/schema#'
+      # The draft-specific applicators are evaluated; only what needs a
+      # dynamic scope or a composition-wide annotation is reported.
       expect(validator.unsupported_keywords({ '$schema' => draft7, 'items' => [], 'additionalItems' => false }))
-        .to eq(['additionalItems'])
-      expect(validator.unsupported_keywords({ '$schema' => draft7, 'dependencies' => {} })).to eq(['dependencies'])
+        .to eq([])
+      expect(validator.unsupported_keywords({ '$schema' => draft7, 'dependencies' => {} })).to eq([])
       expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09, '$recursiveRef' => '#' }))
         .to eq(['$recursiveRef'])
+      expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09,
+                                              'unevaluatedItems' => false })).to eq(['unevaluatedItems'])
     end
 
     it 'treats $dynamicRef to another document as unusable' do
@@ -203,6 +211,22 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
         expect(e.message.bytesize).to be < 5000
       }
       expect(log_output.string).not_to include("\nWARN forged")
+    end
+
+    it 'truncates a violation whose errors run past the message limit' do
+      # Enough genuine errors to overrun MAX_VIOLATION_TEXT, so the cap is
+      # what keeps the message small rather than the schema being small.
+      properties = (0...validator::MAX_ERRORS).to_h { |i| ["p#{i}#{'x' * 60}", { 'type' => 'string' }] }
+      client = client_with([tool({ 'type' => 'object', 'properties' => properties })],
+                           validate_structured_content: :strict)
+      content = properties.keys.to_h { |name| [name, 1] }
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => content })
+
+      expect { client.call_tool('tool', {}) }.to raise_error(MCPClient::Errors::ValidationError) { |e|
+        joined = validator.validate(content, { 'type' => 'object', 'properties' => properties }).join('; ')
+        expect(joined.bytesize).to be > MCPClient::Client::MAX_VIOLATION_TEXT
+        expect(e.message.bytesize).to be < MCPClient::Client::MAX_VIOLATION_TEXT + 200
+      }
     end
 
     it 're-checks an input schema when the tool definition changes' do

--- a/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
     end
 
     it 'rejects a $ref that points at something that is not a schema' do
-      schema = { '$ref' => '#/$defs/name', '$defs' => { 'name' => 'not a schema' } }
+      schema = { '$ref' => '#/x-name', 'x-name' => 'not a schema' }
       expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/does not point at a schema/))
       expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/does not point at a schema/))
     end

--- a/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
@@ -132,11 +132,13 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
       expect(validator.validate({ 'p' => 'text' }, modern)).to contain_exactly(a_string_matching(%r{#/p}))
     end
 
-    it 'reports draft-specific keywords it does not evaluate' do
-      expect(validator.unsupported_keywords({ 'items' => [], 'additionalItems' => false }))
+    it 'reports draft-specific keywords it does not evaluate under the dialect that defines them' do
+      draft7 = 'http://json-schema.org/draft-07/schema#'
+      expect(validator.unsupported_keywords({ '$schema' => draft7, 'items' => [], 'additionalItems' => false }))
         .to eq(['additionalItems'])
-      expect(validator.unsupported_keywords({ 'dependencies' => {} })).to eq(['dependencies'])
-      expect(validator.unsupported_keywords({ '$recursiveRef' => '#' })).to eq(['$recursiveRef'])
+      expect(validator.unsupported_keywords({ '$schema' => draft7, 'dependencies' => {} })).to eq(['dependencies'])
+      expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09, '$recursiveRef' => '#' }))
+        .to eq(['$recursiveRef'])
     end
 
     it 'treats $dynamicRef to another document as unusable' do

--- a/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 JSON Schema handling, second review round: aborted
+# validations never fail open, error output is bounded, resource bounds
+# cannot be bypassed, draft-07 tuples and $ref siblings follow their
+# dialect, JSON pointers follow RFC 6901, boolean root schemas work, and
+# schema-derived text is sanitized before it reaches logs or exceptions.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
+  let(:validator) { MCPClient::SchemaValidator }
+
+  describe 'aborted validations' do
+    it 'reports a $ref chain abort as an error even under not or oneOf' do
+      recursive = { 'not' => { '$ref' => '#/$defs/loop' },
+                    '$defs' => { 'loop' => { '$ref' => '#/$defs/loop2' }, 'loop2' => { '$ref' => '#/$defs/loop' } } }
+      expect(validator.validate(1, recursive)).to contain_exactly(a_string_matching(/\$ref.*(cycle|depth|chain)/))
+
+      one_of = { 'oneOf' => [{ 'type' => 'integer' }, { '$ref' => '#/$defs/loop' }],
+                 '$defs' => { 'loop' => { '$ref' => '#/$defs/loop' } } }
+      expect(validator.validate(1, one_of)).to contain_exactly(a_string_matching(/\$ref.*(cycle|depth|chain)/))
+    end
+
+    it 'stops at the time budget with a single error instead of one per item' do
+      schema = { 'type' => 'array', 'items' => { 'type' => 'string', 'pattern' => 'a' } }
+      allow(validator).to receive(:pattern_budget_remaining).and_return(0.0)
+
+      errors = validator.validate(Array.new(500, 'a'), schema)
+
+      expect(errors.size).to eq(1)
+      expect(errors.first).to match(/budget/)
+    end
+
+    it 'does not let not accept a value once the budget is gone' do
+      schema = { 'not' => { 'type' => 'string', 'pattern' => 'a' } }
+      allow(validator).to receive(:pattern_budget_remaining).and_return(0.0)
+
+      expect(validator.validate('a', schema)).to contain_exactly(a_string_matching(/budget/))
+    end
+  end
+
+  describe 'bounded output' do
+    it 'keeps the error list and each message small for a tiny recursive allOf schema' do
+      schema = { 'allOf' => [{ '$ref' => '#' }, { '$ref' => '#' }], 'type' => 'string' }
+
+      errors = validator.validate(1, schema)
+
+      expect(errors.size).to be <= validator::MAX_ERRORS
+      expect(errors.sum(&:bytesize)).to be < 20_000
+    end
+
+    it 'caps the number of errors' do
+      schema = { 'type' => 'array', 'items' => { 'type' => 'integer' } }
+
+      errors = validator.validate(Array.new(5000, 'x'), schema)
+
+      expect(errors.size).to be <= validator::MAX_ERRORS
+      expect(errors.last).to match(/more errors|truncated/i)
+    end
+
+    it 'truncates inspected values in enum and const messages' do
+      long = 'x' * 10_000
+      errors = validator.validate(long, { 'enum' => ['a'] })
+      expect(errors.first.bytesize).to be < 600
+    end
+  end
+
+  describe 'resource bounds' do
+    it 'counts boolean subschemas toward the subschema cap' do
+      wide = { 'anyOf' => Array.new(validator::MAX_SUBSCHEMAS + 1, true) }
+      expect(validator.check_schema(wide)).to contain_exactly(a_string_matching(/subschemas/))
+    end
+
+    it 'reports an unusable $ref chain during preflight' do
+      chain = {}
+      chain['$ref'] = '#/$defs/d0'
+      defs = {}
+      (validator::MAX_REF_DEPTH + 2).times { |i| defs["d#{i}"] = { '$ref' => "#/$defs/d#{i + 1}" } }
+      defs["d#{validator::MAX_REF_DEPTH + 2}"] = { 'type' => 'integer' }
+      chain['$defs'] = defs
+      expect(validator.check_schema(chain)).to contain_exactly(a_string_matching(/\$ref chain/))
+
+      cycle = { '$ref' => '#/$defs/a',
+                '$defs' => { 'a' => { '$ref' => '#/$defs/b' }, 'b' => { '$ref' => '#/$defs/a' } } }
+      expect(validator.check_schema(cycle)).to contain_exactly(a_string_matching(/\$ref chain/))
+    end
+
+    it 'does not overflow on deeply nested const or enum values' do
+      deep = 1
+      2000.times { deep = [deep] }
+      expect { validator.check_schema({ 'const' => deep }) }.not_to raise_error
+      expect(validator.validate(deep, { 'const' => deep })).to be_empty
+    end
+
+    it 'rejects a $ref that points at something that is not a schema' do
+      schema = { '$ref' => '#/$defs/name', '$defs' => { 'name' => 'not a schema' } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/does not point at a schema/))
+      expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/does not point at a schema/))
+    end
+  end
+
+  describe 'dialects' do
+    it 'validates draft-07 tuple items and finds an external $ref inside them' do
+      schema = { '$schema' => 'http://json-schema.org/draft-07/schema#', 'type' => 'array',
+                 'items' => [{ 'type' => 'integer' }, { 'type' => 'string' }] }
+      expect(validator.validate([1, 'a'], schema)).to be_empty
+      expect(validator.validate(['a', 1], schema)).to contain_exactly(a_string_matching(%r{#/0}),
+                                                                      a_string_matching(%r{#/1}))
+
+      external = { '$schema' => 'http://json-schema.org/draft-07/schema#', 'type' => 'array',
+                   'items' => [{ '$ref' => 'https://example.com/s.json' }] }
+      expect(validator.check_schema(external)).to contain_exactly(a_string_matching(/external \$ref/))
+    end
+
+    it 'validates 2020-12 prefixItems' do
+      schema = { 'type' => 'array', 'prefixItems' => [{ 'type' => 'integer' }], 'items' => { 'type' => 'string' } }
+      expect(validator.validate([1, 'a', 'b'], schema)).to be_empty
+      expect(validator.validate(%w[x a], schema)).to contain_exactly(a_string_matching(%r{#/0}))
+      expect(validator.validate([1, 2], schema)).to contain_exactly(a_string_matching(%r{#/1}))
+      expect(validator::UNSUPPORTED_KEYWORDS).not_to include('prefixItems')
+    end
+
+    it 'ignores the siblings of $ref under draft-07 but applies them under 2020-12' do
+      draft7 = { '$schema' => 'http://json-schema.org/draft-07/schema#',
+                 'properties' => { 'p' => { '$ref' => '#/definitions/s', 'type' => 'integer' } },
+                 'definitions' => { 's' => { 'type' => 'string' } } }
+      expect(validator.validate({ 'p' => 'text' }, draft7)).to be_empty
+
+      modern = { 'properties' => { 'p' => { '$ref' => '#/$defs/s', 'type' => 'integer' } },
+                 '$defs' => { 's' => { 'type' => 'string' } } }
+      expect(validator.validate({ 'p' => 'text' }, modern)).to contain_exactly(a_string_matching(%r{#/p}))
+    end
+
+    it 'reports draft-specific keywords it does not evaluate' do
+      expect(validator.unsupported_keywords({ 'items' => [], 'additionalItems' => false }))
+        .to eq(['additionalItems'])
+      expect(validator.unsupported_keywords({ 'dependencies' => {} })).to eq(['dependencies'])
+      expect(validator.unsupported_keywords({ '$recursiveRef' => '#' })).to eq(['$recursiveRef'])
+    end
+
+    it 'treats $dynamicRef to another document as unusable' do
+      expect(validator.check_schema({ '$dynamicRef' => 'https://example.com/x' }))
+        .to contain_exactly(a_string_matching(/external/))
+    end
+  end
+
+  describe 'JSON pointers' do
+    it 'keeps literal plus signs and rejects indexes with leading zeros' do
+      schema = { '$defs' => { 'a+b' => { 'type' => 'integer' } }, 'items' => [{ 'type' => 'string' }],
+                 'properties' => { 'p' => { '$ref' => '#/$defs/a+b' }, 'q' => { '$ref' => '#/items/00' } } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(%r{unresolvable.*#/items/00}))
+      expect(validator.validate({ 'p' => 'x' }, { '$defs' => { 'a+b' => { 'type' => 'integer' } },
+                                                  'properties' => { 'p' => { '$ref' => '#/$defs/a+b' } } }))
+        .to contain_exactly(a_string_matching(%r{#/p: expected type integer}))
+    end
+  end
+
+  describe 'boolean root schemas and symbol keys' do
+    it 'accepts a boolean root schema' do
+      expect(validator.check_schema(true)).to be_empty
+      expect(validator.validate(1, true)).to be_empty
+      expect(validator.validate(1, false)).to contain_exactly(a_string_matching(/false/))
+    end
+
+    it 'compares symbol-keyed const and enum values as given' do
+      expect(validator.validate({ a: 1 }, { const: { a: 1 } })).to be_empty
+      expect(validator.validate({ 'a' => 1 }, { 'enum' => [{ 'a' => 1 }] })).to be_empty
+    end
+
+    it 'lets a tool declare a boolean output schema' do
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' }, output_schema: true)
+      expect(tool.structured_output?).to be(true)
+    end
+  end
+
+  describe 'through MCPClient::Client' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+
+    def tool(output_schema, name: 'tool', schema: { 'type' => 'object' })
+      MCPClient::Tool.new(name: name, description: 'd', schema: schema, output_schema: output_schema,
+                          server: mock_server)
+    end
+
+    def client_with(tools, **opts)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+      allow(mock_server).to receive(:on_notification)
+      allow(mock_server).to receive(:list_tools).and_return(tools)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger, **opts)
+    end
+
+    it 'sanitizes and bounds schema-derived text in violations' do
+      schema = { 'type' => 'object', 'properties' => { 'p' => { '$ref' => "https://example.com/\nWARN forged.json" } } }
+      client = client_with([tool(schema, name: "tool\nWARN forged")], validate_structured_content: :strict)
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => { 'p' => 1 } })
+
+      expect { client.call_tool("tool\nWARN forged", {}) }.to raise_error(MCPClient::Errors::ValidationError) { |e|
+        expect(e.message).not_to include("\nWARN forged")
+        expect(e.message.bytesize).to be < 5000
+      }
+      expect(log_output.string).not_to include("\nWARN forged")
+    end
+
+    it 're-checks an input schema when the tool definition changes' do
+      bad = { '$ref' => 'https://example.com/in.json' }
+      good = { 'type' => 'object' }
+      client = client_with([tool(nil, name: 'x', schema: good)])
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [] })
+      client.call_tool('x', {})
+      expect(log_output.string).not_to match(/input schema/)
+
+      allow(mock_server).to receive(:list_tools).and_return([tool(nil, name: 'x', schema: bad)])
+      client.list_tools(cache: false)
+      client.call_tool('x', {})
+
+      expect(log_output.string).to match(/input schema.*external \$ref/)
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
@@ -146,14 +146,17 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
     it 'reports draft-specific keywords it does not evaluate under the dialect that defines them' do
       draft7 = 'http://json-schema.org/draft-07/schema#'
       # The draft-specific applicators are evaluated; only what needs a
-      # dynamic scope or a composition-wide annotation is reported.
+      # dynamic scope is reported — a `$recursiveRef` whose target carries
+      # `$recursiveAnchor: true`, never the plain reference one without is.
       expect(validator.unsupported_keywords({ '$schema' => draft7, 'items' => [], 'additionalItems' => false }))
         .to eq([])
       expect(validator.unsupported_keywords({ '$schema' => draft7, 'dependencies' => {} })).to eq([])
+      expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09, '$recursiveAnchor' => true,
+                                              '$recursiveRef' => '#' })).to eq(['$recursiveRef'])
       expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09, '$recursiveRef' => '#' }))
-        .to eq(['$recursiveRef'])
+        .to eq([])
       expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09, 'allOf' => [true],
-                                              'unevaluatedItems' => false })).to eq(['unevaluatedItems'])
+                                              'unevaluatedItems' => false })).to eq([])
     end
 
     it 'treats $dynamicRef to another document as unusable' do

--- a/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
       long = 'x' * 10_000
       errors = validator.validate(long, { 'enum' => ['a'] })
       expect(errors.first.bytesize).to be < 600
+      # The const half of the same message, from both sides: the instance
+      # and the schema's value are peer-controlled alike.
+      errors = validator.validate(long, { 'const' => 'a' })
+      expect(errors.first.bytesize).to be < 600
+      errors = validator.validate('a', { 'const' => long })
+      expect(errors.first.bytesize).to be < 600
+      expect(errors.first).to match(/does not equal const/)
     end
   end
 
@@ -145,7 +152,7 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
       expect(validator.unsupported_keywords({ '$schema' => draft7, 'dependencies' => {} })).to eq([])
       expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09, '$recursiveRef' => '#' }))
         .to eq(['$recursiveRef'])
-      expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09,
+      expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09, 'allOf' => [true],
                                               'unevaluatedItems' => false })).to eq(['unevaluatedItems'])
     end
 

--- a/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
@@ -145,10 +145,9 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
 
     it 'reports draft-specific keywords it does not evaluate under the dialect that defines them' do
       draft7 = 'http://json-schema.org/draft-07/schema#'
-      # The draft-specific applicators are evaluated; only what needs the
-      # evaluation path to choose a binding is reported — a `$recursiveRef`
-      # several non-root resources could bind, never a root-anchored one nor
-      # the plain reference one without a `$recursiveAnchor: true` is.
+      # The draft-specific applicators are evaluated, the recursive reference
+      # among them: it binds against the dynamic scope, so nothing here is
+      # reported as beyond this validator.
       expect(validator.unsupported_keywords({ '$schema' => draft7, 'items' => [], 'additionalItems' => false }))
         .to eq([])
       expect(validator.unsupported_keywords({ '$schema' => draft7, 'dependencies' => {} })).to eq([])
@@ -159,7 +158,7 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
               'b' => { '$id' => 'https://example.com/rb', '$recursiveAnchor' => true, 'type' => 'string' } }
       expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09,
                                               '$ref' => 'https://example.com/ra', '$defs' => two }))
-        .to eq(['$recursiveRef'])
+        .to eq([])
       expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09, '$recursiveRef' => '#' }))
         .to eq([])
       expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09, 'allOf' => [true],

--- a/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round2_spec.rb
@@ -145,14 +145,21 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 2' do
 
     it 'reports draft-specific keywords it does not evaluate under the dialect that defines them' do
       draft7 = 'http://json-schema.org/draft-07/schema#'
-      # The draft-specific applicators are evaluated; only what needs a
-      # dynamic scope is reported — a `$recursiveRef` whose target carries
-      # `$recursiveAnchor: true`, never the plain reference one without is.
+      # The draft-specific applicators are evaluated; only what needs the
+      # evaluation path to choose a binding is reported — a `$recursiveRef`
+      # several non-root resources could bind, never a root-anchored one nor
+      # the plain reference one without a `$recursiveAnchor: true` is.
       expect(validator.unsupported_keywords({ '$schema' => draft7, 'items' => [], 'additionalItems' => false }))
         .to eq([])
       expect(validator.unsupported_keywords({ '$schema' => draft7, 'dependencies' => {} })).to eq([])
       expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09, '$recursiveAnchor' => true,
-                                              '$recursiveRef' => '#' })).to eq(['$recursiveRef'])
+                                              '$recursiveRef' => '#' })).to eq([])
+      two = { 'a' => { '$id' => 'https://example.com/ra', '$recursiveAnchor' => true, 'type' => 'object',
+                       'properties' => { 'v' => { '$recursiveRef' => '#' } } },
+              'b' => { '$id' => 'https://example.com/rb', '$recursiveAnchor' => true, 'type' => 'string' } }
+      expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09,
+                                              '$ref' => 'https://example.com/ra', '$defs' => two }))
+        .to eq(['$recursiveRef'])
       expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09, '$recursiveRef' => '#' }))
         .to eq([])
       expect(validator.unsupported_keywords({ '$schema' => validator::DRAFT_2019_09, 'allOf' => [true],

--- a/spec/lib/mcp_client/json_schema_2026_round30_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round30_spec.rb
@@ -1,0 +1,460 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 JSON Schema handling, thirtieth round.
+#
+# The ECMA-262 translation round 29 introduced walked the pattern by index
+# — quadratic on a multibyte pattern — without ever consulting the budget,
+# so a peer-sized `pattern` held the calling thread past the one-second
+# budget the client advertises (and reported a pass). The translation also
+# still read Ruby-only syntax as Ruby (inline flags, possessive quantifiers),
+# failed a back-reference to a group that did not participate (ECMA-262
+# matches the empty string there), and dropped a pattern Ruby could not
+# compile at all (a surrogate-pair escape) as if it were absent. Malformed
+# core keywords (`$id` that is no URI reference, `$vocabulary`,
+# `$recursiveAnchor`) were read as usable schemas. :strict accepted a result
+# against a schema whose keywords this validator does not evaluate. The
+# HeaderMismatch retry checked one definition's dialect and went out under
+# the next list's. And the required-argument check read the root only, not
+# what the root's `$ref` or `allOf` apply.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 30' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+  let(:draft2019) { 'https://json-schema.org/draft/2019-09/schema' }
+
+  def with_clock(step)
+    now = 0.0
+    allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { now += step }
+    yield
+  end
+
+  describe 'the validation budget over pattern translation' do
+    it 'aborts translating a huge pattern once the budget is out' do
+      # Every clock read advances the stubbed clock: a translation that
+      # consults the deadline as it goes runs out; one that never looks
+      # finishes and, under `not`, reports the unmatched pattern as a pass.
+      pattern = 'é' * 8_000
+      errors = with_clock(0.05) { validator.validate('x', { 'not' => { 'pattern' => pattern } }) }
+      expect(errors).to contain_exactly(a_string_matching(/aborted/))
+    end
+
+    it 'refuses a pattern longer than the bound at preflight, in both keywords' do
+      long = 'a' * (validator::MAX_PATTERN_LENGTH + 1)
+      expect(validator.check_schema({ 'pattern' => long }))
+        .to contain_exactly(a_string_matching(/pattern is longer than #{validator::MAX_PATTERN_LENGTH}/))
+      expect(validator.check_schema({ 'patternProperties' => { long => true } }))
+        .to contain_exactly(a_string_matching(/patternProperties pattern is longer than/))
+      expect(validator.validate('x', { 'not' => { 'pattern' => long } }))
+        .to contain_exactly(a_string_matching(/pattern is longer than/))
+      expect(validator.check_schema({ 'pattern' => 'a' * validator::MAX_PATTERN_LENGTH })).to be_empty
+    end
+
+    it 'bounds the length in the translator itself, whoever calls it' do
+      expect { validator.ecma_source('a' * (validator::MAX_PATTERN_LENGTH + 1)) }
+        .to raise_error(RegexpError, /longer than/)
+    end
+
+    it 'answers a pattern of the maximum length well inside the budget' do
+      pattern = 'é' * validator::MAX_PATTERN_LENGTH
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      errors = validator.validate('x', { 'not' => { 'pattern' => pattern } })
+      expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).to be < 1.0
+      expect(errors).to be_empty
+    end
+
+    it 'answers the reported quadratic case without running the budget out' do
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      errors = validator.validate('x', { 'not' => { 'pattern' => 'é' * 100_000 } })
+      expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).to be < 1.0
+      expect(errors).to contain_exactly(a_string_matching(/pattern is longer than/))
+    end
+  end
+
+  describe 'ECMA-262 pattern semantics, continued' do
+    it 'matches the empty string for a back-reference to a group that did not participate' do
+      expect(validator.validate('', { 'pattern' => '^(a)?\\1$' })).to be_empty
+      expect(validator.validate('aa', { 'pattern' => '^(a)?\\1$' })).to be_empty
+      expect(validator.validate('a', { 'pattern' => '^(a)?\\1$' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+      # A group that did participate is still held to what it captured.
+      expect(validator.validate('a', { 'pattern' => '^(a)\\1$' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+      expect(validator.validate('b', { 'pattern' => '^(?<n>a)?b\\k<n>$' })).to be_empty
+    end
+
+    it 'reads a back-reference with no such group as the legacy octal escape' do
+      expect(validator.check_schema({ 'pattern' => '\\1' })).to be_empty
+      expect(validator.validate("\u0001", { 'pattern' => '^\\1$' })).to be_empty
+      expect(validator.validate('1', { 'pattern' => '^\\1$' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+    end
+
+    it 'reads a surrogate pair as the character it encodes' do
+      pair = { 'pattern' => '^\\uD83D\\uDE00$' }
+      expect(validator.check_schema(pair)).to be_empty
+      expect(validator.validate("\u{1F600}", pair)).to be_empty
+      expect(validator.validate('x', pair)).to contain_exactly(a_string_matching(/does not match pattern/))
+      # A lone surrogate is no character any string carries: it matches nothing.
+      expect(validator.validate("\u{1F600}", { 'pattern' => '\\uD83D' }))
+        .to contain_exactly(a_string_matching(/does not match pattern/))
+    end
+
+    it 'refuses the Ruby-only syntax ECMA-262 does not define' do
+      ['(?i)ok', 'a++', 'a*+', 'a{2}+', 'a?+', '(?>a)', '(?#c)', "(?'n'a)"].each do |pattern|
+        expect(validator.check_schema({ 'pattern' => pattern }))
+          .to contain_exactly(a_string_matching(/pattern .* is not an ECMA-262 regular expression/)), pattern
+        expect(validator.validate('OK', { 'pattern' => pattern }))
+          .to contain_exactly(a_string_matching(/is not an ECMA-262 regular expression/)), pattern
+      end
+      expect(validator.validate('OK', { 'not' => { 'pattern' => '(?i)ok' } }))
+        .to contain_exactly(a_string_matching(/is not an ECMA-262 regular expression/))
+      expect(validator.check_schema({ 'patternProperties' => { '(?i)ok' => true } }))
+        .to contain_exactly(a_string_matching(/patternProperties pattern .* is not an ECMA-262/))
+    end
+
+    it 'keeps the groups and quantifiers both dialects define' do
+      ['(?:a)+?', '(?=a)a', '(?!b)a', '(?<=x)a', '(?<!x)a', '(?<n>a)\\k<n>', 'a{1,2}?', '\\+', 'a|b'].each do |pattern|
+        expect(validator.check_schema({ 'pattern' => pattern })).to be_empty, pattern
+      end
+      expect(validator.validate('xaa', { 'pattern' => '(?<=x)a' })).to be_empty
+      expect(validator.validate('ok', { 'pattern' => '(?i)ok' }))
+        .to contain_exactly(a_string_matching(/is not an ECMA-262/))
+    end
+
+    it 'never reads an unreadable pattern as absent' do
+      # A pattern that is no expression is a malformed keyword; a schema
+      # carrying one is unusable, not a schema without the keyword.
+      expect(validator.check_schema({ 'pattern' => '(' }))
+        .to contain_exactly(a_string_matching(/pattern .* is not an ECMA-262 regular expression/))
+      expect(validator.validate('anything', { 'pattern' => '[' }))
+        .to contain_exactly(a_string_matching(/is not an ECMA-262/))
+      # The matcher itself reports one too, should a pattern reach it
+      # without the preflight.
+      expect(validator.validate_pattern('OK', '(?i)ok', '#'))
+        .to contain_exactly(a_string_matching(/is not an ECMA-262 regular expression/))
+    end
+  end
+
+  describe 'malformed core keywords at preflight' do
+    it 'refuses an $id that is not a URI reference' do
+      expect(validator.check_schema({ '$id' => 'https://example.com/a b', 'type' => 'integer' }))
+        .to contain_exactly(a_string_matching(/\$id .* must be a URI reference/))
+      expect(validator.validate(1, { '$id' => 'https://example.com/a b', 'type' => 'integer' }))
+        .to contain_exactly(a_string_matching(/\$id .* must be a URI reference/))
+      expect(validator.check_schema({ '$id' => 'https://example.com/root', 'type' => 'integer' })).to be_empty
+      expect(validator.check_schema({ '$id' => 'relative/path', 'type' => 'integer' })).to be_empty
+    end
+
+    it 'refuses a $vocabulary that is not an object of booleans keyed by URI' do
+      expect(validator.check_schema({ '$vocabulary' => [] }))
+        .to contain_exactly(a_string_matching(/\$vocabulary must be an object of booleans/))
+      expect(validator.check_schema({ '$vocabulary' => { 'https://example.com/v' => 'yes' } }))
+        .to contain_exactly(a_string_matching(/\$vocabulary must be an object of booleans/))
+      expect(validator.check_schema({ '$vocabulary' => { 'not a uri' => true } }))
+        .to contain_exactly(a_string_matching(/\$vocabulary must be an object of booleans/))
+      expect(validator.check_schema({ '$vocabulary' => { 'https://example.com/v' => true } })).to be_empty
+      expect(validator.check_schema({ '$schema' => draft2019, '$vocabulary' => { 'https://e.com/v' => false } }))
+        .to be_empty
+      # draft-07 does not define the keyword: unknown there, never malformed.
+      expect(validator.check_schema({ '$schema' => draft7, '$vocabulary' => [] })).to be_empty
+    end
+
+    it 'refuses a $recursiveAnchor that is not a boolean' do
+      expect(validator.check_schema({ '$schema' => draft2019, '$recursiveAnchor' => 'yes' }))
+        .to contain_exactly(a_string_matching(/\$recursiveAnchor must be a boolean/))
+      expect(validator.validate(1, { '$schema' => draft2019, '$recursiveAnchor' => 'yes' }))
+        .to contain_exactly(a_string_matching(/\$recursiveAnchor must be a boolean/))
+      expect(validator.check_schema({ '$schema' => draft2019, '$recursiveAnchor' => true })).to be_empty
+      # 2020-12 replaced it with $dynamicAnchor: unknown there.
+      expect(validator.check_schema({ '$recursiveAnchor' => 'yes' })).to be_empty
+    end
+  end
+
+  describe 'the validation budget inside loops that visit no node' do
+    # Round 29's examples for these loops still passed with the loop's own
+    # deadline check removed: the members they rejected each visited a node,
+    # and the visit consults the clock too. These sweeps decide every member
+    # without a visit, so only the loop's checkpoint can stop them.
+    it 'aborts a wide sweep past an unconstrained tuple tail' do
+      data = Array.new(500, 'x')
+      schema = { '$schema' => draft2019, 'not' => { 'items' => [{ 'type' => 'string' }] } }
+      errors = with_clock(0.05) { validator.validate(data, schema) }
+      expect(errors).to contain_exactly(a_string_matching(/aborted/))
+    end
+
+    it 'aborts a wide sweep under an empty patternProperties map' do
+      data = (1..500).to_h { |i| ["p#{i}", i] }
+      errors = with_clock(0.05) { validator.validate(data, { 'not' => { 'patternProperties' => {} } }) }
+      expect(errors).to contain_exactly(a_string_matching(/aborted/))
+    end
+  end
+
+  describe 'JSON equality over deep values' do
+    def nested(leaf)
+      deep = leaf
+      2000.times { deep = [deep] }
+      deep
+    end
+
+    it 'compares separately allocated deep const and enum values' do
+      expect(validator.validate(nested(1), { 'const' => nested(1) })).to be_empty
+      expect(validator.validate(nested(2), { 'const' => nested(1) }))
+        .to contain_exactly(a_string_matching(/does not equal const/))
+      expect(validator.validate(nested(1), { 'enum' => [nested(0), nested(1)] })).to be_empty
+      expect(validator.validate(nested(3), { 'enum' => [nested(0), nested(1)] }))
+        .to contain_exactly(a_string_matching(/is not in enum/))
+    end
+  end
+
+  describe 'concurrent validations' do
+    it 'keeps each validation to its own schema and dialect' do
+      schemas = [
+        { 'prefixItems' => [{ 'type' => 'integer' }], 'items' => false },
+        { '$schema' => draft7, 'items' => [{ 'type' => 'integer' }], 'additionalItems' => false },
+        { 'pattern' => '^\\d+$' }
+      ]
+      barrier = Queue.new
+      threads = Array.new(6) do |i|
+        Thread.new do
+          barrier.pop
+          Array.new(20) do
+            i % 3 == 2 ? validator.validate('12', schemas[2]) : validator.validate([1, 2], schemas[i % 3])
+          end
+        end
+      end
+      6.times { barrier << true }
+      threads.each_with_index do |thread, i|
+        thread.value.each do |answer|
+          if i % 3 == 2
+            expect(answer).to be_empty
+          else
+            expect(answer).to contain_exactly(a_string_matching(%r{item 1 is not allowed|#/1}))
+          end
+        end
+      end
+    end
+
+    it 'aborts one validation without touching another' do
+      expired = Process.clock_gettime(Process::CLOCK_MONOTONIC) - 1
+      schema = { 'items' => { 'type' => 'integer' } }
+      aborted = Thread.new { validator.validate([1, 'x'], schema, deadline: expired) }
+      fine = Thread.new { validator.validate([1, 'x'], schema) }
+      expect(aborted.value).to contain_exactly(a_string_matching(/aborted/))
+      expect(fine.value).to contain_exactly(a_string_matching(%r{#/1}))
+    end
+  end
+
+  describe 'the client entry points a result reaches' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:leak) do
+      { 'resultType' => 'complete', 'content' => [], 'structuredContent' => { 'id' => '1', 'secret' => 'leak' } }
+    end
+    # The canonical 2020-12 closed composition (SEP-2106 made it legal on a
+    # tool schema): a full validator rejects `secret`.
+    let(:closed) do
+      { '$ref' => '#/$defs/base', 'unevaluatedProperties' => false,
+        '$defs' => { 'base' => { 'type' => 'object', 'properties' => { 'id' => { 'type' => 'string' } },
+                                 'required' => ['id'] } } }
+    end
+
+    def stub_server(output_schema, chunk, input_schema: { 'type' => 'object' })
+      srv = instance_double(MCPClient::ServerBase, name: 's')
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: input_schema,
+                                 output_schema: output_schema, server: srv)
+      allow(srv).to receive(:on_notification)
+      allow(srv).to receive(:list_tools).and_return([tool])
+      allow(srv).to receive(:call_tool).and_return(chunk)
+      allow(srv).to receive(:call_tool_streaming) { |*| Enumerator.new { |y| y << chunk } }
+      srv
+    end
+
+    def client_over(srv, mode)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(srv)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger,
+                            validate_structured_content: mode)
+    end
+
+    describe 'a schema this validator cannot fully evaluate' do
+      # This validator does not collect the annotations a composition
+      # produces, so it cannot show the result conforms — and :strict is a
+      # gate: a result it cannot show to conform is refused, not returned
+      # beside a warning.
+      it 'refuses the result in :strict mode' do
+        client = client_over(stub_server(closed, leak), :strict)
+
+        expect { client.call_tool('t', {}) }
+          .to raise_error(MCPClient::Errors::ValidationError,
+                          /cannot be checked.*does not evaluate.*unevaluatedProperties/m)
+      end
+
+      it 'refuses it on every call, not only the one that logged the warning' do
+        client = client_over(stub_server(closed, leak), :strict)
+
+        2.times do
+          expect { client.call_tool('t', {}) }
+            .to raise_error(MCPClient::Errors::ValidationError, /unevaluatedProperties/)
+        end
+        expect(log_output.string.scan('validation is partial').size).to eq(1)
+      end
+
+      it 'refuses the other assertions it does not evaluate the same way' do
+        [{ 'allOf' => [{ 'properties' => { 'id' => true } }], 'unevaluatedProperties' => false },
+         { '$dynamicRef' => '#/$defs/n', '$defs' => { 'n' => { 'type' => 'integer' } } },
+         { '$schema' => draft2019, '$recursiveRef' => '#' }].each do |schema|
+          client = client_over(stub_server(schema, leak), :strict)
+          expect { client.call_tool('t', {}) }
+            .to raise_error(MCPClient::Errors::ValidationError, /does not evaluate/), schema.inspect
+        end
+        items = { 'contains' => { 'type' => 'string' }, 'unevaluatedItems' => false }
+        result = { 'resultType' => 'complete', 'content' => [], 'structuredContent' => ['x', 1] }
+        expect { client_over(stub_server(items, result), :strict).call_tool('t', {}) }
+          .to raise_error(MCPClient::Errors::ValidationError, /unevaluatedItems/)
+      end
+
+      it 'lets a keyword that only annotates through in :strict mode' do
+        schema = { 'type' => 'object', 'properties' => { 'id' => { 'type' => 'string', 'format' => 'uuid' } } }
+        client = client_over(stub_server(schema, leak), :strict)
+
+        expect(client.call_tool('t', {})).to eq(leak)
+        expect(log_output.string).to include('validation is partial')
+      end
+
+      it 'keeps warning once, and returns the result, in :warn mode' do
+        client = client_over(stub_server(closed, leak), :warn)
+
+        expect(client.call_tool('t', {})).to eq(leak)
+        expect(client.call_tool('t', {})).to eq(leak)
+        expect(log_output.string.scan('validation is partial').size).to eq(1)
+      end
+
+      it 'refuses on the streaming path too' do
+        client = client_over(stub_server(closed, leak), :strict)
+
+        expect { client.call_tool_streaming('t', {}).to_a }
+          .to raise_error(MCPClient::Errors::ValidationError, /unevaluatedProperties/)
+      end
+
+      it 'refuses a task-delivered result the same way' do
+        client = client_over(stub_server(closed, leak), :strict)
+        tool = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
+                                   output_schema: closed, server: nil)
+        handle = MCPClient::Task.completed_locally(leak, server: nil).with_called_tool(tool)
+
+        expect { client.send(:validated_task_result, handle, leak) }
+          .to raise_error(MCPClient::Errors::ValidationError, /unevaluatedProperties/)
+      end
+    end
+
+    describe 'the required arguments an input schema names through its applicators' do
+      # Tools spec: "clients SHOULD follow $ref resolution when validating
+      # tool inputs". SEP-2106 made `$ref` and `allOf` legal on an
+      # inputSchema; a `required` behind them is as required as one at the
+      # root, and the call is refused locally rather than sent.
+      let(:chunk) { { 'resultType' => 'complete', 'content' => [] } }
+
+      it 'refuses a call missing an argument required behind a root $ref' do
+        schema = { '$ref' => '#/$defs/t',
+                   '$defs' => { 't' => { 'type' => 'object', 'required' => ['x'],
+                                         'properties' => { 'x' => { 'type' => 'string' } } } } }
+        srv = stub_server(nil, chunk, input_schema: schema)
+        client = client_over(srv, :warn)
+
+        expect { client.call_tool('t', {}) }
+          .to raise_error(MCPClient::Errors::ValidationError, /Missing required parameters: x/)
+        expect(srv).not_to have_received(:call_tool)
+        expect(client.call_tool('t', { 'x' => 'a' })).to eq(chunk)
+      end
+
+      it 'follows allOf, and a default the applied schema declares' do
+        schema = { 'type' => 'object',
+                   'allOf' => [{ 'required' => %w[x y], 'properties' => { 'y' => { 'default' => 1 } } }] }
+        client = client_over(stub_server(nil, chunk, input_schema: schema), :warn)
+
+        expect { client.call_tool('t', {}) }
+          .to raise_error(MCPClient::Errors::ValidationError, /Missing required parameters: x$/)
+        expect(client.call_tool('t', { 'x' => 1 })).to eq(chunk)
+      end
+
+      it 'leaves a branch it cannot decide to the server' do
+        schema = { 'type' => 'object', 'oneOf' => [{ 'required' => ['x'] }, { 'required' => ['y'] }] }
+        srv = stub_server(nil, chunk, input_schema: schema)
+        client = client_over(srv, :warn)
+
+        expect(client.call_tool('t', {})).to eq(chunk)
+        expect(srv).to have_received(:call_tool)
+      end
+    end
+  end
+
+  describe 'the HeaderMismatch retry and the definition it was checked against' do
+    let(:base_url) { 'https://example.com' }
+    let(:endpoint) { '/mcp' }
+    let(:url) { "#{base_url}#{endpoint}" }
+    let(:json) { { 'Content-Type' => 'application/json' } }
+
+    def json_response(id, result)
+      { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result), headers: json }
+    end
+
+    def listing(header, dialect: nil)
+      schema = { 'type' => 'object',
+                 'properties' => { 'region' => { 'type' => 'string', 'x-mcp-header' => header } } }
+      schema = { '$schema' => dialect }.merge(schema) if dialect
+      # A zero TTL: every access to the list is a fresh fetch.
+      { 'tools' => [{ 'name' => 'execute_sql', 'inputSchema' => schema }], 'ttlMs' => 0 }
+    end
+
+    # The dialect check before the retry and the header derivation of the
+    # retry each looked the definition up, and on a list the server bounds
+    # with `ttlMs: 0` each lookup is a fetch: the check passed one
+    # definition and the retry went out under the next, whose dialect
+    # nothing here could read — the "refuse before sending" the check is
+    # for, defeated between two lines. The definition the check read is the
+    # one the retry goes out under.
+    it 'sends the retry under the definition the dialect check read' do
+      calls = []
+      lists_after_rejection = 0
+      lists_at_retry = nil
+      rejected = false
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'server/discover'
+          json_response(body['id'], { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+                                      'capabilities' => { 'tools' => {} } })
+        when 'tools/list'
+          next json_response(body['id'], listing('Region')) unless rejected
+
+          # The refresh and the dialect check read a readable definition; any
+          # list read after those declares a dialect nothing here can read.
+          lists_after_rejection += 1
+          readable = lists_after_rejection <= 2
+          json_response(body['id'], listing('Zone', dialect: readable ? nil : 'urn:unknown-dialect'))
+        when 'tools/call'
+          calls << request.headers.slice('Mcp-Param-Region', 'Mcp-Param-Zone')
+          if request.headers['Mcp-Param-Zone']
+            lists_at_retry = lists_after_rejection
+            next json_response(body['id'], { 'resultType' => 'complete', 'content' => [] })
+          end
+          rejected = true
+          { status: 400, headers: json,
+            body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'],
+                                'error' => { 'code' => -32_020, 'message' => 'Mcp-Param-Zone missing' }) }
+        end
+      end
+      client = MCPClient::Client.new(
+        mcp_server_configs: [MCPClient.streamable_http_config(base_url: base_url, endpoint: endpoint, retries: 0)],
+        validate_structured_content: :strict
+      )
+
+      expect(client.call_tool('execute_sql', { 'region' => 'eu' }))
+        .to eq({ 'resultType' => 'complete', 'content' => [] })
+      expect(calls).to eq([{ 'Mcp-Param-Region' => 'eu' }, { 'Mcp-Param-Zone' => 'eu' }])
+      expect(lists_at_retry).to eq(2)
+      client.cleanup
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round30_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round30_spec.rb
@@ -301,8 +301,16 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 30' do
       end
 
       it 'refuses the dynamic references it does not evaluate the same way, and only those' do
-        [{ '$dynamicRef' => '#node', '$defs' => { 'n' => { '$dynamicAnchor' => 'node', 'type' => 'object' } } },
-         { '$schema' => draft2019, '$recursiveAnchor' => true, 'type' => 'object', '$recursiveRef' => '#' }]
+        # Several non-root resources declare the anchor: only the evaluation
+        # path could choose the binding, which is the one case left unevaluated.
+        two = { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node', 'type' => 'object',
+                         'properties' => { 'id' => { '$dynamicRef' => '#node' } } },
+                'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node', 'type' => 'string' } }
+        recursive = { 'a' => { '$id' => 'https://example.com/ra', '$recursiveAnchor' => true, 'type' => 'object',
+                               'properties' => { 'id' => { '$recursiveRef' => '#' } } },
+                      'b' => { '$id' => 'https://example.com/rb', '$recursiveAnchor' => true, 'type' => 'string' } }
+        [{ '$ref' => 'https://example.com/a', 'type' => 'object', '$defs' => two },
+         { '$schema' => draft2019, '$ref' => 'https://example.com/ra', 'type' => 'object', '$defs' => recursive }]
           .each do |schema|
           client = client_over(stub_server(schema, leak), :strict)
           expect { client.call_tool('t', {}) }

--- a/spec/lib/mcp_client/json_schema_2026_round30_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round30_spec.rb
@@ -300,22 +300,28 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 30' do
         expect(log_output.string).not_to include('validation is partial')
       end
 
-      it 'refuses the dynamic references it does not evaluate the same way, and only those' do
-        # Several non-root resources declare the anchor: only the evaluation
-        # path could choose the binding, which is the one case left unevaluated.
+      it 'checks a result against the schema each dynamic reference binds to' do
+        # The dynamic scope decides the binding, and `b` is never entered: the
+        # result is checked against `a`, which the leak violates.
         two = { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node', 'type' => 'object',
                          'properties' => { 'id' => { '$dynamicRef' => '#node' } } },
                 'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node', 'type' => 'string' } }
         recursive = { 'a' => { '$id' => 'https://example.com/ra', '$recursiveAnchor' => true, 'type' => 'object',
                                'properties' => { 'id' => { '$recursiveRef' => '#' } } },
                       'b' => { '$id' => 'https://example.com/rb', '$recursiveAnchor' => true, 'type' => 'string' } }
+        # `id` binds to `a` (an object), so the string the result carries is
+        # refused for what is wrong with it rather than for a keyword nothing
+        # evaluated.
         [{ '$ref' => 'https://example.com/a', 'type' => 'object', '$defs' => two },
          { '$schema' => draft2019, '$ref' => 'https://example.com/ra', 'type' => 'object', '$defs' => recursive }]
           .each do |schema|
-          client = client_over(stub_server(schema, leak), :strict)
-          expect { client.call_tool('t', {}) }
-            .to raise_error(MCPClient::Errors::ValidationError, /does not evaluate/), schema.inspect
+          expect { client_over(stub_server(schema, leak), :strict).call_tool('t', {}) }
+            .to raise_error(MCPClient::Errors::ValidationError, /expected type object/), schema.inspect
         end
+        # The same shape accepts what the binding admits.
+        nested = { 'resultType' => 'complete', 'content' => [], 'structuredContent' => { 'id' => {} } }
+        expect(client_over(stub_server({ '$ref' => 'https://example.com/a', 'type' => 'object', '$defs' => two },
+                                       nested), :strict).call_tool('t', {})).to eq(nested)
         # A pointer-form `$dynamicRef` and a `$recursiveRef` to a root without
         # `$recursiveAnchor` are the plain references they resolve to.
         [{ '$dynamicRef' => '#/$defs/n', '$defs' => { 'n' => { 'type' => 'object' } } },

--- a/spec/lib/mcp_client/json_schema_2026_round30_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round30_spec.rb
@@ -278,36 +278,46 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 30' do
     end
 
     describe 'a schema this validator cannot fully evaluate' do
-      # This validator does not collect the annotations a composition
-      # produces, so it cannot show the result conforms — and :strict is a
-      # gate: a result it cannot show to conform is refused, not returned
-      # beside a warning.
-      it 'refuses the result in :strict mode' do
+      # :strict is a gate: a result the validator cannot show to conform is
+      # refused, not returned beside a warning. Since round 31 that is only
+      # a dynamic reference the dynamic scope could re-bind; the closed
+      # composition is evaluated, and its verdict is what :strict enforces.
+      it 'rejects the leaked property in :strict mode, on the closed composition' do
         client = client_over(stub_server(closed, leak), :strict)
 
         expect { client.call_tool('t', {}) }
-          .to raise_error(MCPClient::Errors::ValidationError,
-                          /cannot be checked.*does not evaluate.*unevaluatedProperties/m)
+          .to raise_error(MCPClient::Errors::ValidationError, /'secret' is not allowed \(unevaluatedProperties/)
+        expect(log_output.string).not_to include('validation is partial')
       end
 
-      it 'refuses it on every call, not only the one that logged the warning' do
+      it 'rejects it on every call' do
         client = client_over(stub_server(closed, leak), :strict)
 
         2.times do
           expect { client.call_tool('t', {}) }
             .to raise_error(MCPClient::Errors::ValidationError, /unevaluatedProperties/)
         end
-        expect(log_output.string.scan('validation is partial').size).to eq(1)
+        expect(log_output.string).not_to include('validation is partial')
       end
 
-      it 'refuses the other assertions it does not evaluate the same way' do
-        [{ 'allOf' => [{ 'properties' => { 'id' => true } }], 'unevaluatedProperties' => false },
-         { '$dynamicRef' => '#/$defs/n', '$defs' => { 'n' => { 'type' => 'integer' } } },
-         { '$schema' => draft2019, '$recursiveRef' => '#' }].each do |schema|
+      it 'refuses the dynamic references it does not evaluate the same way, and only those' do
+        [{ '$dynamicRef' => '#node', '$defs' => { 'n' => { '$dynamicAnchor' => 'node', 'type' => 'object' } } },
+         { '$schema' => draft2019, '$recursiveAnchor' => true, 'type' => 'object', '$recursiveRef' => '#' }]
+          .each do |schema|
           client = client_over(stub_server(schema, leak), :strict)
           expect { client.call_tool('t', {}) }
             .to raise_error(MCPClient::Errors::ValidationError, /does not evaluate/), schema.inspect
         end
+        # A pointer-form `$dynamicRef` and a `$recursiveRef` to a root without
+        # `$recursiveAnchor` are the plain references they resolve to.
+        [{ '$dynamicRef' => '#/$defs/n', '$defs' => { 'n' => { 'type' => 'object' } } },
+         { '$schema' => draft2019, 'type' => 'object',
+           'properties' => { 'child' => { '$recursiveRef' => '#' } } }].each do |schema|
+          expect(client_over(stub_server(schema, leak), :strict).call_tool('t', {})).to eq(leak), schema.inspect
+        end
+        composed = { 'allOf' => [{ 'properties' => { 'id' => true } }], 'unevaluatedProperties' => false }
+        expect { client_over(stub_server(composed, leak), :strict).call_tool('t', {}) }
+          .to raise_error(MCPClient::Errors::ValidationError, /'secret' is not allowed/)
         items = { 'contains' => { 'type' => 'string' }, 'unevaluatedItems' => false }
         result = { 'resultType' => 'complete', 'content' => [], 'structuredContent' => ['x', 1] }
         expect { client_over(stub_server(items, result), :strict).call_tool('t', {}) }
@@ -322,12 +332,13 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 30' do
         expect(log_output.string).to include('validation is partial')
       end
 
-      it 'keeps warning once, and returns the result, in :warn mode' do
+      it 'warns about the leaked property on every call, and returns the result, in :warn mode' do
         client = client_over(stub_server(closed, leak), :warn)
 
         expect(client.call_tool('t', {})).to eq(leak)
         expect(client.call_tool('t', {})).to eq(leak)
-        expect(log_output.string.scan('validation is partial').size).to eq(1)
+        expect(log_output.string.scan('\'secret\' is not allowed').size).to eq(2)
+        expect(log_output.string).not_to include('validation is partial')
       end
 
       it 'refuses on the streaming path too' do

--- a/spec/lib/mcp_client/json_schema_2026_round31_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round31_spec.rb
@@ -242,14 +242,15 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema unevaluated keywords (round 31)' do
       expect_verdicts(dynamic, valid: [1], invalid: ['bad'])
     end
 
-    it 'keeps a $dynamicRef that several non-root resources could bind out of reach, and says so' do
+    it 'binds a $dynamicRef by the resources the instance entered, not by the ones it did not' do
       dynamic = { '$ref' => 'https://example.com/a',
                   '$defs' => { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node',
                                         'type' => 'object',
                                         'properties' => { 'child' => { '$dynamicRef' => '#node' } } },
                                'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node',
                                         'type' => 'string' } } }
-      expect(validator.unsupported_keywords(dynamic)).to contain_exactly('$dynamicRef')
+      expect(validator.unsupported_keywords(dynamic)).to be_empty
+      expect_verdicts(dynamic, valid: [{ 'child' => {} }], invalid: [{ 'child' => 1 }])
       expect(validator.validate({ 'child' => 1 }, { 'not' => dynamic })).to be_empty
     end
 
@@ -328,16 +329,24 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema unevaluated keywords (round 31)' do
         .to raise_error(MCPClient::Errors::ValidationError, /item 1 is not allowed \(unevaluatedItems/)
     end
 
-    it 'still refuses, in :strict mode, a schema whose dynamic reference it cannot follow' do
+    # The reference is evaluated now, so :strict gates on the verdict rather
+    # than refusing the schema: a conforming result passes, and one the
+    # binding rejects is refused for what is wrong with it.
+    it 'checks, in :strict mode, a result against the schema its dynamic reference binds to' do
       dynamic = { '$ref' => 'https://example.com/a', 'type' => 'object',
                   '$defs' => { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node',
                                         'type' => 'object', 'properties' => { 'id' => { '$dynamicRef' => '#node' } } },
                                'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node',
                                         'type' => 'string' } } }
-      client = client_over(stub_server(dynamic, conforming), :strict)
 
-      expect { client.call_tool('t', {}) }
-        .to raise_error(MCPClient::Errors::ValidationError, /does not evaluate.*\$dynamicRef/)
+      # `id` binds to the resource the evaluation entered, whose `type` is
+      # object: a nested object passes and the string `conforming` carries is
+      # refused for the type it is.
+      nested = { 'resultType' => 'complete', 'content' => [], 'structuredContent' => { 'id' => {} } }
+      expect(client_over(stub_server(dynamic, nested), :strict).call_tool('t', {})).to eq(nested)
+
+      expect { client_over(stub_server(dynamic, conforming), :strict).call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /expected type object/)
     end
   end
 end

--- a/spec/lib/mcp_client/json_schema_2026_round31_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round31_spec.rb
@@ -1,0 +1,326 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, thirty-first round.
+#
+# `unevaluatedProperties` and `unevaluatedItems` are decided by the
+# annotations a whole composition produces (JSON Schema 2020-12 Core
+# Sections 11.2 and 11.3): what `properties`, `patternProperties`,
+# `additionalProperties`, `prefixItems`, `items`, `contains` and the two
+# keywords themselves evaluated, collected through every in-place applicator
+# that passed (`$ref`, `allOf`, `anyOf`, `oneOf`, `if`/`then`/`else`,
+# `dependentSchemas`) and never from a cousin. Round 30 refused such a schema
+# in :strict and let it through in :warn; both are the wrong verdict on the
+# canonical closed composition SEP-2106 made legal on a tool schema. The
+# annotations are collected now, and the two keywords are evaluated wherever
+# they appear. A `$dynamicRef` or `$recursiveRef` that names no dynamic
+# anchor is the plain reference the specification says it is; only a
+# reference the dynamic scope could re-bind stays out of reach.
+RSpec.describe 'MCP 2026-07-28 JSON Schema unevaluated keywords (round 31)' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft2019) { MCPClient::SchemaValidator::DRAFT_2019_09 }
+  let(:draft7) { MCPClient::SchemaValidator::DRAFT_07 }
+
+  def valid?(data, schema)
+    errors = validator.validate(data, schema)
+    expect(errors).not_to include(a_string_matching(/aborted|not supported/)), errors.inspect
+    errors.empty?
+  end
+
+  # Every case is a pair: a conforming instance the keyword must let through
+  # and a non-conforming one it must reject, so a keyword that decided
+  # nothing — or refused everything — fails the example.
+  def expect_verdicts(schema, valid:, invalid:)
+    valid.each { |data| expect(valid?(data, schema)).to be(true), "expected #{data.inspect} to conform" }
+    invalid.each { |data| expect(valid?(data, schema)).to be(false), "expected #{data.inspect} to be rejected" }
+  end
+
+  describe 'unevaluatedProperties' do
+    it 'is applied beside adjacent properties, patternProperties and additionalProperties' do
+      expect_verdicts({ 'properties' => { 'foo' => true }, 'unevaluatedProperties' => false },
+                      valid: [{ 'foo' => 1 }, {}], invalid: [{ 'foo' => 1, 'bar' => 2 }])
+      expect_verdicts({ 'patternProperties' => { '^f' => true }, 'unevaluatedProperties' => false },
+                      valid: [{ 'foo' => 1 }], invalid: [{ 'bar' => 2 }])
+      expect_verdicts({ 'properties' => { 'foo' => true }, 'additionalProperties' => true,
+                        'unevaluatedProperties' => false },
+                      valid: [{ 'foo' => 1, 'bar' => 2 }], invalid: [])
+    end
+
+    it 'reads the annotations a $ref target produces' do
+      schema = { '$ref' => '#/$defs/bar', 'properties' => { 'foo' => { 'type' => 'string' } },
+                 'unevaluatedProperties' => false,
+                 '$defs' => { 'bar' => { 'properties' => { 'bar' => { 'type' => 'string' } } } } }
+      expect_verdicts(schema, valid: [{ 'foo' => 'a', 'bar' => 'b' }],
+                              invalid: [{ 'foo' => 'a', 'bar' => 'b', 'baz' => 'c' }])
+    end
+
+    it 'closes the canonical SEP-2106 composition' do
+      closed = { '$ref' => '#/$defs/base', 'unevaluatedProperties' => false,
+                 '$defs' => { 'base' => { 'type' => 'object', 'properties' => { 'id' => { 'type' => 'string' } },
+                                          'required' => ['id'] } } }
+      expect_verdicts(closed, valid: [{ 'id' => '1' }], invalid: [{ 'id' => '1', 'secret' => 'leak' }, {}])
+    end
+
+    it 'reads the annotations nested allOf members produce, at any depth' do
+      schema = { 'properties' => { 'foo' => true },
+                 'allOf' => [{ 'properties' => { 'bar' => true } },
+                             { 'allOf' => [{ 'patternProperties' => { '^q' => true } }] }],
+                 'unevaluatedProperties' => false }
+      expect_verdicts(schema, valid: [{ 'foo' => 1, 'bar' => 2, 'quux' => 3 }],
+                              invalid: [{ 'foo' => 1, 'bar' => 2, 'baz' => 3 }])
+    end
+
+    it 'reads the annotations of every anyOf branch that passed, and none of a branch that failed' do
+      schema = { 'properties' => { 'foo' => true },
+                 'anyOf' => [{ 'properties' => { 'bar' => { 'const' => 'bar' } }, 'required' => ['bar'] },
+                             { 'properties' => { 'baz' => { 'const' => 'baz' } }, 'required' => ['baz'] },
+                             { 'properties' => { 'quux' => { 'const' => 'quux' } }, 'required' => ['quux'] }],
+                 'unevaluatedProperties' => false }
+      expect_verdicts(schema,
+                      valid: [{ 'foo' => 1, 'bar' => 'bar' }, { 'foo' => 1, 'bar' => 'bar', 'baz' => 'baz' },
+                              { 'foo' => 1, 'bar' => 'bar', 'baz' => 'baz', 'quux' => 'quux' }],
+                      invalid: [{ 'foo' => 1, 'bar' => 'bar', 'baz' => 'not-baz' },
+                                { 'foo' => 1, 'bar' => 'bar', 'quux' => 'not-quux' }])
+    end
+
+    it 'reads the annotations of the one oneOf branch that passed' do
+      schema = { 'properties' => { 'foo' => true },
+                 'oneOf' => [{ 'properties' => { 'bar' => { 'const' => 'bar' } }, 'required' => ['bar'] },
+                             { 'properties' => { 'baz' => { 'const' => 'baz' } }, 'required' => ['baz'] }],
+                 'unevaluatedProperties' => false }
+      expect_verdicts(schema, valid: [{ 'foo' => 1, 'bar' => 'bar' }, { 'foo' => 1, 'baz' => 'baz' }],
+                              invalid: [{ 'foo' => 1, 'bar' => 'bar', 'quux' => 2 }])
+    end
+
+    it 'reads nothing from not' do
+      schema = { 'properties' => { 'foo' => true },
+                 'not' => { 'not' => { 'properties' => { 'bar' => { 'const' => 'bar' } }, 'required' => ['bar'] } },
+                 'unevaluatedProperties' => false }
+      expect_verdicts(schema, valid: [], invalid: [{ 'foo' => 1, 'bar' => 'bar' }])
+    end
+
+    it 'reads the annotations of if (only when it passed) and of the branch that applied' do
+      schema = { 'if' => { 'properties' => { 'foo' => { 'const' => 'then' } }, 'required' => ['foo'] },
+                 'then' => { 'properties' => { 'bar' => true }, 'required' => ['bar'] },
+                 'else' => { 'properties' => { 'baz' => true }, 'required' => ['baz'] },
+                 'unevaluatedProperties' => false }
+      expect_verdicts(schema,
+                      valid: [{ 'foo' => 'then', 'bar' => 1 }, { 'baz' => 1 }],
+                      invalid: [{ 'foo' => 'then', 'bar' => 1, 'baz' => 2 }, { 'foo' => 'else', 'baz' => 1 }])
+    end
+
+    it 'reads the annotations of a triggered dependentSchemas member' do
+      schema = { 'properties' => { 'foo' => true },
+                 'dependentSchemas' => { 'foo' => { 'properties' => { 'bar' => true } } },
+                 'unevaluatedProperties' => false }
+      expect_verdicts(schema, valid: [{ 'foo' => 1, 'bar' => 2 }], invalid: [{ 'bar' => 2 }])
+    end
+
+    it 'never sees a cousin, whichever side of the allOf it is on' do
+      expect_verdicts({ 'allOf' => [{ 'properties' => { 'foo' => true } }, { 'unevaluatedProperties' => false }] },
+                      valid: [{}], invalid: [{ 'foo' => 1 }])
+      expect_verdicts({ 'allOf' => [{ 'unevaluatedProperties' => false }, { 'properties' => { 'foo' => true } }] },
+                      valid: [{}], invalid: [{ 'foo' => 1 }])
+    end
+
+    it 'is itself an annotation a nested one produces' do
+      schema = { 'properties' => { 'foo' => true }, 'allOf' => [{ 'unevaluatedProperties' => true }],
+                 'unevaluatedProperties' => { 'type' => 'string', 'maxLength' => 2 } }
+      expect_verdicts(schema, valid: [{ 'foo' => 1, 'bar' => 'a long value' }], invalid: [])
+    end
+
+    it 'applies its schema to what was left unevaluated' do
+      schema = { 'properties' => { 'foo' => true },
+                 'unevaluatedProperties' => { 'type' => 'string', 'minLength' => 3 } }
+      expect_verdicts(schema, valid: [{ 'foo' => 1, 'bar' => 'bar' }], invalid: [{ 'foo' => 1, 'bar' => 'ba' }])
+    end
+
+    it 'does not read a property evaluated on another instance level' do
+      schema = { 'properties' => { 'child' => { 'properties' => { 'bar' => true } } },
+                 'unevaluatedProperties' => false }
+      expect_verdicts(schema, valid: [{ 'child' => { 'bar' => 1 } }], invalid: [{ 'child' => {}, 'bar' => 1 }])
+    end
+
+    it 'is unknown under draft-07, where nothing defines it' do
+      expect_verdicts({ '$schema' => draft7, 'unevaluatedProperties' => false }, valid: [{ 'foo' => 1 }], invalid: [])
+    end
+  end
+
+  describe 'unevaluatedItems' do
+    it 'is applied beside prefixItems and items' do
+      expect_verdicts({ 'prefixItems' => [{ 'type' => 'string' }], 'unevaluatedItems' => false },
+                      valid: [['foo'], []], invalid: [['foo', 42]])
+      expect_verdicts({ 'items' => { 'type' => 'string' }, 'unevaluatedItems' => false },
+                      valid: [%w[foo bar]], invalid: [])
+    end
+
+    it 'reads the items contains matched' do
+      expect_verdicts({ 'contains' => { 'type' => 'string' }, 'unevaluatedItems' => false },
+                      valid: [['foo']], invalid: [['foo', 42], [42]])
+      expect_verdicts({ 'prefixItems' => [{ 'type' => 'number' }], 'contains' => { 'type' => 'string' },
+                        'unevaluatedItems' => false },
+                      valid: [[1, 'x'], [1, 'x', 'y']], invalid: [[1, 'x', true]])
+    end
+
+    it 'reads the tuple a nested allOf member evaluated' do
+      schema = { 'prefixItems' => [{ 'type' => 'string' }],
+                 'allOf' => [{ 'prefixItems' => [true, { 'type' => 'number' }] }],
+                 'unevaluatedItems' => false }
+      expect_verdicts(schema, valid: [['foo', 42]], invalid: [['foo', 42, true]])
+    end
+
+    it 'reads the annotations of the anyOf branches that passed' do
+      schema = { 'prefixItems' => [{ 'const' => 'foo' }],
+                 'anyOf' => [{ 'prefixItems' => [true, { 'const' => 'bar' }] },
+                             { 'prefixItems' => [true, true, { 'const' => 'baz' }] }],
+                 'unevaluatedItems' => false }
+      expect_verdicts(schema, valid: [%w[foo bar], %w[foo bar baz]], invalid: [%w[foo bar baz quux]])
+    end
+
+    it 'reads nothing from not' do
+      schema = { 'not' => { 'not' => { 'prefixItems' => [true] } }, 'unevaluatedItems' => false }
+      expect_verdicts(schema, valid: [[]], invalid: [['foo']])
+    end
+
+    it 'reads the annotations of if and of the branch that applied' do
+      schema = { 'if' => { 'prefixItems' => [{ 'const' => 'then' }] },
+                 'then' => { 'prefixItems' => [true, { 'type' => 'number' }] },
+                 'else' => { 'prefixItems' => [true, { 'type' => 'string' }] },
+                 'unevaluatedItems' => false }
+      expect_verdicts(schema, valid: [['then', 1], %w[else x]], invalid: [['then', 1, 2], %w[else x y]])
+    end
+
+    it 'reads the annotations a $ref target produces' do
+      schema = { '$ref' => '#/$defs/head', 'unevaluatedItems' => false,
+                 '$defs' => { 'head' => { 'prefixItems' => [{ 'type' => 'string' }] } } }
+      expect_verdicts(schema, valid: [['foo']], invalid: [%w[foo bar]])
+    end
+
+    it 'never sees a cousin' do
+      expect_verdicts({ 'allOf' => [{ 'prefixItems' => [true] }, { 'unevaluatedItems' => false }] },
+                      valid: [[]], invalid: [['foo']])
+    end
+
+    it 'is itself an annotation a nested one produces, and applies its schema to what is left' do
+      expect_verdicts({ 'prefixItems' => [true], 'allOf' => [{ 'unevaluatedItems' => true }],
+                        'unevaluatedItems' => { 'type' => 'string' } },
+                      valid: [[1, 2]], invalid: [])
+      expect_verdicts({ 'prefixItems' => [true], 'unevaluatedItems' => { 'type' => 'string' } },
+                      valid: [[1, 'a']], invalid: [[1, 2]])
+    end
+
+    it 'reads a 2019-09 tuple and its additionalItems' do
+      expect_verdicts({ '$schema' => draft2019, 'items' => [{ 'type' => 'string' }], 'unevaluatedItems' => false },
+                      valid: [['foo']], invalid: [%w[foo bar]])
+      expect_verdicts({ '$schema' => draft2019, 'items' => [{ 'type' => 'string' }], 'additionalItems' => true,
+                        'unevaluatedItems' => false },
+                      valid: [%w[foo bar]], invalid: [])
+    end
+  end
+
+  describe 'the dynamic references' do
+    it 'applies a $dynamicRef that names no dynamic anchor as the plain reference it is' do
+      pointer = { '$dynamicRef' => '#/$defs/n', '$defs' => { 'n' => { 'type' => 'integer' } } }
+      expect_verdicts(pointer, valid: [1], invalid: ['bad'])
+      expect(validator.unsupported_keywords(pointer)).to be_empty
+
+      plain_anchor = { '$dynamicRef' => '#n', '$defs' => { 'n' => { '$anchor' => 'n', 'type' => 'integer' } } }
+      expect_verdicts(plain_anchor, valid: [1], invalid: ['bad'])
+      expect(validator.unsupported_keywords(plain_anchor)).to be_empty
+    end
+
+    it 'applies a $dynamicRef beside a $ref, after it' do
+      schema = { '$ref' => '#/$defs/a', '$dynamicRef' => '#/$defs/b',
+                 '$defs' => { 'a' => { 'minimum' => 1 }, 'b' => { 'maximum' => 5 } } }
+      expect_verdicts(schema, valid: [3], invalid: [0, 6])
+    end
+
+    it 'keeps a $dynamicRef that a dynamic anchor could re-bind out of reach, and says so' do
+      dynamic = { '$dynamicRef' => '#node', '$defs' => { 'n' => { '$dynamicAnchor' => 'node', 'type' => 'integer' } } }
+      expect(validator.unsupported_keywords(dynamic)).to contain_exactly('$dynamicRef')
+      expect(validator.validate('bad', { 'not' => dynamic })).to be_empty
+    end
+
+    it 'applies a 2019-09 $recursiveRef whose target has no true $recursiveAnchor as a $ref' do
+      schema = { '$schema' => draft2019, 'type' => 'object',
+                 'properties' => { 'child' => { '$recursiveRef' => '#' } } }
+      expect_verdicts(schema, valid: [{ 'child' => {} }], invalid: [{ 'child' => 1 }])
+      expect(validator.unsupported_keywords(schema)).to be_empty
+
+      dynamic = { '$schema' => draft2019, '$recursiveAnchor' => true, 'type' => 'object',
+                  'properties' => { 'child' => { '$recursiveRef' => '#' } } }
+      expect(validator.unsupported_keywords(dynamic)).to contain_exactly('$recursiveRef')
+    end
+  end
+
+  describe 'the client' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:closed) do
+      { '$ref' => '#/$defs/base', 'unevaluatedProperties' => false,
+        '$defs' => { 'base' => { 'type' => 'object', 'properties' => { 'id' => { 'type' => 'string' } },
+                                 'required' => ['id'] } } }
+    end
+    let(:conforming) { { 'resultType' => 'complete', 'content' => [], 'structuredContent' => { 'id' => '1' } } }
+    let(:leak) do
+      { 'resultType' => 'complete', 'content' => [], 'structuredContent' => { 'id' => '1', 'secret' => 'leak' } }
+    end
+
+    def stub_server(output_schema, chunk)
+      srv = instance_double(MCPClient::ServerBase, name: 's')
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
+                                 output_schema: output_schema, server: srv)
+      allow(srv).to receive(:on_notification)
+      allow(srv).to receive(:list_tools).and_return([tool])
+      allow(srv).to receive(:call_tool).and_return(chunk)
+      allow(srv).to receive(:call_tool_streaming) { |*| Enumerator.new { |y| y << chunk } }
+      srv
+    end
+
+    def client_over(srv, mode)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(srv)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger,
+                            validate_structured_content: mode)
+    end
+
+    it 'accepts a conforming result against the closed composition in :strict mode, silently' do
+      client = client_over(stub_server(closed, conforming), :strict)
+
+      expect(client.call_tool('t', {})).to eq(conforming)
+      expect(log_output.string).not_to include('validation is partial')
+    end
+
+    it 'rejects the leaked property in :strict mode, naming it' do
+      client = client_over(stub_server(closed, leak), :strict)
+
+      expect { client.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /'secret' is not allowed \(unevaluatedProperties/)
+    end
+
+    it 'warns about the leaked property in :warn mode and returns the result' do
+      client = client_over(stub_server(closed, leak), :warn)
+
+      expect(client.call_tool('t', {})).to eq(leak)
+      expect(log_output.string).to match(/'secret' is not allowed \(unevaluatedProperties/)
+      expect(log_output.string).not_to include('validation is partial')
+    end
+
+    it 'rejects an item contains did not evaluate in :strict mode, on the streaming path too' do
+      items = { 'contains' => { 'type' => 'string' }, 'unevaluatedItems' => false }
+      result = { 'resultType' => 'complete', 'content' => [], 'structuredContent' => ['x', 1] }
+      client = client_over(stub_server(items, result), :strict)
+
+      expect { client.call_tool_streaming('t', {}).to_a }
+        .to raise_error(MCPClient::Errors::ValidationError, /item 1 is not allowed \(unevaluatedItems/)
+    end
+
+    it 'still refuses, in :strict mode, a schema whose dynamic reference it cannot follow' do
+      dynamic = { '$dynamicRef' => '#node', '$defs' => { 'n' => { '$dynamicAnchor' => 'node', 'type' => 'object' } } }
+      client = client_over(stub_server(dynamic, conforming), :strict)
+
+      expect { client.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /does not evaluate.*\$dynamicRef/)
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round31_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round31_spec.rb
@@ -236,10 +236,21 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema unevaluated keywords (round 31)' do
       expect_verdicts(schema, valid: [3], invalid: [0, 6])
     end
 
-    it 'keeps a $dynamicRef that a dynamic anchor could re-bind out of reach, and says so' do
+    it 'binds a $dynamicRef to the dynamic anchor its root resource declares' do
       dynamic = { '$dynamicRef' => '#node', '$defs' => { 'n' => { '$dynamicAnchor' => 'node', 'type' => 'integer' } } }
+      expect(validator.unsupported_keywords(dynamic)).to be_empty
+      expect_verdicts(dynamic, valid: [1], invalid: ['bad'])
+    end
+
+    it 'keeps a $dynamicRef that several non-root resources could bind out of reach, and says so' do
+      dynamic = { '$ref' => 'https://example.com/a',
+                  '$defs' => { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node',
+                                        'type' => 'object',
+                                        'properties' => { 'child' => { '$dynamicRef' => '#node' } } },
+                               'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node',
+                                        'type' => 'string' } } }
       expect(validator.unsupported_keywords(dynamic)).to contain_exactly('$dynamicRef')
-      expect(validator.validate('bad', { 'not' => dynamic })).to be_empty
+      expect(validator.validate({ 'child' => 1 }, { 'not' => dynamic })).to be_empty
     end
 
     it 'applies a 2019-09 $recursiveRef whose target has no true $recursiveAnchor as a $ref' do
@@ -250,7 +261,9 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema unevaluated keywords (round 31)' do
 
       dynamic = { '$schema' => draft2019, '$recursiveAnchor' => true, 'type' => 'object',
                   'properties' => { 'child' => { '$recursiveRef' => '#' } } }
-      expect(validator.unsupported_keywords(dynamic)).to contain_exactly('$recursiveRef')
+      # The root's own $recursiveAnchor is the outermost one there is.
+      expect(validator.unsupported_keywords(dynamic)).to be_empty
+      expect_verdicts(dynamic, valid: [{ 'child' => {} }], invalid: [{ 'child' => 1 }])
     end
   end
 
@@ -316,7 +329,11 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema unevaluated keywords (round 31)' do
     end
 
     it 'still refuses, in :strict mode, a schema whose dynamic reference it cannot follow' do
-      dynamic = { '$dynamicRef' => '#node', '$defs' => { 'n' => { '$dynamicAnchor' => 'node', 'type' => 'object' } } }
+      dynamic = { '$ref' => 'https://example.com/a', 'type' => 'object',
+                  '$defs' => { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node',
+                                        'type' => 'object', 'properties' => { 'id' => { '$dynamicRef' => '#node' } } },
+                               'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node',
+                                        'type' => 'string' } } }
       client = client_over(stub_server(dynamic, conforming), :strict)
 
       expect { client.call_tool('t', {}) }

--- a/spec/lib/mcp_client/json_schema_2026_round32_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round32_spec.rb
@@ -1,0 +1,295 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, thirty-second round: the dialect an
+# embedded resource declares governs what an input schema requires through
+# it, ECMA-262 word boundaries and group numbering are what ECMA-262 says,
+# the preflight runs under the validation-wide deadline, and the core
+# declarations it accepts are the well-formed ones.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 32' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { MCPClient::SchemaValidator::DRAFT_07 }
+  let(:draft2019) { MCPClient::SchemaValidator::DRAFT_2019_09 }
+
+  describe 'input requirements through an embedded resource' do
+    it 'reads a draft-07 resource embedded in a 2020-12 document under its own dialect' do
+      # draft-07: a `$ref` replaces its siblings, so the `required` beside
+      # it is never applied — and never required of the arguments.
+      schema = { 'type' => 'object', '$ref' => 'https://example.com/legacy',
+                 '$defs' => { 'legacy' => { '$id' => 'https://example.com/legacy', '$schema' => draft7,
+                                            'allOf' => [{ '$ref' => '#/definitions/base', 'required' => ['ignored'] }],
+                                            'definitions' => { 'base' => { 'type' => 'object' } } } } }
+      expect(validator.check_schema(schema)).to be_empty
+      required, = validator.input_requirements(schema)
+      expect(required).to eq([])
+    end
+
+    it 'reads a 2020-12 resource embedded in a draft-07 document under its own dialect' do
+      # 2020-12: the `required` beside the `$ref` applies alongside it. (The
+      # resource root itself carries no `$ref`: under the containing
+      # draft-07 one would replace the whole object, `$id` included.)
+      schema = { '$schema' => draft7, 'type' => 'object',
+                 'definitions' => { 'modern' => { '$id' => 'https://example.com/modern',
+                                                  '$schema' => MCPClient::SchemaValidator::DEFAULT_DIALECT,
+                                                  'allOf' => [{ '$ref' => '#/$defs/base', 'required' => ['counted'] }],
+                                                  '$defs' => { 'base' => { 'required' => ['also'] } } } },
+                 'allOf' => [{ '$ref' => 'https://example.com/modern' }] }
+      expect(validator.check_schema(schema)).to be_empty
+      required, = validator.input_requirements(schema)
+      expect(required).to contain_exactly('counted', 'also')
+    end
+
+    it 'follows a chain of references and allOf members, and lets the nearer property win' do
+      schema = { '$ref' => '#/$defs/a', 'properties' => { 'x' => { 'default' => 1 } },
+                 '$defs' => { 'a' => { '$ref' => '#/$defs/b', 'required' => ['x'],
+                                       'properties' => { 'x' => { 'type' => 'string' } } },
+                              'b' => { 'allOf' => [{ 'required' => ['y'] },
+                                                   { 'allOf' => [{ 'required' => ['z'] }] }] } } }
+      required, properties = validator.input_requirements(schema)
+      expect(required).to contain_exactly('x', 'y', 'z')
+      expect(properties['x']).to eq({ 'default' => 1 })
+    end
+  end
+
+  describe 'ECMA-262 word boundaries' do
+    it 'sees a word boundary only at an ASCII word character' do
+      # ECMA-262 `\w` is [A-Za-z0-9_]: "é" has no word boundary at all.
+      expect(validator.validate('é', { 'pattern' => '\\b' })).to contain_exactly(a_string_matching(/pattern/))
+      expect(validator.validate('é', { 'pattern' => '\\B' })).to be_empty
+      expect(validator.validate('e', { 'pattern' => '\\b' })).to be_empty
+      expect(validator.validate('e', { 'pattern' => '^\\Be' })).to contain_exactly(a_string_matching(/pattern/))
+      expect(validator.validate('a b', { 'pattern' => '^a\\b b$' })).to be_empty
+      expect(validator.validate('aé', { 'pattern' => 'a\\bé' })).to be_empty
+      expect(validator.validate('aé', { 'pattern' => 'a\\Bé' })).to contain_exactly(a_string_matching(/pattern/))
+      # Through `not` the verdict flips, never the other way round.
+      expect(validator.validate('é', { 'not' => { 'pattern' => '\\b' } })).to be_empty
+    end
+
+    it 'reads \\b inside a class as a backspace, as both dialects do' do
+      expect(validator.validate("\b", { 'pattern' => '^[\\b]$' })).to be_empty
+      expect(validator.validate('b', { 'pattern' => '^[\\b]$' })).to contain_exactly(a_string_matching(/pattern/))
+    end
+  end
+
+  describe 'ECMA-262 group numbering' do
+    it 'numbers named and unnamed groups alike, so a numbered reference beside a named group works' do
+      schema = { 'pattern' => '^(?<a>x)(y)\\2$' }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate('xyy', schema)).to be_empty
+      expect(validator.validate('xyz', schema)).to contain_exactly(a_string_matching(/pattern/))
+      expect(validator.validate('xyx', schema)).to contain_exactly(a_string_matching(/pattern/))
+    end
+
+    it 'refers to a named group by its number too' do
+      schema = { 'pattern' => '^(?<a>x)\\1(?<b>y)\\k<b>$' }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate('xxyy', schema)).to be_empty
+      expect(validator.validate('xxyz', schema)).to contain_exactly(a_string_matching(/pattern/))
+    end
+
+    it 'lets an unnamed group capture beside a named one' do
+      schema = { 'pattern' => '^(a)(?<n>b)\\1$' }
+      expect(validator.validate('aba', schema)).to be_empty
+      expect(validator.validate('abb', schema)).to contain_exactly(a_string_matching(/pattern/))
+    end
+
+    it 'keeps a numbered reference to a group that did not participate an empty match' do
+      schema = { 'pattern' => '^(?<n>x)?(y)?\\1\\2$' }
+      expect(validator.validate('', schema)).to be_empty
+      expect(validator.validate('xyxy', schema)).to be_empty
+    end
+  end
+
+  describe 'lookarounds' do
+    it 'decides by what a negative lookahead and lookbehind refuse' do
+      expect(validator.validate('bar', { 'pattern' => '^(?!foo)bar$' })).to be_empty
+      expect(validator.validate('foobar', { 'pattern' => '^(?!foo)' })).to contain_exactly(a_string_matching(/pattern/))
+      expect(validator.validate('xa', { 'pattern' => '(?<!x)a' })).to contain_exactly(a_string_matching(/pattern/))
+      expect(validator.validate('ya', { 'pattern' => '(?<!x)a' })).to be_empty
+      expect(validator.validate('xa', { 'pattern' => '(?<=x)a' })).to be_empty
+      expect(validator.validate('ya', { 'pattern' => '(?<=x)a' })).to contain_exactly(a_string_matching(/pattern/))
+    end
+  end
+
+  describe 'the preflight under the deadline' do
+    def many_patterns(count)
+      { 'allOf' => Array.new(count) { |i| { 'pattern' => "^#{'a' * 200}#{i}$" } } }
+    end
+
+    it 'stops checking a schema once the deadline has passed, and says so' do
+      past = Process.clock_gettime(Process::CLOCK_MONOTONIC) - 1
+      expect(validator.check_schema(many_patterns(50), deadline: past))
+        .to contain_exactly(a_string_matching(/time budget exhausted/))
+      expect(validator.validate('a', many_patterns(50), deadline: past))
+        .to contain_exactly(a_string_matching(/time budget exhausted/))
+    end
+
+    it 'does not compile the patterns past the deadline' do
+      compiled = 0
+      allow(validator).to receive(:ecma_regexp).and_wrap_original do |m, *args|
+        compiled += 1
+        m.call(*args)
+      end
+      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      clock = [now, now, now + 10] # the first pattern is compiled before the clock jumps past the deadline
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { clock.length > 1 ? clock.shift : clock.first }
+      problems = validator.check_schema(many_patterns(400), deadline: now + 1)
+      expect(problems).to contain_exactly(a_string_matching(/time budget exhausted/))
+      expect(compiled).to be < 10
+    end
+
+    it 'gives check_schema its own budget when the caller names none' do
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      problems = validator.check_schema({ 'allOf' => Array.new(1500) { { 'pattern' => "(#{'a' * 9_000})" } } })
+      expect(problems).not_to be_empty
+      expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).to be < 5
+    end
+  end
+
+  describe 'the client' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:complete) { { 'resultType' => 'complete', 'content' => [], 'structuredContent' => { 'n' => 1 } } }
+
+    def stub_server(input_schema: { 'type' => 'object' }, output_schema: { 'type' => 'object' }, answer: complete)
+      srv = instance_double(MCPClient::ServerBase, name: 's')
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: input_schema, output_schema: output_schema,
+                                 server: srv)
+      allow(srv).to receive(:on_notification)
+      allow(srv).to receive(:list_tools).and_return([tool])
+      allow(srv).to receive(:call_tool).and_return(answer)
+      allow(srv).to receive(:call_tool_streaming) { |*| Enumerator.new { |y| Array(answer).each { |c| y << c } } }
+      srv
+    end
+
+    def client_over(srv, mode = :strict)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(srv)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger,
+                            validate_structured_content: mode)
+    end
+
+    describe 'a streamed chunk without resultType' do
+      it 'hands a progress object that is no CallToolResult to the host unchanged, in :strict mode' do
+        progress = { 'progress' => 3, 'total' => 10 }
+        srv = stub_server(output_schema: { 'type' => 'object', 'required' => ['n'] }, answer: [progress, complete])
+        client = client_over(srv)
+
+        expect(client.call_tool_streaming('t', {}).to_a).to eq([progress, complete])
+        expect(log_output.string).not_to include('structuredContent')
+      end
+
+      it 'still validates a legacy result, which has no resultType either' do
+        legacy = { 'content' => [], 'structuredContent' => { 'n' => 'not a number' } }
+        srv = stub_server(output_schema: { 'type' => 'object', 'properties' => { 'n' => { 'type' => 'integer' } } },
+                          answer: [legacy])
+        client = client_over(srv)
+
+        expect { client.call_tool_streaming('t', {}).to_a }
+          .to raise_error(MCPClient::Errors::ValidationError, /does not match its output schema/)
+      end
+    end
+
+    describe 'an output schema whose dialect this client cannot read' do
+      let(:unreadable) { { '$schema' => 'urn:unknown', 'type' => 'object' } }
+
+      it 'refuses the call before it is sent' do
+        srv = stub_server(output_schema: unreadable)
+        client = client_over(srv, :warn)
+
+        expect { client.call_tool('t', {}) }
+          .to raise_error(MCPClient::Errors::ValidationError, /output schema.*urn:unknown.*not supported/m)
+        expect(srv).not_to have_received(:call_tool)
+      end
+
+      it 'refuses the streaming call before it is sent' do
+        srv = stub_server(output_schema: unreadable)
+        client = client_over(srv, :warn)
+
+        expect { client.call_tool_streaming('t', {}).to_a }
+          .to raise_error(MCPClient::Errors::ValidationError, /output schema.*urn:unknown/m)
+        expect(srv).not_to have_received(:call_tool_streaming)
+      end
+
+      it 'refuses an error result under it too: the dialect error is not limited to successful results' do
+        srv = stub_server(output_schema: unreadable)
+        client = client_over(srv, :warn)
+        tool = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
+                                   output_schema: unreadable, server: srv)
+
+        expect { client.send(:validate_structured_content!, tool, { 'isError' => true, 'content' => [] }) }
+          .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown/)
+      end
+    end
+
+    describe 'the required arguments under a draft-07 input schema' do
+      it 'does not require what a `required` beside a root $ref names, since draft-07 ignores the sibling' do
+        input = { '$schema' => draft7, '$ref' => '#/definitions/b', 'required' => ['hidden'],
+                  'definitions' => { 'b' => { 'type' => 'object', 'required' => ['x'] } } }
+        client = client_over(stub_server(input_schema: input), :warn)
+
+        expect { client.call_tool('t', { 'x' => 1 }) }.not_to raise_error
+        expect { client.call_tool('t', {}) }
+          .to raise_error(MCPClient::Errors::ValidationError, /Missing required parameters: x$/)
+      end
+    end
+
+    describe 'two calls overlapping on one client' do
+      it 'validates each against its own definition' do
+        srv = instance_double(MCPClient::ServerBase, name: 's')
+        ok = { 'resultType' => 'complete', 'content' => [], 'structuredContent' => { 'n' => 1 } }
+        tools = %w[a b].map do |name|
+          MCPClient::Tool.new(name: name, description: 'd', schema: { 'type' => 'object' },
+                              output_schema: { 'type' => 'object', 'required' => [name == 'a' ? 'n' : 'm'] },
+                              server: srv)
+        end
+        allow(srv).to receive(:on_notification)
+        allow(srv).to receive(:list_tools).and_return(tools)
+        barrier = Queue.new
+        allow(srv).to receive(:call_tool) do |name, _|
+          barrier << name
+          sleep 0.01 until barrier.size >= 2 || Thread.current[:released]
+          ok
+        end
+        client = client_over(srv)
+
+        results = %w[a b].map do |name|
+          Thread.new do
+            client.call_tool(name, {})
+            :ok
+          rescue MCPClient::Errors::ValidationError => e
+            e.message
+          end
+        end.map(&:value)
+
+        expect(results[0]).to eq(:ok)
+        expect(results[1]).to match(/missing required property 'm'/)
+      end
+    end
+  end
+
+  describe 'malformed core declarations' do
+    it 'refuses a $schema on a subschema that is no resource root' do
+      schema = { 'properties' => { 'x' => { '$schema' => 'urn:unsupported', 'type' => 'integer' } } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/\$schema.*resource root/))
+      expect(validator.validate({ 'x' => 1 }, schema)).to contain_exactly(a_string_matching(/\$schema.*resource root/))
+      supported = { 'properties' => { 'x' => { '$schema' => draft7, 'type' => 'integer' } } }
+      expect(validator.check_schema(supported)).to contain_exactly(a_string_matching(/\$schema.*resource root/))
+    end
+
+    it 'still reads a $schema at an embedded resource root' do
+      schema = { 'properties' => { 'x' => { '$id' => 'https://example.com/x', '$schema' => draft7,
+                                            'items' => [{ 'type' => 'integer' }] } } }
+      expect(validator.check_schema(schema)).to be_empty
+    end
+
+    it 'requires every $vocabulary identifier to be an absolute URI' do
+      expect(validator.check_schema({ '$vocabulary' => { 'relative' => true } }))
+        .to contain_exactly(a_string_matching(/\$vocabulary/))
+      expect(validator.check_schema({ '$vocabulary' => { '' => true } }))
+        .to contain_exactly(a_string_matching(/\$vocabulary/))
+      core = 'https://json-schema.org/draft/2020-12/vocab/core'
+      expect(validator.check_schema({ '$vocabulary' => { core => true } })).to be_empty
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round32_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round32_spec.rb
@@ -132,11 +132,12 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 32' do
         m.call(*args)
       end
       now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      clock = [now, now, now + 10] # the first pattern is compiled before the clock jumps past the deadline
-      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { clock.length > 1 ? clock.shift : clock.first }
+      # The clock stands still until a pattern has been compiled, then jumps
+      # past the deadline: compilation demonstrably started, and stopped.
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { compiled.zero? ? now : now + 10 }
       problems = validator.check_schema(many_patterns(400), deadline: now + 1)
       expect(problems).to contain_exactly(a_string_matching(/time budget exhausted/))
-      expect(compiled).to be < 10
+      expect(compiled).to be_between(1, 9)
     end
 
     it 'gives check_schema its own budget when the caller names none' do

--- a/spec/lib/mcp_client/json_schema_2026_round33_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round33_spec.rb
@@ -218,5 +218,242 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema dynamic references, branchless if, ca
       expect(calls).to eq(1)
       client.cleanup
     end
+
+    # The definition pinned for a retry is that retry's alone: once the
+    # retry was refused, the next call reads a fresh list and derives its
+    # headers from what it read, not from what the refused retry held.
+    it 'leaves no pinned definition behind once the retry was refused' do
+      headers = []
+      lists = 0
+      rejected = false
+      readable_again = false
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'server/discover'
+          json_response(body['id'], { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+                                      'capabilities' => { 'tools' => {} } })
+        when 'tools/list'
+          lists += 1
+          next json_response(body['id'], listing('Region')) unless rejected
+
+          # Every list read while the first call recovers is unreadable; the
+          # lists the second call reads name a new header.
+          json_response(body['id'], listing('Zone', output_dialect: readable_again ? nil : 'urn:unknown-dialect'))
+        when 'tools/call'
+          headers << request.headers.slice('Mcp-Param-Region', 'Mcp-Param-Zone')
+          if rejected
+            next json_response(body['id'], { 'resultType' => 'complete', 'content' => [],
+                                             'structuredContent' => {} })
+          end
+
+          rejected = true
+          { status: 400, headers: json,
+            body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'],
+                                'error' => { 'code' => -32_020, 'message' => 'Mcp-Param-Zone missing' }) }
+        end
+      end
+      client = MCPClient::Client.new(
+        mcp_server_configs: [MCPClient.streamable_http_config(base_url: base_url, endpoint: endpoint, retries: 0)],
+        validate_structured_content: :strict
+      )
+
+      expect { client.call_tool('wipe', { 'region' => 'eu' }) }.to raise_error(MCPClient::Errors::ValidationError)
+      readable_again = true
+      expect(client.call_tool('wipe', { 'region' => 'us' }))
+        .to eq({ 'resultType' => 'complete', 'content' => [], 'structuredContent' => {} })
+      expect(headers).to eq([{ 'Mcp-Param-Region' => 'eu' }, { 'Mcp-Param-Zone' => 'us' }])
+      expect(lists).to be >= 3
+      client.cleanup
+    end
+
+    # Two calls of one tool recovering at once each retry under the
+    # definition their own refresh read: a pin shared between them would
+    # send both retries under one of the two.
+    it 'pins each overlapping retry to the definition its own refresh read' do
+      retries = Queue.new
+      rejections = Queue.new
+      refreshes = 0
+      lock = Mutex.new
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'server/discover'
+          json_response(body['id'], { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+                                      'capabilities' => { 'tools' => {} } })
+        when 'tools/list'
+          n = lock.synchronize { refreshes += 1 }
+          json_response(body['id'], listing(n == 1 ? 'Region' : "H#{n}"))
+        when 'tools/call'
+          mirrored = request.headers.select { |k, _| k.start_with?('Mcp-Param-') }
+          if mirrored.key?('Mcp-Param-Region')
+            rejections << body['id']
+            deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 1
+            sleep 0.01 while rejections.size < 2 && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+            { status: 400, headers: json,
+              body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'],
+                                  'error' => { 'code' => -32_020, 'message' => 'header missing' }) }
+          else
+            retries << mirrored
+            json_response(body['id'], { 'resultType' => 'complete', 'content' => [], 'structuredContent' => {} })
+          end
+        end
+      end
+      client = MCPClient::Client.new(
+        mcp_server_configs: [MCPClient.streamable_http_config(base_url: base_url, endpoint: endpoint, retries: 0)]
+      )
+      client.list_tools
+
+      threads = %w[a b].map { |region| Thread.new { client.call_tool('wipe', { 'region' => region }) } }
+      expect(threads.map(&:value))
+        .to all(eq({ 'resultType' => 'complete', 'content' => [], 'structuredContent' => {} }))
+      sent = Array.new(2) { retries.pop }
+      expect(sent.map(&:keys).flatten.uniq.size).to eq(2)
+      expect(sent.map(&:values).flatten).to contain_exactly('a', 'b')
+      client.cleanup
+    end
+  end
+
+  describe 'validations overlapping with opposite verdicts' do
+    it 'keeps each to its own schema, including a resource-local $ref that resolves differently' do
+      accepting = { '$ref' => '#/$defs/x', '$defs' => { 'x' => { 'type' => 'integer' } } }
+      rejecting = { '$ref' => '#/$defs/x', '$defs' => { 'x' => { 'type' => 'string' } } }
+      open_tuple = { 'prefixItems' => [{ 'type' => 'integer' }], 'items' => true }
+      closed_tuple = { 'prefixItems' => [{ 'type' => 'integer' }], 'items' => false }
+      barrier = Queue.new
+      threads = Array.new(8) do |i|
+        Thread.new do
+          barrier.pop
+          Array.new(25) do
+            case i % 4
+            when 0 then [:empty, validator.validate(1, accepting)]
+            when 1 then [:error, validator.validate(1, rejecting)]
+            when 2 then [:empty, validator.validate([1, 2], open_tuple)]
+            else [:error, validator.validate([1, 2], closed_tuple)]
+            end
+          end
+        end
+      end
+      8.times { barrier << true }
+      threads.each do |thread|
+        thread.value.each do |expectation, answer|
+          expectation == :empty ? expect(answer).to(be_empty) : expect(answer).not_to(be_empty)
+        end
+      end
+    end
+  end
+
+  describe 'a session negotiated to 2025-11-25' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:schema) { { 'type' => 'object', 'properties' => { 'n' => { 'type' => 'integer' } } } }
+
+    def legacy_server(*chunks)
+      srv = instance_double(MCPClient::ServerStdio, name: 's', modern?: false)
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
+                                 output_schema: schema, server: srv)
+      allow(srv).to receive(:on_notification)
+      allow(srv).to receive(:list_tools).and_return([tool])
+      allow(srv).to receive(:call_tool_streaming) { |*| Enumerator.new { |y| chunks.each { |c| y << c } } }
+      srv
+    end
+
+    def client_over(srv, mode)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(srv)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger,
+                            validate_structured_content: mode)
+    end
+
+    it 'validates an object structuredContent a streamed legacy result carries' do
+      legacy = { 'content' => [], 'structuredContent' => { 'n' => 'x' } }
+      expect { client_over(legacy_server(legacy), :strict).call_tool_streaming('t', {}).to_a }
+        .to raise_error(MCPClient::Errors::ValidationError, /does not match its output schema/)
+    end
+
+    it 'treats a non-object structuredContent as absent on the streaming path, as 2025-11-25 types it' do
+      legacy = { 'content' => [], 'structuredContent' => [1] }
+      client = client_over(legacy_server(legacy), :warn)
+      expect(client.call_tool_streaming('t', {}).to_a).to eq([legacy])
+      expect(log_output.string).to include('carries no structuredContent')
+    end
+  end
+
+  describe 'the public task API' do
+    let(:stdio) { MCPClient::ServerStdio.new(command: 'echo test', read_timeout: 1, name: 'a') }
+    let(:tasks_ext) { MCPClient::JsonRpcCommon::TASKS_EXTENSION }
+    let(:strict_schema) do
+      { 'type' => 'object', 'required' => ['n'], 'properties' => { 'n' => { 'type' => 'integer' } } }
+    end
+
+    def tool_with(output_schema)
+      MCPClient::Tool.new(name: 'sync', description: 'd', schema: { 'type' => 'object' },
+                          output_schema: output_schema, server: stdio)
+    end
+
+    def create_result
+      now = Time.now.utc.iso8601(3)
+      { 'resultType' => 'task', 'taskId' => 'task-1', 'status' => 'working', 'createdAt' => now,
+        'lastUpdatedAt' => now, 'ttlMs' => nil, 'pollIntervalMs' => 1 }
+    end
+
+    def completed(result)
+      now = Time.now.utc.iso8601(3)
+      { 'resultType' => 'complete', 'taskId' => 'task-1', 'status' => 'completed', 'createdAt' => now,
+        'lastUpdatedAt' => now, 'ttlMs' => nil, 'pollIntervalMs' => 1, 'result' => result }
+    end
+
+    def client_for(tool, delivered:)
+      allow(stdio).to receive_messages(modern?: true, ping: true,
+                                       capabilities: { 'tools' => {}, 'extensions' => { tasks_ext => {} } })
+      allow(stdio).to receive(:ensure_session_ready)
+      stdio.singleton_class.include(MCPClient::CalledToolDefinition)
+      allow(stdio).to receive(:list_tools).and_return([tool])
+      allow(stdio).to receive(:call_tool) do
+        stdio.send(:note_called_tool_definition, 'sync', tool)
+        create_result
+      end
+      allow(stdio).to receive(:rpc_request) do |method, *_args, **_opts|
+        raise "unexpected #{method}" unless method == 'tasks/get'
+
+        completed(delivered)
+      end
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(stdio)
+      client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'x', name: 'a' }],
+                                     extensions: [tasks_ext], validate_structured_content: :strict)
+      allow(client).to receive(:sleep)
+      client
+    end
+
+    it 'refuses to create a task under an output dialect it cannot read, before anything is sent' do
+      unreadable = tool_with({ '$schema' => 'urn:unknown', 'type' => 'object' })
+      client = client_for(unreadable, delivered: {})
+
+      expect { client.call_tool_as_task('sync', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown.*not supported/m)
+      expect(stdio).not_to have_received(:call_tool)
+    end
+
+    it 'refuses a delivered result a closed composition rejects' do
+      closed = { '$ref' => '#/$defs/b', 'unevaluatedProperties' => false,
+                 '$defs' => { 'b' => { 'type' => 'object', 'properties' => { 'n' => { 'type' => 'integer' } } } } }
+      leak = { 'content' => [], 'structuredContent' => { 'n' => 1, 'secret' => 'x' } }
+      client = client_for(tool_with(closed), delivered: leak)
+      handle = client.call_tool_as_task('sync', {})
+
+      expect { client.get_task_result(handle) }
+        .to raise_error(MCPClient::Errors::ValidationError, /'secret' is not allowed/)
+    end
+
+    it 'validates the delivered result against the definition the task was created under' do
+      client = client_for(tool_with(strict_schema), delivered: { 'content' => [], 'structuredContent' => { 'n' => 1 } })
+      handle = client.call_tool_as_task('sync', {})
+      # The definition changes while the task runs: what the server refreshed
+      # to would reject the result the creating call was promised.
+      refreshed = tool_with({ 'type' => 'object', 'required' => ['m'] })
+      allow(stdio).to receive(:list_tools).and_return([refreshed])
+      client.send(:clear_tool_cache)
+
+      expect(client.get_task_result(handle)).to eq({ 'content' => [], 'structuredContent' => { 'n' => 1 } })
+    end
   end
 end

--- a/spec/lib/mcp_client/json_schema_2026_round33_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round33_spec.rb
@@ -70,16 +70,20 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema dynamic references, branchless if, ca
   end
 
   describe 'a dynamic anchor several non-root resources declare' do
-    let(:ambiguous) do
+    let(:elsewhere) do
       { '$ref' => 'https://example.com/a',
         '$defs' => { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node', 'type' => 'object',
                               'properties' => { 'child' => { '$dynamicRef' => '#node' } } },
                      'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node', 'type' => 'string' } } }
     end
 
-    it 'is the one dynamic reference still reported as not evaluated' do
-      expect(validator.unsupported_keywords(ambiguous)).to contain_exactly('$dynamicRef')
-      expect(validator.validate({ 'child' => 1 }, { 'not' => ambiguous })).to be_empty
+    # The dynamic scope holds the resources the evaluation entered, and `b`
+    # is not one of them: it declares nothing for this reference, so the
+    # binding is decided and the verdict is whole (see round 34).
+    it 'is evaluated against the resources the instance entered' do
+      expect(validator.unsupported_keywords(elsewhere)).to be_empty
+      expect(validator.validate({ 'child' => 1 }, elsewhere)).not_to be_empty
+      expect(validator.validate({ 'child' => 1 }, { 'not' => elsewhere })).to be_empty
     end
   end
 
@@ -179,11 +183,11 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema dynamic references, branchless if, ca
       { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result), headers: json }
     end
 
-    def listing(header, output_dialect: nil)
+    def listing(header, output_dialect: nil, ttl: 0)
       input = { 'type' => 'object', 'properties' => { 'region' => { 'type' => 'string', 'x-mcp-header' => header } } }
       output = { 'type' => 'object' }
       output = { '$schema' => output_dialect }.merge(output) if output_dialect
-      { 'tools' => [{ 'name' => 'wipe', 'inputSchema' => input, 'outputSchema' => output }], 'ttlMs' => 0 }
+      { 'tools' => [{ 'name' => 'wipe', 'inputSchema' => input, 'outputSchema' => output }], 'ttlMs' => ttl }
     end
 
     # The refreshed definition is checked before the retry goes out, on both
@@ -267,13 +271,18 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema dynamic references, branchless if, ca
       client.cleanup
     end
 
-    # Two calls of one tool recovering at once each retry under the
-    # definition their own refresh read: a pin shared between them would
-    # send both retries under one of the two.
-    it 'pins each overlapping retry to the definition its own refresh read' do
+    # Two calls of one tool recovering at once: both first attempts really are
+    # rejected and both really are re-sent, each under the header its own
+    # refresh read. NOTE: `take_pinned_retry_definition` answers nil on this
+    # path, so what keeps the two apart here is the per-call definition
+    # lookup, not the retry pin — the pin itself is still unpinned by any
+    # example, which is worth closing.
+    it 'sends each overlapping retry under the definition its own refresh read' do
       retries = Queue.new
       rejections = Queue.new
+      refreshed = Queue.new
       refreshes = 0
+      calls = []
       lock = Mutex.new
       stub_request(:post, url).to_return do |request|
         body = JSON.parse(request.body)
@@ -282,10 +291,27 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema dynamic references, branchless if, ca
           json_response(body['id'], { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
                                       'capabilities' => { 'tools' => {} } })
         when 'tools/list'
+          # Every list before both calls have been rejected still annotates
+          # `region` with Region, so both first attempts really do go out
+          # under it and really are rejected; each refresh that follows
+          # brings a header of its own, which is what the two retries must
+          # not share.
           n = lock.synchronize { refreshes += 1 }
-          json_response(body['id'], listing(n == 1 ? 'Region' : "H#{n}"))
+          next json_response(body['id'], listing('Region')) if rejections.size < 2
+
+          # Neither refreshed list is handed back until both have been
+          # produced, so the list the transport caches is the later one for
+          # both callers: only the definition each retry pinned for itself
+          # can still tell the two apart.
+          refreshed << n
+          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 1
+          sleep 0.01 while refreshed.size < 2 && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+          # Cacheable, so the retry that reads the transport's list rather
+          # than the definition it pinned for itself finds the other's.
+          json_response(body['id'], listing("H#{n}", ttl: 60_000))
         when 'tools/call'
           mirrored = request.headers.select { |k, _| k.start_with?('Mcp-Param-') }
+          lock.synchronize { calls << body['id'] }
           if mirrored.key?('Mcp-Param-Region')
             rejections << body['id']
             deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 1
@@ -310,6 +336,11 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema dynamic references, branchless if, ca
       sent = Array.new(2) { retries.pop }
       expect(sent.map(&:keys).flatten.uniq.size).to eq(2)
       expect(sent.map(&:values).flatten).to contain_exactly('a', 'b')
+      # Both calls were rejected once and re-sent once, each under a request
+      # id of its own: four requests, no id reused.
+      expect(rejections.size).to eq(2)
+      expect(calls.size).to eq(4)
+      expect(calls.uniq.size).to eq(4)
       client.cleanup
     end
   end

--- a/spec/lib/mcp_client/json_schema_2026_round33_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round33_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 JSON Schema handling, thirty-third round.
+#
+# A dynamic reference resolves to the outermost dynamic scope that declares
+# its anchor (JSON Schema 2020-12 Core Section 8.2.3.2; 2019-09 Section
+# 8.2.4.2.2 for `$recursiveRef`). The dynamic scope always starts at the
+# schema being applied, so where that root resource declares the anchor —
+# the recursive-tree shape the specification illustrates the keyword with —
+# the reference re-binds to the root wherever it is met; and where exactly
+# one resource declares it, it is the target the reference named. Only a
+# document in which several non-root resources declare the same dynamic
+# anchor needs the evaluation path to choose, and stays out of reach. A
+# branchless `if` still produces annotations (Section 10.2.2.1), and a
+# generated capture-group name never collides with one the pattern wrote.
+RSpec.describe 'MCP 2026-07-28 JSON Schema dynamic references, branchless if, captures (round 33)' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft2019) { MCPClient::SchemaValidator::DRAFT_2019_09 }
+
+  def valid?(data, schema)
+    errors = validator.validate(data, schema)
+    expect(errors).not_to include(a_string_matching(/aborted|not supported/)), errors.inspect
+    errors.empty?
+  end
+
+  def expect_verdicts(schema, valid:, invalid:)
+    valid.each { |data| expect(valid?(data, schema)).to be(true), "expected #{data.inspect} to conform" }
+    invalid.each { |data| expect(valid?(data, schema)).to be(false), "expected #{data.inspect} to be rejected" }
+  end
+
+  describe 'a $dynamicRef whose anchor the root resource declares' do
+    it 'binds to the root: the recursive node shape' do
+      schema = { '$dynamicAnchor' => 'node', 'type' => 'object',
+                 'properties' => { 'child' => { '$dynamicRef' => '#node' } } }
+      expect(validator.unsupported_keywords(schema)).to be_empty
+      expect_verdicts(schema, valid: [{ 'child' => {} }, { 'child' => { 'child' => {} } }],
+                              invalid: [{ 'child' => 1 }, { 'child' => { 'child' => 'x' } }])
+    end
+
+    it 'binds to the anchor a definition of the root resource declares' do
+      schema = { '$dynamicRef' => '#node', '$defs' => { 'n' => { '$dynamicAnchor' => 'node', 'type' => 'integer' } } }
+      expect(validator.unsupported_keywords(schema)).to be_empty
+      expect_verdicts(schema, valid: [1], invalid: ['bad'])
+    end
+
+    it 're-binds a reference met inside another resource to the root, so the strict tree stays closed' do
+      tree = { '$id' => 'https://example.com/tree', '$dynamicAnchor' => 'node', 'type' => 'object',
+               'properties' => { 'data' => true,
+                                 'children' => { 'type' => 'array', 'items' => { '$dynamicRef' => '#node' } } } }
+      strict = { '$id' => 'https://example.com/strict-tree', '$dynamicAnchor' => 'node',
+                 '$ref' => 'tree', 'unevaluatedProperties' => false, '$defs' => { 'tree' => tree } }
+      expect(validator.unsupported_keywords(strict)).to be_empty
+      expect_verdicts(strict,
+                      valid: [{ 'data' => 1, 'children' => [{ 'data' => 2 }] }],
+                      invalid: [{ 'data' => 1, 'children' => [{ 'data' => 2, 'extra' => 3 }] },
+                                { 'data' => 1, 'extra' => 3 }])
+      # The tree alone is open: nothing re-binds the reference to a closed root.
+      expect_verdicts(tree, valid: [{ 'data' => 1, 'children' => [{ 'data' => 2, 'extra' => 3 }] }], invalid: [])
+    end
+
+    it 'applies a 2019-09 $recursiveRef to a root whose $recursiveAnchor is true' do
+      schema = { '$schema' => draft2019, '$recursiveAnchor' => true, 'type' => 'object',
+                 'properties' => { 'child' => { '$recursiveRef' => '#' } } }
+      expect(validator.unsupported_keywords(schema)).to be_empty
+      expect_verdicts(schema, valid: [{ 'child' => {} }], invalid: [{ 'child' => 1 }])
+    end
+  end
+
+  describe 'a dynamic anchor several non-root resources declare' do
+    let(:ambiguous) do
+      { '$ref' => 'https://example.com/a',
+        '$defs' => { 'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node', 'type' => 'object',
+                              'properties' => { 'child' => { '$dynamicRef' => '#node' } } },
+                     'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node', 'type' => 'string' } } }
+    end
+
+    it 'is the one dynamic reference still reported as not evaluated' do
+      expect(validator.unsupported_keywords(ambiguous)).to contain_exactly('$dynamicRef')
+      expect(validator.validate({ 'child' => 1 }, { 'not' => ambiguous })).to be_empty
+    end
+  end
+
+  describe 'a branchless if' do
+    it 'still contributes the annotations of a condition that passed' do
+      expect_verdicts({ 'if' => { 'properties' => { 'foo' => true } }, 'unevaluatedProperties' => false },
+                      valid: [{ 'foo' => 1 }, {}], invalid: [{ 'bar' => 1 }, { 'foo' => 1, 'bar' => 2 }])
+      expect_verdicts({ 'if' => { 'prefixItems' => [true] }, 'unevaluatedItems' => false },
+                      valid: [[1], []], invalid: [[1, 2]])
+    end
+
+    it 'contributes nothing when the condition failed' do
+      expect_verdicts({ 'if' => { 'properties' => { 'foo' => { 'type' => 'string' } } },
+                        'unevaluatedProperties' => false },
+                      valid: [{ 'foo' => 'a' }], invalid: [{ 'foo' => 1 }])
+    end
+
+    it 'keeps the verdict when the whole thing sits under not' do
+      schema = { 'not' => { 'if' => { 'properties' => { 'foo' => true } }, 'unevaluatedProperties' => false } }
+      expect_verdicts(schema, valid: [{ 'bar' => 1 }], invalid: [{ 'foo' => 1 }])
+    end
+  end
+
+  describe 'a pattern whose own group name looks generated' do
+    it 'numbers the unnamed group without colliding with the written name' do
+      schema = { 'type' => 'string', 'pattern' => '^(a)(?<__mcp_g1>b)\\1$' }
+      expect_verdicts(schema, valid: ['aba'], invalid: %w[abb ab])
+    end
+
+    it 'decides patternProperties by the right match' do
+      schema = { 'patternProperties' => { '^(a)(?<__mcp_g1>b)\\1$' => { 'type' => 'integer' } } }
+      expect_verdicts(schema, valid: [{ 'abb' => 'x' }, { 'aba' => 1 }], invalid: [{ 'aba' => 'x' }])
+    end
+  end
+
+  describe 'the client' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:complete) { { 'resultType' => 'complete', 'content' => [], 'structuredContent' => { 'n' => 1 } } }
+
+    def stub_server(output_schema:, answer: complete)
+      srv = instance_double(MCPClient::ServerBase, name: 's')
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
+                                 output_schema: output_schema, server: srv)
+      allow(srv).to receive(:on_notification)
+      allow(srv).to receive(:list_tools).and_return([tool])
+      allow(srv).to receive(:call_tool).and_return(answer)
+      srv
+    end
+
+    def client_over(srv, mode = :strict)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(srv)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger,
+                            validate_structured_content: mode)
+    end
+
+    it 'accepts, in :strict mode, a result under a schema whose dynamic anchor the root declares' do
+      schema = { '$dynamicAnchor' => 'node', 'type' => 'object',
+                 'properties' => { 'child' => { '$dynamicRef' => '#node' } } }
+      good = complete.merge('structuredContent' => { 'child' => { 'child' => {} } })
+      bad = complete.merge('structuredContent' => { 'child' => 1 })
+
+      expect(client_over(stub_server(output_schema: schema, answer: good)).call_tool('t', {})).to eq(good)
+      expect { client_over(stub_server(output_schema: schema, answer: bad)).call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /does not match its output schema/)
+      expect(log_output.string).not_to include('validation is partial')
+    end
+
+    # An error result may omit structuredContent; one that carries it is
+    # still bound by the output schema (the tools specification exempts
+    # nothing about error results), so :strict checks what is there.
+    it 'validates the structuredContent an error result carries, in :strict mode' do
+      schema = { 'type' => 'object', 'properties' => { 'n' => { 'type' => 'integer' } } }
+      wrong = { 'resultType' => 'complete', 'content' => [], 'isError' => true, 'structuredContent' => { 'n' => 'x' } }
+      bare = { 'resultType' => 'complete', 'content' => [{ 'type' => 'text', 'text' => 'boom' }], 'isError' => true }
+
+      expect { client_over(stub_server(output_schema: schema, answer: wrong)).call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /does not match its output schema/)
+      expect(client_over(stub_server(output_schema: schema, answer: bare)).call_tool('t', {})).to eq(bare)
+    end
+
+    it 'refuses every structured result under an outputSchema of false, in :strict mode' do
+      expect { client_over(stub_server(output_schema: false)).call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /does not match its output schema/)
+      expect(client_over(stub_server(output_schema: false), :warn).call_tool('t', {})).to eq(complete)
+      expect(log_output.string).to include('does not match its output schema')
+    end
+  end
+
+  describe 'the HeaderMismatch retry on Streamable HTTP' do
+    let(:base_url) { 'https://example.com' }
+    let(:endpoint) { '/mcp' }
+    let(:url) { "#{base_url}#{endpoint}" }
+    let(:json) { { 'Content-Type' => 'application/json' } }
+
+    def json_response(id, result)
+      { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result), headers: json }
+    end
+
+    def listing(header, output_dialect: nil)
+      input = { 'type' => 'object', 'properties' => { 'region' => { 'type' => 'string', 'x-mcp-header' => header } } }
+      output = { 'type' => 'object' }
+      output = { '$schema' => output_dialect }.merge(output) if output_dialect
+      { 'tools' => [{ 'name' => 'wipe', 'inputSchema' => input, 'outputSchema' => output }], 'ttlMs' => 0 }
+    end
+
+    # The refreshed definition is checked before the retry goes out, on both
+    # of its schemas: a tool run under an output dialect nothing here can
+    # read would only be refused after it ran.
+    it 'is not sent under a refreshed output dialect this client cannot read' do
+      calls = 0
+      rejected = false
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'server/discover'
+          json_response(body['id'], { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+                                      'capabilities' => { 'tools' => {} } })
+        when 'tools/list'
+          json_response(body['id'], listing('Region', output_dialect: rejected ? 'urn:unknown-dialect' : nil))
+        when 'tools/call'
+          calls += 1
+          rejected = true
+          { status: 400, headers: json,
+            body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'],
+                                'error' => { 'code' => -32_020, 'message' => 'Mcp-Param-Region missing' }) }
+        end
+      end
+      client = MCPClient::Client.new(
+        mcp_server_configs: [MCPClient.streamable_http_config(base_url: base_url, endpoint: endpoint, retries: 0)],
+        validate_structured_content: :strict
+      )
+
+      expect { client.call_tool('wipe', { 'region' => 'eu' }) }
+        .to raise_error(MCPClient::Errors::ValidationError, /output schema.*urn:unknown-dialect.*not supported/m)
+      expect(calls).to eq(1)
+      client.cleanup
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round34_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round34_spec.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 JSON Schema handling, thirty-fourth round.
+#
+# A dynamic reference binds to the outermost schema resource in the *dynamic
+# scope* — the resources evaluation actually entered on the way to it (JSON
+# Schema 2020-12 Core Section 8.2.3.2; 2019-09 Section 8.2.4.2.2 for
+# `$recursiveRef`). A resource the instance never enters declares nothing
+# for it, so a duplicate anchor elsewhere in the document decides nothing.
+# `contains` produces the item annotations `unevaluatedItems` reads in
+# 2020-12 and not in 2019-09, and a pattern whose ECMA-262 meaning Ruby's
+# engine cannot be made to reproduce is refused rather than answered wrongly.
+RSpec.describe 'MCP 2026-07-28 JSON Schema dynamic scope, contains annotations, patterns (round 34)' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft2019) { MCPClient::SchemaValidator::DRAFT_2019_09 }
+
+  def valid?(data, schema)
+    errors = validator.validate(data, schema)
+    expect(errors).not_to include(a_string_matching(/aborted|not supported/)), errors.inspect
+    errors.empty?
+  end
+
+  def expect_verdicts(schema, valid:, invalid:)
+    valid.each { |data| expect(valid?(data, schema)).to be(true), "expected #{data.inspect} to conform" }
+    invalid.each { |data| expect(valid?(data, schema)).to be(false), "expected #{data.inspect} to be rejected" }
+  end
+
+  describe 'the dynamic scope is the resources evaluation entered' do
+    # Two resources declare `node`; only `a` is ever entered, so the
+    # reference inside it binds to `a` and nothing about `b` reaches the
+    # verdict. Deciding this statically ("several non-root declarations, so
+    # the path would have to choose") left the reference unevaluated and the
+    # instance wrongly accepted.
+    let(:unused_duplicate) do
+      { '$ref' => 'https://example.com/a',
+        '$defs' => {
+          'a' => { '$id' => 'https://example.com/a', '$dynamicAnchor' => 'node', 'type' => 'object',
+                   'properties' => { 'child' => { '$dynamicRef' => '#node' } } },
+          'b' => { '$id' => 'https://example.com/b', '$dynamicAnchor' => 'node', 'type' => 'string' }
+        } }
+    end
+
+    it 'ignores a duplicate anchor in a resource the instance never enters' do
+      expect_verdicts(unused_duplicate,
+                      valid: [{ 'child' => {} }, { 'child' => { 'child' => {} } }],
+                      invalid: [{ 'child' => 1 }, { 'child' => { 'child' => 'x' } }])
+    end
+
+    it 'inverts that verdict under not, rather than accepting both sides' do
+      expect_verdicts({ 'not' => unused_duplicate },
+                      valid: [{ 'child' => 1 }],
+                      invalid: [{ 'child' => {} }])
+    end
+
+    it 'reports no unsupported keyword for it, so :strict can gate on the verdict' do
+      expect(validator.unsupported_keywords(unused_duplicate)).to be_empty
+    end
+
+    # The specification's own illustration: the outer resource overrides the
+    # anchor the inner one declares, so the reference inside the inner
+    # resource re-binds outward to whichever resource the evaluation began at.
+    let(:tree) do
+      { '$id' => 'https://example.com/tree', '$dynamicAnchor' => 'node',
+        'type' => 'object',
+        'properties' => { 'data' => true,
+                          'children' => { 'type' => 'array', 'items' => { '$dynamicRef' => '#node' } } } }
+    end
+
+    def strict_tree(tree)
+      { '$id' => 'https://example.com/strict-tree', '$dynamicAnchor' => 'node',
+        '$ref' => 'https://example.com/tree', 'unevaluatedProperties' => false,
+        '$defs' => { 'tree' => tree } }
+    end
+
+    it 'binds a reference met inside an entered resource to the outermost declaration' do
+      expect_verdicts(strict_tree(tree),
+                      valid: [{ 'data' => 1 }, { 'data' => 1, 'children' => [{ 'data' => 2 }] }],
+                      invalid: [{ 'data' => 1, 'extra' => 2 },
+                                { 'data' => 1, 'children' => [{ 'data' => 2, 'extra' => 3 }] }])
+    end
+
+    it 'binds to the entered resource itself when nothing outer declares the anchor' do
+      expect_verdicts({ '$id' => 'https://example.com/plain', '$ref' => 'https://example.com/tree',
+                        '$defs' => { 'tree' => tree } },
+                      valid: [{ 'data' => 1, 'extra' => 2 },
+                              { 'children' => [{ 'data' => 2, 'extra' => 3 }] }],
+                      invalid: [{ 'children' => [1] }])
+    end
+
+    # 2019-09 spells the same rule with `$recursiveRef`/`$recursiveAnchor`.
+    it 'follows the 2019-09 recursive reference outward the same way' do
+      inner = { '$id' => 'https://example.com/r-tree', '$recursiveAnchor' => true,
+                'type' => 'object',
+                'properties' => { 'data' => true,
+                                  'children' => { 'type' => 'array',
+                                                  'items' => { '$recursiveRef' => '#' } } } }
+      strict = { '$schema' => draft2019, '$id' => 'https://example.com/r-strict',
+                 '$recursiveAnchor' => true, '$ref' => 'https://example.com/r-tree',
+                 'unevaluatedProperties' => false, '$defs' => { 'tree' => inner } }
+      expect(validator.unsupported_keywords(strict)).to be_empty
+      expect_verdicts(strict,
+                      valid: [{ 'data' => 1, 'children' => [{ 'data' => 2 }] }],
+                      invalid: [{ 'data' => 1, 'children' => [{ 'data' => 2, 'extra' => 3 }] }])
+    end
+
+    it 'refuses a dynamic reference whose anchor no entered resource declares' do
+      schema = { '$dynamicRef' => '#nowhere', 'type' => 'object' }
+      expect(validator.validate({}, schema)).to include(a_string_matching(/\$dynamicRef/))
+    end
+  end
+
+  describe 'contains annotations belong to 2020-12' do
+    let(:schema) { { 'contains' => { 'type' => 'integer' }, 'unevaluatedItems' => false } }
+
+    it 'lets a matched item satisfy unevaluatedItems under 2020-12' do
+      expect_verdicts(schema, valid: [[1]], invalid: [%w[a]])
+    end
+
+    # 2019-09 Core Section 9.3.1.3: unevaluatedItems reads the annotations of
+    # items/additionalItems only, so a `contains` match leaves the item
+    # unevaluated and `false` refuses it. `items` still annotates there, so
+    # the same array passes once something evaluates it.
+    it 'does not, under 2019-09' do
+      expect_verdicts(schema.merge('$schema' => draft2019), valid: [], invalid: [[1], %w[a]])
+      expect_verdicts(schema.merge('$schema' => draft2019, 'items' => true), valid: [[1]], invalid: [%w[a]])
+    end
+
+    # The dialect belongs to the resource root, so it is declared there and
+    # the composed branch is read under it.
+    it 'inverts under not, so the dialect decides both directions' do
+      expect(valid?([1], { 'not' => schema })).to be(false)
+      expect(valid?([1], { '$schema' => draft2019, 'not' => schema })).to be(true)
+    end
+  end
+
+  describe 'patterns whose ECMA-262 meaning Ruby cannot reproduce' do
+    # ECMAScript clears the captures inside a quantified group at the start of
+    # every iteration, Ruby keeps the last one that participated: "aba" is
+    # valid there and "abab" is not, and Ruby's engine says the opposite of
+    # both. A wrong verdict in either direction is worse than no verdict.
+    let(:reset_pattern) { { 'pattern' => '^(a|(b))*\2$' } }
+
+    it 'refuses the schema instead of answering either way' do
+      %w[aba abab].each do |data|
+        errors = validator.validate(data, reset_pattern)
+        expect(errors).to include(a_string_matching(/cannot be evaluated faithfully/)), errors.inspect
+      end
+    end
+
+    it 'never reports it as no ECMA-262 regular expression' do
+      expect(validator.validate('aba', reset_pattern))
+        .not_to include(a_string_matching(/is not an ECMA-262 regular expression/))
+    end
+
+    # ES2018 lookbehind is variable-length; Ruby's is not. The pattern is a
+    # perfectly good ECMA-262 expression, so saying it is not one was wrong.
+    it 'says the same of a variable-length lookbehind' do
+      errors = validator.validate('aab', { 'pattern' => '(?<=a+)b' })
+      expect(errors).to include(a_string_matching(/cannot be evaluated faithfully/))
+      expect(errors).not_to include(a_string_matching(/is not an ECMA-262 regular expression/))
+    end
+
+    it 'still refuses an expression that is no regular expression at all' do
+      expect(validator.validate('x', { 'pattern' => '(' }))
+        .to include(a_string_matching(/is not an ECMA-262 regular expression/))
+    end
+
+    it 'keeps evaluating a back-reference to a group no quantifier repeats' do
+      expect_verdicts({ 'pattern' => '^(a)(?<b>x)?\1$' }, valid: %w[aa], invalid: %w[ab])
+    end
+
+    it 'reads an astral escape written as a surrogate pair' do
+      expect_verdicts({ 'pattern' => '\\uD83D\\uDE00' }, valid: ["\u{1F600}!"], invalid: %w[x])
+    end
+  end
+
+  # The definition a call goes out under is the one header extraction reads,
+  # and that read may bring a newer list than the client preflighted. A tool
+  # whose refreshed schema declares a dialect nothing here can read must be
+  # refused before it runs, not after — the retry path already was.
+  describe 'a definition replaced between the preflight and the initial send' do
+    let(:base_url) { 'https://example.com' }
+    let(:endpoint) { '/mcp' }
+    let(:url) { "#{base_url}#{endpoint}" }
+    let(:json) { { 'Content-Type' => 'application/json' } }
+
+    def json_response(id, result)
+      { status: 200, body: JSON.generate('jsonrpc' => '2.0', 'id' => id, 'result' => result), headers: json }
+    end
+
+    def listing(dialect_side)
+      input = { 'type' => 'object', 'properties' => { 'region' => { 'type' => 'string', 'x-mcp-header' => 'Region' } } }
+      output = { 'type' => 'object' }
+      input = { '$schema' => 'urn:unknown-dialect' }.merge(input) if dialect_side == 'input'
+      output = { '$schema' => 'urn:unknown-dialect' }.merge(output) if dialect_side == 'output'
+      { 'tools' => [{ 'name' => 'wipe', 'inputSchema' => input, 'outputSchema' => output }], 'ttlMs' => 0 }
+    end
+
+    %w[input output].each do |side|
+      it "refuses the call before it runs when the refreshed #{side} dialect cannot be read" do
+        lists = 0
+        calls = 0
+        stub_request(:post, url).to_return do |request|
+          body = JSON.parse(request.body)
+          case body['method']
+          when 'server/discover'
+            json_response(body['id'], { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+                                        'capabilities' => { 'tools' => {} } })
+          when 'tools/list'
+            # The zero-TTL list is read three times before the call goes out:
+            # by list_tools, by the client's own preflight, and by the header
+            # extraction that decides what the request carries. Only the last
+            # one brings the unreadable dialect, so the preflight passes and
+            # the transport is the only thing left to catch it.
+            lists += 1
+            json_response(body['id'], listing(lists >= 3 ? side : nil))
+          when 'tools/call'
+            calls += 1
+            json_response(body['id'], { 'resultType' => 'complete', 'content' => [], 'structuredContent' => {} })
+          end
+        end
+        client = MCPClient::Client.new(
+          mcp_server_configs: [MCPClient.streamable_http_config(base_url: base_url, endpoint: endpoint, retries: 0)]
+        )
+        client.list_tools
+
+        expect { client.call_tool('wipe', { 'region' => 'eu' }) }
+          .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown-dialect/)
+        expect(calls).to eq(0)
+        expect(lists).to be >= 3
+        client.cleanup
+      end
+    end
+
+    it 'still sends the call when the refreshed definition stays readable' do
+      lists = 0
+      headers = []
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        case body['method']
+        when 'server/discover'
+          json_response(body['id'], { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+                                      'capabilities' => { 'tools' => {} } })
+        when 'tools/list'
+          lists += 1
+          json_response(body['id'], listing(nil))
+        when 'tools/call'
+          headers << request.headers.select { |k, _| k.start_with?('Mcp-Param-') }
+          json_response(body['id'], { 'resultType' => 'complete', 'content' => [], 'structuredContent' => {} })
+        end
+      end
+      client = MCPClient::Client.new(
+        mcp_server_configs: [MCPClient.streamable_http_config(base_url: base_url, endpoint: endpoint, retries: 0)]
+      )
+      client.list_tools
+
+      expect(client.call_tool('wipe', { 'region' => 'eu' }))
+        .to eq({ 'resultType' => 'complete', 'content' => [], 'structuredContent' => {} })
+      expect(headers).to eq([{ 'Mcp-Param-Region' => 'eu' }])
+      client.cleanup
+    end
+  end
+
+  # MCP 2025-11-25 types structuredContent as an object, so anything else was
+  # no structured content at all on a session negotiated to that revision. An
+  # error result is allowed to carry none — dropping the non-object must
+  # leave it an error result, not turn it into a successful one missing its
+  # output.
+  describe 'an error result carrying a non-object structuredContent on a legacy session' do
+    let(:logger) { instance_double(Logger, warn: nil, info: nil, debug: nil, error: nil, :level= => nil) }
+    let(:server) { instance_double(MCPClient::ServerStdio, modern?: false, name: 'legacy') }
+    let(:tool) do
+      MCPClient::Tool.new(name: 'run', description: 'd', schema: { 'type' => 'object' }, server: server,
+                          output_schema: { 'type' => 'object' })
+    end
+
+    def client_with(mode)
+      client = MCPClient::Client.new(mcp_server_configs: [])
+      client.instance_variable_set(:@logger, logger)
+      client.instance_variable_set(:@validate_structured_content, mode)
+      client
+    end
+
+    [nil, 'text', 1, true, []].each do |content|
+      it "returns it unchanged in :strict when structuredContent is #{content.inspect}" do
+        result = { 'isError' => true, 'content' => [], 'structuredContent' => content }
+
+        expect(client_with(:strict).send(:validate_structured_content!, tool, result)).to eq(result)
+        expect(logger).not_to have_received(:warn).with(/carries no structuredContent/)
+      end
+    end
+
+    it 'still refuses a successful result whose structuredContent is not an object' do
+      result = { 'content' => [], 'structuredContent' => 'text' }
+
+      expect { client_with(:strict).send(:validate_structured_content!, tool, result) }
+        .to raise_error(MCPClient::Errors::ValidationError, /carries no structuredContent/)
+    end
+
+    it 'still checks an error result whose structuredContent is an object' do
+      result = { 'isError' => true, 'content' => [], 'structuredContent' => { 'a' => 1 } }
+      tool = MCPClient::Tool.new(name: 'run', description: 'd', schema: { 'type' => 'object' }, server: server,
+                                 output_schema: { 'type' => 'object', 'properties' => { 'a' => { 'type' => 'string' } },
+                                                  'required' => ['a'] })
+
+      expect { client_with(:strict).send(:validate_structured_content!, tool, result) }
+        .to raise_error(MCPClient::Errors::ValidationError)
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round3_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round3_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, third review round: a false output
+# schema survives parsing, speculative composition branches do not eat the
+# error budget, positional keywords follow the dialect, and a malformed
+# $schema declaration is not the default dialect.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 3' do
+  let(:validator) { MCPClient::SchemaValidator }
+
+  it 'keeps an outputSchema of false through Tool.from_json' do
+    tool = MCPClient::Tool.from_json({ 'name' => 't', 'description' => 'd', 'inputSchema' => { 'type' => 'object' },
+                                       'outputSchema' => false })
+
+    expect(tool.output_schema).to be(false)
+    expect(tool).to be_structured_output
+    expect(validator.validate({}, tool.output_schema)).to contain_exactly(a_string_matching(/false/))
+  end
+
+  it 'does not count the errors of rejected anyOf, oneOf, not or if branches' do
+    alternatives = Array.new(validator::MAX_ERRORS + 50) { { 'type' => 'string' } } + [{ 'type' => 'integer' }]
+    expect(validator.validate(1, { 'anyOf' => alternatives })).to be_empty
+    expect(validator.validate(1, { 'oneOf' => alternatives })).to be_empty
+
+    nots = Array.new(validator::MAX_ERRORS + 50) { { 'not' => { 'type' => 'string' } } }
+    expect(validator.validate(1, { 'allOf' => nots })).to be_empty
+
+    conditionals = Array.new(validator::MAX_ERRORS + 50) { { 'if' => { 'type' => 'string' }, 'then' => false } }
+    expect(validator.validate(1, { 'allOf' => conditionals })).to be_empty
+  end
+
+  it 'chooses the positional keyword by dialect' do
+    draft7 = { '$schema' => 'http://json-schema.org/draft-07/schema#', 'type' => 'array',
+               'prefixItems' => [{ 'type' => 'integer' }] }
+    expect(validator.validate(['x'], draft7)).to be_empty
+
+    modern = { 'type' => 'array', 'items' => [{ 'type' => 'integer' }] }
+    expect(validator.check_schema(modern)).to contain_exactly(a_string_matching(/items.*prefixItems/))
+  end
+
+  it 'rejects a present but malformed $schema declaration' do
+    [nil, 7, ''].each do |declared|
+      problems = validator.check_schema({ '$schema' => declared, 'type' => 'object' })
+      expect(problems).to contain_exactly(a_string_matching(/\$schema/)), "expected #{declared.inspect} to be rejected"
+    end
+    expect(validator.check_schema({ 'type' => 'object' })).to be_empty
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round4_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round4_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, fourth review round: contentSchema
+# is walked, speculative branches never abort a conforming value, applicator
+# values that are not schemas are rejected, boolean item schemas still
+# count against the bounds, and log lines sanitize the tool name.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 4' do
+  let(:validator) { MCPClient::SchemaValidator }
+
+  it 'walks contentSchema so an external $ref there makes the schema unusable' do
+    schema = { 'type' => 'string', 'contentMediaType' => 'application/json',
+               'contentSchema' => { '$ref' => 'https://example.com/inner.json' } }
+    expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/external \$ref/))
+    expect(validator.unsupported_keywords({ 'contentSchema' => { 'type' => 'object' } })).to eq(['contentSchema'])
+  end
+
+  it 'never lets a fat rejected branch abort a conforming value' do
+    fat = { 'type' => 'object', 'properties' => {} }
+    (validator::MAX_ERRORS + 20).times { |i| fat['properties']["p#{i}"] = { 'type' => 'string' } }
+    fat['required'] = fat['properties'].keys
+    schema = { 'anyOf' => [fat, { 'type' => 'integer' }] }
+    expect(validator.validate(1, schema)).to be_empty
+
+    expect(validator.validate(1, { 'not' => fat })).to be_empty
+    expect(validator.validate(1, { 'if' => fat, 'then' => false })).to be_empty
+  end
+
+  it 'rejects applicator values that are not schemas' do
+    expect(validator.check_schema({ 'not' => 5 })).to contain_exactly(a_string_matching(/not.*schema/))
+    expect(validator.check_schema({ 'allOf' => [{ 'type' => 'string' }, 'x'] }))
+      .to contain_exactly(a_string_matching(/allOf.*schema/))
+    expect(validator.check_schema({ 'items' => 'nope' })).to contain_exactly(a_string_matching(/items.*schema/))
+    expect(validator.check_schema({ 'properties' => { 'a' => 1 } }))
+      .to contain_exactly(a_string_matching(/properties.*schema/))
+  end
+
+  it 'counts array elements under a boolean item schema against the visit bound' do
+    huge = Array.new(validator::MAX_NODE_VISITS + 10, 1)
+    errors = validator.validate(huge, { 'type' => 'array', 'items' => true })
+    expect(errors).to contain_exactly(a_string_matching(/aborted/))
+  end
+
+  it 'clips huge values without inspecting them whole' do
+    huge = Array.new(200_000) { 'x' * 10 }
+    allow(huge).to receive(:inspect).and_raise('inspect must not run on the whole value')
+    errors = validator.validate(huge, { 'type' => 'string' })
+    expect(errors.first).to match(/expected type string, got array/)
+    expect(validator.validate(huge, { 'const' => 1 }).first.bytesize).to be < 300
+  end
+
+  describe 'through MCPClient::Client' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+
+    def tool(output_schema)
+      MCPClient::Tool.new(name: "tool\nWARN forged", description: 'd', schema: { 'type' => 'object' },
+                          output_schema: output_schema, server: mock_server)
+    end
+
+    def client_with(tools)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+      allow(mock_server).to receive(:on_notification)
+      allow(mock_server).to receive(:list_tools).and_return(tools)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger)
+    end
+
+    it 'sanitizes the tool name on the missing-content and partial-coverage log paths' do
+      client = client_with([tool({ 'type' => 'object', 'format' => 'custom' })])
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [] })
+
+      client.call_tool("tool\nWARN forged", {})
+
+      expect(log_output.string).to include('no structuredContent')
+      expect(log_output.string).to include('validation is partial')
+      expect(log_output.string).not_to include("\nWARN forged")
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round4_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round4_spec.rb
@@ -20,11 +20,18 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 4' do
     fat = { 'type' => 'object', 'properties' => {} }
     (validator::MAX_ERRORS + 20).times { |i| fat['properties']["p#{i}"] = { 'type' => 'string' } }
     fat['required'] = fat['properties'].keys
-    schema = { 'anyOf' => [fat, { 'type' => 'integer' }] }
-    expect(validator.validate(1, schema)).to be_empty
+    # An object, so the branch really runs its required list and produces the
+    # hundred-odd errors: an integer would be decided by `type` alone and the
+    # branch would never reach the error cap this example is about.
+    data = { 'other' => 1 }
+    # The branch really runs: on its own it produces past the error cap.
+    expect(validator.validate(data, fat)).to contain_exactly(a_string_matching(/more than .* validation errors/))
 
-    expect(validator.validate(1, { 'not' => fat })).to be_empty
-    expect(validator.validate(1, { 'if' => fat, 'then' => false })).to be_empty
+    expect(validator.validate(data, { 'anyOf' => [fat, { 'type' => 'object' }] })).to be_empty
+    expect(validator.validate(data, { 'not' => fat })).to be_empty
+    expect(validator.validate(data, { 'if' => fat, 'then' => false })).to be_empty
+    # And a branch the value satisfies still decides the composition.
+    expect(validator.validate(1, { 'anyOf' => [fat, { 'type' => 'integer' }] })).to be_empty
   end
 
   it 'rejects applicator values that are not schemas' do

--- a/spec/lib/mcp_client/json_schema_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round5_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 # grammar follows the dialect (draft-07 dependencies, keywords unknown to a
 # dialect are ignored), a draft-07 $ref hides its siblings at preflight
 # too, plain-name fragments resolve to anchors, an empty outputSchema is a
-# schema, draft-07 boolean exclusive bounds apply, and an external
+# schema, exclusive bounds are numbers under draft-07 too, and an external
 # $recursiveRef makes a 2019-09 schema unusable.
 RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 5' do
   let(:validator) { MCPClient::SchemaValidator }
@@ -92,18 +92,18 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 5' do
   end
 
   describe 'draft-07 exclusive bounds' do
-    it 'applies boolean exclusiveMinimum / exclusiveMaximum to minimum / maximum' do
-      min = { '$schema' => draft7, 'type' => 'number', 'minimum' => 5, 'exclusiveMinimum' => true }
-      max = { '$schema' => draft7, 'type' => 'number', 'maximum' => 10, 'exclusiveMaximum' => true }
+    it 'applies numeric exclusiveMinimum / exclusiveMaximum (draft-07 validation Sections 6.2.3 and 6.2.5)' do
+      min = { '$schema' => draft7, 'type' => 'number', 'exclusiveMinimum' => 5 }
+      max = { '$schema' => draft7, 'type' => 'number', 'exclusiveMaximum' => 10 }
       expect(validator.validate(5, min)).to contain_exactly(a_string_matching(/greater than/))
       expect(validator.validate(6, min)).to be_empty
       expect(validator.validate(10, max)).to contain_exactly(a_string_matching(/less than/))
       expect(validator.validate(9, max)).to be_empty
     end
 
-    it 'rejects the form the dialect does not define' do
-      expect(validator.check_schema({ '$schema' => draft7, 'exclusiveMinimum' => 5 }))
-        .to contain_exactly(a_string_matching(/exclusiveMinimum.*boolean/))
+    it 'rejects the draft-04 boolean form' do
+      expect(validator.check_schema({ '$schema' => draft7, 'exclusiveMinimum' => true }))
+        .to contain_exactly(a_string_matching(/exclusiveMinimum.*number/))
       expect(validator.check_schema({ 'exclusiveMaximum' => true }))
         .to contain_exactly(a_string_matching(/exclusiveMaximum.*number/))
     end

--- a/spec/lib/mcp_client/json_schema_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round5_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, fifth review round: the keyword
+# grammar follows the dialect (draft-07 dependencies, keywords unknown to a
+# dialect are ignored), a draft-07 $ref hides its siblings at preflight
+# too, plain-name fragments resolve to anchors, an empty outputSchema is a
+# schema, draft-07 boolean exclusive bounds apply, and an external
+# $recursiveRef makes a 2019-09 schema unusable.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 5' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+  let(:draft2019) { 'https://json-schema.org/draft/2019-09/schema' }
+
+  describe 'dialect-specific keyword grammar' do
+    let(:dependencies) do
+      { 'type' => 'object',
+        'properties' => { 'credit_card' => { 'type' => 'string' }, 'billing_address' => { 'type' => 'string' } },
+        'dependencies' => { 'credit_card' => ['billing_address'] } }
+    end
+
+    it 'accepts the draft-07 property form of dependencies and reports it as unevaluated' do
+      schema = dependencies.merge('$schema' => draft7)
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'credit_card' => '4111', 'billing_address' => 'x' }, schema)).to be_empty
+      expect(validator.unsupported_keywords(schema)).to eq(['dependencies'])
+    end
+
+    it 'ignores dependencies entirely under 2020-12, where the keyword does not exist' do
+      expect(validator.check_schema(dependencies)).to be_empty
+      expect(validator.validate({ 'credit_card' => '4111' }, dependencies)).to be_empty
+      expect(validator.unsupported_keywords(dependencies)).to be_empty
+    end
+
+    it 'still rejects a draft-07 dependencies entry that is neither a schema nor property names' do
+      schema = { '$schema' => draft7, 'dependencies' => { 'a' => 5 } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/dependencies/))
+    end
+
+    it 'walks the schema-valued dependencies entries under draft-07' do
+      schema = { '$schema' => draft7, 'dependencies' => { 'a' => { '$ref' => 'https://example.com/x' } } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/external \$ref/))
+    end
+
+    it 'neither shape-checks nor reports keywords unknown to the dialect' do
+      expect(validator.check_schema({ 'additionalItems' => 'nope' })).to be_empty
+      expect(validator.check_schema({ '$recursiveRef' => 'https://example.com/x' })).to be_empty
+      expect(validator.unsupported_keywords({ '$recursiveRef' => 'https://example.com/x' })).to be_empty
+      expect(validator.check_schema({ '$schema' => draft7, 'prefixItems' => 'nope' })).to be_empty
+      expect(validator.check_schema({ '$schema' => draft7, '$dynamicRef' => 'https://example.com/x' })).to be_empty
+      expect(validator.unsupported_keywords({ '$schema' => draft7, 'unevaluatedProperties' => false })).to be_empty
+    end
+  end
+
+  it 'does not preflight the siblings a draft-07 $ref replaces' do
+    schema = { '$schema' => draft7, '$ref' => '#/definitions/a',
+               'allOf' => [{ '$ref' => 'https://example.com/x' }],
+               'definitions' => { 'a' => { 'type' => 'integer' } } }
+    expect(validator.check_schema(schema)).to be_empty
+    expect(validator.validate(1, schema)).to be_empty
+    expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/integer/))
+  end
+
+  it 'still preflights the definitions next to a draft-07 $ref' do
+    schema = { '$schema' => draft7, '$ref' => '#/definitions/a',
+               'definitions' => { 'a' => { 'properties' => { 'p' => { '$ref' => 'https://example.com/x' } } } } }
+    expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/external \$ref/))
+  end
+
+  describe 'plain-name fragments' do
+    it 'resolves $ref "#name" to the subschema carrying $anchor under 2020-12' do
+      schema = { '$ref' => '#node', '$defs' => { 'n' => { '$anchor' => 'node', 'type' => 'integer' } } }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(1, schema)).to be_empty
+      expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/integer/))
+    end
+
+    it 'resolves $ref "#name" to the subschema whose $id is "#name" under draft-07' do
+      schema = { '$schema' => draft7, '$ref' => '#node',
+                 'definitions' => { 'n' => { '$id' => '#node', 'type' => 'integer' } } }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/integer/))
+    end
+
+    it 'keeps an unknown anchor an error' do
+      expect(validator.check_schema({ '$ref' => '#missing' })).to contain_exactly(a_string_matching(/unresolvable/))
+      # $anchor does not exist in draft-07, so it names nothing there.
+      schema = { '$schema' => draft7, '$ref' => '#node', 'definitions' => { 'n' => { '$anchor' => 'node' } } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable/))
+    end
+  end
+
+  describe 'draft-07 exclusive bounds' do
+    it 'applies boolean exclusiveMinimum / exclusiveMaximum to minimum / maximum' do
+      min = { '$schema' => draft7, 'type' => 'number', 'minimum' => 5, 'exclusiveMinimum' => true }
+      max = { '$schema' => draft7, 'type' => 'number', 'maximum' => 10, 'exclusiveMaximum' => true }
+      expect(validator.validate(5, min)).to contain_exactly(a_string_matching(/greater than/))
+      expect(validator.validate(6, min)).to be_empty
+      expect(validator.validate(10, max)).to contain_exactly(a_string_matching(/less than/))
+      expect(validator.validate(9, max)).to be_empty
+    end
+
+    it 'rejects the form the dialect does not define' do
+      expect(validator.check_schema({ '$schema' => draft7, 'exclusiveMinimum' => 5 }))
+        .to contain_exactly(a_string_matching(/exclusiveMinimum.*boolean/))
+      expect(validator.check_schema({ 'exclusiveMaximum' => true }))
+        .to contain_exactly(a_string_matching(/exclusiveMaximum.*number/))
+    end
+  end
+
+  it 'treats an external $recursiveRef like an external $dynamicRef under 2019-09' do
+    external = { '$schema' => draft2019, '$recursiveRef' => 'https://example.com/x' }
+    expect(validator.check_schema(external)).to contain_exactly(a_string_matching(/external \$recursiveRef/))
+    expect(validator.validate(1, external)).not_to be_empty
+
+    local = { '$schema' => draft2019, '$recursiveRef' => '#' }
+    expect(validator.check_schema(local)).to be_empty
+    expect(validator.unsupported_keywords(local)).to eq(['$recursiveRef'])
+  end
+
+  describe 'an empty outputSchema' do
+    let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+
+    it 'is a schema (it accepts every value) for Tool.new and Tool.from_json' do
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' }, output_schema: {})
+      expect(tool).to be_structured_output
+      parsed = MCPClient::Tool.from_json({ 'name' => 't', 'inputSchema' => { 'type' => 'object' },
+                                           'outputSchema' => {} })
+      expect(parsed).to be_structured_output
+      expect(MCPClient::Tool.from_json({ 'name' => 't', 'inputSchema' => {} })).not_to be_structured_output
+    end
+
+    it 'makes the client require structuredContent' do
+      log_output = StringIO.new
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' }, output_schema: {},
+                                 server: mock_server)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+      allow(mock_server).to receive(:on_notification)
+      allow(mock_server).to receive(:list_tools).and_return([tool])
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [] })
+      client = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }],
+                                     logger: Logger.new(log_output))
+
+      client.call_tool('t', {})
+
+      expect(log_output.string).to include('no structuredContent')
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round5_spec.rb
@@ -20,11 +20,13 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 5' do
         'dependencies' => { 'credit_card' => ['billing_address'] } }
     end
 
-    it 'accepts the draft-07 property form of dependencies and reports it as unevaluated' do
+    it 'applies the draft-07 property form of dependencies' do
       schema = dependencies.merge('$schema' => draft7)
       expect(validator.check_schema(schema)).to be_empty
       expect(validator.validate({ 'credit_card' => '4111', 'billing_address' => 'x' }, schema)).to be_empty
-      expect(validator.unsupported_keywords(schema)).to eq(['dependencies'])
+      expect(validator.validate({ 'credit_card' => '4111' }, schema))
+        .to contain_exactly(a_string_matching(/requires property 'billing_address'/))
+      expect(validator.unsupported_keywords(schema)).to eq([])
     end
 
     it 'ignores dependencies entirely under 2020-12, where the keyword does not exist' do

--- a/spec/lib/mcp_client/json_schema_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round5_spec.rb
@@ -116,9 +116,13 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 5' do
     expect(validator.check_schema(external)).to contain_exactly(a_string_matching(/external \$recursiveRef/))
     expect(validator.validate(1, external)).not_to be_empty
 
+    # A root whose $recursiveAnchor is true is the outermost dynamic scope
+    # there is: the reference is bound to it and evaluated — here onto the
+    # same instance again, which is the cycle it is reported as.
     local = { '$schema' => draft2019, '$recursiveAnchor' => true, '$recursiveRef' => '#' }
     expect(validator.check_schema(local)).to be_empty
-    expect(validator.unsupported_keywords(local)).to eq(['$recursiveRef'])
+    expect(validator.unsupported_keywords(local)).to eq([])
+    expect(validator.validate(1, local)).to contain_exactly(a_string_matching(/cycle/))
     # Without a `$recursiveAnchor: true` at its target it is a plain `#`.
     plain = { '$schema' => draft2019, '$recursiveRef' => '#' }
     expect(validator.check_schema(plain)).to be_empty

--- a/spec/lib/mcp_client/json_schema_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round5_spec.rb
@@ -116,9 +116,13 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 5' do
     expect(validator.check_schema(external)).to contain_exactly(a_string_matching(/external \$recursiveRef/))
     expect(validator.validate(1, external)).not_to be_empty
 
-    local = { '$schema' => draft2019, '$recursiveRef' => '#' }
+    local = { '$schema' => draft2019, '$recursiveAnchor' => true, '$recursiveRef' => '#' }
     expect(validator.check_schema(local)).to be_empty
     expect(validator.unsupported_keywords(local)).to eq(['$recursiveRef'])
+    # Without a `$recursiveAnchor: true` at its target it is a plain `#`.
+    plain = { '$schema' => draft2019, '$recursiveRef' => '#' }
+    expect(validator.check_schema(plain)).to be_empty
+    expect(validator.unsupported_keywords(plain)).to eq([])
   end
 
   describe 'an empty outputSchema' do

--- a/spec/lib/mcp_client/json_schema_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round6_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, sixth review round: exclusive bounds
+# are numbers under every supported dialect (the boolean modifier form is
+# draft-04), inclusive and exclusive bounds are independent assertions,
+# each validation error counts once, and percent-encoded plain-name
+# fragments resolve to their anchor.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 6' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+  let(:draft2019) { 'https://json-schema.org/draft/2019-09/schema' }
+
+  describe 'exclusive bounds' do
+    it 'evaluates numeric exclusiveMinimum / exclusiveMaximum under draft-07 like the later drafts' do
+      min = { '$schema' => draft7, 'type' => 'number', 'exclusiveMinimum' => 5 }
+      max = { '$schema' => draft7, 'type' => 'number', 'exclusiveMaximum' => 10 }
+      expect(validator.check_schema(min)).to be_empty
+      expect(validator.check_schema(max)).to be_empty
+      expect(validator.validate(5, min)).to contain_exactly(a_string_matching(/greater than/))
+      expect(validator.validate(6, min)).to be_empty
+      expect(validator.validate(10, max)).to contain_exactly(a_string_matching(/less than/))
+      expect(validator.validate(9, max)).to be_empty
+    end
+
+    it 'rejects the draft-04 boolean form under every supported dialect' do
+      [draft7, draft2019, nil].each do |dialect|
+        schema = { 'minimum' => 5, 'exclusiveMinimum' => true, 'exclusiveMaximum' => false }
+        schema['$schema'] = dialect if dialect
+        expect(validator.check_schema(schema))
+          .to contain_exactly(a_string_matching(/exclusiveMinimum.*number/),
+                              a_string_matching(/exclusiveMaximum.*number/)),
+              "expected the boolean form to be rejected under #{dialect.inspect}"
+      end
+    end
+
+    it 'applies minimum and exclusiveMinimum (maximum and exclusiveMaximum) independently' do
+      schema = { 'type' => 'number', 'minimum' => 10, 'exclusiveMinimum' => 5,
+                 'maximum' => 20, 'exclusiveMaximum' => 30 }
+      expect(validator.validate(7, schema)).to contain_exactly(a_string_matching(/less than minimum 10/))
+      expect(validator.validate(5, schema))
+        .to contain_exactly(a_string_matching(/less than minimum 10/),
+                            a_string_matching(/greater than exclusiveMinimum 5/))
+      expect(validator.validate(25, schema)).to contain_exactly(a_string_matching(/greater than maximum 20/))
+      expect(validator.validate(30, schema))
+        .to contain_exactly(a_string_matching(/greater than maximum 20/),
+                            a_string_matching(/less than exclusiveMaximum 30/))
+      expect(validator.validate(15, schema)).to be_empty
+    end
+  end
+
+  describe 'error accounting' do
+    it 'counts each array element error once' do
+      count = (validator::MAX_ERRORS / 2) + 1
+      errors = validator.validate(Array.new(count, 'x'), { 'type' => 'array', 'items' => { 'type' => 'integer' } })
+      expect(errors.size).to eq(count)
+      expect(errors).to all(match(/expected type integer/))
+    end
+
+    it 'counts nested object errors once through every ancestor' do
+      count = (validator::MAX_ERRORS / 3) + 1
+      leaf = { 'type' => 'object', 'properties' => { 'n' => { 'type' => 'integer' } } }
+      schema = { 'type' => 'object',
+                 'properties' => { 'items' => { 'type' => 'array', 'items' => { 'allOf' => [leaf] } } } }
+      data = { 'items' => Array.new(count) { { 'n' => 'x' } } }
+      errors = validator.validate(data, schema)
+      expect(errors.size).to eq(count)
+      expect(errors).to all(match(/expected type integer/))
+    end
+
+    it 'still aborts once the bound is really exceeded' do
+      errors = validator.validate(Array.new(validator::MAX_ERRORS + 1, 'x'),
+                                  { 'type' => 'array', 'items' => { 'type' => 'integer' } })
+      expect(errors).to contain_exactly(a_string_matching(/more than #{validator::MAX_ERRORS}/))
+    end
+  end
+
+  describe 'anchors' do
+    it 'percent-decodes a plain-name fragment before looking up the anchor' do
+      schema = { 'type' => 'object',
+                 'properties' => { 'a' => { '$ref' => '#foo%2Dbar' } },
+                 '$defs' => { 'x' => { '$anchor' => 'foo-bar', 'type' => 'integer' } } }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => 1 }, schema)).to be_empty
+      expect(validator.validate({ 'a' => 'x' }, schema)).to contain_exactly(a_string_matching(/expected type integer/))
+    end
+
+    it 'keeps an unknown anchor unresolvable after decoding' do
+      schema = { '$ref' => '#no%2Dsuch', '$defs' => { 'x' => { '$anchor' => 'other' } } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable/))
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round7_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, seventh review round: plain-name
+# fragments are scoped to their schema resource, a draft-07 `$id` is an
+# anchor only when it is a pure fragment, keywords beside a draft-07 `$ref`
+# contribute no anchors, `$defs` / `definitions` belong to the dialects that
+# define them, and the unsupported-keyword scan is bounded and memoized.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 7' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+
+  describe 'resource-scoped anchors' do
+    it 'does not resolve an anchor declared inside an embedded resource from the outside' do
+      schema = {
+        'type' => 'object',
+        'properties' => { 'child' => { '$ref' => '#node' } },
+        '$defs' => { 'embedded' => { '$id' => 'https://example.com/embedded', '$anchor' => 'node',
+                                     'type' => 'string' } }
+      }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable local \$ref "#node"/))
+      expect(validator.validate({ 'child' => 'ok' }, schema)).not_to be_empty
+    end
+
+    it 'does not resolve the root anchor from inside an embedded resource' do
+      schema = {
+        '$anchor' => 'node',
+        'type' => 'object',
+        'properties' => {
+          'child' => { '$id' => 'https://example.com/child', 'type' => 'object',
+                       'properties' => { 'inner' => { '$ref' => '#node' } } }
+        }
+      }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable local \$ref "#node"/))
+    end
+
+    it 'resolves an anchor within its own resource, embedded or root' do
+      schema = {
+        '$anchor' => 'top',
+        'type' => 'object',
+        'properties' => {
+          'again' => { '$ref' => '#top' },
+          'child' => { '$id' => 'https://example.com/child', 'type' => 'object',
+                       'properties' => { 'inner' => { '$ref' => '#leaf' } },
+                       '$defs' => { 'leaf' => { '$anchor' => 'leaf', 'type' => 'integer' } } }
+        }
+      }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'again' => {}, 'child' => { 'inner' => 1 } }, schema)).to be_empty
+      expect(validator.validate({ 'child' => { 'inner' => 'x' } },
+                                schema)).to contain_exactly(a_string_matching(/inner/))
+    end
+  end
+
+  describe 'draft-07 identifiers' do
+    it 'treats only a pure-fragment $id as a plain-name anchor' do
+      relative = { '$schema' => draft7, '$ref' => '#item.json',
+                   'definitions' => { 'n' => { '$id' => 'item.json', 'type' => 'string' } } }
+      expect(validator.check_schema(relative)).to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+
+      bare = { '$schema' => draft7, '$ref' => '#item',
+               'definitions' => { 'n' => { '$id' => 'item', 'type' => 'string' } } }
+      expect(validator.check_schema(bare)).to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+
+      fragment = { '$schema' => draft7, '$ref' => '#item',
+                   'definitions' => { 'n' => { '$id' => '#item', 'type' => 'string' } } }
+      expect(validator.check_schema(fragment)).to be_empty
+      expect(validator.validate(1, fragment)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+
+    it 'ignores anchors declared under the siblings of a draft-07 $ref' do
+      schema = {
+        '$schema' => draft7,
+        'properties' => {
+          'a' => { '$ref' => '#trap' },
+          'b' => { '$ref' => '#/definitions/x', 'allOf' => [{ '$id' => '#trap', 'type' => 'string' }] }
+        },
+        'definitions' => { 'x' => { 'type' => 'integer' } }
+      }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable local \$ref "#trap"/))
+    end
+  end
+
+  describe 'dialect-scoped definition containers' do
+    it 'does not walk definitions under 2020-12 nor $defs under draft-07' do
+      modern = { 'type' => 'integer', 'definitions' => { 'hidden' => { '$ref' => 'https://example.com/x' } } }
+      expect(validator.check_schema(modern)).to be_empty
+      expect(validator.validate(1, modern)).to be_empty
+
+      legacy = { '$schema' => draft7, 'type' => 'integer', '$defs' => { 'hidden' => { '$ref' => 'https://example.com/x' } } }
+      expect(validator.check_schema(legacy)).to be_empty
+      expect(validator.validate(1, legacy)).to be_empty
+    end
+
+    it 'still resolves JSON pointers into either container and checks what they reach' do
+      modern = { 'type' => 'object', 'properties' => { 'n' => { '$ref' => '#/definitions/x' } },
+                 'definitions' => { 'x' => { 'type' => 'integer' } } }
+      expect(validator.check_schema(modern)).to be_empty
+      expect(validator.validate({ 'n' => 'x' }, modern)).to contain_exactly(a_string_matching(/expected type integer/))
+
+      reached = { 'type' => 'object', 'properties' => { 'n' => { '$ref' => '#/definitions/x' } },
+                  'definitions' => { 'x' => { 'allOf' => [{ '$ref' => 'https://example.com/x' }] } } }
+      expect(validator.check_schema(reached)).to contain_exactly(a_string_matching(/external \$ref/))
+    end
+
+    it 'keeps recursive schemas through a definitions pointer usable' do
+      kids = { 'type' => 'array', 'items' => { '$ref' => '#/$defs/node' } }
+      tree = { 'type' => 'object', 'properties' => { 'kids' => kids },
+               '$defs' => { 'node' => { 'type' => 'object', 'properties' => { 'kids' => kids.dup } } } }
+      expect(validator.check_schema(tree)).to be_empty
+      expect(validator.validate({ 'kids' => [{ 'kids' => [{}] }] }, tree)).to be_empty
+    end
+  end
+
+  describe 'bounded unsupported-keyword scan' do
+    it 'stops walking at MAX_SUBSCHEMAS' do
+      huge = { 'type' => 'object', 'properties' => {} }
+      (validator::MAX_SUBSCHEMAS * 3).times do |i|
+        huge['properties']["p#{i}"] = { 'type' => 'string', 'format' => 'x' }
+      end
+      allow(validator).to receive(:each_subschema).and_call_original
+
+      expect(validator.unsupported_keywords(huge)).to eq(['format'])
+      expect(validator).to have_received(:each_subschema).at_most(validator::MAX_SUBSCHEMAS + 1).times
+    end
+  end
+
+  describe 'through MCPClient::Client' do
+    let(:logger) { Logger.new(File::NULL) }
+    let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+
+    def client_with(tools)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+      allow(mock_server).to receive(:on_notification)
+      allow(mock_server).to receive(:list_tools).and_return(tools)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger)
+    end
+
+    it 'computes the unsupported keywords of an output schema once per schema' do
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
+                                 output_schema: { 'type' => 'object', 'format' => 'custom' }, server: mock_server)
+      client = client_with([tool])
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => {} })
+      allow(MCPClient::SchemaValidator).to receive(:unsupported_keywords).and_call_original
+
+      3.times { client.call_tool('t', {}) }
+
+      expect(MCPClient::SchemaValidator).to have_received(:unsupported_keywords).once
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round7_spec.rb
@@ -83,12 +83,16 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 7' do
   end
 
   describe 'dialect-scoped definition containers' do
-    it 'does not walk definitions under 2020-12 nor $defs under draft-07' do
+    it 'walks definitions under 2020-12, where it is the deprecated $defs' do
+      # JSON Schema 2020-12 Validation Appendix A: `definitions` is retained
+      # by the meta-schema and behaves as `$defs` does.
       modern = { 'type' => 'integer', 'definitions' => { 'hidden' => { '$ref' => 'https://example.com/x' } } }
-      expect(validator.check_schema(modern)).to be_empty
-      expect(validator.validate(1, modern)).to be_empty
+      expect(validator.check_schema(modern)).to contain_exactly(a_string_matching(/external \$ref/))
+    end
 
-      legacy = { '$schema' => draft7, 'type' => 'integer', '$defs' => { 'hidden' => { '$ref' => 'https://example.com/x' } } }
+    it 'does not walk $defs under draft-07, which does not define it' do
+      legacy = { '$schema' => draft7, 'type' => 'integer',
+                 '$defs' => { 'hidden' => { '$ref' => 'https://example.com/x' } } }
       expect(validator.check_schema(legacy)).to be_empty
       expect(validator.validate(1, legacy)).to be_empty
     end

--- a/spec/lib/mcp_client/json_schema_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round7_spec.rb
@@ -115,14 +115,22 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 7' do
 
   describe 'bounded unsupported-keyword scan' do
     it 'stops walking at MAX_SUBSCHEMAS' do
+      # More subschemas than the walk admits, but within the structural
+      # bound (every object entry counts), so the document is still read.
       huge = { 'type' => 'object', 'properties' => {} }
-      (validator::MAX_SUBSCHEMAS * 3).times do |i|
-        huge['properties']["p#{i}"] = { 'type' => 'string', 'format' => 'x' }
-      end
+      (validator::MAX_SUBSCHEMAS + 500).times { |i| huge['properties']["p#{i}"] = { 'format' => 'x' } }
       allow(validator).to receive(:each_subschema).and_call_original
 
       expect(validator.unsupported_keywords(huge)).to eq(['format'])
       expect(validator).to have_received(:each_subschema).at_most(validator::MAX_SUBSCHEMAS + 1).times
+    end
+
+    it 'reports nothing for a document too wide to read, which check_schema rejects' do
+      huge = { 'type' => 'object', 'properties' => {} }
+      (validator::MAX_STRUCTURAL_OBJECTS + 10).times { |i| huge['properties']["p#{i}"] = { 'format' => 'x' } }
+
+      expect(validator.unsupported_keywords(huge)).to eq([])
+      expect(validator.check_schema(huge)).to contain_exactly(a_string_matching(/structural elements/))
     end
   end
 

--- a/spec/lib/mcp_client/json_schema_2026_round8_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round8_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, eighth review round: pointer
+# fragments are relative to the schema resource the `$ref` sits in, the
+# unsupported-keyword scan follows local references, an `if` without a
+# branch is inert, and a schema wider than the bounds is rejected before it
+# is copied whole.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 8' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+
+  describe 'resource-relative pointer fragments' do
+    let(:schema) do
+      {
+        'type' => 'object',
+        '$defs' => { 'n' => { 'type' => 'string' } },
+        'properties' => {
+          'child' => {
+            '$id' => 'https://example.com/child',
+            'type' => 'object',
+            '$defs' => { 'n' => { 'type' => 'integer' } },
+            'properties' => { 'inner' => { '$ref' => '#/$defs/n' }, 'self' => { '$ref' => '#' } }
+          }
+        }
+      }
+    end
+
+    it 'resolves a pointer inside an embedded resource against that resource' do
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'child' => { 'inner' => 1 } }, schema)).to be_empty
+      expect(validator.validate({ 'child' => { 'inner' => 'x' } }, schema))
+        .to contain_exactly(a_string_matching(%r{#/child/inner: expected type integer}))
+    end
+
+    it 'resolves "#" inside an embedded resource to that resource' do
+      expect(validator.validate({ 'child' => { 'self' => { 'inner' => 2 } } }, schema)).to be_empty
+      expect(validator.validate({ 'child' => { 'self' => 'x' } }, schema))
+        .to contain_exactly(a_string_matching(%r{#/child/self: expected type object}))
+    end
+
+    it 'reports a pointer that only exists in the enclosing document' do
+      schema['properties']['child']['properties']['outer'] = { '$ref' => '#/properties/child' }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+  end
+
+  describe 'unsupported keywords behind local references' do
+    it 'scans a target inside a definition bag the dialect does not walk' do
+      schema = { 'type' => 'object',
+                 'properties' => { 'email' => { '$ref' => '#/definitions/email' } },
+                 'definitions' => { 'email' => { 'type' => 'string', 'format' => 'email' } } }
+      expect(validator.unsupported_keywords(schema)).to eq(['format'])
+    end
+
+    it 'scans a target reached through an anchor and stops at a cycle' do
+      schema = { 'properties' => { 'a' => { '$ref' => '#node' } },
+                 '$defs' => { 'n' => { '$anchor' => 'node', 'format' => 'uri', 'items' => { '$ref' => '#node' } } } }
+      expect(validator.unsupported_keywords(schema)).to eq(['format'])
+    end
+
+    it 'ignores keywords beside a draft-07 $ref' do
+      schema = { '$schema' => draft7, '$ref' => '#/definitions/x', 'format' => 'email',
+                 'definitions' => { 'x' => { 'type' => 'string' } } }
+      expect(validator.unsupported_keywords(schema)).to be_empty
+    end
+  end
+
+  describe 'an if without branches' do
+    it 'is not evaluated' do
+      expect(validator.check_schema({ 'if' => { '$ref' => '#' } })).to be_empty
+      expect(validator.validate(1, { 'if' => { '$ref' => '#' } })).to be_empty
+      expect(validator.validate(1, { 'if' => { 'type' => 'string' } })).to be_empty
+    end
+
+    it 'still selects a branch when one exists' do
+      expect(validator.validate(1, { 'if' => { 'type' => 'string' }, 'else' => false })).not_to be_empty
+      expect(validator.validate('s', { 'if' => { 'type' => 'string' }, 'then' => { 'minLength' => 3 } }))
+        .not_to be_empty
+    end
+  end
+
+  describe 'a schema wider than the bounds' do
+    let(:recorder) do
+      Class.new(Hash) do
+        def self.visits = @visits ||= [0]
+
+        def to_h(&)
+          self.class.visits[0] += 1
+          super
+        end
+      end
+    end
+
+    let(:huge) do
+      props = {}
+      (validator::MAX_SUBSCHEMAS * 8).times { |i| props["p#{i}"] = recorder[{ 'type' => 'string' }] }
+      { 'type' => 'object', 'properties' => props }
+    end
+
+    it 'is rejected before it is copied whole' do
+      expect(validator.check_schema(huge)).to contain_exactly(a_string_matching(/more than/))
+      expect(recorder.visits[0]).to be < validator::MAX_SUBSCHEMAS * 8
+      expect(validator.validate({}, huge)).to contain_exactly(a_string_matching(/more than/))
+      expect(validator.unsupported_keywords(huge)).to eq([])
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round8_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round8_spec.rb
@@ -48,9 +48,11 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 8' do
 
   describe 'unsupported keywords behind local references' do
     it 'scans a target inside a definition bag the dialect does not walk' do
-      schema = { 'type' => 'object',
-                 'properties' => { 'email' => { '$ref' => '#/definitions/email' } },
-                 'definitions' => { 'email' => { 'type' => 'string', 'format' => 'email' } } }
+      # draft-07 predates `$defs`, so nothing walks it there: only following
+      # the reference reaches what it holds.
+      schema = { '$schema' => draft7, 'type' => 'object',
+                 'properties' => { 'email' => { '$ref' => '#/$defs/email' } },
+                 '$defs' => { 'email' => { 'type' => 'string', 'format' => 'email' } } }
       expect(validator.unsupported_keywords(schema)).to eq(['format'])
     end
 

--- a/spec/lib/mcp_client/json_schema_2026_round8_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round8_spec.rb
@@ -70,10 +70,15 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 8' do
   end
 
   describe 'an if without branches' do
-    it 'is not evaluated' do
+    # The condition is evaluated all the same (its annotations are what an
+    # `unevaluated*` beside it reads, 2020-12 Section 10.2.2.1), it just
+    # asserts nothing; one that applies the schema to the same instance
+    # again is the cycle it is reported as.
+    it 'is evaluated but asserts nothing' do
       expect(validator.check_schema({ 'if' => { '$ref' => '#' } })).to be_empty
-      expect(validator.validate(1, { 'if' => { '$ref' => '#' } })).to be_empty
+      expect(validator.validate(1, { 'if' => { '$ref' => '#' } })).to contain_exactly(a_string_matching(/cycle/))
       expect(validator.validate(1, { 'if' => { 'type' => 'string' } })).to be_empty
+      expect(validator.validate(1, { 'if' => { 'type' => 'integer' } })).to be_empty
     end
 
     it 'still selects a branch when one exists' do

--- a/spec/lib/mcp_client/json_schema_2026_round9_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round9_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 9' do
   let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
 
   describe 'anchors only from schema positions' do
-    it 'does not take an $anchor from a definition bag the dialect does not define' do
+    it 'does not take an $anchor from a bag under a keyword no dialect defines' do
       schema = {
         'type' => 'object',
         'properties' => { 'a' => { '$ref' => '#trap' } },
-        'definitions' => { 'x' => { '$anchor' => 'trap', 'type' => 'string' } }
+        'x-defs' => { 'x' => { '$anchor' => 'trap', 'type' => 'string' } }
       }
       expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable local \$ref "#trap"/))
       expect(validator.validate({ 'a' => 'ok' }, schema)).to contain_exactly(a_string_matching(/unresolvable/))

--- a/spec/lib/mcp_client/json_schema_2026_round9_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round9_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 9' do
     end
 
     it 'still resolves a pointer into that bag' do
-      schema = { 'properties' => { 'a' => { '$ref' => '#/definitions/x' } },
-                 'definitions' => { 'x' => { 'type' => 'string' } } }
+      schema = { 'properties' => { 'a' => { '$ref' => '#/x-defs/x' } },
+                 'x-defs' => { 'x' => { 'type' => 'string' } } }
       expect(validator.check_schema(schema)).to be_empty
       expect(validator.validate({ 'a' => 1 }, schema)).to contain_exactly(a_string_matching(/expected type string/))
     end

--- a/spec/lib/mcp_client/json_schema_2026_round9_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round9_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, ninth review round: plain-name
+# anchors come only from schema positions the dialect walks, an embedded
+# resource's `$schema` is its dialect, wide documents are rejected before
+# they are copied, and numeric messages clip what they quote.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 9' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+
+  describe 'anchors only from schema positions' do
+    it 'does not take an $anchor from a definition bag the dialect does not define' do
+      schema = {
+        'type' => 'object',
+        'properties' => { 'a' => { '$ref' => '#trap' } },
+        'definitions' => { 'x' => { '$anchor' => 'trap', 'type' => 'string' } }
+      }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable local \$ref "#trap"/))
+      expect(validator.validate({ 'a' => 'ok' }, schema)).to contain_exactly(a_string_matching(/unresolvable/))
+    end
+
+    it 'still resolves a pointer into that bag' do
+      schema = { 'properties' => { 'a' => { '$ref' => '#/definitions/x' } },
+                 'definitions' => { 'x' => { 'type' => 'string' } } }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => 1 }, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+
+    it 'takes no draft-07 identifier from $defs beside a $ref' do
+      schema = {
+        '$schema' => draft7,
+        'properties' => {
+          'a' => { '$ref' => '#trap' },
+          'b' => { '$ref' => '#/definitions/x', '$defs' => { 't' => { '$id' => '#trap', 'type' => 'string' } } }
+        },
+        'definitions' => { 'x' => { 'type' => 'integer' } }
+      }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable local \$ref "#trap"/))
+    end
+
+    it 'takes no draft-07 identifier from a root $defs bag' do
+      schema = { '$schema' => draft7, 'properties' => { 'a' => { '$ref' => '#trap' } },
+                 '$defs' => { 't' => { '$id' => '#trap', 'type' => 'string' } } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable local \$ref "#trap"/))
+    end
+
+    it 'takes identifiers from the definition bag the dialect does define' do
+      schema = { '$schema' => draft7, 'properties' => { 'a' => { '$ref' => '#ok' } },
+                 'definitions' => { 't' => { '$id' => '#ok', 'type' => 'string' } } }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => 1 }, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+  end
+
+  describe 'embedded resource dialects' do
+    let(:schema) do
+      {
+        'properties' => {
+          'child' => {
+            '$id' => 'https://example.com/child',
+            '$schema' => draft7,
+            '$ref' => '#/definitions/x',
+            'type' => 'string',
+            'definitions' => { 'x' => { 'type' => 'integer', '$id' => '#int' } },
+            'properties' => { 'anchored' => { '$ref' => '#int' } }
+          }
+        }
+      }
+    end
+
+    it 'applies the embedded $schema to the embedded resource' do
+      expect(validator.check_schema(schema)).to be_empty
+      # draft-07 in the child: the $ref replaces its siblings, so 1 is valid.
+      expect(validator.validate({ 'child' => 1 }, schema)).to be_empty
+      expect(validator.validate({ 'child' => 'x' },
+                                schema)).to contain_exactly(a_string_matching(/expected type integer/))
+    end
+
+    it 'indexes the embedded resource anchors in the embedded dialect' do
+      inner = { 'properties' => { 'child' => { '$id' => 'https://example.com/c', '$schema' => draft7,
+                                               'definitions' => { 'x' => { '$id' => '#int', 'type' => 'integer' } },
+                                               'properties' => { 'v' => { '$ref' => '#int' } } } } }
+      expect(validator.check_schema(inner)).to be_empty
+      expect(validator.validate({ 'child' => { 'v' => 'x' } }, inner))
+        .to contain_exactly(a_string_matching(%r{#/child/v: expected type integer}))
+    end
+
+    it 'rejects an embedded $schema that is malformed or unsupported' do
+      bad = { 'properties' => { 'c' => { '$id' => 'https://example.com/c', '$schema' => 7 } } }
+      expect(validator.check_schema(bad)).to contain_exactly(a_string_matching(/\$schema/))
+      old = { 'properties' => { 'c' => { '$id' => 'https://example.com/c',
+                                         '$schema' => 'http://json-schema.org/draft-04/schema#' } } }
+      expect(validator.check_schema(old)).to contain_exactly(a_string_matching(/draft-04.*not supported/))
+      expect(validator.validate({}, old)).to contain_exactly(a_string_matching(/not supported/))
+    end
+
+    it 'ignores a $schema that is not at a resource root' do
+      schema = { 'properties' => { 'c' => { '$schema' => 'http://json-schema.org/draft-04/schema#',
+                                            'type' => 'string' } } }
+      expect(validator.check_schema(schema)).to be_empty
+    end
+  end
+
+  describe 'bounds and messages' do
+    it 'rejects a wide array of boolean schemas before copying it' do
+      wide = Array.new(validator::MAX_STRUCTURAL_OBJECTS + 10, true)
+      expect(validator.check_schema({ 'anyOf' => wide })).to contain_exactly(a_string_matching(/structural elements/))
+      expect(validator.validate(1, { 'anyOf' => wide })).to contain_exactly(a_string_matching(/structural elements/))
+    end
+
+    it 'clips the values quoted by numeric bound errors' do
+      huge = 10**500
+      errors = validator.validate(huge, { 'maximum' => 1, 'exclusiveMaximum' => 1 })
+      expect(errors.size).to eq(2)
+      expect(errors.map(&:length).max).to be < 250
+      expect(validator.validate(5, { 'minimum' => huge }).first.length).to be < 250
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_round9_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_round9_spec.rb
@@ -96,10 +96,12 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — round 9' do
       expect(validator.validate({}, old)).to contain_exactly(a_string_matching(/not supported/))
     end
 
-    it 'ignores a $schema that is not at a resource root' do
+    it 'refuses a $schema that is not at a resource root' do
+      # A `$schema` is read at a resource root only; anywhere else it is a
+      # malformed keyword (round 32), never silently applied or ignored.
       schema = { 'properties' => { 'c' => { '$schema' => 'http://json-schema.org/draft-04/schema#',
                                             'type' => 'string' } } }
-      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/\$schema.*resource root/))
     end
   end
 

--- a/spec/lib/mcp_client/json_schema_2026_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_spec.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 JSON Schema usage (basic/index "JSON Schema Usage",
+# server/tools "Structured Content" / "Output Schema"):
+# - the default dialect is JSON Schema 2020-12; an explicit `$schema` MAY
+#   name another dialect and an unsupported one is an error, not a pass;
+# - inputSchema / outputSchema may use any 2020-12 keyword;
+# - structuredContent is any JSON value, including null;
+# - `$ref` values that resolve to a network URI MUST NOT be dereferenced,
+#   and a schema that cannot be validated because of one is rejected rather
+#   than treated as permissive;
+# - composition keywords are bounded (depth, subschema count, time).
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling' do
+  let(:validator) { MCPClient::SchemaValidator }
+
+  describe 'dialects' do
+    it 'defaults to 2020-12 and accepts its known URIs' do
+      expect(validator.dialect({ 'type' => 'object' })).to eq('https://json-schema.org/draft/2020-12/schema')
+      expect(validator.check_schema({ 'type' => 'object' })).to be_empty
+      expect(validator.check_schema({ '$schema' => 'https://json-schema.org/draft/2020-12/schema' })).to be_empty
+      expect(validator.check_schema({ '$schema' => 'https://json-schema.org/draft/2020-12/schema#' })).to be_empty
+      expect(validator.check_schema({ '$schema' => 'http://json-schema.org/draft-07/schema#' })).to be_empty
+    end
+
+    it 'reports an unsupported dialect instead of validating permissively' do
+      problems = validator.check_schema({ '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' })
+      expect(problems).to contain_exactly(a_string_matching(/dialect.*draft-04.*not supported/))
+
+      errors = validator.validate({}, { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' })
+      expect(errors).to contain_exactly(a_string_matching(/dialect.*not supported/))
+    end
+
+    it 'documents the supported dialects' do
+      expect(validator::SUPPORTED_DIALECTS).to include('https://json-schema.org/draft/2020-12/schema',
+                                                       'https://json-schema.org/draft/2019-09/schema',
+                                                       'http://json-schema.org/draft-07/schema')
+    end
+
+    it 'requires a schema to be an object' do
+      expect(validator.check_schema(nil)).to contain_exactly(a_string_matching(/must be an object/))
+      expect(validator.check_schema('string')).to contain_exactly(a_string_matching(/must be an object/))
+      expect(validator.validate({}, nil)).to contain_exactly(a_string_matching(/must be an object/))
+    end
+  end
+
+  describe 'local $ref resolution' do
+    let(:schema) do
+      { 'type' => 'object',
+        '$defs' => { 'point' => { 'type' => 'object', 'required' => %w[x y],
+                                  'properties' => { 'x' => { 'type' => 'number' }, 'y' => { 'type' => 'number' } } } },
+        'properties' => { 'origin' => { '$ref' => '#/$defs/point' },
+                          'legacy' => { '$ref' => '#/definitions/name' } },
+        'definitions' => { 'name' => { 'type' => 'string' } } }
+    end
+
+    it 'resolves $defs and definitions pointers within the root schema' do
+      expect(validator.validate({ 'origin' => { 'x' => 1, 'y' => 2 }, 'legacy' => 'n' }, schema)).to be_empty
+      errors = validator.validate({ 'origin' => { 'x' => 1 }, 'legacy' => 3 }, schema)
+      expect(errors).to contain_exactly(a_string_matching(%r{#/origin: missing required property 'y'}),
+                                        a_string_matching(%r{#/legacy: expected type string}))
+    end
+
+    it 'decodes JSON pointer escapes and percent-encoding in $ref' do
+      schema = { '$defs' => { 'a/b' => { 'type' => 'integer' }, 'c~d' => { 'type' => 'boolean' } },
+                 'properties' => { 'p' => { '$ref' => '#/$defs/a~1b' }, 'q' => { '$ref' => '#/%24defs/c~0d' } } }
+      expect(validator.validate({ 'p' => 1, 'q' => true }, schema)).to be_empty
+      expect(validator.validate({ 'p' => 'x' }, schema)).to contain_exactly(a_string_matching(%r{#/p: expected type}))
+    end
+
+    it 'follows recursive references without looping forever' do
+      tree = { 'type' => 'object', 'properties' => { 'children' => { 'type' => 'array', 'items' => { '$ref' => '#' } },
+                                                     'value' => { 'type' => 'integer' } } }
+      good = { 'value' => 1, 'children' => [{ 'value' => 2, 'children' => [] }] }
+      bad = { 'value' => 1, 'children' => [{ 'value' => 'two' }] }
+      expect(validator.validate(good, tree)).to be_empty
+      expect(validator.validate(bad, tree)).to contain_exactly(a_string_matching(%r{#/children/0/value}))
+
+      loop_schema = { '$ref' => '#/$defs/a',
+                      '$defs' => { 'a' => { '$ref' => '#/$defs/b' }, 'b' => { '$ref' => '#/$defs/a' } } }
+      expect(validator.validate(1, loop_schema)).to contain_exactly(a_string_matching(/\$ref.*(cycle|depth)/))
+    end
+
+    it 'rejects an unresolvable local $ref instead of ignoring it' do
+      schema = { 'properties' => { 'p' => { '$ref' => '#/$defs/missing' } } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(%r{unresolvable.*#/\$defs/missing}))
+      expect(validator.validate({ 'p' => 1 }, schema)).to contain_exactly(a_string_matching(/unresolvable/))
+    end
+  end
+
+  describe 'external $ref' do
+    it 'never dereferences a network URI and rejects the schema' do
+      schema = { 'type' => 'object', 'properties' => { 'p' => { '$ref' => 'https://example.com/schemas/p.json' } } }
+      # WebMock raises on any real request; the reference must never be fetched.
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/external \$ref.*not dereferenced/))
+      errors = validator.validate({ 'p' => 1 }, schema)
+      expect(errors).to contain_exactly(a_string_matching(/external \$ref/))
+      expect(a_request(:any, /example\.com/)).not_to have_been_made
+    end
+
+    it 'treats relative, urn and $id-based references as external too' do
+      ['other.json', 'urn:example:schema', 'other.json#/x', 'file:///etc/passwd'].each do |ref|
+        expect(validator.check_schema({ '$ref' => ref })).to contain_exactly(a_string_matching(/external \$ref/)),
+                                                             "expected #{ref} to count as external"
+      end
+    end
+  end
+
+  describe 'composition keywords' do
+    it 'evaluates allOf, anyOf, oneOf and not' do
+      expect(validator.validate(5, { 'allOf' => [{ 'type' => 'integer' }, { 'minimum' => 3 }] })).to be_empty
+      expect(validator.validate(1, { 'allOf' => [{ 'type' => 'integer' }, { 'minimum' => 3 }] }))
+        .to contain_exactly(a_string_matching(/allOf/))
+      expect(validator.validate('s', { 'anyOf' => [{ 'type' => 'integer' }, { 'type' => 'string' }] })).to be_empty
+      expect(validator.validate(true, { 'anyOf' => [{ 'type' => 'integer' }, { 'type' => 'string' }] }))
+        .to contain_exactly(a_string_matching(/anyOf/))
+      expect(validator.validate(2, { 'oneOf' => [{ 'type' => 'integer' }, { 'minimum' => 10 }] })).to be_empty
+      expect(validator.validate(12, { 'oneOf' => [{ 'type' => 'integer' }, { 'minimum' => 10 }] }))
+        .to contain_exactly(a_string_matching(/oneOf/))
+      expect(validator.validate('x', { 'not' => { 'type' => 'integer' } })).to be_empty
+      expect(validator.validate(1, { 'not' => { 'type' => 'integer' } })).to contain_exactly(a_string_matching(/not/))
+    end
+
+    it 'evaluates if/then/else' do
+      schema = { 'if' => { 'properties' => { 'kind' => { 'const' => 'a' } }, 'required' => ['kind'] },
+                 'then' => { 'required' => ['a_value'] }, 'else' => { 'required' => ['other'] } }
+      expect(validator.validate({ 'kind' => 'a', 'a_value' => 1 }, schema)).to be_empty
+      expect(validator.validate({ 'kind' => 'a' }, schema)).to contain_exactly(a_string_matching(/a_value/))
+      expect(validator.validate({ 'kind' => 'b', 'other' => 1 }, schema)).to be_empty
+      expect(validator.validate({ 'kind' => 'b' }, schema)).to contain_exactly(a_string_matching(/other/))
+    end
+
+    it 'no longer reports the composition and reference keywords as unsupported' do
+      %w[$ref $defs allOf anyOf oneOf not if then else].each do |keyword|
+        expect(validator::UNSUPPORTED_KEYWORDS).not_to include(keyword)
+      end
+      expect(validator.unsupported_keywords({ 'allOf' => [{ 'format' => 'email' }] })).to eq(['format'])
+    end
+  end
+
+  describe 'resource bounds' do
+    it 'rejects a schema nested deeper than MAX_SCHEMA_DEPTH' do
+      deep = { 'type' => 'integer' }
+      (validator::MAX_SCHEMA_DEPTH + 1).times { deep = { 'type' => 'array', 'items' => deep } }
+
+      expect(validator.check_schema(deep)).to contain_exactly(a_string_matching(/depth/))
+      expect(validator.validate([[]], deep)).to contain_exactly(a_string_matching(/depth/))
+    end
+
+    it 'rejects a schema with more than MAX_SUBSCHEMAS subschemas' do
+      wide = { 'anyOf' => Array.new(validator::MAX_SUBSCHEMAS + 1) { { 'type' => 'integer' } } }
+
+      expect(validator.check_schema(wide)).to contain_exactly(a_string_matching(/subschemas/))
+      expect(validator.validate(1, wide)).to contain_exactly(a_string_matching(/subschemas/))
+    end
+
+    it 'stops validating once the time budget is exhausted' do
+      schema = { 'type' => 'array', 'items' => { 'type' => 'string', 'pattern' => 'a' } }
+      allow(validator).to receive(:pattern_budget_remaining).and_return(0.0)
+
+      errors = validator.validate(%w[a b], schema)
+
+      expect(errors).to contain_exactly(a_string_matching(/budget/))
+    end
+  end
+
+  it 'ignores the x-mcp-header annotation' do
+    schema = { 'type' => 'object', 'properties' => { 'region' => { 'type' => 'string', 'x-mcp-header' => 'Region' } } }
+    expect(validator.validate({ 'region' => 'eu' }, schema)).to be_empty
+    expect(validator.unsupported_keywords(schema)).to be_empty
+    expect(validator.check_schema(schema)).to be_empty
+  end
+
+  describe 'structuredContent through MCPClient::Client' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+
+    def tool(output_schema, name: 'tool')
+      MCPClient::Tool.new(name: name, description: 'd', schema: { 'type' => 'object' }, output_schema: output_schema,
+                          server: mock_server)
+    end
+
+    def client_with(tools, **opts)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+      allow(mock_server).to receive(:on_notification)
+      allow(mock_server).to receive(:list_tools).and_return(tools)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger, **opts)
+    end
+
+    it 'accepts a null structuredContent when the key is present and the schema allows it' do
+      client = client_with([tool({ 'type' => 'null' })], validate_structured_content: :strict)
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => nil })
+
+      expect(client.call_tool('tool', {})['structuredContent']).to be_nil
+      expect(log_output.string).not_to include('structuredContent')
+    end
+
+    it 'rejects a null structuredContent that the schema does not allow, and still requires the key' do
+      client = client_with([tool({ 'type' => 'object' })], validate_structured_content: :strict)
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => nil })
+      expect { client.call_tool('tool', {}) }.to raise_error(MCPClient::Errors::ValidationError, /expected type object/)
+
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [] })
+      expect { client.call_tool('tool', {}) }.to raise_error(MCPClient::Errors::ValidationError, /no structuredContent/)
+    end
+
+    it 'validates non-object structured content (arrays, scalars)' do
+      client = client_with([tool({ 'type' => 'array', 'items' => { 'type' => 'integer' } })],
+                           validate_structured_content: :strict)
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => [1, 2] })
+      expect(client.call_tool('tool', {})['structuredContent']).to eq([1, 2])
+
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => ['x'] })
+      expect { client.call_tool('tool', {}) }.to raise_error(MCPClient::Errors::ValidationError, %r{#/0})
+    end
+
+    it 'treats an output schema with an external $ref as a violation rather than as permissive' do
+      schema = { 'type' => 'object', 'properties' => { 'p' => { '$ref' => 'https://example.com/p.json' } } }
+      client = client_with([tool(schema)], validate_structured_content: :strict)
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => { 'p' => 1 } })
+
+      expect { client.call_tool('tool', {}) }.to raise_error(MCPClient::Errors::ValidationError, /external \$ref/)
+      expect(a_request(:any, /example\.com/)).not_to have_been_made
+    end
+
+    it 'warns (default mode) when the output schema uses an unsupported dialect' do
+      schema = { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' }
+      client = client_with([tool(schema)])
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => {} })
+
+      client.call_tool('tool', {})
+
+      expect(log_output.string).to match(/dialect.*not supported/)
+    end
+
+    it 'warns once about an unusable input schema and still calls the tool' do
+      bad_input = MCPClient::Tool.new(name: 'bad', description: 'd',
+                                      schema: { '$ref' => 'https://example.com/in.json' }, server: mock_server)
+      client = client_with([bad_input])
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [] })
+
+      client.call_tool('bad', {})
+      client.call_tool('bad', {})
+
+      expect(log_output.string.scan(/input schema.*external \$ref/).size).to eq(1)
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_spec.rb
@@ -33,10 +33,13 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling' do
       expect(errors).to contain_exactly(a_string_matching(/dialect.*not supported/))
     end
 
-    it 'documents the supported dialects' do
-      expect(validator::SUPPORTED_DIALECTS).to include('https://json-schema.org/draft/2020-12/schema',
-                                                       'https://json-schema.org/draft/2019-09/schema',
-                                                       'http://json-schema.org/draft-07/schema')
+    it 'implements exactly 2020-12, 2019-09 and draft-07' do
+      expect(validator::SUPPORTED_DIALECTS).to contain_exactly('https://json-schema.org/draft/2020-12/schema',
+                                                               'https://json-schema.org/draft/2019-09/schema',
+                                                               'http://json-schema.org/draft-07/schema')
+      validator::SUPPORTED_DIALECTS.each do |dialect|
+        expect(validator.check_schema({ '$schema' => dialect, 'type' => 'object' })).to be_empty
+      end
     end
 
     it 'requires a schema to be an object' do
@@ -194,7 +197,11 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling' do
       client = client_with([tool({ 'type' => 'null' })], validate_structured_content: :strict)
       allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => nil })
 
-      expect(client.call_tool('tool', {})['structuredContent']).to be_nil
+      returned = client.call_tool('tool', {})
+      # The key itself must survive: reading it as nil would pass just as
+      # well for a result the client had dropped it from.
+      expect(returned).to have_key('structuredContent')
+      expect(returned['structuredContent']).to be_nil
       expect(log_output.string).not_to include('structuredContent')
     end
 
@@ -217,6 +224,33 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling' do
       expect { client.call_tool('tool', {}) }.to raise_error(MCPClient::Errors::ValidationError, %r{#/0})
     end
 
+    # "structuredContent can be any JSON value (object, array, string,
+    # number, boolean, or null)": every one of them is validated, and a
+    # symbol-keyed result carries the value just as a string-keyed one does.
+    {
+      'string' => ['ok', 42], 'number' => [1.5, 'no'], 'boolean' => [false, 'no'], 'null' => [nil, 1]
+    }.each do |type, (conforming, violating)|
+      it "validates #{type} structured content" do
+        client = client_with([tool({ 'type' => type })], validate_structured_content: :strict)
+        allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => conforming })
+        expect(client.call_tool('tool', {})['structuredContent']).to eq(conforming)
+
+        allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => violating })
+        expect { client.call_tool('tool', {}) }
+          .to raise_error(MCPClient::Errors::ValidationError, /expected type #{type}/)
+      end
+    end
+
+    it 'reads a symbol-keyed result the same way' do
+      client = client_with([tool({ 'type' => 'string' })], validate_structured_content: :strict)
+      allow(mock_server).to receive(:call_tool).and_return({ content: [], structuredContent: 'ok' })
+      expect(client.call_tool('tool', {})[:structuredContent]).to eq('ok')
+
+      allow(mock_server).to receive(:call_tool).and_return({ content: [], structuredContent: 42 })
+      expect { client.call_tool('tool', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /expected type string/)
+    end
+
     it 'treats an output schema with an external $ref as a violation rather than as permissive' do
       schema = { 'type' => 'object', 'properties' => { 'p' => { '$ref' => 'https://example.com/p.json' } } }
       client = client_with([tool(schema)], validate_structured_content: :strict)
@@ -226,14 +260,17 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling' do
       expect(a_request(:any, /example\.com/)).not_to have_been_made
     end
 
-    it 'warns (default mode) when the output schema uses an unsupported dialect' do
+    it 'errors (in either mode) when the output schema uses an unsupported dialect' do
+      # MCP 2026-07-28 basic "Implementation Requirements": the client MUST
+      # return an error saying the dialect is not supported. That is not a
+      # structured-content mismatch the host's mode may reduce to a log line.
       schema = { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' }
-      client = client_with([tool(schema)])
       allow(mock_server).to receive(:call_tool).and_return({ 'content' => [], 'structuredContent' => {} })
 
-      client.call_tool('tool', {})
-
-      expect(log_output.string).to match(/dialect.*not supported/)
+      expect { client_with([tool(schema)]).call_tool('tool', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /dialect.*not supported/)
+      expect { client_with([tool(schema)], validate_structured_content: :strict).call_tool('tool', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /dialect.*not supported/)
     end
 
     it 'warns once about an unusable input schema and still calls the tool' do

--- a/spec/lib/mcp_client/json_schema_2026_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_spec.rb
@@ -42,6 +42,24 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling' do
       end
     end
 
+    it 'reads each of them with its own grammar, not all as 2020-12' do
+      # Positional schemas live in `items` before 2020-12 and in
+      # `prefixItems` from it, so the same document means different things
+      # under two of the three dialects this validator implements.
+      tuple = { 'items' => [{ 'type' => 'integer' }], 'additionalItems' => false }
+      legacy = tuple.merge('$schema' => 'http://json-schema.org/draft-07/schema#')
+      expect(validator.check_schema(legacy)).to be_empty
+      expect(validator.validate([1, 2], legacy)).to contain_exactly(a_string_matching(/additionalItems is false/))
+      modern = tuple.merge('$schema' => validator::DEFAULT_DIALECT)
+      expect(validator.check_schema(modern)).to include(a_string_matching(/items must be a schema/))
+      # And a `$ref` replaces its siblings under draft-07 only.
+      sibling = { '$ref' => '#/$defs/s', 'maxLength' => 1, '$defs' => { 's' => { 'type' => 'string' } } }
+      expect(validator.validate('xy', sibling)).to contain_exactly(a_string_matching(/maxLength/))
+      expect(validator.validate('xy', sibling.merge('$schema' => 'http://json-schema.org/draft-07/schema#',
+                                                    'definitions' => { 's' => { 'type' => 'string' } })))
+        .to be_empty
+    end
+
     it 'requires a schema to be an object' do
       expect(validator.check_schema(nil)).to contain_exactly(a_string_matching(/must be an object/))
       expect(validator.check_schema('string')).to contain_exactly(a_string_matching(/must be an object/))

--- a/spec/lib/mcp_client/json_schema_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_verify_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — verification round' do
 
     it 'scans a long chain of shallow references for unsupported keywords' do
       scanned = chained_refs(400)
-      scanned['$defs']['400'] = { 'uniqueItems' => true }
-      expect(on_thread { validator.unsupported_keywords(scanned) }).to contain_exactly('uniqueItems')
+      scanned['$defs']['400'] = { 'unevaluatedItems' => false }
+      expect(on_thread { validator.unsupported_keywords(scanned) }).to contain_exactly('unevaluatedItems')
     end
 
     it 'validates against a long chain on the hop budget, never on the call stack' do
@@ -194,8 +194,8 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — verification round' do
     end
 
     it 'scans a modern definitions bag for unsupported keywords' do
-      schema = { 'type' => 'array', 'definitions' => { 'x' => { 'uniqueItems' => true } } }
-      expect(validator.unsupported_keywords(schema)).to contain_exactly('uniqueItems')
+      schema = { 'type' => 'array', 'definitions' => { 'x' => { 'unevaluatedItems' => false } } }
+      expect(validator.unsupported_keywords(schema)).to contain_exactly('unevaluatedItems')
     end
 
     it 'leaves $defs unknown to draft-07' do
@@ -260,8 +260,8 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — verification round' do
         { 'type' => [] } => /type must be/,
         { 'type' => ['objekt'] } => /type must be/,
         { 'enum' => 'a' } => /enum must be an array/,
-        { 'required' => 'a' } => /required must be an array of property names/,
-        { 'required' => [1] } => /required must be an array of property names/,
+        { 'required' => 'a' } => /required must be an array of distinct property names/,
+        { 'required' => [1] } => /required must be an array of distinct property names/,
         { 'pattern' => 5 } => /pattern must be a string/,
         { 'minLength' => 'a' } => /minLength must be a non-negative integer/,
         { 'maxItems' => -1 } => /maxItems must be a non-negative integer/,
@@ -287,32 +287,42 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — verification round' do
   end
 
   describe 'a condition the validator cannot decide' do
+    # `unevaluatedItems` is decided by the annotations a whole composition
+    # produces, which this validator does not collect, so a condition
+    # carrying one is genuinely undecidable — unlike the standard assertions,
+    # which are evaluated and decide their condition outright.
+    let(:undecidable) { { 'unevaluatedItems' => false } }
+
     it 'reports a failure both branches agree on' do
-      schema = { 'if' => { 'multipleOf' => 2 }, 'then' => false, 'else' => false }
-      expect(validator.validate(3, schema)).to contain_exactly(a_string_matching(/if/))
-      expect(validator.validate(4, schema)).to contain_exactly(a_string_matching(/if/))
+      schema = { 'if' => undecidable, 'then' => false, 'else' => false }
+      expect(validator.validate([1], schema)).to contain_exactly(a_string_matching(/if/))
+      expect(validator.validate([1, 2], schema)).to contain_exactly(a_string_matching(/if/))
     end
 
     it 'reports it when both branches assert the same rejected type' do
-      schema = { 'if' => { 'multipleOf' => 2 }, 'then' => { 'type' => 'string' },
-                 'else' => { 'type' => 'string' } }
-      expect(validator.validate(3, schema)).to contain_exactly(a_string_matching(/expected type string/))
+      schema = { 'if' => undecidable, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'string' } }
+      expect(validator.validate([1], schema)).to contain_exactly(a_string_matching(/expected type string/))
       expect(validator.validate('x', schema)).to be_empty
     end
 
     it 'stays silent when the branches genuinely disagree' do
-      schema = { 'if' => { 'multipleOf' => 2 }, 'then' => { 'type' => 'string' },
-                 'else' => { 'type' => 'integer' } }
-      expect(validator.validate(3, schema)).to be_empty
+      schema = { 'if' => undecidable, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'array' } }
+      expect(validator.validate([1], schema)).to be_empty
     end
 
     it 'stays silent when only one branch is written' do
-      expect(validator.validate(3, { 'if' => { 'multipleOf' => 2 }, 'then' => false })).to be_empty
-      expect(validator.validate(3, { 'if' => { 'multipleOf' => 2 }, 'else' => false })).to be_empty
+      expect(validator.validate([1], { 'if' => undecidable, 'then' => false })).to be_empty
+      expect(validator.validate([1], { 'if' => undecidable, 'else' => false })).to be_empty
     end
 
     it 'does not treat an unconditional failure as a match for not' do
-      schema = { 'not' => { 'if' => { 'multipleOf' => 2 }, 'then' => false, 'else' => false } }
+      schema = { 'not' => { 'if' => undecidable, 'then' => false, 'else' => false } }
+      expect(validator.validate([1], schema)).to be_empty
+    end
+
+    it 'applies the branch a condition the validator does evaluate selects' do
+      schema = { 'if' => { 'multipleOf' => 2 }, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'integer' } }
+      expect(validator.validate(4, schema)).to contain_exactly(a_string_matching(/expected type string/))
       expect(validator.validate(3, schema)).to be_empty
     end
   end

--- a/spec/lib/mcp_client/json_schema_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_verify_spec.rb
@@ -1,0 +1,329 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 JSON Schema handling, verification round: the preflight and
+# the unsupported-keyword scan run on an explicit work list rather than the
+# call stack, an unsupported input dialect is an error the caller sees, a
+# reference to a resource the document bundles resolves inside it,
+# `definitions` is the deprecated `$defs` of the modern dialects, 2019-09
+# anchor names admit a colon, malformed keyword shapes are rejected at
+# preflight, and a condition the validator cannot decide still reports a
+# failure both of its branches agree on.
+RSpec.describe 'MCP 2026-07-28 JSON Schema handling — verification round' do
+  let(:validator) { MCPClient::SchemaValidator }
+  let(:draft7) { 'http://json-schema.org/draft-07/schema#' }
+  let(:draft2019) { 'https://json-schema.org/draft/2019-09/schema' }
+
+  # A shallow document whose references chain through hundreds of schemas:
+  # far below every structural bound, but one Ruby frame per hop would
+  # overflow the small stack a transport's reader thread runs on.
+  def chained_refs(length)
+    defs = {}
+    length.times { |i| defs[i.to_s] = { 'allOf' => [{ '$ref' => "#/$defs/#{i + 1}" }] } }
+    defs[length.to_s] = {}
+    { '$ref' => '#/$defs/0', '$defs' => defs }
+  end
+
+  # Run a block on a fresh thread (the stack a transport's reader owns) and
+  # re-raise whatever it raised, SystemStackError included.
+  def on_thread(&block)
+    thread = Thread.new(&block)
+    thread.report_on_exception = false
+    thread.value
+  end
+
+  describe 'a reference chain that does not nest the document' do
+    let(:schema) { chained_refs(400) }
+
+    it 'preflights a long chain of shallow references without the call stack' do
+      expect(on_thread { validator.check_schema(schema) }).to be_empty
+    end
+
+    it 'scans a long chain of shallow references for unsupported keywords' do
+      scanned = chained_refs(400)
+      scanned['$defs']['400'] = { 'uniqueItems' => true }
+      expect(on_thread { validator.unsupported_keywords(scanned) }).to contain_exactly('uniqueItems')
+    end
+
+    it 'validates against a long chain on the hop budget, never on the call stack' do
+      errors = on_thread { validator.validate({}, schema) }
+      expect(errors).to contain_exactly(a_string_matching(/exceeds #{validator::MAX_REF_DEPTH} hops/))
+    end
+
+    it 'validates against a chain within the hop budget' do
+      short = chained_refs(validator::MAX_REF_DEPTH - 2)
+      expect(on_thread { validator.validate({}, short) }).to be_empty
+    end
+
+    describe 'through MCPClient::Client' do
+      let(:logger) { Logger.new(StringIO.new) }
+      let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+
+      def client_with(tool)
+        allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+        allow(mock_server).to receive(:on_notification)
+        allow(mock_server).to receive(:list_tools).and_return([tool])
+        allow(mock_server).to receive(:call_tool).and_return({ 'structuredContent' => {} })
+        MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger)
+      end
+
+      it 'checks a chained input schema on the calling thread without overflowing it' do
+        tool = MCPClient::Tool.new(name: 't', description: 'd', schema: schema, server: mock_server)
+        client = client_with(tool)
+        expect(on_thread { client.call_tool('t', {}) }).to eq({ 'structuredContent' => {} })
+      end
+
+      it 'checks a chained output schema on the calling thread without overflowing it' do
+        tool = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
+                                   output_schema: schema, server: mock_server)
+        client = client_with(tool)
+        expect(on_thread { client.call_tool('t', {}) }).to eq({ 'structuredContent' => {} })
+      end
+    end
+  end
+
+  describe 'an unsupported input dialect' do
+    let(:logger) { Logger.new(StringIO.new) }
+    let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
+
+    def client_for(schema)
+      tool = MCPClient::Tool.new(name: 't', description: 'd', schema: schema, server: mock_server)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
+      allow(mock_server).to receive(:on_notification)
+      allow(mock_server).to receive(:list_tools).and_return([tool])
+      allow(mock_server).to receive(:call_tool).and_return({ 'content' => [] })
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger)
+    end
+
+    it 'is an error the caller sees, and the call never goes out' do
+      client = client_for({ '$schema' => 'urn:unknown-dialect', 'type' => 'object' })
+      expect { client.call_tool('t', {}) }
+        .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown-dialect.*not supported/)
+      expect { client.call_tool('t', {}) }.to raise_error(MCPClient::Errors::ValidationError)
+      expect(mock_server).not_to have_received(:call_tool)
+    end
+
+    it 'reports an unsupported dialect declared by an embedded resource too' do
+      embedded = { 'type' => 'object',
+                   'properties' => { 'a' => { '$id' => 'https://example.com/a',
+                                              '$schema' => 'http://json-schema.org/draft-04/schema#' } } }
+      client = client_for(embedded)
+      expect { client.call_tool('t', {}) }.to raise_error(MCPClient::Errors::ValidationError, /draft-04/)
+      expect(mock_server).not_to have_received(:call_tool)
+    end
+
+    it 'still sends the call when a supported-dialect schema is merely unusable' do
+      client = client_for({ 'type' => 'object', 'required' => ['x'],
+                            'properties' => { 'x' => { '$ref' => 'https://example.com/x' } } })
+      expect { client.call_tool('t', {}) }.not_to raise_error
+      expect(mock_server).to have_received(:call_tool)
+    end
+
+    it 'names the unsupported dialect through the validator' do
+      expect(validator.unsupported_dialect({ '$schema' => 'urn:unknown-dialect' })).to eq('urn:unknown-dialect')
+      expect(validator.unsupported_dialect({ 'type' => 'object' })).to be_nil
+      expect(validator.unsupported_dialect(true)).to be_nil
+    end
+  end
+
+  describe 'references to resources the document bundles' do
+    it 'resolves an absolute $ref naming an embedded $id' do
+      schema = { '$defs' => { 's' => { '$id' => 'urn:example:s', 'type' => 'string' } },
+                 '$ref' => 'urn:example:s' }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate('ok', schema)).to be_empty
+      expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+
+    it 'resolves a relative $ref against the base its resource declares' do
+      schema = { '$id' => 'https://example.com/root.json',
+                 'type' => 'object',
+                 'properties' => { 'a' => { '$ref' => 'sub.json' } },
+                 '$defs' => { 's' => { '$id' => 'sub.json', 'type' => 'integer' } } }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => 1 }, schema)).to be_empty
+      expect(validator.validate({ 'a' => 'x' }, schema)).to contain_exactly(a_string_matching(/expected type integer/))
+    end
+
+    it 'resolves a pointer into a bundled resource' do
+      schema = { '$defs' => { 's' => { '$id' => 'urn:example:s',
+                                       '$defs' => { 'inner' => { 'type' => 'boolean' } } } },
+                 '$ref' => 'urn:example:s#/$defs/inner' }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(true, schema)).to be_empty
+      expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/expected type boolean/))
+    end
+
+    it 'resolves an anchor inside a bundled resource' do
+      schema = { '$defs' => { 's' => { '$id' => 'urn:example:s',
+                                       '$defs' => { 'a' => { '$anchor' => 'leaf', 'type' => 'null' } } } },
+                 '$ref' => 'urn:example:s#leaf' }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(nil, schema)).to be_empty
+      expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/expected type null/))
+    end
+
+    it 'reads the empty URI reference as the current resource' do
+      schema = { 'type' => 'object', 'properties' => { 'a' => { '$ref' => '' } } }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate({ 'a' => { 'a' => {} } }, schema)).to be_empty
+      expect(validator.validate({ 'a' => 1 }, schema)).to contain_exactly(a_string_matching(/expected type object/))
+    end
+
+    it 'still reports a reference the document does not bundle as external' do
+      schema = { '$defs' => { 's' => { '$id' => 'urn:example:s', 'type' => 'string' } },
+                 '$ref' => 'urn:example:other' }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/external \$ref/))
+      relative = { '$id' => 'https://example.com/root.json', '$ref' => 'sibling.json' }
+      expect(validator.check_schema(relative)).to contain_exactly(a_string_matching(/external \$ref/))
+    end
+  end
+
+  describe 'definitions under the modern dialects' do
+    it 'takes an anchor from definitions the way it does from $defs' do
+      schema = { 'definitions' => { 'x' => { '$anchor' => 'x', 'type' => 'integer' } }, '$ref' => '#x' }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(1, schema)).to be_empty
+      expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/expected type integer/))
+    end
+
+    it 'preflights what a modern definitions bag holds' do
+      schema = { 'type' => 'integer', 'definitions' => { 'hidden' => { '$ref' => 'https://example.com/x' } } }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/external \$ref/))
+    end
+
+    it 'scans a modern definitions bag for unsupported keywords' do
+      schema = { 'type' => 'array', 'definitions' => { 'x' => { 'uniqueItems' => true } } }
+      expect(validator.unsupported_keywords(schema)).to contain_exactly('uniqueItems')
+    end
+
+    it 'leaves $defs unknown to draft-07' do
+      legacy = { '$schema' => draft7, 'properties' => { 'a' => { '$ref' => '#trap' } },
+                 '$defs' => { 't' => { '$id' => '#trap', 'type' => 'string' } } }
+      expect(validator.check_schema(legacy)).to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+  end
+
+  describe '2019-09 anchor names' do
+    it 'accepts a colon in a 2019-09 anchor' do
+      schema = { '$schema' => draft2019,
+                 '$defs' => { 'a' => { '$anchor' => 'a:b', 'type' => 'string' } }, '$ref' => '#a:b' }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate('ok', schema)).to be_empty
+      expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+
+    it 'accepts a colon in a draft-07 plain-name $id' do
+      schema = { '$schema' => draft7,
+                 'definitions' => { 'a' => { '$id' => '#a:b', 'type' => 'string' } }, '$ref' => '#a:b' }
+      expect(validator.check_schema(schema)).to be_empty
+      expect(validator.validate(1, schema)).to contain_exactly(a_string_matching(/expected type string/))
+    end
+
+    it 'keeps the 2020-12 name syntax for 2020-12' do
+      colon = { '$defs' => { 'a' => { '$anchor' => 'a:b', 'type' => 'string' } }, '$ref' => '#a:b' }
+      expect(validator.check_schema(colon)).to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+      underscore = { '$defs' => { 'a' => { '$anchor' => '_b', 'type' => 'string' } }, '$ref' => '#_b' }
+      expect(validator.check_schema(underscore)).to be_empty
+    end
+
+    it 'rejects a leading underscore under 2019-09, which does not allow one' do
+      schema = { '$schema' => draft2019,
+                 '$defs' => { 'a' => { '$anchor' => '_b', 'type' => 'string' } }, '$ref' => '#_b' }
+      expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(/unresolvable local \$ref/))
+    end
+  end
+
+  describe 'malformed keyword shapes at preflight' do
+    it 'rejects an empty composition array' do
+      %w[allOf anyOf oneOf].each do |keyword|
+        expect(validator.check_schema({ keyword => [] }))
+          .to contain_exactly(a_string_matching(/#{Regexp.escape(keyword)} must be a non-empty array/))
+      end
+      expect(validator.check_schema({ 'prefixItems' => [] }))
+        .to contain_exactly(a_string_matching(/prefixItems must be a non-empty array/))
+    end
+
+    it 'rejects a definition bag entry that is not a schema' do
+      expect(validator.check_schema({ '$defs' => { 'x' => 5 } }))
+        .to contain_exactly(a_string_matching(/\$defs must be an object of schemas/))
+      expect(validator.check_schema({ '$schema' => draft7, 'definitions' => { 'x' => 5 } }))
+        .to contain_exactly(a_string_matching(/definitions must be an object of schemas/))
+      expect(validator.check_schema({ '$defs' => [] }))
+        .to contain_exactly(a_string_matching(/\$defs must be an object of schemas/))
+    end
+
+    it 'rejects malformed assertion keyword values' do
+      cases = {
+        { 'type' => 42 } => /type must be/,
+        { 'type' => [] } => /type must be/,
+        { 'type' => ['objekt'] } => /type must be/,
+        { 'enum' => 'a' } => /enum must be an array/,
+        { 'required' => 'a' } => /required must be an array of property names/,
+        { 'required' => [1] } => /required must be an array of property names/,
+        { 'pattern' => 5 } => /pattern must be a string/,
+        { 'minLength' => 'a' } => /minLength must be a non-negative integer/,
+        { 'maxItems' => -1 } => /maxItems must be a non-negative integer/,
+        { 'minimum' => 'a' } => /minimum must be a number/
+      }
+      cases.each do |schema, message|
+        expect(validator.check_schema(schema)).to contain_exactly(a_string_matching(message)),
+                                                  "expected #{schema.inspect} to be rejected"
+      end
+    end
+
+    it 'still accepts the well-formed shapes' do
+      expect(validator.check_schema({ 'type' => %w[string null], 'enum' => [1], 'required' => ['a'],
+                                      'pattern' => 'x', 'minLength' => 0, 'maxItems' => 2,
+                                      'minimum' => 1.5, 'allOf' => [true],
+                                      '$defs' => { 'x' => false } })).to be_empty
+    end
+
+    it 'refuses to validate against a malformed schema instead of passing the data' do
+      expect(validator.validate([1], { 'prefixItems' => [] }))
+        .to contain_exactly(a_string_matching(/prefixItems must be a non-empty array/))
+    end
+  end
+
+  describe 'a condition the validator cannot decide' do
+    it 'reports a failure both branches agree on' do
+      schema = { 'if' => { 'multipleOf' => 2 }, 'then' => false, 'else' => false }
+      expect(validator.validate(3, schema)).to contain_exactly(a_string_matching(/if/))
+      expect(validator.validate(4, schema)).to contain_exactly(a_string_matching(/if/))
+    end
+
+    it 'reports it when both branches assert the same rejected type' do
+      schema = { 'if' => { 'multipleOf' => 2 }, 'then' => { 'type' => 'string' },
+                 'else' => { 'type' => 'string' } }
+      expect(validator.validate(3, schema)).to contain_exactly(a_string_matching(/expected type string/))
+      expect(validator.validate('x', schema)).to be_empty
+    end
+
+    it 'stays silent when the branches genuinely disagree' do
+      schema = { 'if' => { 'multipleOf' => 2 }, 'then' => { 'type' => 'string' },
+                 'else' => { 'type' => 'integer' } }
+      expect(validator.validate(3, schema)).to be_empty
+    end
+
+    it 'stays silent when only one branch is written' do
+      expect(validator.validate(3, { 'if' => { 'multipleOf' => 2 }, 'then' => false })).to be_empty
+      expect(validator.validate(3, { 'if' => { 'multipleOf' => 2 }, 'else' => false })).to be_empty
+    end
+
+    it 'does not treat an unconditional failure as a match for not' do
+      schema = { 'not' => { 'if' => { 'multipleOf' => 2 }, 'then' => false, 'else' => false } }
+      expect(validator.validate(3, schema)).to be_empty
+    end
+  end
+
+  describe 'the normalization deadline' do
+    it 'stops copying before it reads the rest of the document' do
+      tripwire = { 'k' => 1 }
+      allow(tripwire).to receive(:to_h).and_raise('the schema must not be copied past the deadline')
+      schema = { 'type' => 'integer', 'x-rest' => tripwire }
+      past = Process.clock_gettime(Process::CLOCK_MONOTONIC) - 1
+      expect(validator.validate(1, schema, deadline: past)).to contain_exactly(a_string_matching(/aborted|time/))
+    end
+  end
+end

--- a/spec/lib/mcp_client/json_schema_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_verify_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — verification round' do
 
     it 'scans a long chain of shallow references for unsupported keywords' do
       scanned = chained_refs(400)
-      scanned['$defs']['400'] = { 'allOf' => [true], 'unevaluatedItems' => false }
-      expect(on_thread { validator.unsupported_keywords(scanned) }).to contain_exactly('unevaluatedItems')
+      scanned['$defs']['400'] = { 'format' => 'uuid' }
+      expect(on_thread { validator.unsupported_keywords(scanned) }).to contain_exactly('format')
     end
 
     it 'validates against a long chain on the hop budget, never on the call stack' do
@@ -222,9 +222,8 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — verification round' do
     end
 
     it 'scans a modern definitions bag for unsupported keywords' do
-      schema = { 'type' => 'array', 'definitions' => { 'x' => { 'allOf' => [true],
-                                                                'unevaluatedItems' => false } } }
-      expect(validator.unsupported_keywords(schema)).to contain_exactly('unevaluatedItems')
+      schema = { 'type' => 'array', 'definitions' => { 'x' => { 'format' => 'uuid' } } }
+      expect(validator.unsupported_keywords(schema)).to contain_exactly('format')
     end
 
     it 'leaves $defs unknown to draft-07' do

--- a/spec/lib/mcp_client/json_schema_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_verify_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — verification round' do
 
     it 'scans a long chain of shallow references for unsupported keywords' do
       scanned = chained_refs(400)
-      scanned['$defs']['400'] = { 'unevaluatedItems' => false }
+      scanned['$defs']['400'] = { 'allOf' => [true], 'unevaluatedItems' => false }
       expect(on_thread { validator.unsupported_keywords(scanned) }).to contain_exactly('unevaluatedItems')
     end
 
@@ -60,25 +60,53 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — verification round' do
       let(:logger) { Logger.new(StringIO.new) }
       let(:mock_server) { instance_double(MCPClient::ServerBase, name: 'server1') }
 
-      def client_with(tool)
+      # :strict, so a check that did not run is not the same observation as
+      # a check that ran and passed: an unusable schema raises here.
+      def client_with(tool, result = { 'structuredContent' => {} })
         allow(MCPClient::ServerFactory).to receive(:create).and_return(mock_server)
         allow(mock_server).to receive(:on_notification)
         allow(mock_server).to receive(:list_tools).and_return([tool])
-        allow(mock_server).to receive(:call_tool).and_return({ 'structuredContent' => {} })
-        MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger)
+        allow(mock_server).to receive(:call_tool).and_return(result)
+        MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'test' }], logger: logger,
+                              validate_structured_content: :strict)
       end
 
       it 'checks a chained input schema on the calling thread without overflowing it' do
         tool = MCPClient::Tool.new(name: 't', description: 'd', schema: schema, server: mock_server)
         client = client_with(tool)
         expect(on_thread { client.call_tool('t', {}) }).to eq({ 'structuredContent' => {} })
+
+        # The control: the same chain ending in a dialect nothing can read is
+        # refused, so the walk really reached the end of it.
+        unreadable = chained_refs(400)
+        unreadable['$defs']['400'] = { '$id' => 'https://example.com/r', '$schema' => 'urn:unknown' }
+        broken = MCPClient::Tool.new(name: 'u', description: 'd', schema: unreadable, server: mock_server)
+        allow(mock_server).to receive(:list_tools).and_return([broken])
+        expect { on_thread { client_with(broken).call_tool('u', {}) } }
+          .to raise_error(MCPClient::Errors::ValidationError, /urn:unknown/)
       end
 
       it 'checks a chained output schema on the calling thread without overflowing it' do
         tool = MCPClient::Tool.new(name: 't', description: 'd', schema: { 'type' => 'object' },
                                    output_schema: schema, server: mock_server)
-        client = client_with(tool)
-        expect(on_thread { client.call_tool('t', {}) }).to eq({ 'structuredContent' => {} })
+        # No SystemStackError on the calling thread: the hop budget stops the
+        # chain, and an aborted validation is a violation like any other
+        # rather than a pass (or a crash out of the tool call).
+        expect { on_thread { client_with(tool).call_tool('t', {}) } }
+          .to raise_error(MCPClient::Errors::ValidationError, /exceeds #{validator::MAX_REF_DEPTH} hops/)
+
+        # A chain within the hop budget is walked to its end, which really
+        # decides the result.
+        length = validator::MAX_REF_DEPTH - 2
+        typed = chained_refs(length)
+        typed['$defs'][length.to_s] = { 'type' => 'array' }
+        checked = MCPClient::Tool.new(name: 'v', description: 'd', schema: { 'type' => 'object' },
+                                      output_schema: typed, server: mock_server)
+        allow(mock_server).to receive(:list_tools).and_return([checked])
+        expect { on_thread { client_with(checked).call_tool('v', {}) } }
+          .to raise_error(MCPClient::Errors::ValidationError, %r{does not satisfy allOf/0})
+        expect(on_thread { client_with(checked, { 'structuredContent' => [] }).call_tool('v', {}) })
+          .to eq({ 'structuredContent' => [] })
       end
     end
   end
@@ -194,7 +222,8 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — verification round' do
     end
 
     it 'scans a modern definitions bag for unsupported keywords' do
-      schema = { 'type' => 'array', 'definitions' => { 'x' => { 'unevaluatedItems' => false } } }
+      schema = { 'type' => 'array', 'definitions' => { 'x' => { 'allOf' => [true],
+                                                                'unevaluatedItems' => false } } }
       expect(validator.unsupported_keywords(schema)).to contain_exactly('unevaluatedItems')
     end
 
@@ -287,11 +316,13 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — verification round' do
   end
 
   describe 'a condition the validator cannot decide' do
-    # `unevaluatedItems` is decided by the annotations a whole composition
-    # produces, which this validator does not collect, so a condition
-    # carrying one is genuinely undecidable — unlike the standard assertions,
-    # which are evaluated and decide their condition outright.
-    let(:undecidable) { { 'unevaluatedItems' => false } }
+    # A `$dynamicRef` resolves through the dynamic scope a validation was
+    # entered through, which this validator does not track, so a condition
+    # carrying one is genuinely undecidable — unlike the standard
+    # assertions, which are evaluated and decide their condition outright,
+    # and unlike an `unevaluatedItems` whose annotations its own node
+    # produces, which is now evaluated too.
+    let(:undecidable) { { '$dynamicRef' => '#node' } }
 
     it 'reports a failure both branches agree on' do
       schema = { 'if' => undecidable, 'then' => false, 'else' => false }

--- a/spec/lib/mcp_client/json_schema_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/json_schema_2026_verify_spec.rb
@@ -315,39 +315,46 @@ RSpec.describe 'MCP 2026-07-28 JSON Schema handling — verification round' do
   end
 
   describe 'a condition the validator cannot decide' do
-    # A `$dynamicRef` resolves through the dynamic scope a validation was
-    # entered through, which this validator does not track, so a condition
-    # carrying one is genuinely undecidable — unlike the standard
-    # assertions, which are evaluated and decide their condition outright,
-    # and unlike an `unevaluatedItems` whose annotations its own node
-    # produces, which is now evaluated too.
-    let(:undecidable) { { '$dynamicRef' => '#node' } }
+    # draft-07 `format` asserts (Validation Section 7.2) and this validator
+    # does not evaluate formats, so a string branch carrying one is
+    # genuinely undecidable — unlike the standard assertions, which are
+    # evaluated and decide their condition outright, unlike an
+    # `unevaluatedItems` whose annotations its own node produces, and unlike
+    # a dynamic reference, which binds against the dynamic scope.
+    let(:draft7) { MCPClient::SchemaValidator::DRAFT_07 }
+    let(:undecidable) { { 'format' => 'email' } }
+
+    def under_draft7(schema)
+      { '$schema' => draft7 }.merge(schema)
+    end
 
     it 'reports a failure both branches agree on' do
-      schema = { 'if' => undecidable, 'then' => false, 'else' => false }
-      expect(validator.validate([1], schema)).to contain_exactly(a_string_matching(/if/))
-      expect(validator.validate([1, 2], schema)).to contain_exactly(a_string_matching(/if/))
+      schema = under_draft7({ 'if' => undecidable, 'then' => false, 'else' => false })
+      expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/if/))
+      expect(validator.validate('yy', schema)).to contain_exactly(a_string_matching(/if/))
     end
 
     it 'reports it when both branches assert the same rejected type' do
-      schema = { 'if' => undecidable, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'string' } }
-      expect(validator.validate([1], schema)).to contain_exactly(a_string_matching(/expected type string/))
-      expect(validator.validate('x', schema)).to be_empty
+      schema = under_draft7({ 'if' => undecidable, 'then' => { 'type' => 'integer' },
+                              'else' => { 'type' => 'integer' } })
+      expect(validator.validate('x', schema)).to contain_exactly(a_string_matching(/expected type integer/))
+      expect(validator.validate(1, schema)).to be_empty
     end
 
     it 'stays silent when the branches genuinely disagree' do
-      schema = { 'if' => undecidable, 'then' => { 'type' => 'string' }, 'else' => { 'type' => 'array' } }
-      expect(validator.validate([1], schema)).to be_empty
+      schema = under_draft7({ 'if' => undecidable, 'then' => { 'type' => 'integer' },
+                              'else' => { 'type' => 'string' } })
+      expect(validator.validate('x', schema)).to be_empty
     end
 
     it 'stays silent when only one branch is written' do
-      expect(validator.validate([1], { 'if' => undecidable, 'then' => false })).to be_empty
-      expect(validator.validate([1], { 'if' => undecidable, 'else' => false })).to be_empty
+      expect(validator.validate('x', under_draft7({ 'if' => undecidable, 'then' => false }))).to be_empty
+      expect(validator.validate('x', under_draft7({ 'if' => undecidable, 'else' => false }))).to be_empty
     end
 
     it 'does not treat an unconditional failure as a match for not' do
-      schema = { 'not' => { 'if' => undecidable, 'then' => false, 'else' => false } }
-      expect(validator.validate([1], schema)).to be_empty
+      schema = under_draft7({ 'not' => { 'if' => undecidable, 'then' => false, 'else' => false } })
+      expect(validator.validate('x', schema)).to be_empty
     end
 
     it 'applies the branch a condition the validator does evaluate selects' do

--- a/spec/lib/mcp_client/structured_content_validation_spec.rb
+++ b/spec/lib/mcp_client/structured_content_validation_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe MCPClient::SchemaValidator do
     it 'detects every keyword in the unsupported list' do
       keywords = %w[$dynamicRef $recursiveRef
                     additionalProperties patternProperties propertyNames dependentSchemas dependencies
-                    additionalItems contains minContains maxContains uniqueItems
+                    additionalItems contains minContains maxContains uniqueItems contentSchema
                     multipleOf format dependentRequired minProperties maxProperties
                     unevaluatedProperties unevaluatedItems]
       expect(described_class::UNSUPPORTED_KEYWORDS).to match_array(keywords)

--- a/spec/lib/mcp_client/structured_content_validation_spec.rb
+++ b/spec/lib/mcp_client/structured_content_validation_spec.rb
@@ -141,12 +141,14 @@ RSpec.describe MCPClient::SchemaValidator do
       expect(described_class.validate(1, schema)).to contain_exactly(a_string_matching(/string or null/))
     end
 
-    it 'ignores JSON Schema keywords outside the supported subset' do
-      # The remaining 2020-12 vocabulary (uniqueItems, format, ...) is
-      # documented as out of scope: unrecognized keywords must be ignored,
-      # not misapplied.
+    it 'applies the standard assertions and ignores only what it documents as out of scope' do
+      # uniqueItems is a standard assertion: leaving it unevaluated would
+      # accept an array the schema rejects. `format` only annotates in
+      # 2020-12, so it decides nothing about the instance.
       schema = { 'type' => 'array', 'uniqueItems' => true, 'format' => 'custom' }
-      expect(described_class.validate([1, 1], schema)).to be_empty
+      expect(described_class.validate([1, 1], schema)).to contain_exactly(a_string_matching(/unique/))
+      expect(described_class.validate([1, 2], schema)).to be_empty
+      expect(described_class.validate(['not-an-email'], { 'items' => { 'format' => 'email' } })).to be_empty
     end
 
     it 'handles symbol-keyed schemas and data' do
@@ -169,15 +171,12 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'detects top-level unsupported keywords' do
-      schema = { 'type' => 'object', 'additionalProperties' => false, 'uniqueItems' => true }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly('additionalProperties', 'uniqueItems')
+      schema = { 'type' => 'object', 'unevaluatedProperties' => false, 'format' => 'custom' }
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('unevaluatedProperties', 'format')
     end
 
     it 'detects every keyword in the unsupported list' do
-      keywords = %w[$dynamicRef $recursiveRef
-                    additionalProperties patternProperties propertyNames dependentSchemas dependencies
-                    additionalItems contains minContains maxContains uniqueItems contentSchema
-                    multipleOf format dependentRequired minProperties maxProperties
+      keywords = %w[$dynamicRef $recursiveRef contentSchema format
                     unevaluatedProperties unevaluatedItems]
       expect(described_class::UNSUPPORTED_KEYWORDS).to match_array(keywords)
       keywords.each do |keyword|
@@ -187,9 +186,10 @@ RSpec.describe MCPClient::SchemaValidator do
       end
     end
 
-    it 'detects unapplied 2020-12 assertion keywords nested in property subschemas' do
+    it 'reports only the assertions it cannot evaluate, applying the rest' do
       schema = {
-        # additionalItems and the items tuple only exist before 2020-12.
+        # additionalItems and the items tuple only exist before 2020-12,
+        # where `format` also asserts.
         '$schema' => 'http://json-schema.org/draft-07/schema#',
         'type' => 'object',
         'properties' => {
@@ -200,25 +200,31 @@ RSpec.describe MCPClient::SchemaValidator do
           'names' => { 'type' => 'object', 'propertyNames' => { 'pattern' => '^a' } }
         }
       }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly(
-        'format', 'multipleOf', 'uniqueItems', 'contains', 'additionalItems', 'propertyNames'
-      )
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('format')
+      expect(described_class.validate({ 'count' => 3 }, schema)).to contain_exactly(a_string_matching(/multiple of 5/))
+      expect(described_class.validate({ 'tags' => %w[a a] }, schema)).to contain_exactly(a_string_matching(/unique/))
+      expect(described_class.validate({ 'tags' => [1] }, schema))
+        .to contain_exactly(a_string_matching(/items matching contains/))
+      expect(described_class.validate({ 'pair' => %w[a b] }, schema))
+        .to contain_exactly(a_string_matching(/additionalItems is false/))
+      expect(described_class.validate({ 'names' => { 'b' => 1 } }, schema))
+        .to contain_exactly(a_string_matching(/propertyNames/))
     end
 
     it 'detects unsupported keywords nested in properties and items' do
       schema = {
         'type' => 'object',
         'properties' => {
-          'a' => { 'multipleOf' => 2 },
+          'a' => { '$dynamicRef' => '#x' },
           'b' => { 'type' => 'array', 'items' => { 'format' => 'email' } }
         }
       }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly('multipleOf', 'format')
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('$dynamicRef', 'format')
     end
 
     it 'detects unsupported keywords nested inside applicator schemas' do
-      schema = { 'anyOf' => [{ 'type' => 'object', 'patternProperties' => { '^x' => { 'type' => 'string' } } }] }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly('patternProperties')
+      schema = { 'anyOf' => [{ 'type' => 'object', 'unevaluatedProperties' => false }] }
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('unevaluatedProperties')
     end
 
     it 'does not mistake property names for keywords' do
@@ -267,8 +273,8 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'handles symbol-keyed schemas' do
-      schema = { type: 'object', additionalProperties: false, properties: { a: { anyOf: [{ format: 'email' }] } } }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly('additionalProperties', 'format')
+      schema = { type: 'object', unevaluatedProperties: false, properties: { a: { anyOf: [{ format: 'email' }] } } }
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('unevaluatedProperties', 'format')
     end
 
     it 'returns an empty array for non-hash input' do
@@ -438,7 +444,7 @@ RSpec.describe MCPClient::Client do
             'conditions' => { 'type' => 'string', 'format' => 'custom' }
           },
           'required' => %w[temperature conditions],
-          'additionalProperties' => false
+          'unevaluatedProperties' => false
         }
       end
       let(:result) do
@@ -450,7 +456,7 @@ RSpec.describe MCPClient::Client do
       it 'warns that validation is partial, naming the unsupported keywords, in the default mode' do
         expect(build_client.call_tool('get_weather', {})).to eq(result)
         expect(log_output.string).to match(/get_weather.*validation is partial: schema uses unsupported keywords/)
-        expect(log_output.string).to include('format').and include('additionalProperties')
+        expect(log_output.string).to include('format').and include('unevaluatedProperties')
       end
 
       it 'warns that validation is partial in :strict mode instead of silently passing' do
@@ -458,7 +464,7 @@ RSpec.describe MCPClient::Client do
 
         expect(client.call_tool('get_weather', {})).to eq(result)
         expect(log_output.string).to match(/get_weather.*validation is partial: schema uses unsupported keywords/)
-        expect(log_output.string).to include('format').and include('additionalProperties')
+        expect(log_output.string).to include('format').and include('unevaluatedProperties')
       end
 
       it 'still validates and reports mismatches on the supported subset' do
@@ -478,7 +484,7 @@ RSpec.describe MCPClient::Client do
       end
     end
 
-    context 'when the output schema uses unapplied assertion keywords (format/uniqueItems)' do
+    context 'when the output schema mixes an unapplied annotation with applied assertions' do
       let(:output_schema) do
         {
           'type' => 'object',
@@ -494,12 +500,13 @@ RSpec.describe MCPClient::Client do
 
       before { allow(mock_server).to receive(:call_tool).and_return(result) }
 
-      it 'warns that validation is partial instead of passing silently in :strict mode' do
+      it 'warns that validation is partial and still rejects what it evaluates in :strict mode' do
         client = build_client(validate_structured_content: :strict)
 
-        expect(client.call_tool('get_weather', {})).to eq(result)
+        expect { client.call_tool('get_weather', {}) }
+          .to raise_error(MCPClient::Errors::ValidationError, /unique/)
         expect(log_output.string).to match(/get_weather.*validation is partial: schema uses unsupported keywords/)
-        expect(log_output.string).to include('format').and include('uniqueItems')
+        expect(log_output.string).to include('format')
       end
     end
 

--- a/spec/lib/mcp_client/structured_content_validation_spec.rb
+++ b/spec/lib/mcp_client/structured_content_validation_spec.rb
@@ -181,12 +181,16 @@ RSpec.describe MCPClient::SchemaValidator do
                     unevaluatedProperties unevaluatedItems]
       expect(described_class::UNSUPPORTED_KEYWORDS).to match_array(keywords)
       keywords.each do |keyword|
-        expect(described_class.unsupported_keywords({ keyword => {} })).to eq([keyword])
+        # Under a dialect that defines the keyword.
+        dialect = described_class::DIALECT_KEYWORDS.fetch(keyword, [described_class::DEFAULT_DIALECT]).first
+        expect(described_class.unsupported_keywords({ '$schema' => dialect, keyword => {} })).to eq([keyword])
       end
     end
 
     it 'detects unapplied 2020-12 assertion keywords nested in property subschemas' do
       schema = {
+        # additionalItems and the items tuple only exist before 2020-12.
+        '$schema' => 'http://json-schema.org/draft-07/schema#',
         'type' => 'object',
         'properties' => {
           'email' => { 'type' => 'string', 'format' => 'email' },

--- a/spec/lib/mcp_client/structured_content_validation_spec.rb
+++ b/spec/lib/mcp_client/structured_content_validation_spec.rb
@@ -142,10 +142,11 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'ignores JSON Schema keywords outside the supported subset' do
-      # Full 2020-12 vocabulary (allOf/anyOf/$ref/...) is documented as out of
-      # scope: unrecognized keywords must be ignored, not misapplied.
-      schema = { 'allOf' => [{ 'type' => 'string' }], '$ref' => '#/$defs/x' }
-      expect(described_class.validate(42, schema)).to be_empty
+      # The remaining 2020-12 vocabulary (uniqueItems, format, ...) is
+      # documented as out of scope: unrecognized keywords must be ignored,
+      # not misapplied.
+      schema = { 'type' => 'array', 'uniqueItems' => true, 'format' => 'custom' }
+      expect(described_class.validate([1, 1], schema)).to be_empty
     end
 
     it 'handles symbol-keyed schemas and data' do
@@ -168,12 +169,12 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'detects top-level unsupported keywords' do
-      schema = { 'type' => 'object', 'additionalProperties' => false, 'allOf' => [{ 'type' => 'object' }] }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly('additionalProperties', 'allOf')
+      schema = { 'type' => 'object', 'additionalProperties' => false, 'uniqueItems' => true }
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('additionalProperties', 'uniqueItems')
     end
 
     it 'detects every keyword in the unsupported list' do
-      keywords = %w[$ref $dynamicRef $defs allOf anyOf oneOf not if then else
+      keywords = %w[$dynamicRef
                     additionalProperties patternProperties propertyNames dependentSchemas
                     prefixItems contains minContains maxContains uniqueItems
                     multipleOf format dependentRequired minProperties maxProperties
@@ -204,16 +205,16 @@ RSpec.describe MCPClient::SchemaValidator do
       schema = {
         'type' => 'object',
         'properties' => {
-          'a' => { 'oneOf' => [{ 'type' => 'string' }] },
-          'b' => { 'type' => 'array', 'items' => { '$ref' => '#/$defs/x' } }
+          'a' => { 'multipleOf' => 2 },
+          'b' => { 'type' => 'array', 'items' => { 'format' => 'email' } }
         }
       }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly('oneOf', '$ref')
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('multipleOf', 'format')
     end
 
     it 'detects unsupported keywords nested inside applicator schemas' do
       schema = { 'anyOf' => [{ 'type' => 'object', 'patternProperties' => { '^x' => { 'type' => 'string' } } }] }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly('anyOf', 'patternProperties')
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('patternProperties')
     end
 
     it 'does not mistake property names for keywords' do
@@ -254,16 +255,16 @@ RSpec.describe MCPClient::SchemaValidator do
       schema = {
         'type' => 'object',
         'properties' => {
-          'a' => { '$ref' => '#/$defs/x' },
-          'b' => { '$ref' => '#/$defs/y' }
+          'a' => { 'format' => 'email' },
+          'b' => { 'format' => 'uri' }
         }
       }
-      expect(described_class.unsupported_keywords(schema)).to eq(['$ref'])
+      expect(described_class.unsupported_keywords(schema)).to eq(['format'])
     end
 
     it 'handles symbol-keyed schemas' do
-      schema = { type: 'object', additionalProperties: false, properties: { a: { anyOf: [{ type: 'string' }] } } }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly('additionalProperties', 'anyOf')
+      schema = { type: 'object', additionalProperties: false, properties: { a: { anyOf: [{ format: 'email' }] } } }
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('additionalProperties', 'format')
     end
 
     it 'returns an empty array for non-hash input' do
@@ -430,7 +431,7 @@ RSpec.describe MCPClient::Client do
           'type' => 'object',
           'properties' => {
             'temperature' => { 'type' => 'number' },
-            'conditions' => { 'oneOf' => [{ 'type' => 'string' }, { 'type' => 'null' }] }
+            'conditions' => { 'type' => 'string', 'format' => 'custom' }
           },
           'required' => %w[temperature conditions],
           'additionalProperties' => false
@@ -445,7 +446,7 @@ RSpec.describe MCPClient::Client do
       it 'warns that validation is partial, naming the unsupported keywords, in the default mode' do
         expect(build_client.call_tool('get_weather', {})).to eq(result)
         expect(log_output.string).to match(/get_weather.*validation is partial: schema uses unsupported keywords/)
-        expect(log_output.string).to include('oneOf').and include('additionalProperties')
+        expect(log_output.string).to include('format').and include('additionalProperties')
       end
 
       it 'warns that validation is partial in :strict mode instead of silently passing' do
@@ -453,7 +454,7 @@ RSpec.describe MCPClient::Client do
 
         expect(client.call_tool('get_weather', {})).to eq(result)
         expect(log_output.string).to match(/get_weather.*validation is partial: schema uses unsupported keywords/)
-        expect(log_output.string).to include('oneOf').and include('additionalProperties')
+        expect(log_output.string).to include('format').and include('additionalProperties')
       end
 
       it 'still validates and reports mismatches on the supported subset' do

--- a/spec/lib/mcp_client/structured_content_validation_spec.rb
+++ b/spec/lib/mcp_client/structured_content_validation_spec.rb
@@ -174,9 +174,9 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'detects every keyword in the unsupported list' do
-      keywords = %w[$dynamicRef
-                    additionalProperties patternProperties propertyNames dependentSchemas
-                    prefixItems contains minContains maxContains uniqueItems
+      keywords = %w[$dynamicRef $recursiveRef
+                    additionalProperties patternProperties propertyNames dependentSchemas dependencies
+                    additionalItems contains minContains maxContains uniqueItems
                     multipleOf format dependentRequired minProperties maxProperties
                     unevaluatedProperties unevaluatedItems]
       expect(described_class::UNSUPPORTED_KEYWORDS).to match_array(keywords)
@@ -192,12 +192,12 @@ RSpec.describe MCPClient::SchemaValidator do
           'email' => { 'type' => 'string', 'format' => 'email' },
           'count' => { 'type' => 'integer', 'multipleOf' => 5 },
           'tags' => { 'type' => 'array', 'uniqueItems' => true, 'contains' => { 'type' => 'string' } },
-          'pair' => { 'type' => 'array', 'prefixItems' => [{ 'type' => 'string' }] },
+          'pair' => { 'type' => 'array', 'items' => [{ 'type' => 'string' }], 'additionalItems' => false },
           'names' => { 'type' => 'object', 'propertyNames' => { 'pattern' => '^a' } }
         }
       }
       expect(described_class.unsupported_keywords(schema)).to contain_exactly(
-        'format', 'multipleOf', 'uniqueItems', 'contains', 'prefixItems', 'propertyNames'
+        'format', 'multipleOf', 'uniqueItems', 'contains', 'additionalItems', 'propertyNames'
       )
     end
 

--- a/spec/lib/mcp_client/structured_content_validation_spec.rb
+++ b/spec/lib/mcp_client/structured_content_validation_spec.rb
@@ -171,24 +171,20 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'detects top-level unsupported keywords' do
-      # `unevaluatedProperties` beside an in-place applicator: the annotations
-      # it reads come from a whole composition there, so it stays unevaluated
-      # (a node that produces them itself now applies the keyword).
+      # `unevaluatedProperties` is evaluated, beside an in-place applicator
+      # too; `format` only annotates in 2020-12 and is reported.
       schema = { 'type' => 'object', 'allOf' => [true], 'unevaluatedProperties' => false, 'format' => 'custom' }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly('unevaluatedProperties', 'format')
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('format')
     end
 
     it 'detects every keyword in the unsupported list' do
-      keywords = %w[$dynamicRef $recursiveRef contentSchema format
-                    unevaluatedProperties unevaluatedItems]
+      keywords = %w[$dynamicRef $recursiveRef contentSchema format]
       expect(described_class::UNSUPPORTED_KEYWORDS).to match_array(keywords)
       keywords.each do |keyword|
-        # Under a dialect that defines the keyword.
+        # Under a dialect that defines the keyword. A dynamic reference that
+        # is no string resolves to nothing, and is reported as dynamic.
         dialect = described_class::DIALECT_KEYWORDS.fetch(keyword, [described_class::DEFAULT_DIALECT]).first
         schema = { '$schema' => dialect, keyword => {} }
-        # The annotation-driven pair is evaluated where a node produces every
-        # annotation it reads, so it is reported beside an in-place applicator.
-        schema['allOf'] = [true] if keyword.start_with?('unevaluated')
         expect(described_class.unsupported_keywords(schema)).to eq([keyword])
       end
     end
@@ -230,8 +226,8 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'detects unsupported keywords nested inside applicator schemas' do
-      schema = { 'anyOf' => [{ 'type' => 'object', 'allOf' => [true], 'unevaluatedProperties' => false }] }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly('unevaluatedProperties')
+      schema = { 'anyOf' => [{ 'type' => 'object', 'properties' => { 'a' => { 'format' => 'uuid' } } }] }
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('format')
     end
 
     it 'does not mistake property names for keywords' do
@@ -280,9 +276,9 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'handles symbol-keyed schemas' do
-      schema = { type: 'object', allOf: [true], unevaluatedProperties: false,
+      schema = { type: 'object', allOf: [true], unevaluatedProperties: false, contentSchema: true,
                  properties: { a: { anyOf: [{ format: 'email' }] } } }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly('unevaluatedProperties', 'format')
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('contentSchema', 'format')
     end
 
     it 'returns an empty array for non-hash input' do
@@ -452,8 +448,8 @@ RSpec.describe MCPClient::Client do
             'conditions' => { 'type' => 'string', 'format' => 'custom' }
           },
           'required' => %w[temperature conditions],
-          # Beside an in-place applicator, `unevaluatedProperties` reads
-          # annotations this validator does not collect and stays unevaluated.
+          # `unevaluatedProperties` beside an in-place applicator is evaluated
+          # from the composition's annotations; only `format` annotates.
           'allOf' => [{ 'type' => 'object' }],
           'unevaluatedProperties' => false
         }
@@ -467,20 +463,29 @@ RSpec.describe MCPClient::Client do
       it 'warns that validation is partial, naming the unsupported keywords, in the default mode' do
         expect(build_client.call_tool('get_weather', {})).to eq(result)
         expect(log_output.string).to match(/get_weather.*validation is partial: schema uses unsupported keywords/)
-        expect(log_output.string).to include('format').and include('unevaluatedProperties')
+        expect(log_output.string).to include('format')
+        expect(log_output.string).not_to include('unevaluatedProperties')
       end
 
       # Round 30: an assertion this validator does not evaluate leaves the
       # result unshown to conform, and :strict is a gate — a warning beside a
       # returned result was a silent pass in everything but the log.
-      it 'refuses the result in :strict mode, since the schema cannot be shown to accept it' do
+      it 'returns the conforming result in :strict mode: format only annotates' do
+        client = build_client(validate_structured_content: :strict)
+
+        expect(client.call_tool('get_weather', {})).to eq(result)
+        expect(log_output.string).to match(/get_weather.*validation is partial: schema uses unsupported keywords/)
+        expect(log_output.string).to include('format')
+      end
+
+      it 'rejects, in :strict mode, a member the closed composition leaves unevaluated' do
+        leak = { 'content' => [],
+                 'structuredContent' => { 'temperature' => 22.5, 'conditions' => 'sunny', 'secret' => 'x' } }
+        allow(mock_server).to receive(:call_tool).and_return(leak)
         client = build_client(validate_structured_content: :strict)
 
         expect { client.call_tool('get_weather', {}) }
-          .to raise_error(MCPClient::Errors::ValidationError,
-                          /get_weather.*cannot be checked.*does not evaluate.*unevaluatedProperties/m)
-        expect(log_output.string).to match(/get_weather.*validation is partial: schema uses unsupported keywords/)
-        expect(log_output.string).to include('format').and include('unevaluatedProperties')
+          .to raise_error(MCPClient::Errors::ValidationError, /'secret' is not allowed \(unevaluatedProperties/)
       end
 
       it 'still validates and reports mismatches on the supported subset' do

--- a/spec/lib/mcp_client/structured_content_validation_spec.rb
+++ b/spec/lib/mcp_client/structured_content_validation_spec.rb
@@ -470,10 +470,15 @@ RSpec.describe MCPClient::Client do
         expect(log_output.string).to include('format').and include('unevaluatedProperties')
       end
 
-      it 'warns that validation is partial in :strict mode instead of silently passing' do
+      # Round 30: an assertion this validator does not evaluate leaves the
+      # result unshown to conform, and :strict is a gate — a warning beside a
+      # returned result was a silent pass in everything but the log.
+      it 'refuses the result in :strict mode, since the schema cannot be shown to accept it' do
         client = build_client(validate_structured_content: :strict)
 
-        expect(client.call_tool('get_weather', {})).to eq(result)
+        expect { client.call_tool('get_weather', {}) }
+          .to raise_error(MCPClient::Errors::ValidationError,
+                          /get_weather.*cannot be checked.*does not evaluate.*unevaluatedProperties/m)
         expect(log_output.string).to match(/get_weather.*validation is partial: schema uses unsupported keywords/)
         expect(log_output.string).to include('format').and include('unevaluatedProperties')
       end

--- a/spec/lib/mcp_client/structured_content_validation_spec.rb
+++ b/spec/lib/mcp_client/structured_content_validation_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe MCPClient::SchemaValidator do
         compiled = orig.call(*args, **kwargs)
       end
 
-      described_class.validate('abc', { 'type' => 'string', 'pattern' => '\\A[a-z]+\\z' })
+      described_class.validate('abc', { 'type' => 'string', 'pattern' => '^[a-z]+$' })
 
       expect(compiled.timeout).to be > 0
       expect(compiled.timeout).to be <= MCPClient::SchemaValidator::PATTERN_MATCH_TIMEOUT
@@ -80,7 +80,7 @@ RSpec.describe MCPClient::SchemaValidator do
       # because the constraint could not be evaluated.
       stub_const('MCPClient::SchemaValidator::PATTERN_MATCH_TIMEOUT', 0.001)
       stub_const('MCPClient::SchemaValidator::MIN_PATTERN_MATCH_TIMEOUT', 0.0005)
-      schema = { 'type' => 'string', 'pattern' => '\\A(a|b|ab)*\\z' }
+      schema = { 'type' => 'string', 'pattern' => '^(a|b|ab)*$' }
 
       expect(described_class.validate("#{'ab' * 20_000}c", schema))
         .to contain_exactly(a_string_matching(/pattern.*budget/i))
@@ -90,7 +90,7 @@ RSpec.describe MCPClient::SchemaValidator do
       # The server controls how many strings it sends as well as the pattern,
       # so a per-match limit would multiply: N items x limit.
       stub_const('MCPClient::SchemaValidator::PATTERN_MATCH_TIMEOUT', 0.3)
-      schema = { 'type' => 'array', 'items' => { 'type' => 'string', 'pattern' => '\\A(a|b|ab)*\\z' } }
+      schema = { 'type' => 'array', 'items' => { 'type' => 'string', 'pattern' => '^(a|b|ab)*$' } }
       data = Array.new(8) { "#{'ab' * 20_000}c" }
 
       started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -103,7 +103,7 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'enforces string patterns' do
-      schema = { 'type' => 'string', 'pattern' => '\\A[a-z]+\\z' }
+      schema = { 'type' => 'string', 'pattern' => '^[a-z]+$' }
       expect(described_class.validate('abc', schema)).to be_empty
       expect(described_class.validate('123', schema)).to contain_exactly(a_string_matching(/pattern/))
     end
@@ -171,7 +171,10 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'detects top-level unsupported keywords' do
-      schema = { 'type' => 'object', 'unevaluatedProperties' => false, 'format' => 'custom' }
+      # `unevaluatedProperties` beside an in-place applicator: the annotations
+      # it reads come from a whole composition there, so it stays unevaluated
+      # (a node that produces them itself now applies the keyword).
+      schema = { 'type' => 'object', 'allOf' => [true], 'unevaluatedProperties' => false, 'format' => 'custom' }
       expect(described_class.unsupported_keywords(schema)).to contain_exactly('unevaluatedProperties', 'format')
     end
 
@@ -182,7 +185,11 @@ RSpec.describe MCPClient::SchemaValidator do
       keywords.each do |keyword|
         # Under a dialect that defines the keyword.
         dialect = described_class::DIALECT_KEYWORDS.fetch(keyword, [described_class::DEFAULT_DIALECT]).first
-        expect(described_class.unsupported_keywords({ '$schema' => dialect, keyword => {} })).to eq([keyword])
+        schema = { '$schema' => dialect, keyword => {} }
+        # The annotation-driven pair is evaluated where a node produces every
+        # annotation it reads, so it is reported beside an in-place applicator.
+        schema['allOf'] = [true] if keyword.start_with?('unevaluated')
+        expect(described_class.unsupported_keywords(schema)).to eq([keyword])
       end
     end
 
@@ -223,7 +230,7 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'detects unsupported keywords nested inside applicator schemas' do
-      schema = { 'anyOf' => [{ 'type' => 'object', 'unevaluatedProperties' => false }] }
+      schema = { 'anyOf' => [{ 'type' => 'object', 'allOf' => [true], 'unevaluatedProperties' => false }] }
       expect(described_class.unsupported_keywords(schema)).to contain_exactly('unevaluatedProperties')
     end
 
@@ -273,7 +280,8 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'handles symbol-keyed schemas' do
-      schema = { type: 'object', unevaluatedProperties: false, properties: { a: { anyOf: [{ format: 'email' }] } } }
+      schema = { type: 'object', allOf: [true], unevaluatedProperties: false,
+                 properties: { a: { anyOf: [{ format: 'email' }] } } }
       expect(described_class.unsupported_keywords(schema)).to contain_exactly('unevaluatedProperties', 'format')
     end
 
@@ -444,6 +452,9 @@ RSpec.describe MCPClient::Client do
             'conditions' => { 'type' => 'string', 'format' => 'custom' }
           },
           'required' => %w[temperature conditions],
+          # Beside an in-place applicator, `unevaluatedProperties` reads
+          # annotations this validator does not collect and stays unevaluated.
+          'allOf' => [{ 'type' => 'object' }],
           'unevaluatedProperties' => false
         }
       end

--- a/spec/lib/mcp_client/structured_content_validation_spec.rb
+++ b/spec/lib/mcp_client/structured_content_validation_spec.rb
@@ -375,12 +375,12 @@ RSpec.describe MCPClient::Client do
         expect(log_output.string).not_to include('structuredContent')
       end
 
-      it 'skips validation for error results (isError: true)' do
+      it 'still checks the structuredContent an error result carries' do
         result = { 'isError' => true, 'content' => [], 'structuredContent' => { 'temperature' => 'hot' } }
         allow(mock_server).to receive(:call_tool).and_return(result)
 
         expect(build_client.call_tool('get_weather', {})).to eq(result)
-        expect(log_output.string).not_to include('output schema')
+        expect(log_output.string).to include('does not match its output schema')
       end
 
       it 'does not require structuredContent on error results' do

--- a/spec/lib/mcp_client/structured_content_validation_spec.rb
+++ b/spec/lib/mcp_client/structured_content_validation_spec.rb
@@ -178,14 +178,18 @@ RSpec.describe MCPClient::SchemaValidator do
     end
 
     it 'detects every keyword in the unsupported list' do
-      keywords = %w[$dynamicRef $recursiveRef contentSchema format]
+      # What is left unevaluated is the two keywords that only annotate; the
+      # dynamic references bind against the dynamic scope and are evaluated.
+      keywords = %w[contentSchema format]
       expect(described_class::UNSUPPORTED_KEYWORDS).to match_array(keywords)
       keywords.each do |keyword|
-        # Under a dialect that defines the keyword. A dynamic reference that
-        # is no string resolves to nothing, and is reported as dynamic.
         dialect = described_class::DIALECT_KEYWORDS.fetch(keyword, [described_class::DEFAULT_DIALECT]).first
         schema = { '$schema' => dialect, keyword => {} }
         expect(described_class.unsupported_keywords(schema)).to eq([keyword])
+      end
+      %w[$dynamicRef $recursiveRef].each do |keyword|
+        dialect = described_class::DIALECT_KEYWORDS.fetch(keyword, [described_class::DEFAULT_DIALECT]).first
+        expect(described_class.unsupported_keywords({ '$schema' => dialect, keyword => '#x' })).to be_empty
       end
     end
 
@@ -218,11 +222,11 @@ RSpec.describe MCPClient::SchemaValidator do
       schema = {
         'type' => 'object',
         'properties' => {
-          'a' => { '$dynamicRef' => '#x' },
+          'a' => { 'contentSchema' => { 'type' => 'object' } },
           'b' => { 'type' => 'array', 'items' => { 'format' => 'email' } }
         }
       }
-      expect(described_class.unsupported_keywords(schema)).to contain_exactly('$dynamicRef', 'format')
+      expect(described_class.unsupported_keywords(schema)).to contain_exactly('contentSchema', 'format')
     end
 
     it 'detects unsupported keywords nested inside applicator schemas' do

--- a/spec/lib/mcp_client/tool_spec.rb
+++ b/spec/lib/mcp_client/tool_spec.rb
@@ -506,9 +506,9 @@ RSpec.describe MCPClient::Tool do
         expect(tool.structured_output?).to be false
       end
 
-      it 'returns false when output_schema is empty' do
+      it 'returns true when output_schema is the empty schema (it accepts every value)' do
         t = described_class.new(name: 't', description: 'd', schema: {}, output_schema: {})
-        expect(t.structured_output?).to be false
+        expect(t.structured_output?).to be true
       end
 
       it 'returns true when output_schema is present' do

--- a/spec/lib/mcp_client/x_mcp_header_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/x_mcp_header_2026_verify_spec.rb
@@ -775,6 +775,10 @@ RSpec.describe 'MCP 2026-07-28 x-mcp-header — a failure that escaped host code
       { 'content' => [] }
     end
     allow(server).to receive(:refresh_tools_after_header_mismatch)
+    # The refreshed definition's dialect is checked before the retry goes
+    # out; that check is pinned by the JSON Schema examples, and this one is
+    # about the recovery alone, with no connection to resolve a tool through.
+    allow(server).to receive(:reject_unreadable_refreshed_schema!)
 
     expect(server.send(:attempt_request, 'tools/call', {}, nil, false) { nil }).to eq({ 'content' => [] })
     expect(attempts).to eq(2)


### PR DESCRIPTION
PR 10 of the MCP 2026-07-28 series (stacked on #232). Implements the JSON Schema rules: https://modelcontextprotocol.io/specification/2026-07-28/basic#json-schema-usage and the tools changes (any 2020-12 keywords in `inputSchema` / `outputSchema`, `structuredContent` as any JSON value).

## What changes

- **Dialects.** A schema without `$schema` is 2020-12; 2020-12, 2019-09 and draft-07 are accepted (`SchemaValidator::SUPPORTED_DIALECTS`, documented); any other declared dialect is reported as "not supported" instead of validating permissively. `SchemaValidator.check_schema` explains why a schema is unusable. An unusable `outputSchema` is a structured-content violation (warning, or `ValidationError` in `:strict` mode); an unusable `inputSchema` is logged once per tool while the call still goes out.
- **`$ref`.** Local references (`#`, `#/$defs/...`, `#/definitions/...`, any JSON pointer with `~0`/`~1` and percent escapes) are resolved, recursively, with a hop limit that turns cycles into errors. A `$ref` to a network URI, another document, `urn:` or `file:` is never dereferenced (no opt-in fetch mode exists) and makes the schema unusable rather than permissive; an unresolvable local `$ref` is an error too.
- **Composition and bounds.** `allOf`, `anyOf`, `oneOf`, `not`, `if`/`then`/`else` and boolean schemas are evaluated and no longer count as unsupported keywords. Bounds: `MAX_SCHEMA_DEPTH`, `MAX_SUBSCHEMAS`, `MAX_REF_DEPTH`, and the existing per-validation time budget now stops the whole walk.
- **structuredContent.** Presence is decided by the key, so `null` is a valid value validated like any other; arrays and scalars are validated against the output schema. `x-mcp-header` is ignored by the validator.

## Tests

`spec/lib/mcp_client/json_schema_2026_spec.rb` (23 examples) plus updates to the existing validator spec for the widened keyword set. Full suite green; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoErzDypnq7hhuFBtueML7