### PR TITLE
MCP 2026-07-28: deprecation notices and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,10 +73,38 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   `transport:` entries of `MCPClient.connect`, its SSE `@example`, and
   `MCPClient.sse_config`, which gains a `@deprecated` tag pointing at
   `MCPClient.streamable_http_config`.
+- **A reservation is not a notice (round 9).** `MCPClient::Deprecations`
+  used to mark a feature spent the moment a caller claimed the right to log
+  it, so two first uses racing with different loggers could lose the notice
+  outright: the claiming caller blocked inside a broken logger, the
+  contender holding a working one saw the slot taken and stood down, and the
+  claim's later failure left the notice owed to a use that might never come.
+  A feature is now `:pending` while a caller is inside `logger.warn` and
+  `:emitted` only once one succeeded, so a contender waits for the outcome
+  and takes the notice over when the reservation fails. The wait is bounded
+  by `Deprecations::PENDING_WAIT_SECONDS`: a notice never holds up the
+  deprecated operation, so a logger that blocks forever costs the contender
+  the notice, not its progress. `Deprecations.emitted?` reports notices that
+  actually went out, never one still in flight.
+- **HTTP+SSE marked in the last places it was offered (round 9).**
+  Continuing the round 8 sweep: the README's Advanced Configuration
+  `sse_config` example and the auto-detect fallback row of the
+  transport-detection table, and, in `MCPClient.connect`'s YARD, the
+  "Other HTTP URLs" fallback text; the multiple-server `@example` no longer
+  reaches for an `/sse` URL at all.
+- **`protocol:` and `discover_timeout:` documented as they behave.** The
+  README offered both on `MCPClient.connect` without qualification, but
+  `MCPClient::ServerSSE` accepts neither and `MCPClient.connect` drops them
+  for an `/sse` URL. The deprecated transport has no era of its own, so the
+  documentation now names the three transports that carry the options
+  (stdio, HTTP, Streamable HTTP) and says HTTP+SSE is not one of them,
+  rather than adding era support to a transport on its way out.
 - **Documentation.** README documents the 2026-07-28 support (discovery
   and per-request metadata, multi round-trip requests, `x-mcp-header`,
   subscriptions, cacheable results, the tasks extension, authorization) and
-  the deprecated features with their earliest removals and migrations; the
+  the deprecated features with their earliest removals and migrations —
+  each row naming what actually triggers the notice, Sampling's
+  transport-level `on_sampling_request` included; the
   2026-07-28 section flags `log_level=` as deprecated where it presents it,
   rather than only in the table further down, and states what actually
   triggers the Roots notice (a configured list, a `roots=` call or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,43 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   `ServerStreamableHTTP` and marks the HTTP+SSE entry with SEP-2596 and its
   earliest removal, like the README, `MCPClient.connect` and
   `MCPClient.sse_config`.
+- **A notice never queues from inside a notice (round 11).** Round 10's
+  emission gate is held across `logger.warn`, which is host code that may
+  itself reach a deprecated feature — a formatter, a log subscriber. A
+  thread already inside a notice that then queued for a gate could wait
+  forever: for its own gate, when the callback warns for the feature being
+  logged, or (through a logger that serializes its writes, as `::Logger`
+  does) for the gate of a second feature held by a thread that is waiting
+  for that very logger. Both threads then hang, and the sampling request,
+  the log level or the SSE `connect` behind the notice never returns. A
+  thread inside a notice now never queues: its nested attempt stands down
+  at once and leaves that notice owed to a later use, exactly as a dropped
+  one is — the notice it stood down from is being written by whoever holds
+  the gate. Round 10's contract is untouched: one notice per feature per
+  process, and a plain contender still waits for another thread's emission
+  and takes the notice over when that emission fails.
+- **A logger that writes nowhere does not spend a notice (round 11).**
+  `Logger.new(nil)` is a supported no-output logger: it keeps every level,
+  so the level probe passed it, and its `warn` returns successfully having
+  written nothing — which marked the notice emitted and silenced every
+  later use, including one holding a logger that does write. A logger with
+  no device is now treated like one that drops warnings: the deprecated
+  operation is unaffected and the notice stays owed.
+- **The log level in request metadata is Logging too (round 11).** MCP
+  2026-07-28 moved the log level off `logging/setLevel` and onto every
+  request, so `log_level=` and an incoming `notifications/message` are not
+  the only ways into the deprecated Logging utility: a host that puts
+  `io.modelcontextprotocol/logLevel` in `request_meta` or in a per-call
+  `_meta` adopts it just as squarely, and `with_request_meta` forwards the
+  key on the wire. That now raises the Logging notice on first use, on the
+  modern path and on the legacy one that passes a supplied `_meta` through
+  untouched.
+- **HTTP+SSE marked in the last two places it was offered (round 11).** The
+  README's Protocol Support elicitation bullet listed SSE as an ordinary
+  elicitation transport with no mark (it now leads with Streamable HTTP and
+  marks HTTP+SSE), and `MCPClient.connect`'s `transport: :sse` entry named
+  SEP-2596 without its earliest removal (three months after SEP-2596
+  reaches Final), which every other mark carries.
 - **`protocol:` and `discover_timeout:` documented as they behave.** The
   README offered both on `MCPClient.connect` without qualification, but
   `MCPClient::ServerSSE` accepts neither and `MCPClient.connect` drops them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,23 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   `roots=` call or an answer carrying a root all warn. The deprecated
   keyword arguments name the earliest removal next to their SEP too:
   `Client.new`'s `roots:` and `sampling_handler:`, and the
-  `sampling_handler` option of `MCPClient.connect`.
+  `sampling_handler` option of `MCPClient.connect`. The transport-level
+  registrations carry the same mark: `on_roots_list_request` and
+  `on_sampling_request` on `ServerStdio`, `ServerSSE`, `ServerHTTP` and
+  `ServerStreamableHTTP` are tagged `@deprecated` with SEP-2577 and the
+  earliest removal, so a host that drives a transport directly meets the
+  deprecation in the YARD rather than in the first runtime notice — and the
+  Roots tag says what round 7 made true, that registering a handler is not
+  itself use and only an answer carrying a root adopts the feature.
+- **HTTP+SSE marked where it is offered.** SEP-2596 puts the HTTP+SSE
+  transport on the only short clock in the registry (three months after
+  SEP-2596 reaches Final), so every place that presents it as an ordinary
+  transport choice now says so and points at Streamable HTTP: the README
+  Overview, the Quick Connect example (which now leads with Streamable
+  HTTP) and the transport-detection table, and, in YARD, the `/sse` and
+  `transport:` entries of `MCPClient.connect`, its SSE `@example`, and
+  `MCPClient.sse_config`, which gains a `@deprecated` tag pointing at
+  `MCPClient.streamable_http_config`.
 - **Documentation.** README documents the 2026-07-28 support (discovery
   and per-request metadata, multi round-trip requests, `x-mcp-header`,
   subscriptions, cacheable results, the tasks extension, authorization) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,19 +79,55 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   outright: the claiming caller blocked inside a broken logger, the
   contender holding a working one saw the slot taken and stood down, and the
   claim's later failure left the notice owed to a use that might never come.
-  A feature is now `:pending` while a caller is inside `logger.warn` and
-  `:emitted` only once one succeeded, so a contender waits for the outcome
-  and takes the notice over when the reservation fails. The wait is bounded
-  by `Deprecations::PENDING_WAIT_SECONDS`: a notice never holds up the
-  deprecated operation, so a logger that blocks forever costs the contender
-  the notice, not its progress. `Deprecations.emitted?` reports notices that
-  actually went out, never one still in flight.
+  A notice is now spent only once a `logger.warn` came back without raising,
+  so a caller that arrives while another is inside the logger either finds
+  the notice out (and stands down) or takes it over when that attempt
+  failed. `Deprecations.emitted?` reports notices that actually went out,
+  never one still in flight. (Round 10 kept that outcome and replaced the
+  reservation states, condition variable and bounded wait that carried it
+  with a per-feature emission gate.)
 - **HTTP+SSE marked in the last places it was offered (round 9).**
   Continuing the round 8 sweep: the README's Advanced Configuration
   `sse_config` example and the auto-detect fallback row of the
   transport-detection table, and, in `MCPClient.connect`'s YARD, the
   "Other HTTP URLs" fallback text; the multiple-server `@example` no longer
   reaches for an `/sse` URL at all.
+- **What a notice costs its caller, said honestly (round 10).** The
+  reservation machinery bounded the wait of a caller that met a notice in
+  flight, on the strength of a promise this path cannot keep — that a notice
+  never holds up the deprecated operation. The bound constrained the
+  contenders, never the caller actually stuck in the logger: a first use
+  whose logger blocks forever (a synchronous remote logger, stalled I/O)
+  never returned from `warn` at all, so the client construction, SSE
+  connection or incoming request that triggered it never completed either.
+  And the contenders bought nothing with their wait: a reservation that
+  hangs is never released, so every later first use of Sampling, Logging or
+  the HTTP+SSE transport — all features whose trigger points are hit
+  repeatedly — waited the timeout out again and still came away without the
+  notice. Keeping the stronger promise would have meant a detached emission
+  thread (which loses the ordering between the notice and the operation it
+  describes) or `Timeout.timeout` around a host's logger (which raises
+  inside arbitrary third-party code, during its own IO, ensure blocks or
+  locking). So the promise is narrowed to the one the rest of the library
+  already makes: a notice costs its caller what one `logger.warn` costs it,
+  and no more — every other `logger.warn` here blocks its caller the same
+  way, and a logger that blocks forever blocks the library everywhere, not
+  only in this path. `Deprecations::PENDING_WAIT_SECONDS`, the `:pending`
+  state and the condition variable are gone; an attempt is serialized on a
+  gate held only for the feature being logged, so nothing is timed, no
+  caller comes away from a wait with the notice neither emitted nor its own
+  to write, and a notice in flight still never delays another feature's
+  notice, `Deprecations.emitted?` or `Deprecations.reset!`. Everything the
+  earlier rounds established stands: one notice per feature per process, a
+  logger that raises or drops warnings neither breaks the deprecated
+  operation nor spends the notice, and the bookkeeping (gates included) is
+  rebuilt after a fork.
+- **HTTP+SSE marked in the `ServerHTTP` elicitation note (round 10).** The
+  note listing the transports that do support server-initiated elicitation
+  still offered `ServerSSE` as an ordinary alternative; it now leads with
+  `ServerStreamableHTTP` and marks the HTTP+SSE entry with SEP-2596 and its
+  earliest removal, like the README, `MCPClient.connect` and
+  `MCPClient.sse_config`.
 - **`protocol:` and `discover_timeout:` documented as they behave.** The
   README offered both on `MCPClient.connect` without qualification, but
   `MCPClient::ServerSSE` accepts neither and `MCPClient.connect` drops them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,43 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   documentation now names the three transports that carry the options
   (stdio, HTTP, Streamable HTTP) and says HTTP+SSE is not one of them,
   rather than adding era support to a transport on its way out.
+- **No caller waits for a notice (verification pass).** Round 11 stopped a
+  thread that is already inside a notice from queueing for an emission gate,
+  but the thread holding the logger's lock need not be inside a notice at
+  all: an ordinary `logger.info` holds `::Logger`'s device lock for the
+  length of the write, and the device — a formatter, a log subscriber, an
+  audit hook — may itself reach a deprecated feature. That thread then
+  queued for the gate of a second thread which was waiting for the very
+  device lock the first one held, and neither moved again; round 11's
+  `emitting?` guard could not see it, because the first thread was doing
+  ordinary logging rather than writing a notice. No rule about who may queue
+  fixes that, since a waiter cannot know what it is holding, so the gates
+  are gone: the once-per-process accounting is an atomic claim, taken and
+  released under a mutex this module never holds while calling out, and a
+  caller that meets a notice in flight stands down at once instead of
+  queueing behind it. What that gives up is round 9's takeover — a contender
+  no longer writes the notice a failed emission owed — and what it keeps is
+  what mattered: one notice per feature per process, and a notice that was
+  not written is not spent, so the feature's next use raises it again.
+- **A notice is not spent on a warning the logger filtered (verification
+  pass).** `Logger#warn` returns true whether it wrote the line or dropped
+  it for its level, so the level probe was the only evidence a notice was
+  readable — and a contender that waited behind a failing emission carried a
+  probe taken before the wait: with its logger's level raised to ERROR in
+  the meantime, its warning was filtered, the process's one notice was
+  marked emitted having been written nowhere, and lowering the level again
+  did not bring it back. Nothing waits any more, and the probe now sits next
+  to the write rather than at the top of `Deprecations.warn`.
+- **`Root`, `Client#roots` and `declare_sampling_tools` marked (verification
+  pass).** The marking checks counted `@deprecated` tags, which cannot show
+  that a given API carries one, and accepted any window from the registry,
+  which cannot show that a tag names its own. An explicit API-to-feature
+  inventory replaces both, and it named three surfaces that carried no mark:
+  `MCPClient::Root`, the `Client#roots` reader, and `declare_sampling_tools`
+  (the sampling.tools sub-capability, which goes with the capability it
+  refines). Each now cites its feature's SEP and its own earliest removal,
+  none of them warns where it did not warn before, and every `@deprecated`
+  tag in the library is accounted for by the inventory.
 - **Documentation.** README documents the 2026-07-28 support (discovery
   and per-request metadata, multi round-trip requests, `x-mcp-header`,
   subscriptions, cacheable results, the tasks extension, authorization) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,21 +19,39 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   silences the notices. The registry records when each feature entered the
   Deprecated state (the HTTP+SSE transport since 2025-03-26, the
   `includeContext` values since 2025-11-25) alongside each feature's
-  `earliest_removal`: only the HTTP+SSE transport has the short clock
-  (three months after SEP-2596 is Final), while the `includeContext` values
-  follow Sampling into the twelve-month window despite the earlier
-  deprecation date. The HTTP+SSE notice is logged once the transport is
-  actually connected (so `MCPClient.connect` probing a URL does not spend
-  it), Logging warns on every entry point (`log_level=` on a client or
-  server, an incoming `notifications/message`), a logger that drops
-  warnings, fails to report its level or raises does not consume the notice
-  (no logger failure ever reaches the deprecated operation, and the logger
-  is called outside the registry's lock), and the deprecated APIs —
-  including each transport's `log_level=` — carry YARD `@deprecated` tags.
+  `earliest_removal`, carrying the deprecated-features registry's own
+  "Earliest removal" wording: what Roots, Sampling, Logging and Dynamic
+  Client Registration wait for is *the first revision released on or after
+  2027-07-28* — a revision, not a date a host can plan around — while the
+  `includeContext` values *follow Sampling (SEP-2577)* and only the HTTP+SSE
+  transport has a clock of its own (*three months after SEP-2596 reaches
+  Final*). Every notice and every YARD `@deprecated` tag names that earliest
+  removal next to the deprecation SEP, as the feature lifecycle policy's
+  tier-1 SDK obligation requires.
+  The notices fire from the transport, not only from `MCPClient::Client`, so
+  a host that drives a `ServerStdio`, `ServerSSE`, `ServerHTTP` or
+  `ServerStreamableHTTP` object directly still sees them: serving a
+  `roots/list` or `sampling/createMessage` request through
+  `on_roots_list_request` / `on_sampling_request` warns (including the
+  `includeContext` values on the request), whether the request arrives
+  server-initiated or through the multi round-trip pattern, and a
+  `notifications/message` warns from the shared notification routing so a
+  bare `on_notification` callback is covered too. The HTTP+SSE notice is
+  logged once the transport is actually connected (so `MCPClient.connect`
+  probing a URL does not spend it) and a later `connect` on an
+  already-established connection retries a notice the first one could not
+  emit. A logger that drops warnings, fails to report its level or raises
+  does not consume the notice (no logger failure ever reaches the deprecated
+  operation, and the logger is called outside the registry's lock), and the
+  once-per-process bookkeeping is scoped to the owning PID, so a prefork
+  server (Puma, Unicorn) that warned while preloading does not silence each
+  worker's own first use.
 - **Documentation.** README documents the 2026-07-28 support (discovery
   and per-request metadata, multi round-trip requests, `x-mcp-header`,
   subscriptions, cacheable results, the tasks extension, authorization) and
-  the deprecated features with their migrations.
+  the deprecated features with their earliest removals and migrations; the
+  2026-07-28 section flags `log_level=` as deprecated where it presents it,
+  rather than only in the table further down.
 
 ### JSON Schema handling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   logged once the transport is actually connected (so `MCPClient.connect`
   probing a URL does not spend it), Logging warns on every entry point
   (`log_level=` on a client or server, an incoming `notifications/message`),
-  a logger that drops warnings or raises does not consume the notice, and
-  the deprecated APIs carry YARD `@deprecated` tags.
+  a logger that drops warnings or raises does not consume the notice (a
+  logger failure never reaches the deprecated operation, and the logger is
+  called outside the registry's lock), and the deprecated APIs — including
+  each transport's `log_level=` — carry YARD `@deprecated` tags.
 - **Documentation.** README documents the 2026-07-28 support (discovery
   and per-request metadata, multi round-trip requests, `x-mcp-header`,
   subscriptions, cacheable results, the tasks extension, authorization) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,15 +18,18 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   Everything keeps working; `MCPClient::Deprecations.enabled = false`
   silences the notices. The registry records when each feature entered the
   Deprecated state (the HTTP+SSE transport since 2025-03-26, the
-  `includeContext` values since 2025-11-25) because the deprecated features
-  registry sets their earliest removal separately; the HTTP+SSE notice is
-  logged once the transport is actually connected (so `MCPClient.connect`
-  probing a URL does not spend it), Logging warns on every entry point
-  (`log_level=` on a client or server, an incoming `notifications/message`),
-  a logger that drops warnings or raises does not consume the notice (a
-  logger failure never reaches the deprecated operation, and the logger is
-  called outside the registry's lock), and the deprecated APIs — including
-  each transport's `log_level=` — carry YARD `@deprecated` tags.
+  `includeContext` values since 2025-11-25) alongside each feature's
+  `earliest_removal`: only the HTTP+SSE transport has the short clock
+  (three months after SEP-2596 is Final), while the `includeContext` values
+  follow Sampling into the twelve-month window despite the earlier
+  deprecation date. The HTTP+SSE notice is logged once the transport is
+  actually connected (so `MCPClient.connect` probing a URL does not spend
+  it), Logging warns on every entry point (`log_level=` on a client or
+  server, an incoming `notifications/message`), a logger that drops
+  warnings, fails to report its level or raises does not consume the notice
+  (no logger failure ever reaches the deprecated operation, and the logger
+  is called outside the registry's lock), and the deprecated APIs —
+  including each transport's `log_level=` — carry YARD `@deprecated` tags.
 - **Documentation.** README documents the 2026-07-28 support (discovery
   and per-request metadata, multi round-trip requests, `x-mcp-header`,
   subscriptions, cacheable results, the tasks extension, authorization) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,15 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   `thisServer` / `allServers` received in a sampling request (still served)
   and OAuth Dynamic Client Registration (SEP-2577, SEP-2596, MCP PR #2858).
   Everything keeps working; `MCPClient::Deprecations.enabled = false`
-  silences the notices.
+  silences the notices. The registry records when each feature entered the
+  Deprecated state (the HTTP+SSE transport since 2025-03-26, the
+  `includeContext` values since 2025-11-25) because the deprecated features
+  registry sets their earliest removal separately; the HTTP+SSE notice is
+  logged once the transport is actually connected (so `MCPClient.connect`
+  probing a URL does not spend it), Logging warns on every entry point
+  (`log_level=` on a client or server, an incoming `notifications/message`),
+  a logger that drops warnings or raises does not consume the notice, and
+  the deprecated APIs carry YARD `@deprecated` tags.
 - **Documentation.** README documents the 2026-07-28 support (discovery
   and per-request metadata, multi round-trip requests, `x-mcp-header`,
   subscriptions, cacheable results, the tasks extension, authorization) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,10 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   The notices fire from the transport, not only from `MCPClient::Client`, so
   a host that drives a `ServerStdio`, `ServerSSE`, `ServerHTTP` or
   `ServerStreamableHTTP` object directly still sees them: serving a
-  `roots/list` or `sampling/createMessage` request through
-  `on_roots_list_request` / `on_sampling_request` warns (including the
-  `includeContext` values on the request), whether the request arrives
+  `sampling/createMessage` request through `on_sampling_request` warns
+  (including the `includeContext` values on the request), and so does
+  answering a `roots/list` request through `on_roots_list_request` with a
+  list that carries a root, whether the request arrives
   server-initiated or through the multi round-trip pattern, and a
   `notifications/message` warns from the shared notification routing so a
   bare `on_notification` callback is covered too. The HTTP+SSE notice is
@@ -46,12 +47,25 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   once-per-process bookkeeping is scoped to the owning PID, so a prefork
   server (Puma, Unicorn) that warned while preloading does not silence each
   worker's own first use.
+  The Roots notice follows use of the feature, not the presence of a
+  handler: `MCPClient::Client` registers a `roots/list` handler on every
+  server so that a later `client.roots = [...]` is served without
+  reconnecting, and it answers `roots/list` with an empty list until a root
+  is set — so a host that never passed `roots:` and never called
+  `Client#roots=` is never warned about Roots, while a configured list, a
+  `roots=` call or an answer carrying a root all warn. The deprecated
+  keyword arguments name the earliest removal next to their SEP too:
+  `Client.new`'s `roots:` and `sampling_handler:`, and the
+  `sampling_handler` option of `MCPClient.connect`.
 - **Documentation.** README documents the 2026-07-28 support (discovery
   and per-request metadata, multi round-trip requests, `x-mcp-header`,
   subscriptions, cacheable results, the tasks extension, authorization) and
   the deprecated features with their earliest removals and migrations; the
   2026-07-28 section flags `log_level=` as deprecated where it presents it,
-  rather than only in the table further down.
+  rather than only in the table further down, and states what actually
+  triggers the Roots notice (a configured list, a `roots=` call or a
+  non-empty `roots/list` answer — never the empty answer a client that never
+  configured a root gives).
 
 ### JSON Schema handling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3228,6 +3228,19 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   for most of the timeout can no longer buy a full pause and another request
   on top of it. A transport that configures no read timeout is unbounded as
   before, with the round-trip ceiling as its only limit.
+- **URL-mode elicitation drops `elicitationId` on modern servers.**
+  2026-07-28 removed the `notifications/elicitation/complete` notification
+  and the `elicitationId` field of URL-mode `elicitation/create` requests:
+  the outcome is learned by retrying the original request, and a server that
+  must correlate an elicitation across retries carries its own identifier in
+  the opaque `requestState`. The metadata hash handed to an elicitation
+  handler therefore no longer carries an `elicitationId` key at all for a
+  modern server — a modern server that sends the field anyway cannot smuggle
+  a correlation id to the host through it, and the client logs one warning
+  naming the field (never its value). On a 2025-11-25 server the field is
+  part of the protocol and the host contract is unchanged, key present (nil
+  when the server sent none) and all. This library never implemented
+  `notifications/elicitation/complete`, so nothing there had to be removed.
 - **Limits and errors.** More than 10 consecutive `input_required` answers,
   an input request this client cannot honour (unknown method, no handler,
   handler error) or a malformed `inputRequests` raise
@@ -3385,7 +3398,10 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   `notifications/cancelled` on timeout). Server-initiated JSON-RPC requests on
   a response stream are dropped with a warning; SSE comment keep-alives are
   ignored. `ping` maps to `server/discover` and `log_level=` to the
-  per-request `_meta` level.
+  per-request `_meta` level. A session id a non-conforming modern server
+  sends back anyway is never captured (the only capture point is the
+  `initialize` response, which a modern server is never sent), so it is
+  never echoed on a later request and no DELETE terminates it.
 - **A broken response stream is re-issued, `tools/call` included** (changelog
   major change 9: "A broken response stream loses the in-flight request;
   clients **MUST** re-issue it as a new request with a new request ID"). The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,22 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   non-empty `roots/list` answer — never the empty answer a client that never
   configured a root gives).
 
+- **Sampling notices precede the `sampling.tools` refusal on the multi
+  round-trip path (round 13).** A 2026-07-28 sampling input request that
+  carried `tools` / `toolChoice` this client never declared was refused
+  before the Sampling and `includeContext` notices could fire, while the
+  same request served as a 2025-11-25 server-initiated request warned first
+  and was then refused by the handler. The notice now precedes the refusal
+  on both eras: the deprecated values were on the wire and a host with a
+  sampling handler asked for them. Round 13 also pins what every earlier
+  example on these paths took for granted: the stdio transport's response
+  envelope (result and error) for a legacy sampling request once its notice
+  is out, the `includeContext` value reaching the sampling handler
+  unchanged after being reported, multi round-trip failures with notices
+  enabled, a complete discovery -> input_required -> continuation exchange
+  for a modern URL elicitation next to the legacy response envelope, and
+  `notifications/elicitation/complete` ignored on either era.
+
 ### JSON Schema handling
 
 - **Dynamic references bind against the evaluation path, `contains`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,36 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   refines). Each now cites its feature's SEP and its own earliest removal,
   none of them warns where it did not warn before, and every `@deprecated`
   tag in the library is accounted for by the inventory.
+- **A logger the host wrapped does not spend a notice it dropped (round
+  12).** The level probe asked `logger.level`, which only a bare `::Logger`
+  answers — and a host's logger is rarely one: Rails hands out a tagged or a
+  broadcast logger, and an application that routes its own deprecation
+  output wraps one itself. A `SimpleDelegator` around an ERROR-level
+  `::Logger` forwarded `warn`, returned as if it had written, and marked the
+  process's one notice emitted having printed nothing — silencing the host's
+  own working logger for good. The probe now asks `warn?`, the form a
+  wrapper forwards, of any logger that offers it, and looks through
+  `Delegator` wrappers for the missing device that `Logger.new(nil)` has.
+  A logger implementing `warn` and nothing else is still taken at its word,
+  and asking still cannot fail the deprecated operation: a predicate that
+  raises leaves the notice owed, exactly as a raising `warn` does. A wrapper
+  that filters on something a level cannot express — a tag, a source
+  allow-list — remains beyond reach.
+- **The Logging notice fires on a transport-direct HTTP+SSE session (round
+  12).** The notice for an incoming `notifications/message` was raised in
+  the routing every other transport shares, but `ServerSSE` carries no
+  subscriptions/listen stream and parses its own notifications, so a host
+  driving a `ServerSSE` with `on_notification` — the case the
+  transport-level notices exist for — received log messages and was never
+  told that Logging is deprecated. `Client` + SSE was unaffected (it warns
+  on its own log-message handler).
+- **The elicitation section states the URL-mode contract of both revisions
+  (round 12).** The section introducing elicitation still gave the
+  2025-11-25 hash as universal, so a host reading it looked for
+  `metadata['elicitationId']` on a 2026-07-28 server, found nothing, and
+  correlated against a completion notification the revision removed as well.
+  Both places the README shows that hash now split the two revisions, and a
+  spec pins that they do.
 - **Documentation.** README documents the 2026-07-28 support (discovery
   and per-request metadata, multi round-trip requests, `x-mcp-header`,
   subscriptions, cacheable results, the tasks extension, authorization) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,18 @@ metadata). Each feature lands in its own PR; this section accumulates them.
 - A 2025-11-25 `sampling/createMessage` request reaching a transport with no sampling handler is answered with `-32601` (Method not found) by every transport, as `Client#handle_sampling_request` already did: sampling.mdx § Error Handling reserves `-1` for "User rejected sampling request", and a capability the client never declared is an unsupported method, not a rejection.
 - A 2025-11-25 `sampling/createMessage` carrying `tools`/`toolChoice` is refused by the transport itself with `-32602` when `sampling.tools` was never declared (SEP-1577: "The client MUST return an error if this field is provided but ClientCapabilities.sampling.tools is not declared") — on the server-initiated path as on the multi round-trip one, after the Sampling/includeContext notices a served-or-refused request owes. A host driving a transport directly no longer depends on its own callback for the check.
 
+- **A diagnostic never changes the answer (round 15).** The line the
+  transports log when refusing a tool-enabled `sampling/createMessage` a host
+  never declared `sampling.tools` for is written guarded, so a logger that
+  fails on it leaves the SEP-1577 refusal (`-32602`) on the wire instead of
+  the dispatcher's `-32603`. The stdio transport's answer to a sampling
+  request with no handler (`-32601`, no notice spent) and its service of a
+  tool-enabled request once `declare_sampling_tools` was called are pinned
+  transport-direct. The retry guarantee's one boundary is named: a standard
+  `Logger` over an open device that fails to write reports that on `$stderr`
+  only and returns as if it had written, so that notice is spent — a closed
+  device is recognised, a broken one is not.
+
 ### JSON Schema handling
 
 - **Dynamic references bind against the evaluation path, `contains`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3246,7 +3246,11 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   handler error) or a malformed `inputRequests` raise
   `MCPClient::Errors::InputRequiredError` (exposing `input_requests` and
   `request_state`) without a retry; `input_required` on any other method is
-  an `InvalidResultError`. `server/discover` is not one of the three methods
+  an `InvalidResultError`.
+  Writing that notice is a courtesy, not part of the decision: a logger that
+  raises costs the notice and never the elicitation, the same isolation
+  `MCPClient::Deprecations.warn` has.
+  `server/discover` is not one of the three methods
   that may be answered with `input_required` either: such an answer is
   refused before any protocol version or capability it carries is applied or
   cached, so a probe can never adopt a version out of an unfinished result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,8 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   enabled, a complete discovery -> input_required -> continuation exchange
   for a modern URL elicitation next to the legacy response envelope, and
   `notifications/elicitation/complete` ignored on either era.
+- A 2025-11-25 `sampling/createMessage` request reaching a transport with no sampling handler is answered with `-32601` (Method not found) by every transport, as `Client#handle_sampling_request` already did: sampling.mdx § Error Handling reserves `-1` for "User rejected sampling request", and a capability the client never declared is an unsupported method, not a rejection.
+- A 2025-11-25 `sampling/createMessage` carrying `tools`/`toolChoice` is refused by the transport itself with `-32602` when `sampling.tools` was never declared (SEP-1577: "The client MUST return an error if this field is provided but ClientCapabilities.sampling.tools is not declared") — on the server-initiated path as on the multi round-trip one, after the Sampling/includeContext notices a served-or-refused request owes. A host driving a transport directly no longer depends on its own callback for the check.
 
 ### JSON Schema handling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 Groundwork for the 2026-07-28 protocol revision (stateless, per-request
 metadata). Each feature lands in its own PR; this section accumulates them.
 
+### Deprecations (feature lifecycle policy)
+
+- **Deprecation notices.** `MCPClient::Deprecations` names every feature
+  the 2026-07-28 revision placed in the Deprecated state (`REGISTRY`) and
+  logs one notice per feature per process on first use, with the suggested
+  migration: Roots (`roots:` / `Client#roots=`), Sampling
+  (`sampling_handler:`), Logging (`Client#log_level=`), the HTTP+SSE
+  transport (`MCPClient::ServerSSE`), the `includeContext` values
+  `thisServer` / `allServers` received in a sampling request (still served)
+  and OAuth Dynamic Client Registration (SEP-2577, SEP-2596, MCP PR #2858).
+  Everything keeps working; `MCPClient::Deprecations.enabled = false`
+  silences the notices.
+- **Documentation.** README documents the 2026-07-28 support (discovery
+  and per-request metadata, multi round-trip requests, `x-mcp-header`,
+  subscriptions, cacheable results, the tasks extension, authorization) and
+  the deprecated features with their migrations.
+
 ### JSON Schema handling
 
 - **Dynamic references bind against the evaluation path, `contains`

--- a/OAUTH.md
+++ b/OAUTH.md
@@ -7,7 +7,7 @@ This implementation provides OAuth 2.1 authentication support for the Ruby MCP C
 - **OAuth 2.1 compliance** with security best practices
 - **PKCE (Proof Key for Code Exchange)** for secure authorization
 - **Automatic server discovery** via `.well-known` endpoints
-- **Dynamic client registration** when supported by servers
+- **Client ID Metadata Documents** and **pre-registered credentials**; dynamic client registration (RFC 7591) remains as a fallback but is deprecated since MCP 2026-07-28
 - **Token refresh** and automatic token management
 - **Per-authorization-server credentials and tokens** (MCP 2026-07-28): store pre-registered credentials with
   `registration_type: 'pre_registered'` **and the `issuer:` of the authorization server that issued them**
@@ -61,8 +61,9 @@ oauth_provider = MCPClient::Auth::OAuthProvider.new(
 # Start authorization flow
 auth_url = oauth_provider.start_authorization_flow
 
-# Complete flow after user authorization
-token = oauth_provider.complete_authorization_flow(code, state)
+# Complete flow after user authorization; pass the callback's iss parameter
+# so the response is checked against the authorization server (RFC 9207)
+token = oauth_provider.complete_authorization_flow(code, state, iss: iss)
 ```
 
 ## OAuth Flow Steps
@@ -106,7 +107,7 @@ The implementation follows the standard OAuth 2.1 authorization code flow with P
      keep their fail-closed reading instead. The same standard applies to a record read back from a
      storage backend that persists plain hashes: PKCE support requires an array, and a
      `scopes_supported` that is not one contributes no scopes.
-2. **Client Registration**: Automatically register OAuth client if dynamic registration is supported
+2. **Client Registration**: Use pre-registered credentials or a Client ID Metadata Document; fall back to dynamic registration (deprecated) when the authorization server offers nothing else
    - A registration response names a client only when it is a JSON object whose `client_id` is a
      non-empty string (RFC 7591 Section 3.2.1). A `201` without one registered nothing, so it raises a
      `ConnectionError` and the flow ends *before* the browser is opened, rather than sending the user

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gem install ruby-mcp-client
 MCP enables AI assistants to discover and invoke external tools via different transport mechanisms:
 
 - **stdio** - Local processes implementing the MCP protocol
-- **SSE** - Server-Sent Events with streaming support
+- **SSE** *(deprecated)* - Server-Sent Events with streaming support; the HTTP+SSE transport is deprecated and new integrations should use **Streamable HTTP** instead (see [Deprecated features](#deprecated-features))
 - **HTTP** - Simple request/response (non-streaming)
 - **Streamable HTTP** - HTTP POST with SSE-formatted responses
 
@@ -67,9 +67,9 @@ The simplest way to connect to an MCP server:
 require 'mcp_client'
 
 # Auto-detect transport from URL
-client = MCPClient.connect('http://localhost:8000/sse')      # SSE
 client = MCPClient.connect('http://localhost:8931/mcp')      # Streamable HTTP
 client = MCPClient.connect('npx -y @modelcontextprotocol/server-filesystem /home')  # stdio
+client = MCPClient.connect('http://localhost:8000/sse')      # SSE (HTTP+SSE: deprecated, use Streamable HTTP)
 
 # With options
 client = MCPClient.connect('http://api.example.com/mcp',
@@ -80,7 +80,7 @@ client = MCPClient.connect('http://api.example.com/mcp',
 )
 
 # Multiple servers
-client = MCPClient.connect(['http://server1/mcp', 'http://server2/sse'])
+client = MCPClient.connect(['http://server1/mcp', 'http://server2/mcp'])
 
 # Force specific transport
 client = MCPClient.connect('http://custom.com/api', transport: :streamable_http)
@@ -103,7 +103,7 @@ protocol meaning, send it unchanged.
 
 | URL Pattern | Transport |
 |-------------|-----------|
-| Ends with `/sse` | SSE |
+| Ends with `/sse` | SSE — HTTP+SSE is *deprecated*, prefer Streamable HTTP ([Deprecated features](#deprecated-features)) |
 | Ends with `/mcp` | Streamable HTTP |
 | `stdio://command` or Array | stdio |
 | `npx`, `node`, `python`, etc. | stdio |

--- a/README.md
+++ b/README.md
@@ -519,11 +519,17 @@ warning. A notice costs the deprecated operation exactly what one
 `logger.warn` costs it, and no more: a logger that raises, drops the notice
 or writes nowhere (`Logger.new(nil)`) is swallowed, so the feature keeps
 working and the notice stays owed to a later use — but a logger that blocks,
-blocks its caller here just as it does everywhere else in the library. A
-notice raised from inside another notice's logger (a formatter or a log
-subscriber that reaches a deprecated feature itself) stands down rather than
-wait, for the same reason: it is owed to a later use, and never worth a
-deadlock.
+blocks its caller here just as it does everywhere else in the library.
+Nothing ever waits for a notice. A caller that meets one already in flight —
+another thread's first use, or a formatter, log subscriber or audit hook that
+reaches a deprecated feature from inside the notice being written — stands
+down at once instead of queueing behind it. Queueing would be worth a
+deadlock, since the thread writing a notice holds the logger and the thread
+that would queue may be holding a lock that logger needs (an ordinary
+`logger.info` holds exactly such a lock while its device runs). And it would
+buy nothing: whoever holds the notice is writing it, and if their logger
+fails or filters the warning the notice is owed again, so the feature's next
+use raises it.
 
 ## MCP 2025-11-25 Features
 

--- a/README.md
+++ b/README.md
@@ -500,7 +500,11 @@ root (including from a transport driven directly, without a `Client`).
 `MCPClient::Deprecations.enabled = false` (before constructing clients) to
 silence the notices. Notices go to the logger the client or server was
 given; without one they go to the default `$stdout` logger like every other
-warning.
+warning. A notice costs the deprecated operation exactly what one
+`logger.warn` costs it, and no more: a logger that raises or drops the notice
+is swallowed, so the feature keeps working and the notice stays owed to a
+later use — but a logger that blocks, blocks its caller here just as it does
+everywhere else in the library.
 
 ## MCP 2025-11-25 Features
 

--- a/README.md
+++ b/README.md
@@ -520,7 +520,10 @@ warning. A notice costs the deprecated operation exactly what one
 or writes nowhere (`Logger.new(nil)`, or one whose device has been closed) is
 swallowed, so the feature keeps working and the notice stays owed to a later
 use — but a logger that blocks, blocks its caller here just as it does
-everywhere else in the library. A logger the host wrapped is asked through
+everywhere else in the library. One failure is beyond reach: a standard
+`Logger` over an open device that fails to write hides that from its caller
+(it reports it on `$stderr` only and returns as if it had written), so that
+notice is spent; a closed device is recognised, a broken one is not. A logger the host wrapped is asked through
 the wrapper (`warn?`, and the device of the `Delegator` it holds), so a
 tagged, broadcast or hand-rolled wrapper above WARN leaves the notice owed
 rather than spending it on a line nobody reads; a wrapper that filters on

--- a/README.md
+++ b/README.md
@@ -456,21 +456,23 @@ The 2026-07-28 [deprecated features registry](https://modelcontextprotocol.io/sp
 lists these as Deprecated under the feature lifecycle policy: they keep
 working during their deprecation window, but new integrations should not
 adopt them. Features 2026-07-28 itself deprecates stay for at least twelve
-months; the HTTP+SSE transport and the `includeContext` values were
-deprecated by earlier revisions and may be removed sooner (the registry
-gives the earliest removal of each). The client logs one notice per feature
-per process on first use, naming the suggested migration:
+months. Only the HTTP+SSE transport may go sooner: the `includeContext`
+values were deprecated by an earlier revision, but SEP-2596's transition
+provision ties them to Sampling, so they share the twelve-month window. The
+client logs one notice per feature per process on first use, naming the
+suggested migration:
 
-| Feature | Deprecated since | Migration |
-|---------|------------------|-----------|
-| Roots (`roots:`, `Client#roots=`) | 2026-07-28 (SEP-2577) | Pass directories or files through tool parameters, resource URIs or server configuration |
-| Sampling (`sampling_handler:`) | 2026-07-28 (SEP-2577) | Integrate directly with the LLM provider API |
-| Logging (`log_level=` on the client or a server, `notifications/message`) | 2026-07-28 (SEP-2577) | Log to stderr (stdio) or use OpenTelemetry |
-| HTTP+SSE transport (`MCPClient::ServerSSE`, warned once it is connected) | 2025-03-26 (reclassified by SEP-2596) | Migrate the server to Streamable HTTP |
-| `includeContext` `"thisServer"` / `"allServers"` in sampling requests | 2025-11-25 (reclassified by SEP-2596) | Servers omit the field or send `"none"` |
-| OAuth Dynamic Client Registration | 2026-07-28 (PR #2858) | Client ID Metadata Documents or pre-registered credentials |
+| Feature | Deprecated since | Earliest removal | Migration |
+|---------|------------------|------------------|-----------|
+| Roots (`roots:`, `Client#roots=`) | 2026-07-28 (SEP-2577) | no earlier than twelve months after 2026-07-28 | Pass directories or files through tool parameters, resource URIs or server configuration |
+| Sampling (`sampling_handler:`) | 2026-07-28 (SEP-2577) | no earlier than twelve months after 2026-07-28 | Integrate directly with the LLM provider API |
+| Logging (`log_level=` on the client or a server, `notifications/message`) | 2026-07-28 (SEP-2577) | no earlier than twelve months after 2026-07-28 | Log to stderr (stdio) or use OpenTelemetry |
+| HTTP+SSE transport (`MCPClient::ServerSSE`, warned once it is connected) | 2025-03-26 (reclassified by SEP-2596) | no earlier than three months after SEP-2596 is Final | Migrate the server to Streamable HTTP |
+| `includeContext` `"thisServer"` / `"allServers"` in sampling requests | 2025-11-25 (reclassified by SEP-2596) | no earlier than twelve months after 2026-07-28 (it follows Sampling) | Servers omit the field or send `"none"` |
+| OAuth Dynamic Client Registration | 2026-07-28 (PR #2858) | no earlier than twelve months after 2026-07-28 | Client ID Metadata Documents or pre-registered credentials |
 
-`MCPClient::Deprecations::REGISTRY` lists them; set
+`MCPClient::Deprecations::REGISTRY` lists them, each with its
+`earliest_removal`; set
 `MCPClient::Deprecations.enabled = false` (before constructing clients) to
 silence the notices. Notices go to the logger the client or server was
 given; without one they go to the default `$stdout` logger like every other

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ revision retires.
 - **Tools**: list, call, streaming, annotations (hint-style), structured outputs validated against `outputSchema` (JSON Schema 2020-12 / 2019-09 / draft-07), title, `x-mcp-header` parameters
 - **Prompts**: list, get with parameters
 - **Resources**: list, read, templates, subscriptions, pagination, ResourceLink content
-- **Elicitation**: Server-initiated user interactions (stdio, SSE, Streamable HTTP) and multi round-trip `input_required` results
+- **Elicitation**: Server-initiated user interactions (stdio, Streamable HTTP, and the *deprecated* HTTP+SSE transport) and multi round-trip `input_required` results
 - **Roots** *(deprecated in 2026-07-28)*: Filesystem scope boundaries with change notifications
 - **Sampling** *(deprecated in 2026-07-28)*: Server-requested LLM completions with modelPreferences
 - **Completion**: Autocomplete for prompts/resources with context
@@ -482,7 +482,7 @@ migration:
 |---------|------------------|------------------|-----------|
 | Roots (`roots:`, `Client#roots=`, or answering a `roots/list` request with a non-empty list) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Pass directories or files through tool parameters, resource URIs or server configuration |
 | Sampling (`sampling_handler:` on `Client.new` or `MCPClient.connect`, or serving a request through a transport's `on_sampling_request`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Integrate directly with the LLM provider API |
-| Logging (`log_level=` on the client or a server, `notifications/message`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Log to stderr (stdio) or use OpenTelemetry |
+| Logging (`log_level=` on the client or a server, an `io.modelcontextprotocol/logLevel` in `request_meta` or a per-call `_meta`, `notifications/message`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Log to stderr (stdio) or use OpenTelemetry |
 | HTTP+SSE transport (`MCPClient::ServerSSE`, warned once it is connected) | 2025-03-26 (reclassified by SEP-2596) | three months after SEP-2596 reaches Final | Migrate the server to Streamable HTTP |
 | `includeContext` `"thisServer"` / `"allServers"` in sampling requests | 2025-11-25 (reclassified by SEP-2596) | follows Sampling (SEP-2577) | Servers omit the field or send `"none"` |
 | OAuth Dynamic Client Registration | 2026-07-28 (PR #2858) | the first revision released on or after 2027-07-28 | Client ID Metadata Documents or pre-registered credentials |
@@ -501,10 +501,14 @@ root (including from a transport driven directly, without a `Client`).
 silence the notices. Notices go to the logger the client or server was
 given; without one they go to the default `$stdout` logger like every other
 warning. A notice costs the deprecated operation exactly what one
-`logger.warn` costs it, and no more: a logger that raises or drops the notice
-is swallowed, so the feature keeps working and the notice stays owed to a
-later use — but a logger that blocks, blocks its caller here just as it does
-everywhere else in the library.
+`logger.warn` costs it, and no more: a logger that raises, drops the notice
+or writes nowhere (`Logger.new(nil)`) is swallowed, so the feature keeps
+working and the notice stays owed to a later use — but a logger that blocks,
+blocks its caller here just as it does everywhere else in the library. A
+notice raised from inside another notice's logger (a formatter or a log
+subscriber that reaches a deprecated feature itself) stands down rather than
+wait, for the same reason: it is owed to a later use, and never worth a
+deadlock.
 
 ## MCP 2025-11-25 Features
 

--- a/README.md
+++ b/README.md
@@ -28,24 +28,32 @@ Built-in API conversions: `to_openai_tools()`, `to_anthropic_tools()`, `to_googl
 
 ## MCP Protocol Support
 
-Implements the **MCP 2025-11-25** specification. The client negotiates the
-protocol version during `initialize` and disconnects if the server answers
-with a revision it cannot speak (supported: `2025-11-25`, `2025-06-18`,
-`2025-03-26`, `2024-11-05`):
+Implements the **MCP 2026-07-28** specification and stays compatible with
+every earlier revision (`2025-11-25`, `2025-06-18`, `2025-03-26`,
+`2024-11-05`). The client is dual-era: it probes each server with
+`server/discover` and talks the stateless 2026-07-28 protocol (per-request
+`_meta`, no `initialize`, no sessions) to servers that answer it, and runs
+the classic `initialize` handshake with everyone else — disconnecting if a
+server answers with a revision it cannot speak. See
+[MCP 2026-07-28 Features](#mcp-2026-07-28-features) for the new
+capabilities and [Deprecated features](#deprecated-features) for what the
+revision retires.
 
-- **Tools**: list, call, streaming, annotations (hint-style), structured outputs, title
+- **Tools**: list, call, streaming, annotations (hint-style), structured outputs validated against `outputSchema` (JSON Schema 2020-12 / 2019-09 / draft-07), title, `x-mcp-header` parameters
 - **Prompts**: list, get with parameters
 - **Resources**: list, read, templates, subscriptions, pagination, ResourceLink content
-- **Elicitation**: Server-initiated user interactions (stdio, SSE, Streamable HTTP)
-- **Roots**: Filesystem scope boundaries with change notifications
-- **Sampling**: Server-requested LLM completions with modelPreferences
+- **Elicitation**: Server-initiated user interactions (stdio, SSE, Streamable HTTP) and multi round-trip `input_required` results
+- **Roots** *(deprecated in 2026-07-28)*: Filesystem scope boundaries with change notifications
+- **Sampling** *(deprecated in 2026-07-28)*: Server-requested LLM completions with modelPreferences
 - **Completion**: Autocomplete for prompts/resources with context
-- **Logging**: Server log messages with level filtering
-- **Tasks**: Task-augmented `tools/call` — declare the `io.modelcontextprotocol/tasks` extension, poll `tasks/get`, answer `inputRequests` with `tasks/update`, and `tasks/cancel`. On 2025-11-25 servers the earlier surface (a requested `ttl`, `tasks/result`, `tasks/list`) is still spoken
+- **Logging** *(deprecated in 2026-07-28)*: Server log messages with level filtering
+- **Tasks**: Task-augmented `tools/call` — declare the `io.modelcontextprotocol/tasks` extension, poll `tasks/get`, answer `inputRequests` with `tasks/update`, and take the outcome from `tasks/get`; the 2025-11-25 surface stays as legacy
+- **Subscriptions**: `subscriptions/listen` notification streams (2026-07-28)
+- **Caching**: `ttlMs` / `cacheScope` freshness hints on lists, reads and discovery (2026-07-28)
 - **Audio**: Audio content type support
 - **Progress & Cancellation**: `progressToken` plumbing with per-call callbacks; automatic `notifications/cancelled` for abandoned requests
 - **Metadata**: `icons`, `title` and `_meta` parsed on tools, prompts and resources
-- **OAuth 2.1**: PKCE (S256 required), RFC 8414/9728 discovery, dynamic registration, Client ID Metadata Documents, scope step-up challenges
+- **OAuth 2.1**: PKCE (S256 required), RFC 8414/9728 discovery, RFC 9207 issuer validation, Client ID Metadata Documents, dynamic registration *(deprecated)*, scope step-up challenges
 
 Transports treat the server as untrusted input — see
 [Treating the Server as Untrusted](#treating-the-server-as-untrusted) for the
@@ -328,6 +336,136 @@ refused rather than deferred — a `listen` whose connection is closed while it
 is being opened raises `ConnectionError` instead of POSTing onto a transport
 the host has closed, which no later `cleanup` would find.
 
+## MCP 2026-07-28 Features
+
+The 2026-07-28 revision makes the protocol stateless: there is no
+`initialize` handshake, no session and no server-to-client request channel.
+Every request carries its own metadata, and anything the server needs from
+the client is asked for through the result itself. The client detects which
+era a server speaks and adapts; existing code keeps working unchanged.
+
+### Discovery and per-request metadata
+
+```ruby
+client = MCPClient.connect('http://localhost:8931/mcp')
+server = client.servers.first
+server.modern?            # => true for a 2026-07-28 server
+server.protocol_version   # => "2026-07-28"
+server.protocol_era       # => :modern or :legacy
+```
+
+A modern server is recognised by its answer to `server/discover`; every
+request then carries `io.modelcontextprotocol/protocolVersion`,
+`clientInfo` and `clientCapabilities` in `_meta`, and on HTTP the
+`MCP-Protocol-Version`, `Mcp-Method` and `Mcp-Name` headers. Host-supplied
+metadata (a Hash or a callable evaluated per request) is merged into every
+request with `MCPClient::Client.new(request_meta: ...)`. Force an era with
+`protocol: :modern` / `protocol: :legacy` (default `:auto`) and tune the
+probe with `discover_timeout:`. `ping` maps to `server/discover` and
+`log_level=` to the per-request log level on modern servers. Typed errors
+carry the JSON-RPC code: `MCPClient::Errors::HeaderMismatchError`
+(-32020), `MissingRequiredClientCapabilityError` (-32021) and
+`UnsupportedProtocolVersionError` (-32022).
+
+### Multi round-trip requests
+
+On a modern server `tools/call`, `resources/read` and `prompts/get` may
+answer `resultType: "input_required"`. The client fulfils each request in
+`inputRequests` with the handlers it already has — the elicitation handler,
+the sampling handler and the configured roots — and re-sends the original
+request with `inputResponses` and the server's opaque `requestState`. More
+than 10 rounds, a request the client cannot honour or a malformed
+`inputRequests` raise `MCPClient::Errors::InputRequiredError` (exposing
+`input_requests` and `request_state`).
+
+### Custom headers from tool parameters
+
+Tool parameters annotated with `x-mcp-header` are mirrored into
+`Mcp-Param-{name}` request headers on `tools/call` (Streamable HTTP and
+plain HTTP). A `-32020` HeaderMismatch rejection triggers one `tools/list`
+refresh and a retry; tools with invalid annotations are excluded from the
+list with a warning. `MCPClient::HeaderParams` exposes the validation.
+
+### Subscriptions (`subscriptions/listen`)
+
+```ruby
+subscription = client.listen(notifications: { tools_list_changed: true,
+                                              resource_subscriptions: ['file:///etc/hosts'] }) do |method, params|
+  puts "#{method}: #{params.inspect}"
+end
+subscription.acknowledged   # what the server agreed to watch
+subscription.unsupported    # what it did not
+subscription.close
+```
+
+Each subscription is one long-lived `subscriptions/listen` request; on
+Streamable HTTP it runs on its own stream and is re-opened with backoff when
+the stream drops, on stdio it is re-sent when the process restarts.
+`subscribe_resource` / `unsubscribe_resource` map onto listen streams on
+modern servers.
+
+### Cacheable results
+
+`server/discover`, the `*/list` requests and `resources/read` carry
+`ttlMs` and `cacheScope`. Lists are served while fresh and re-fetched on
+access once stale (a stale list is served with a warning when the re-fetch
+fails transiently); `resources/read` results with a `ttlMs` are cached per
+URI. Entries with `cacheScope: "private"` are bound to the credentials the
+request went out with and never shared across authorization contexts.
+`server.cache_info(:tools)` / `cache_info(:read, uri)` expose `ttl_ms`,
+`cache_scope`, `received_at` and `fresh`.
+
+### Tasks extension (`io.modelcontextprotocol/tasks`)
+
+```ruby
+client = MCPClient::Client.new(mcp_server_configs: [...],
+                               extensions: ['io.modelcontextprotocol/tasks'])
+
+result = client.call_tool('long_running', {})   # polls tasks/get transparently
+
+task = client.call_tool_as_task('long_running', {})
+task = client.wait_for_task(task, timeout: 120)  # answers input_required via tasks/update
+task.result if task.completed?
+client.cancel_task(task)
+```
+
+Task-augmented calls are opt-in through `extensions:`; a server that
+answers `tools/call` with a task is polled at its `pollIntervalMs` until the
+task is terminal or its `ttlMs` elapses, and `input_required` tasks are
+answered with the elicitation / sampling / roots handlers. `tasks/list` and
+`tasks/result` do not exist on 2026-07-28 servers; the legacy task API keeps
+working on 2025-11-25 servers.
+
+### Authorization
+
+`OAuthProvider` records the authorization server's `issuer` with each
+authorization request and validates the callback's `iss` per RFC 9207
+(`complete_authorization_flow(code, state, iss:)`); client credentials and
+tokens are bound to the issuer that produced them, so a server that
+switches authorization servers never sees another server's token. Dynamic
+Client Registration carries `application_type` and is deprecated in favour
+of Client ID Metadata Documents (`client_id_metadata_url:`). See
+[OAUTH.md](OAUTH.md).
+
+### Deprecated features
+
+MCP 2026-07-28 places these in the Deprecated state of its feature
+lifecycle policy: they keep working for at least twelve months, but new
+integrations should not adopt them. The client logs one notice per feature
+per process on first use, naming the suggested migration:
+
+| Feature | Migration |
+|---------|-----------|
+| Roots (`roots:`, `Client#roots=`) | Pass directories or files through tool parameters, resource URIs or server configuration |
+| Sampling (`sampling_handler:`) | Integrate directly with the LLM provider API |
+| Logging (`Client#log_level=`, `notifications/message`) | Log to stderr (stdio) or use OpenTelemetry |
+| HTTP+SSE transport (`MCPClient::ServerSSE`) | Migrate the server to Streamable HTTP |
+| `includeContext` `"thisServer"` / `"allServers"` in sampling requests | Servers omit the field or send `"none"` |
+| OAuth Dynamic Client Registration | Client ID Metadata Documents or pre-registered credentials |
+
+`MCPClient::Deprecations::REGISTRY` lists them; set
+`MCPClient::Deprecations.enabled = false` to silence the notices.
+
 ## MCP 2025-11-25 Features
 
 ### Tool Annotations
@@ -470,6 +608,8 @@ it.
 
 ### Roots
 
+> Deprecated in MCP 2026-07-28 (SEP-2577); see [Deprecated features](#deprecated-features).
+
 ```ruby
 # Set filesystem scope boundaries
 client.roots = [
@@ -482,6 +622,8 @@ client.roots
 ```
 
 ### Sampling (Server-requested LLM completions)
+
+> Deprecated in MCP 2026-07-28 (SEP-2577); see [Deprecated features](#deprecated-features).
 
 ```ruby
 # Configure handler when creating client
@@ -625,6 +767,8 @@ result = client.complete(
 ```
 
 ### Logging
+
+> Deprecated in MCP 2026-07-28 (SEP-2577); see [Deprecated features](#deprecated-features).
 
 ```ruby
 # Set log level

--- a/README.md
+++ b/README.md
@@ -517,13 +517,14 @@ silence the notices. Notices go to the logger the client or server was
 given; without one they go to the default `$stdout` logger like every other
 warning. A notice costs the deprecated operation exactly what one
 `logger.warn` costs it, and no more: a logger that raises, drops the notice
-or writes nowhere (`Logger.new(nil)`) is swallowed, so the feature keeps
-working and the notice stays owed to a later use — but a logger that blocks,
-blocks its caller here just as it does everywhere else in the library.
+or writes nowhere (`Logger.new(nil)`, or one whose device has been closed) is
+swallowed, so the feature keeps working and the notice stays owed to a later
+use — but a logger that blocks, blocks its caller here just as it does
+everywhere else in the library.
 Nothing ever waits for a notice. A caller that meets one already in flight —
-another thread's first use, or a formatter, log subscriber or audit hook that
-reaches a deprecated feature from inside the notice being written — stands
-down at once instead of queueing behind it. Queueing would be worth a
+another thread's first use, or a formatter, log subscriber, audit hook or
+`level` accessor that reaches a deprecated feature from inside the notice
+being written — stands down at once instead of queueing behind it. Queueing would be worth a
 deadlock, since the thread writing a notice holds the logger and the thread
 that would queue may be holding a lock that logger needs (an ordinary
 `logger.info` holds exactly such a lock while its device runs). And it would

--- a/README.md
+++ b/README.md
@@ -356,13 +356,16 @@ server.protocol_era       # => :modern or :legacy
 
 A modern server is recognised by its answer to `server/discover`; every
 request then carries `io.modelcontextprotocol/protocolVersion`,
-`clientInfo` and `clientCapabilities` in `_meta`, and on HTTP the
+`io.modelcontextprotocol/clientInfo` and
+`io.modelcontextprotocol/clientCapabilities` in `_meta`, and on HTTP the
 `MCP-Protocol-Version`, `Mcp-Method` and `Mcp-Name` headers. Host-supplied
 metadata (a Hash or a callable evaluated per request) is merged into every
 request with `MCPClient::Client.new(request_meta: ...)`. Force an era with
 `protocol: :modern` / `protocol: :legacy` (default `:auto`) and tune the
-probe with `discover_timeout:`. `ping` maps to `server/discover` and
-`log_level=` to the per-request log level on modern servers. Typed errors
+probe with `discover_timeout:` on `MCPClient.connect`, `stdio_config`,
+`http_config` and `streamable_http_config` (or the server constructors).
+`ping` maps to `server/discover` and `log_level=` to the per-request log
+level on modern servers. Typed errors
 carry the JSON-RPC code: `MCPClient::Errors::HeaderMismatchError`
 (-32020), `MissingRequiredClientCapabilityError` (-32021) and
 `UnsupportedProtocolVersionError` (-32022).
@@ -449,22 +452,29 @@ of Client ID Metadata Documents (`client_id_metadata_url:`). See
 
 ### Deprecated features
 
-MCP 2026-07-28 places these in the Deprecated state of its feature
-lifecycle policy: they keep working for at least twelve months, but new
-integrations should not adopt them. The client logs one notice per feature
+The 2026-07-28 [deprecated features registry](https://modelcontextprotocol.io/specification/2026-07-28/deprecated)
+lists these as Deprecated under the feature lifecycle policy: they keep
+working during their deprecation window, but new integrations should not
+adopt them. Features 2026-07-28 itself deprecates stay for at least twelve
+months; the HTTP+SSE transport and the `includeContext` values were
+deprecated by earlier revisions and may be removed sooner (the registry
+gives the earliest removal of each). The client logs one notice per feature
 per process on first use, naming the suggested migration:
 
-| Feature | Migration |
-|---------|-----------|
-| Roots (`roots:`, `Client#roots=`) | Pass directories or files through tool parameters, resource URIs or server configuration |
-| Sampling (`sampling_handler:`) | Integrate directly with the LLM provider API |
-| Logging (`Client#log_level=`, `notifications/message`) | Log to stderr (stdio) or use OpenTelemetry |
-| HTTP+SSE transport (`MCPClient::ServerSSE`) | Migrate the server to Streamable HTTP |
-| `includeContext` `"thisServer"` / `"allServers"` in sampling requests | Servers omit the field or send `"none"` |
-| OAuth Dynamic Client Registration | Client ID Metadata Documents or pre-registered credentials |
+| Feature | Deprecated since | Migration |
+|---------|------------------|-----------|
+| Roots (`roots:`, `Client#roots=`) | 2026-07-28 (SEP-2577) | Pass directories or files through tool parameters, resource URIs or server configuration |
+| Sampling (`sampling_handler:`) | 2026-07-28 (SEP-2577) | Integrate directly with the LLM provider API |
+| Logging (`log_level=` on the client or a server, `notifications/message`) | 2026-07-28 (SEP-2577) | Log to stderr (stdio) or use OpenTelemetry |
+| HTTP+SSE transport (`MCPClient::ServerSSE`, warned once it is connected) | 2025-03-26 (reclassified by SEP-2596) | Migrate the server to Streamable HTTP |
+| `includeContext` `"thisServer"` / `"allServers"` in sampling requests | 2025-11-25 (reclassified by SEP-2596) | Servers omit the field or send `"none"` |
+| OAuth Dynamic Client Registration | 2026-07-28 (PR #2858) | Client ID Metadata Documents or pre-registered credentials |
 
 `MCPClient::Deprecations::REGISTRY` lists them; set
-`MCPClient::Deprecations.enabled = false` to silence the notices.
+`MCPClient::Deprecations.enabled = false` (before constructing clients) to
+silence the notices. Notices go to the logger the client or server was
+given; without one they go to the default `$stdout` logger like every other
+warning.
 
 ## MCP 2025-11-25 Features
 
@@ -1157,7 +1167,7 @@ client = MCPClient::Client.new(
 )
 ```
 
-Features: PKCE, server discovery (`.well-known`), dynamic registration, token refresh.
+Features: PKCE, server discovery (`.well-known`), RFC 9207 issuer validation, Client ID Metadata Documents, dynamic registration (deprecated fallback), token refresh.
 
 See [OAUTH.md](OAUTH.md) for full documentation.
 

--- a/README.md
+++ b/README.md
@@ -520,7 +520,12 @@ warning. A notice costs the deprecated operation exactly what one
 or writes nowhere (`Logger.new(nil)`, or one whose device has been closed) is
 swallowed, so the feature keeps working and the notice stays owed to a later
 use — but a logger that blocks, blocks its caller here just as it does
-everywhere else in the library.
+everywhere else in the library. A logger the host wrapped is asked through
+the wrapper (`warn?`, and the device of the `Delegator` it holds), so a
+tagged, broadcast or hand-rolled wrapper above WARN leaves the notice owed
+rather than spending it on a line nobody reads; a wrapper that filters on
+something a level cannot express — a tag, a source allow-list — cannot be
+asked, and does spend it.
 Nothing ever waits for a notice. A caller that meets one already in flight —
 another thread's first use, or a formatter, log subscriber, audit hook or
 `level` accessor that reaches a deprecated feature from inside the notice
@@ -942,8 +947,12 @@ In form mode the handler may return the content on its own (`{ 'field' =>
 `accept`, `decline` or `cancel` — any other value is answered `cancel`, since
 it is not consent the user gave.
 
-In URL mode the handler's second argument is
-`{ 'mode' => 'url', 'url' => ..., 'elicitationId' => ... }` and its answer is
+In URL mode the handler's second argument is `{ 'mode' => 'url', 'url' => ... }`
+on a **2026-07-28** server and
+`{ 'mode' => 'url', 'url' => ..., 'elicitationId' => ... }` on a **2025-11-25**
+one: the newer revision removed `elicitationId`, so a host must not expect that
+key from a modern server (see
+[URL-mode elicitation](#url-mode-elicitation)). Its answer is
 consent, not data: only an explicit `action` of `accept`, `decline` or `cancel`
 (or a literal `true` for accept) counts — anything else is answered `cancel`.
 `content` is dropped, since it is form-mode only, while a handler-supplied

--- a/README.md
+++ b/README.md
@@ -365,7 +365,15 @@ request with `MCPClient::Client.new(request_meta: ...)`. Force an era with
 probe with `discover_timeout:` on `MCPClient.connect`, `stdio_config`,
 `http_config` and `streamable_http_config` (or the server constructors).
 `ping` maps to `server/discover` and `log_level=` to the per-request log
-level on modern servers. Typed errors
+level on modern servers.
+
+> `log_level=` is deprecated in MCP 2026-07-28 (SEP-2577). On a modern
+> server it writes `_meta["io.modelcontextprotocol/logLevel"]`, part of the
+> Logging utility the revision marks Deprecated as a whole: new
+> implementations SHOULD NOT adopt it. See
+> [Deprecated features](#deprecated-features).
+
+Typed errors
 carry the JSON-RPC code: `MCPClient::Errors::HeaderMismatchError`
 (-32020), `MissingRequiredClientCapabilityError` (-32021) and
 `UnsupportedProtocolVersionError` (-32022).
@@ -455,21 +463,25 @@ of Client ID Metadata Documents (`client_id_metadata_url:`). See
 The 2026-07-28 [deprecated features registry](https://modelcontextprotocol.io/specification/2026-07-28/deprecated)
 lists these as Deprecated under the feature lifecycle policy: they keep
 working during their deprecation window, but new integrations should not
-adopt them. Features 2026-07-28 itself deprecates stay for at least twelve
-months. Only the HTTP+SSE transport may go sooner: the `includeContext`
-values were deprecated by an earlier revision, but SEP-2596's transition
-provision ties them to Sampling, so they share the twelve-month window. The
-client logs one notice per feature per process on first use, naming the
-suggested migration:
+adopt them. The earliest removal is the registry's own, and it names a
+*revision*, not a date: what the features 2026-07-28 deprecates wait for is
+the first revision released on or after 2027-07-28, which may itself land
+well after that date — do not plan around 2027-07-28 as a removal date. The
+`includeContext` values follow Sampling, and only the HTTP+SSE transport has
+a clock of its own. The earliest removal is when a feature becomes
+*eligible* for removal; the actual removal is a Core Maintainer decision
+taken during release preparation. The client logs one notice per feature per
+process on first use, naming the earliest removal and the suggested
+migration:
 
 | Feature | Deprecated since | Earliest removal | Migration |
 |---------|------------------|------------------|-----------|
-| Roots (`roots:`, `Client#roots=`) | 2026-07-28 (SEP-2577) | no earlier than twelve months after 2026-07-28 | Pass directories or files through tool parameters, resource URIs or server configuration |
-| Sampling (`sampling_handler:`) | 2026-07-28 (SEP-2577) | no earlier than twelve months after 2026-07-28 | Integrate directly with the LLM provider API |
-| Logging (`log_level=` on the client or a server, `notifications/message`) | 2026-07-28 (SEP-2577) | no earlier than twelve months after 2026-07-28 | Log to stderr (stdio) or use OpenTelemetry |
-| HTTP+SSE transport (`MCPClient::ServerSSE`, warned once it is connected) | 2025-03-26 (reclassified by SEP-2596) | no earlier than three months after SEP-2596 is Final | Migrate the server to Streamable HTTP |
-| `includeContext` `"thisServer"` / `"allServers"` in sampling requests | 2025-11-25 (reclassified by SEP-2596) | no earlier than twelve months after 2026-07-28 (it follows Sampling) | Servers omit the field or send `"none"` |
-| OAuth Dynamic Client Registration | 2026-07-28 (PR #2858) | no earlier than twelve months after 2026-07-28 | Client ID Metadata Documents or pre-registered credentials |
+| Roots (`roots:`, `Client#roots=`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Pass directories or files through tool parameters, resource URIs or server configuration |
+| Sampling (`sampling_handler:`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Integrate directly with the LLM provider API |
+| Logging (`log_level=` on the client or a server, `notifications/message`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Log to stderr (stdio) or use OpenTelemetry |
+| HTTP+SSE transport (`MCPClient::ServerSSE`, warned once it is connected) | 2025-03-26 (reclassified by SEP-2596) | three months after SEP-2596 reaches Final | Migrate the server to Streamable HTTP |
+| `includeContext` `"thisServer"` / `"allServers"` in sampling requests | 2025-11-25 (reclassified by SEP-2596) | follows Sampling (SEP-2577) | Servers omit the field or send `"none"` |
+| OAuth Dynamic Client Registration | 2026-07-28 (PR #2858) | the first revision released on or after 2027-07-28 | Client ID Metadata Documents or pre-registered credentials |
 
 `MCPClient::Deprecations::REGISTRY` lists them, each with its
 `earliest_removal`; set

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ protocol meaning, send it unchanged.
 | Ends with `/mcp` | Streamable HTTP |
 | `stdio://command` or Array | stdio |
 | `npx`, `node`, `python`, etc. | stdio |
-| Other HTTP URLs | Auto-detect (Streamable HTTP → SSE → HTTP) |
+| Other HTTP URLs | Auto-detect (Streamable HTTP → SSE → HTTP) — the SSE step is the *deprecated* HTTP+SSE transport, tried only after Streamable HTTP fails ([Deprecated features](#deprecated-features)) |
 
 ## Working with Tools, Prompts & Resources
 
@@ -362,8 +362,12 @@ request then carries `io.modelcontextprotocol/protocolVersion`,
 metadata (a Hash or a callable evaluated per request) is merged into every
 request with `MCPClient::Client.new(request_meta: ...)`. Force an era with
 `protocol: :modern` / `protocol: :legacy` (default `:auto`) and tune the
-probe with `discover_timeout:` on `MCPClient.connect`, `stdio_config`,
-`http_config` and `streamable_http_config` (or the server constructors).
+probe with `discover_timeout:` on `stdio_config`, `http_config` and
+`streamable_http_config` (or the matching server constructors), and on
+`MCPClient.connect` for those same three transports. The deprecated HTTP+SSE
+transport has no era of its own: `MCPClient::ServerSSE` takes neither option,
+so `MCPClient.connect` drops both for an `/sse` URL rather than passing them
+on ([Deprecated features](#deprecated-features)).
 `ping` maps to `server/discover` and `log_level=` to the per-request log
 level on modern servers.
 
@@ -477,7 +481,7 @@ migration:
 | Feature | Deprecated since | Earliest removal | Migration |
 |---------|------------------|------------------|-----------|
 | Roots (`roots:`, `Client#roots=`, or answering a `roots/list` request with a non-empty list) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Pass directories or files through tool parameters, resource URIs or server configuration |
-| Sampling (`sampling_handler:` on `Client.new` or `MCPClient.connect`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Integrate directly with the LLM provider API |
+| Sampling (`sampling_handler:` on `Client.new` or `MCPClient.connect`, or serving a request through a transport's `on_sampling_request`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Integrate directly with the LLM provider API |
 | Logging (`log_level=` on the client or a server, `notifications/message`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Log to stderr (stdio) or use OpenTelemetry |
 | HTTP+SSE transport (`MCPClient::ServerSSE`, warned once it is connected) | 2025-03-26 (reclassified by SEP-2596) | three months after SEP-2596 reaches Final | Migrate the server to Streamable HTTP |
 | `includeContext` `"thisServer"` / `"allServers"` in sampling requests | 2025-11-25 (reclassified by SEP-2596) | follows Sampling (SEP-2577) | Servers omit the field or send `"none"` |
@@ -923,6 +927,9 @@ For more control, use `create_client` with explicit configs:
 client = MCPClient.create_client(
   mcp_server_configs: [
     MCPClient.stdio_config(command: 'npx server', name: 'local'),
+    # HTTP+SSE is deprecated (SEP-2596): keep this only for an existing SSE
+    # server, and prefer Streamable HTTP (streamable_http_config below) for
+    # anything new. See "Deprecated features".
     MCPClient.sse_config(
       base_url: 'https://api.example.com/sse',
       headers: { 'Authorization' => 'Bearer TOKEN' },

--- a/README.md
+++ b/README.md
@@ -476,12 +476,20 @@ migration:
 
 | Feature | Deprecated since | Earliest removal | Migration |
 |---------|------------------|------------------|-----------|
-| Roots (`roots:`, `Client#roots=`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Pass directories or files through tool parameters, resource URIs or server configuration |
-| Sampling (`sampling_handler:`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Integrate directly with the LLM provider API |
+| Roots (`roots:`, `Client#roots=`, or answering a `roots/list` request with a non-empty list) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Pass directories or files through tool parameters, resource URIs or server configuration |
+| Sampling (`sampling_handler:` on `Client.new` or `MCPClient.connect`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Integrate directly with the LLM provider API |
 | Logging (`log_level=` on the client or a server, `notifications/message`) | 2026-07-28 (SEP-2577) | the first revision released on or after 2027-07-28 | Log to stderr (stdio) or use OpenTelemetry |
 | HTTP+SSE transport (`MCPClient::ServerSSE`, warned once it is connected) | 2025-03-26 (reclassified by SEP-2596) | three months after SEP-2596 reaches Final | Migrate the server to Streamable HTTP |
 | `includeContext` `"thisServer"` / `"allServers"` in sampling requests | 2025-11-25 (reclassified by SEP-2596) | follows Sampling (SEP-2577) | Servers omit the field or send `"none"` |
 | OAuth Dynamic Client Registration | 2026-07-28 (PR #2858) | the first revision released on or after 2027-07-28 | Client ID Metadata Documents or pre-registered credentials |
+
+A client that never adopted Roots is never warned about them. It registers a
+`roots/list` handler on every server unconditionally, so that a later
+`client.roots = [...]` is served without reconnecting, and until a root is set
+it answers `roots/list` with an empty list — an empty answer exposes nothing
+deprecated, so it raises no notice. The notice fires when the host configures
+`roots:`, calls `Client#roots=`, or serves an answer that actually carries a
+root (including from a transport driven directly, without a `Client`).
 
 `MCPClient::Deprecations::REGISTRY` lists them, each with its
 `earliest_removal`; set

--- a/README.md
+++ b/README.md
@@ -393,6 +393,21 @@ than 10 rounds, a request the client cannot honour or a malformed
 `inputRequests` raise `MCPClient::Errors::InputRequiredError` (exposing
 `input_requests` and `request_state`).
 
+### URL-mode elicitation
+
+An elicitation handler of arity 2 (or more) is called with the message and a
+metadata hash when the server asks for an out-of-band (`url`) interaction.
+On a **2025-11-25** server that hash is
+`{ 'mode' => 'url', 'url' => ..., 'elicitationId' => ... }`; on a
+**2026-07-28** server it is `{ 'mode' => 'url', 'url' => ... }` — the
+revision removed `elicitationId` together with
+`notifications/elicitation/complete`, because the outcome is learned by
+retrying the original request rather than from a server-initiated signal, and
+a server that must correlate an elicitation across retries carries its own
+identifier in the opaque `requestState`. A modern server that sends
+`elicitationId` anyway does not reach the host with it: the field is dropped
+and a warning is logged.
+
 ### Custom headers from tool parameters
 
 Tool parameters annotated with `x-mcp-header` are mirrored into

--- a/lib/mcp_client.rb
+++ b/lib/mcp_client.rb
@@ -3,6 +3,7 @@
 # Load all MCPClient components
 require_relative 'mcp_client/errors'
 require_relative 'mcp_client/deep_copy'
+require_relative 'mcp_client/deprecations'
 require_relative 'mcp_client/tool'
 require_relative 'mcp_client/prompt'
 require_relative 'mcp_client/resource'

--- a/lib/mcp_client.rb
+++ b/lib/mcp_client.rb
@@ -68,7 +68,8 @@ module MCPClient
   # - ping [Integer] Ping interval for SSE (default: 10)
   # - endpoint [String] JSON-RPC endpoint path (default: '/rpc')
   # - transport [Symbol] Force transport type (:stdio, :sse, :http, :streamable_http).
-  #   :sse forces the deprecated HTTP+SSE transport (SEP-2596); prefer
+  #   :sse forces the deprecated HTTP+SSE transport (SEP-2596); earliest
+  #   removal is three months after SEP-2596 reaches Final. Prefer
   #   :streamable_http.
   # - sampling_handler [Proc] Handler for sampling requests. Deprecated since MCP
   #   2026-07-28 (SEP-2577); earliest removal is the first revision released on or

--- a/lib/mcp_client.rb
+++ b/lib/mcp_client.rb
@@ -46,7 +46,11 @@ module MCPClient
   # Simplified connection API - auto-detects transport and returns connected client
   #
   # @param target [String, Array<String>] URL(s) or command for connection
-  #   - URLs ending in /sse -> SSE transport
+  #   - URLs ending in /sse -> SSE transport. The HTTP+SSE transport has been
+  #     deprecated since MCP 2025-03-26 and is listed in the 2026-07-28
+  #     deprecated features registry (SEP-2596); earliest removal is three
+  #     months after SEP-2596 reaches Final. New integrations should use
+  #     Streamable HTTP.
   #   - URLs ending in /mcp -> Streamable HTTP transport
   #   - stdio://command or Array commands -> stdio transport
   #   - Commands starting with npx, node, python, ruby, etc. -> stdio transport
@@ -61,7 +65,9 @@ module MCPClient
   # - env [Hash] Environment variables for stdio
   # - ping [Integer] Ping interval for SSE (default: 10)
   # - endpoint [String] JSON-RPC endpoint path (default: '/rpc')
-  # - transport [Symbol] Force transport type (:stdio, :sse, :http, :streamable_http)
+  # - transport [Symbol] Force transport type (:stdio, :sse, :http, :streamable_http).
+  #   :sse forces the deprecated HTTP+SSE transport (SEP-2596); prefer
+  #   :streamable_http.
   # - sampling_handler [Proc] Handler for sampling requests. Deprecated since MCP
   #   2026-07-28 (SEP-2577); earliest removal is the first revision released on or
   #   after 2027-07-28. Integrate directly with the LLM provider API instead.
@@ -70,11 +76,11 @@ module MCPClient
   # @raise [MCPClient::Errors::ConnectionError] if connection fails
   # @raise [MCPClient::Errors::TransportDetectionError] if transport cannot be determined
   #
-  # @example Connect to SSE server
-  #   client = MCPClient.connect('http://localhost:8000/sse')
-  #
   # @example Connect to Streamable HTTP server
   #   client = MCPClient.connect('http://localhost:8000/mcp')
+  #
+  # @example Connect to SSE server (deprecated transport; prefer Streamable HTTP)
+  #   client = MCPClient.connect('http://localhost:8000/sse')
   #
   # @example Connect with options
   #   client = MCPClient.connect('http://api.example.com/mcp',
@@ -445,6 +451,11 @@ module MCPClient
   end
 
   # Create a standard server configuration for SSE
+  #
+  # @deprecated The HTTP+SSE transport has been deprecated since MCP 2025-03-26
+  #   and is listed in the 2026-07-28 deprecated features registry (SEP-2596);
+  #   earliest removal is three months after SEP-2596 reaches Final. Use
+  #   {MCPClient.streamable_http_config} and {MCPClient::ServerStreamableHTTP}.
   # @param base_url [String] base URL for the server
   # @param headers [Hash] HTTP headers to include in requests
   # @param read_timeout [Integer] read timeout in seconds (default: 30)

--- a/lib/mcp_client.rb
+++ b/lib/mcp_client.rb
@@ -62,7 +62,9 @@ module MCPClient
   # - ping [Integer] Ping interval for SSE (default: 10)
   # - endpoint [String] JSON-RPC endpoint path (default: '/rpc')
   # - transport [Symbol] Force transport type (:stdio, :sse, :http, :streamable_http)
-  # - sampling_handler [Proc] Handler for sampling requests
+  # - sampling_handler [Proc] Handler for sampling requests. Deprecated since MCP
+  #   2026-07-28 (SEP-2577); earliest removal is the first revision released on or
+  #   after 2027-07-28. Integrate directly with the LLM provider API instead.
   # @yield [Faraday::Connection] Optional block for Faraday customization
   # @return [MCPClient::Client] Connected client ready to use
   # @raise [MCPClient::Errors::ConnectionError] if connection fails

--- a/lib/mcp_client.rb
+++ b/lib/mcp_client.rb
@@ -54,7 +54,9 @@ module MCPClient
   #   - URLs ending in /mcp -> Streamable HTTP transport
   #   - stdio://command or Array commands -> stdio transport
   #   - Commands starting with npx, node, python, ruby, etc. -> stdio transport
-  #   - Other HTTP URLs -> Try Streamable HTTP, fallback to SSE, then HTTP
+  #   - Other HTTP URLs -> Try Streamable HTTP, then the deprecated HTTP+SSE
+  #     transport (SEP-2596), then HTTP. The SSE step is a fallback for an
+  #     existing server, not a choice a new integration should rely on.
   # Accepts keyword arguments for connection options:
   # - headers [Hash] HTTP headers for remote transports
   # - read_timeout [Integer] Request timeout in seconds (default: 30)
@@ -94,7 +96,7 @@ module MCPClient
   #   client = MCPClient.connect(['npx', '-y', '@modelcontextprotocol/server-filesystem', '/home'])
   #
   # @example Connect to multiple servers
-  #   client = MCPClient.connect(['http://server1/mcp', 'http://server2/sse'])
+  #   client = MCPClient.connect(['http://server1/mcp', 'http://server2/mcp'])
   #
   # @example Force transport type
   #   client = MCPClient.connect('http://custom-server.com', transport: :streamable_http)

--- a/lib/mcp_client/auth/oauth_provider.rb
+++ b/lib/mcp_client/auth/oauth_provider.rb
@@ -1530,7 +1530,8 @@ module MCPClient
 
       # Register OAuth client dynamically
       # @deprecated Dynamic Client Registration is deprecated since MCP 2026-07-28
-      #   (PR #2858); prefer a Client ID Metadata Document (client_id_metadata_url)
+      #   (PR #2858); earliest removal is the first revision released on or after
+      #   2027-07-28. Prefer a Client ID Metadata Document (client_id_metadata_url)
       #   or pre-registered credentials. It remains the fallback for authorization
       #   servers without Client ID Metadata Document support.
       # @param server_metadata [ServerMetadata] Authorization server metadata

--- a/lib/mcp_client/auth/oauth_provider.rb
+++ b/lib/mcp_client/auth/oauth_provider.rb
@@ -1529,6 +1529,10 @@ module MCPClient
       end
 
       # Register OAuth client dynamically
+      # @deprecated Dynamic Client Registration is deprecated since MCP 2026-07-28
+      #   (PR #2858); prefer a Client ID Metadata Document (client_id_metadata_url)
+      #   or pre-registered credentials. It remains the fallback for authorization
+      #   servers without Client ID Metadata Document support.
       # @param server_metadata [ServerMetadata] Authorization server metadata
       # @return [ClientInfo] Registered client information
       # @raise [MCPClient::Errors::ConnectionError] if registration fails

--- a/lib/mcp_client/auth/oauth_provider.rb
+++ b/lib/mcp_client/auth/oauth_provider.rb
@@ -14,6 +14,7 @@ require_relative 'oauth_provider/registration_store'
 require_relative 'oauth_provider/response_validation'
 require_relative 'oauth_provider/scope_selection'
 require_relative 'oauth_provider/token_store'
+require_relative '../deprecations'
 
 module MCPClient
   module Auth
@@ -1532,8 +1533,7 @@ module MCPClient
       # @return [ClientInfo] Registered client information
       # @raise [MCPClient::Errors::ConnectionError] if registration fails
       def register_client(server_metadata)
-        logger.warn('Dynamic Client Registration is deprecated in MCP 2026-07-28; prefer a Client ID Metadata ' \
-                    'Document (client_id_metadata_url) or pre-registered credentials')
+        MCPClient::Deprecations.warn(:dynamic_client_registration, logger)
         logger.debug("Registering OAuth client at: #{safe_error_text(server_metadata.registration_endpoint.to_s)}")
 
         app_type = resolved_application_type

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -166,8 +166,13 @@ module MCPClient
         # supports: transports derive their declared client capabilities from
         # the callbacks registered before connecting, and MCP forbids using
         # capabilities that were not negotiated.
+        # The transports call the callback with (request_id, params) only, so
+        # the asking server is closed over here: the URL-mode host contract
+        # depends on its protocol era (MCP 2026-07-28 removed elicitationId).
         if @elicitation_handler && server.respond_to?(:on_elicitation_request)
-          server.on_elicitation_request(&method(:handle_elicitation_request))
+          server.on_elicitation_request do |request_id, request_params|
+            handle_elicitation_request(request_id, request_params, server)
+          end
         end
         # The client always implements the roots feature (roots/list and
         # list_changed notifications), independent of the current roots list.
@@ -1560,8 +1565,11 @@ module MCPClient
     # Supports both form mode (structured data) and URL mode (out-of-band interaction).
     # @param _request_id [String, Integer] the JSON-RPC request ID (unused at client layer)
     # @param params [Hash] the elicitation parameters
+    # @param server [MCPClient::ServerBase, nil] the server that asked, so the
+    #   URL-mode host contract can follow its protocol era; nil (an era that
+    #   was never established) keeps the 2025-11-25 contract
     # @return [Hash] the elicitation response
-    def handle_elicitation_request(_request_id, params)
+    def handle_elicitation_request(_request_id, params, server = nil)
       mode = params['mode'] || 'form'
       # MCP 2025-11-25: requests with a mode not declared in client
       # capabilities MUST be rejected with -32602 (Invalid params). This check
@@ -1583,7 +1591,7 @@ module MCPClient
 
       begin
         result = if mode == 'url'
-                   handle_url_elicitation(params, message)
+                   handle_url_elicitation(params, message, server)
                  else
                    handle_form_elicitation(params, message)
                  end
@@ -1641,12 +1649,10 @@ module MCPClient
     # Handle URL mode elicitation (MCP 2025-11-25)
     # @param params [Hash] the elicitation parameters
     # @param message [String] the human-readable message
+    # @param server [MCPClient::ServerBase, nil] the server that asked
     # @return [Object] handler result
-    def handle_url_elicitation(params, message)
-      # elicitationId is a 2025-11-25 field: MCP 2026-07-28 dropped it, and a
-      # request without one hands the handler no such key rather than a nil.
-      details = { 'mode' => 'url', 'url' => params['url'] }
-      details['elicitationId'] = params['elicitationId'] if params.key?('elicitationId')
+    def handle_url_elicitation(params, message, server = nil)
+      url_params = url_elicitation_metadata(params, server)
 
       # Call handler with URL-mode specific params
       case @elicitation_handler.arity
@@ -1655,10 +1661,38 @@ module MCPClient
       when 1
         @elicitation_handler.call(message)
       when 2, -1
-        @elicitation_handler.call(message, details)
+        @elicitation_handler.call(message, url_params)
       else
-        @elicitation_handler.call(message, details, params['metadata'])
+        @elicitation_handler.call(message, url_params, params['metadata'])
       end
+    end
+
+    # The URL-mode metadata handed to the host. MCP 2026-07-28 (changelog,
+    # minor change 11) removed the `elicitationId` field along with
+    # `notifications/elicitation/complete`: under the multi round-trip
+    # requests pattern the client learns the outcome by retrying the original
+    # request, and a server that must correlate an elicitation across retries
+    # carries its own identifier in `requestState`. So a modern server's
+    # contract has no such key at all — not even a nil one — and a
+    # non-conforming modern server that sends the field anyway cannot smuggle
+    # a correlation id to the host through it. For a server on an earlier
+    # revision the field is part of the protocol and the contract is
+    # unchanged, key present (nil when the server sent none) and all; a nil
+    # server (an era that was never established) is treated the same way.
+    # @param params [Hash] the elicitation parameters
+    # @param server [MCPClient::ServerBase, nil] the server that asked
+    # @return [Hash] the metadata hash for the host's handler
+    def url_elicitation_metadata(params, server)
+      metadata = { 'mode' => 'url', 'url' => params['url'] }
+      return metadata.merge('elicitationId' => params['elicitationId']) unless modern_server?(server)
+
+      if params.key?('elicitationId')
+        # The value is a server-chosen correlation id: name the field, never
+        # quote it.
+        @logger.warn('Ignoring elicitationId on a URL-mode elicitation request: MCP 2026-07-28 removed the field ' \
+                     '(the outcome is learned by retrying the original request; correlate via requestState)')
+      end
+      metadata
     end
 
     # Format and validate the elicitation response

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -6,6 +6,7 @@ require_relative 'client/sampling_validation'
 require_relative 'deep_copy'
 require_relative 'client/list_aggregation'
 require_relative 'client/cache_slices'
+require_relative 'deprecations'
 require_relative 'client/task_support'
 require_relative 'client/task_api'
 

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -1687,10 +1687,16 @@ module MCPClient
       return metadata.merge('elicitationId' => params['elicitationId']) unless modern_server?(server)
 
       if params.key?('elicitationId')
-        # The value is a server-chosen correlation id: name the field, never
-        # quote it.
-        @logger.warn('Ignoring elicitationId on a URL-mode elicitation request: MCP 2026-07-28 removed the field ' \
-                     '(the outcome is learned by retrying the original request; correlate via requestState)')
+        # Dropping the field is the protocol decision; saying so is a
+        # courtesy. A logger that raises costs the notice, never the
+        # elicitation — the value is a server-chosen correlation id, so the
+        # message names the field and never quotes it.
+        begin
+          @logger.warn('Ignoring elicitationId on a URL-mode elicitation request: MCP 2026-07-28 removed the field ' \
+                       '(the outcome is learned by retrying the original request; correlate via requestState)')
+        rescue StandardError
+          nil
+        end
       end
       metadata
     end

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -69,8 +69,11 @@ module MCPClient
     # @param mcp_server_configs [Array<Hash>] configurations for MCP servers
     # @param logger [Logger, nil] optional logger, defaults to STDOUT
     # @param elicitation_handler [Proc, nil] optional handler for elicitation requests (MCP 2025-06-18)
-    # @param roots [Array<MCPClient::Root, Hash>, nil] optional list of roots (MCP 2025-06-18)
-    # @param sampling_handler [Proc, nil] optional handler for sampling requests (MCP 2025-11-25)
+    # @param roots [Array<MCPClient::Root, Hash>, nil] optional list of roots (MCP 2025-06-18).
+    #   Deprecated since MCP 2026-07-28 (SEP-2577): pass directories or files through tool
+    #   parameters, resource URIs or server configuration instead.
+    # @param sampling_handler [Proc, nil] optional handler for sampling requests (MCP 2025-11-25).
+    #   Deprecated since MCP 2026-07-28 (SEP-2577): integrate directly with the LLM provider API.
     # @param sampling_supports_tools [Boolean] whether the sampling handler supports tool use
     #   (MCP 2025-11-25 / SEP-1577); declares the sampling.tools capability and forwards
     #   tools/toolChoice params to the handler instead of rejecting tool-enabled requests
@@ -472,6 +475,9 @@ module MCPClient
 
     # Set the roots for this client (MCP 2025-06-18)
     # When roots are changed, a notification is sent to all connected servers
+    # @deprecated Roots are deprecated since MCP 2026-07-28 (SEP-2577); pass
+    #   directories or files through tool parameters, resource URIs or server
+    #   configuration instead.
     # @param new_roots [Array<MCPClient::Root, Hash>] the new roots to set
     # @return [void]
     def roots=(new_roots)
@@ -650,6 +656,8 @@ module MCPClient
 
     # Set the logging level on all connected servers (MCP 2025-06-18)
     # To set on a specific server, use: client.find_server('name').log_level = 'debug'
+    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577); have
+    #   the server log to stderr (stdio) or use OpenTelemetry instead.
     # @param level [String] the log level ('debug', 'info', 'notice', 'warning', 'error',
     #   'critical', 'alert', 'emergency')
     # @return [Array<Hash>] results from servers
@@ -1004,6 +1012,7 @@ module MCPClient
     end
 
     def handle_log_message(server_id, params)
+      MCPClient::Deprecations.warn(:logging, @logger)
       level = params['level'] || 'info'
       logger_name = params['logger']
       data = params['data']

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -70,10 +70,12 @@ module MCPClient
     # @param logger [Logger, nil] optional logger, defaults to STDOUT
     # @param elicitation_handler [Proc, nil] optional handler for elicitation requests (MCP 2025-06-18)
     # @param roots [Array<MCPClient::Root, Hash>, nil] optional list of roots (MCP 2025-06-18).
-    #   Deprecated since MCP 2026-07-28 (SEP-2577): pass directories or files through tool
-    #   parameters, resource URIs or server configuration instead.
+    #   Deprecated since MCP 2026-07-28 (SEP-2577); earliest removal is the first revision
+    #   released on or after 2027-07-28. Pass directories or files through tool parameters,
+    #   resource URIs or server configuration instead.
     # @param sampling_handler [Proc, nil] optional handler for sampling requests (MCP 2025-11-25).
-    #   Deprecated since MCP 2026-07-28 (SEP-2577): integrate directly with the LLM provider API.
+    #   Deprecated since MCP 2026-07-28 (SEP-2577); earliest removal is the first revision
+    #   released on or after 2027-07-28. Integrate directly with the LLM provider API instead.
     # @param sampling_supports_tools [Boolean] whether the sampling handler supports tool use
     #   (MCP 2025-11-25 / SEP-1577); declares the sampling.tools capability and forwards
     #   tools/toolChoice params to the handler instead of rejecting tool-enabled requests

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -475,9 +475,10 @@ module MCPClient
 
     # Set the roots for this client (MCP 2025-06-18)
     # When roots are changed, a notification is sent to all connected servers
-    # @deprecated Roots are deprecated since MCP 2026-07-28 (SEP-2577); pass
-    #   directories or files through tool parameters, resource URIs or server
-    #   configuration instead.
+    # @deprecated Roots are deprecated since MCP 2026-07-28 (SEP-2577);
+    #   earliest removal is the first revision released on or after
+    #   2027-07-28. Pass directories or files through tool parameters,
+    #   resource URIs or server configuration instead.
     # @param new_roots [Array<MCPClient::Root, Hash>] the new roots to set
     # @return [void]
     def roots=(new_roots)
@@ -656,8 +657,10 @@ module MCPClient
 
     # Set the logging level on all connected servers (MCP 2025-06-18)
     # To set on a specific server, use: client.find_server('name').log_level = 'debug'
-    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577); have
-    #   the server log to stderr (stdio) or use OpenTelemetry instead.
+    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577);
+    #   earliest removal is the first revision released on or after
+    #   2027-07-28. Have the server log to stderr (stdio) or use
+    #   OpenTelemetry instead.
     # @param level [String] the log level ('debug', 'info', 'notice', 'warning', 'error',
     #   'critical', 'alert', 'emergency')
     # @return [Array<Hash>] results from servers

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -6,6 +6,7 @@ require_relative 'client/sampling_validation'
 require_relative 'deep_copy'
 require_relative 'client/list_aggregation'
 require_relative 'client/cache_slices'
+require_relative 'client/notification_routing'
 require_relative 'deprecations'
 require_relative 'client/task_support'
 require_relative 'client/task_api'
@@ -17,6 +18,7 @@ module MCPClient
     include SamplingValidation
     include ListAggregation
     include CacheSlices
+    include NotificationRouting
     include MCPClient::Client::TaskSupport
     include MCPClient::Client::TaskApi
 
@@ -827,153 +829,12 @@ module MCPClient
       srv.respond_to?(:capabilities) && !srv.capabilities.nil?
     end
 
-    # Wire this client's own notification processing and the host's listeners
-    # onto the transport.
-    #
-    # The cache invalidation goes on the transport's own invalidation hook,
-    # which runs *before* a notification is delivered to a subscription's
-    # listeners — so a listener reacting to a `list_changed` notification
-    # re-fetches instead of reading the entry the notification just
-    # invalidated. Everything else this client does with a notification is host
-    # code or leads to it (logging, progress callbacks, task status), and stays
-    # on the callback that runs last, behind the delivery. A transport that
-    # emits no such hook — a host-supplied adapter written against the older
-    # interface, say — keeps the invalidation on `on_notification`, ahead of
-    # everything else there: it routes no subscriptions, so there is no
-    # delivery for it to be ahead of.
-    #
-    # Which of the two it is cannot be answered by whether the transport *has*
-    # the hook: every {MCPClient::ServerBase} subclass inherits it, so the
-    # answer was yes for every custom adapter as well, and one that fans its
-    # notifications out through `@notification_callback` alone — exactly what
-    # the interface used to be — silently stopped invalidating anything. The
-    # question is whether the hook actually *ran* for the notification in
-    # hand, and the hook answers it itself: every path that emits it does so
-    # immediately before the host callback and on the same thread
-    # ({MCPClient::JsonRpcCommon#notify_cache_invalidation}), so a callback
-    # that arrives without that mark is one nothing invalidated for. Having
-    # the hook still decides whether one is *registered* — a host may supply
-    # an object that is no ServerBase at all — but no longer decides who
-    # invalidates.
-    # @param server [MCPClient::ServerBase] the server to wire
-    # @return [void]
-    def register_notification_handlers(server)
-      if server.class.method_defined?(:on_cache_invalidation)
-        server.on_cache_invalidation do |method, _params|
-          invalidate_caches_for_notification(server, method)
-          Thread.current[CACHE_INVALIDATION_MARK] = [server, method]
-        end
-      end
-      server.on_notification do |method, params|
-        mark = Thread.current[CACHE_INVALIDATION_MARK]
-        Thread.current[CACHE_INVALIDATION_MARK] = nil
-        invalidate_caches_for_notification(server, method) unless mark_covers?(mark, server, method)
-        # Default notification processing (e.g., logging, progress)
-        process_notification(server, method, params)
-        # Invoke user-defined listeners
-        @notification_listeners.each { |cb| cb.call(server, method, params) }
-      end
-    end
-
     # @param mark [Array, nil] what the invalidation hook left behind
     # @param server [MCPClient::ServerBase] the transport routing now
     # @param method [String] the notification being routed
     # @return [Boolean] whether the mark is this notification's
     def mark_covers?(mark, server, method)
       mark.is_a?(Array) && mark[0].equal?(server) && mark[1] == method
-    end
-
-    # Drop the caches a notification invalidates.
-    #
-    # Registered on the transport's `on_cache_invalidation` hook, which runs
-    # before the notification is delivered to a subscription's listeners — so a
-    # listener that reacts to a `list_changed` notification by calling
-    # `list_tools` (or the prompt/resource equivalents) re-fetches instead of
-    # reading the entry the notification just invalidated. It used to ride on
-    # `on_notification`, which round 10 moved to the end of the routing order
-    # for good reason: that callback is host code and may block the very reader
-    # the delivery came from. Only the cache drops moved forward; everything
-    # else {#process_notification} does still runs behind the delivery.
-    # @param server [MCPClient::ServerBase] the server that emitted it
-    # @param method [String] JSON-RPC notification method
-    # @return [void]
-    def invalidate_caches_for_notification(server, method)
-      server_id = notification_server_id(server)
-      case method
-      when 'notifications/tools/list_changed'
-        logger.warn("[#{server_id}] Tool list has changed, clearing tool cache")
-        clear_tool_cache
-      when 'notifications/prompts/list_changed'
-        logger.warn("[#{server_id}] Prompt list has changed, clearing prompt cache")
-        @cache_mutex.synchronize do
-          @cache_version += 1
-          @prompt_cache.clear
-          @cache_params.delete(:prompts)
-          @cache_filled.delete(:prompts)
-        end
-      when 'notifications/resources/list_changed'
-        logger.warn("[#{server_id}] Resource list has changed, clearing resource cache")
-        @cache_mutex.synchronize do
-          @cache_version += 1
-          @resource_cache.clear
-          @cache_params.delete(:resources)
-          @cache_filled.delete(:resources)
-        end
-      end
-    end
-
-    # @param server [MCPClient::ServerBase] the server that emitted a notification
-    # @return [String] the identity used to prefix its log lines
-    def notification_server_id(server)
-      server.name ? "#{server.class}[#{server.name}]" : server.class.to_s
-    end
-
-    # Process incoming JSON-RPC notifications with default handlers
-    # @param server [MCPClient::ServerBase] the server that emitted the notification
-    # @param method [String] JSON-RPC notification method
-    # @param params [Hash] parameters for the notification
-    # @return [void]
-    def process_notification(server, method, params)
-      server_id = notification_server_id(server)
-      case method
-      when 'notifications/tools/list_changed', 'notifications/prompts/list_changed',
-           'notifications/resources/list_changed'
-        # Already handled, ahead of the delivery to any subscription listener
-        # (see {#invalidate_caches_for_notification}).
-        nil
-      when 'notifications/resources/updated'
-        logger.warn("[#{server_id}] Resource #{params['uri']} updated")
-      when 'notifications/message'
-        # MCP 2025-06-18: Handle logging messages from server
-        handle_log_message(server_id, params)
-      when 'notifications/tasks/status', 'notifications/tasks'
-        # (both handled below; the legacy method carries the flat 2025 shape)
-        # MCP 2025-11-25: task status update (params are a flat Task);
-        # MCP 2026-07-28 tasks extension: notifications/tasks carries a
-        # DetailedTask (only ever on a subscriptions/listen stream).
-        handle_task_status_notification(server_id, params, method)
-      when 'notifications/subscriptions/acknowledged'
-        # MCP 2026-07-28: the transport already recorded the acknowledged
-        # filter on the Subscription; log for observability.
-        sub_id = params&.dig('_meta', 'io.modelcontextprotocol/subscriptionId')
-        logger.debug("[#{server_id}] Subscription #{sanitize_peer_log_text(sub_id.to_s)} acknowledged")
-      when 'notifications/cancelled'
-        # MCP 2025-11-25 cancellation utility: the server cancelled one of its
-        # own in-flight requests (sampling/elicitation). Server-request
-        # dispatch is synchronous per transport, so by the time this arrives
-        # the handler has usually completed; receivers MAY ignore
-        # cancellations they cannot honor — log for observability. On MCP
-        # 2026-07-28 it only ever tears down a subscriptions/listen stream,
-        # which the transport handled before this point.
-        request_id = sanitize_peer_log_text(params&.dig('requestId').to_s)
-        reason = sanitize_peer_log_text((params&.dig('reason') || 'no reason given').to_s)
-        logger.debug("[#{server_id}] Server cancelled request #{request_id}: #{reason}")
-      when 'notifications/progress'
-        handle_progress_notification(server_id, params)
-      else
-        # Log unknown notification types for debugging purposes
-        logger.debug("[#{server_id}] Received unknown notification: #{method} - #{params}")
-      end
     end
 
     # Handle logging message notification from server (MCP 2025-06-18)

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -144,12 +144,14 @@ module MCPClient
       @notification_listeners = []
       # Elicitation handler (MCP 2025-06-18)
       @elicitation_handler = elicitation_handler
-      # Sampling handler (MCP 2025-11-25)
+      # Sampling handler (MCP 2025-11-25; deprecated in 2026-07-28, SEP-2577)
       @sampling_handler = sampling_handler
+      MCPClient::Deprecations.warn(:sampling, @logger) if sampling_handler
       # Whether the sampling handler supports tool use (SEP-1577)
       @sampling_supports_tools = sampling_supports_tools
-      # Roots (MCP 2025-06-18)
+      # Roots (MCP 2025-06-18; deprecated in 2026-07-28, SEP-2577)
       @roots = normalize_roots(roots)
+      MCPClient::Deprecations.warn(:roots, @logger) unless @roots.empty?
       # Register default and user-defined notification handlers on each server
       @servers.each do |server|
         configure_server_identity(server, client_info, request_meta)
@@ -472,6 +474,7 @@ module MCPClient
     # @param new_roots [Array<MCPClient::Root, Hash>] the new roots to set
     # @return [void]
     def roots=(new_roots)
+      MCPClient::Deprecations.warn(:roots, @logger)
       @roots = normalize_roots(new_roots)
       # Notify servers that roots have changed
       notify_roots_changed
@@ -651,6 +654,7 @@ module MCPClient
     # @return [Array<Hash>] results from servers
     # @raise [MCPClient::Errors::ServerError] if server returns an error
     def log_level=(level)
+      MCPClient::Deprecations.warn(:logging, @logger)
       @servers.filter_map do |srv|
         # MCP lifecycle: only use capabilities that were successfully
         # negotiated — skip servers whose NEGOTIATED set lacks logging.

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -40,6 +40,12 @@ module MCPClient
     #   @return [Logger] logger for client operations
     # @!attribute [r] roots
     #   @return [Array<MCPClient::Root>] list of MCP roots (MCP 2025-06-18)
+    #   @deprecated Roots is deprecated since MCP 2026-07-28 (SEP-2577); earliest
+    #     removal is the first revision released on or after 2027-07-28. Reading the
+    #     list is not itself a first use of the feature — the notice follows
+    #     configuring a root or serving one — but the list is a deprecated feature's
+    #     state, and a host reading it is holding one. Pass directories or files
+    #     through tool parameters, resource URIs or server configuration instead.
     attr_reader :servers, :tool_cache, :prompt_cache, :resource_cache, :logger, :roots
 
     # Supported modes for structuredContent validation (MCP 2025-11-25):

--- a/lib/mcp_client/client.rb
+++ b/lib/mcp_client/client.rb
@@ -28,25 +28,38 @@ module MCPClient
     # Requests with a mode outside this set are rejected with -32602.
     SUPPORTED_ELICITATION_MODES = %w[form url].freeze
 
-    # @!attribute [r] servers
-    #   @return [Array<MCPClient::ServerBase>] list of servers
-    # @!attribute [r] tool_cache
-    #   @return [Hash<String, MCPClient::Tool>] cache of tools by composite key (server_id:name)
-    # @!attribute [r] prompt_cache
-    #   @return [Hash<String, MCPClient::Prompt>] cache of prompts by composite key (server_id:name)
-    # @!attribute [r] resource_cache
-    #   @return [Hash<String, MCPClient::Resource>] cache of resources by composite key (server_id:uri)
-    # @!attribute [r] logger
-    #   @return [Logger] logger for client operations
-    # @!attribute [r] roots
-    #   @return [Array<MCPClient::Root>] list of MCP roots (MCP 2025-06-18)
-    #   @deprecated Roots is deprecated since MCP 2026-07-28 (SEP-2577); earliest
-    #     removal is the first revision released on or after 2027-07-28. Reading the
-    #     list is not itself a first use of the feature — the notice follows
-    #     configuring a root or serving one — but the list is a deprecated feature's
-    #     state, and a host reading it is holding one. Pass directories or files
-    #     through tool parameters, resource URIs or server configuration instead.
-    attr_reader :servers, :tool_cache, :prompt_cache, :resource_cache, :logger, :roots
+    # These readers are declared one per line with an ordinary doc comment
+    # rather than grouped under `@!attribute` directives, because the directive
+    # form loses documentation silently: YARD drops the docstring of the LAST
+    # directive in a block preceding a combined `attr_reader`, re-registering
+    # that name from the statement itself with the leftover (empty) docstring.
+    # The `roots` deprecation below was absent from the generated API
+    # documentation for exactly that reason, while every check that read the
+    # source found it.
+
+    # @return [Array<MCPClient::ServerBase>] list of servers
+    attr_reader :servers
+
+    # @return [Hash<String, MCPClient::Tool>] cache of tools by composite key (server_id:name)
+    attr_reader :tool_cache
+
+    # @return [Hash<String, MCPClient::Prompt>] cache of prompts by composite key (server_id:name)
+    attr_reader :prompt_cache
+
+    # @return [Hash<String, MCPClient::Resource>] cache of resources by composite key (server_id:uri)
+    attr_reader :resource_cache
+
+    # @return [Logger] logger for client operations
+    attr_reader :logger
+
+    # @return [Array<MCPClient::Root>] list of MCP roots (MCP 2025-06-18)
+    # @deprecated Roots is deprecated since MCP 2026-07-28 (SEP-2577); earliest
+    #   removal is the first revision released on or after 2027-07-28. Reading the
+    #   list is not itself a first use of the feature — the notice follows
+    #   configuring a root or serving one — but the list is a deprecated feature's
+    #   state, and a host reading it is holding one. Pass directories or files
+    #   through tool parameters, resource URIs or server configuration instead.
+    attr_reader :roots
 
     # Supported modes for structuredContent validation (MCP 2025-11-25):
     # :warn logs a warning on mismatch, :strict raises a ValidationError.

--- a/lib/mcp_client/client/notification_routing.rb
+++ b/lib/mcp_client/client/notification_routing.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+module MCPClient
+  class Client
+    # What the client does with a notification a transport delivers: the
+    # caches it drops, the host callbacks it runs, and how a transport's
+    # notifications are hooked up in the first place. A listener is host
+    # code, run after the client's own bookkeeping; its failures are the
+    # transport's to isolate.
+    module NotificationRouting
+      private
+
+      # Process incoming JSON-RPC notifications with default handlers
+      # @param server [MCPClient::ServerBase] the server that emitted the notification
+      # @param method [String] JSON-RPC notification method
+      # @param params [Hash] parameters for the notification
+      # @return [void]
+      # Wire this client's own notification processing and the host's listeners
+      # onto the transport.
+      #
+      # The cache invalidation goes on the transport's own invalidation hook,
+      # which runs *before* a notification is delivered to a subscription's
+      # listeners — so a listener reacting to a `list_changed` notification
+      # re-fetches instead of reading the entry the notification just
+      # invalidated. Everything else this client does with a notification is host
+      # code or leads to it (logging, progress callbacks, task status), and stays
+      # on the callback that runs last, behind the delivery. A transport that
+      # emits no such hook — a host-supplied adapter written against the older
+      # interface, say — keeps the invalidation on `on_notification`, ahead of
+      # everything else there: it routes no subscriptions, so there is no
+      # delivery for it to be ahead of.
+      #
+      # Which of the two it is cannot be answered by whether the transport *has*
+      # the hook: every {MCPClient::ServerBase} subclass inherits it, so the
+      # answer was yes for every custom adapter as well, and one that fans its
+      # notifications out through `@notification_callback` alone — exactly what
+      # the interface used to be — silently stopped invalidating anything. The
+      # question is whether the hook actually *ran* for the notification in
+      # hand, and the hook answers it itself: every path that emits it does so
+      # immediately before the host callback and on the same thread
+      # ({MCPClient::JsonRpcCommon#notify_cache_invalidation}), so a callback
+      # that arrives without that mark is one nothing invalidated for. Having
+      # the hook still decides whether one is *registered* — a host may supply
+      # an object that is no ServerBase at all — but no longer decides who
+      # invalidates.
+      # @param server [MCPClient::ServerBase] the server to wire
+      # @return [void]
+      def register_notification_handlers(server)
+        if server.class.method_defined?(:on_cache_invalidation)
+          server.on_cache_invalidation do |method, _params|
+            invalidate_caches_for_notification(server, method)
+            Thread.current[CACHE_INVALIDATION_MARK] = [server, method]
+          end
+        end
+        server.on_notification do |method, params|
+          mark = Thread.current[CACHE_INVALIDATION_MARK]
+          Thread.current[CACHE_INVALIDATION_MARK] = nil
+          invalidate_caches_for_notification(server, method) unless mark_covers?(mark, server, method)
+          # Default notification processing (e.g., logging, progress)
+          process_notification(server, method, params)
+          # Invoke user-defined listeners
+          @notification_listeners.each { |cb| cb.call(server, method, params) }
+        end
+      end
+
+      # Drop the caches a notification invalidates.
+      #
+      # Registered on the transport's `on_cache_invalidation` hook, which runs
+      # before the notification is delivered to a subscription's listeners — so a
+      # listener that reacts to a `list_changed` notification by calling
+      # `list_tools` (or the prompt/resource equivalents) re-fetches instead of
+      # reading the entry the notification just invalidated. It used to ride on
+      # `on_notification`, which round 10 moved to the end of the routing order
+      # for good reason: that callback is host code and may block the very reader
+      # the delivery came from. Only the cache drops moved forward; everything
+      # else {#process_notification} does still runs behind the delivery.
+      # @param server [MCPClient::ServerBase] the server that emitted it
+      # @param method [String] JSON-RPC notification method
+      # @return [void]
+      def invalidate_caches_for_notification(server, method)
+        server_id = notification_server_id(server)
+        case method
+        when 'notifications/tools/list_changed'
+          logger.warn("[#{server_id}] Tool list has changed, clearing tool cache")
+          clear_tool_cache
+        when 'notifications/prompts/list_changed'
+          logger.warn("[#{server_id}] Prompt list has changed, clearing prompt cache")
+          @cache_mutex.synchronize do
+            @cache_version += 1
+            @prompt_cache.clear
+            @cache_params.delete(:prompts)
+            @cache_filled.delete(:prompts)
+          end
+        when 'notifications/resources/list_changed'
+          logger.warn("[#{server_id}] Resource list has changed, clearing resource cache")
+          @cache_mutex.synchronize do
+            @cache_version += 1
+            @resource_cache.clear
+            @cache_params.delete(:resources)
+            @cache_filled.delete(:resources)
+          end
+        end
+      end
+
+      # @param server [MCPClient::ServerBase] the server that emitted a notification
+      # @return [String] the identity used to prefix its log lines
+      def notification_server_id(server)
+        server.name ? "#{server.class}[#{server.name}]" : server.class.to_s
+      end
+
+      # Process incoming JSON-RPC notifications with default handlers
+      # @param server [MCPClient::ServerBase] the server that emitted the notification
+      # @param method [String] JSON-RPC notification method
+      # @param params [Hash] parameters for the notification
+      # @return [void]
+      def process_notification(server, method, params)
+        server_id = notification_server_id(server)
+        case method
+        when 'notifications/tools/list_changed', 'notifications/prompts/list_changed',
+             'notifications/resources/list_changed'
+          # Already handled, ahead of the delivery to any subscription listener
+          # (see {#invalidate_caches_for_notification}).
+          nil
+        when 'notifications/resources/updated'
+          logger.warn("[#{server_id}] Resource #{params['uri']} updated")
+        when 'notifications/message'
+          # MCP 2025-06-18: Handle logging messages from server
+          handle_log_message(server_id, params)
+        when 'notifications/tasks/status', 'notifications/tasks'
+          # (both handled below; the legacy method carries the flat 2025 shape)
+          # MCP 2025-11-25: task status update (params are a flat Task);
+          # MCP 2026-07-28 tasks extension: notifications/tasks carries a
+          # DetailedTask (only ever on a subscriptions/listen stream).
+          handle_task_status_notification(server_id, params, method)
+        when 'notifications/subscriptions/acknowledged'
+          # MCP 2026-07-28: the transport already recorded the acknowledged
+          # filter on the Subscription; log for observability.
+          sub_id = params&.dig('_meta', 'io.modelcontextprotocol/subscriptionId')
+          logger.debug("[#{server_id}] Subscription #{sanitize_peer_log_text(sub_id.to_s)} acknowledged")
+        when 'notifications/cancelled'
+          # MCP 2025-11-25 cancellation utility: the server cancelled one of its
+          # own in-flight requests (sampling/elicitation). Server-request
+          # dispatch is synchronous per transport, so by the time this arrives
+          # the handler has usually completed; receivers MAY ignore
+          # cancellations they cannot honor — log for observability. On MCP
+          # 2026-07-28 it only ever tears down a subscriptions/listen stream,
+          # which the transport handled before this point.
+          request_id = sanitize_peer_log_text(params&.dig('requestId').to_s)
+          reason = sanitize_peer_log_text((params&.dig('reason') || 'no reason given').to_s)
+          logger.debug("[#{server_id}] Server cancelled request #{request_id}: #{reason}")
+        when 'notifications/progress'
+          handle_progress_notification(server_id, params)
+        else
+          # Log unknown notification types for debugging purposes
+          logger.debug("[#{server_id}] Received unknown notification: #{method} - #{params}")
+        end
+      end
+    end
+  end
+end

--- a/lib/mcp_client/client/sampling_validation.rb
+++ b/lib/mcp_client/client/sampling_validation.rb
@@ -34,6 +34,12 @@ module MCPClient
                                       'capability was not declared')
         end
 
+        # SEP-2596: "thisServer" / "allServers" are deprecated (omit the field
+        # or send "none"); the request is still served as before.
+        if %w[thisServer allServers].include?(params['includeContext'])
+          MCPClient::Deprecations.warn(:include_context, @logger, detail: "includeContext #{params['includeContext']}")
+        end
+
         messages = params['messages'] || []
         # Both parties SHOULD validate message content (sampling.mdx
         # "Security Considerations"): the role, the content, a user message of

--- a/lib/mcp_client/deprecation_notices.rb
+++ b/lib/mcp_client/deprecation_notices.rb
@@ -50,6 +50,24 @@ module MCPClient
       MCPClient::Deprecations.warn(:logging, @logger)
     end
 
+    # A request whose effective `_meta` carries the log level. 2026-07-28
+    # moved the level off `logging/setLevel` and onto every request, so
+    # `log_level=` and an incoming `notifications/message` are not the only
+    # ways in: a host that puts `io.modelcontextprotocol/logLevel` in
+    # `request_meta` or in a per-call `_meta` adopts the same deprecated
+    # utility, and {MCPClient::JsonRpcCommon#with_request_meta} deliberately
+    # forwards it on the wire. That is a first use like any other.
+    # @param meta [Hash, nil] the effective outgoing request metadata
+    # @return [void]
+    def warn_request_log_level_deprecated(meta)
+      return unless meta.is_a?(Hash)
+
+      key = MCPClient::JsonRpcCommon::META_LOG_LEVEL
+      return unless meta.key?(key) || meta.key?(key.to_sym)
+
+      warn_logging_deprecated
+    end
+
     # The notice for an input request fulfilled through the multi round-trip
     # pattern, whose handler is the same callback the legacy
     # server-initiated request would have reached. Asking for a sample IS the

--- a/lib/mcp_client/deprecation_notices.rb
+++ b/lib/mcp_client/deprecation_notices.rb
@@ -13,10 +13,20 @@ module MCPClient
   #
   # Mixed into {MCPClient::JsonRpcCommon}, so every transport has it.
   module DeprecationNotices
-    # Serving a roots/list request means the host declared, and is using, the
-    # deprecated Roots capability.
+    # Serving a roots/list request. The Roots capability counts as USED only
+    # when the answer actually carries a root: a transport's roots handler is
+    # registered independently of whether the host ever configured a root —
+    # {MCPClient::Client} registers one on every server so a later `roots=`
+    # is served, and answers with an empty list until a root is set — so a
+    # registered handler is no evidence the host adopted the feature, while a
+    # non-empty answer is. A host that never opted in must not be told it is
+    # using a deprecated feature.
+    # @param result [Hash, nil] the roots/list result about to be served
     # @return [void]
-    def warn_roots_deprecated
+    def warn_roots_deprecated(result)
+      roots = result.is_a?(Hash) ? (result['roots'] || result[:roots]) : nil
+      return unless roots.is_a?(Array) && !roots.empty?
+
       MCPClient::Deprecations.warn(:roots, @logger)
     end
 
@@ -42,15 +52,25 @@ module MCPClient
 
     # The notice for an input request fulfilled through the multi round-trip
     # pattern, whose handler is the same callback the legacy
-    # server-initiated request would have reached.
+    # server-initiated request would have reached. Asking for a sample IS the
+    # use of Sampling, so its notice is raised before the handler runs; Roots
+    # is only used once the answer carries a root, so its notice waits for
+    # {#warn_input_request_answer_deprecated}.
     # @param method [String] the input request's JSON-RPC method
     # @param params [Hash, nil] the input request's params
     # @return [void]
     def warn_input_request_deprecated(method, params)
-      case method
-      when 'roots/list' then warn_roots_deprecated
-      when 'sampling/createMessage' then warn_sampling_deprecated(params)
-      end
+      warn_sampling_deprecated(params) if method == 'sampling/createMessage'
+    end
+
+    # The half of the input-request notice that needs the handler's answer:
+    # Roots is deprecated, but answering roots/list with no roots is not use
+    # of it (see {#warn_roots_deprecated}).
+    # @param method [String] the input request's JSON-RPC method
+    # @param result [Hash, nil] the handler's result
+    # @return [void]
+    def warn_input_request_answer_deprecated(method, result)
+      warn_roots_deprecated(result) if method == 'roots/list'
     end
   end
 end

--- a/lib/mcp_client/deprecation_notices.rb
+++ b/lib/mcp_client/deprecation_notices.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative 'deprecations'
+
+module MCPClient
+  # The 2026-07-28 deprecation notices raised from the TRANSPORT, so a host
+  # that drives a `ServerStdio`, `ServerSSE`, `ServerHTTP` or
+  # `ServerStreamableHTTP` object directly still sees them. Constructing a
+  # {MCPClient::Client} is not the only way to negotiate and serve Roots,
+  # Sampling or Logging: `on_roots_list_request`, `on_sampling_request` and
+  # `on_notification` are public transport APIs, and a notice tied to the
+  # Client constructor never fires for a caller that uses them.
+  #
+  # Mixed into {MCPClient::JsonRpcCommon}, so every transport has it.
+  module DeprecationNotices
+    # Serving a roots/list request means the host declared, and is using, the
+    # deprecated Roots capability.
+    # @return [void]
+    def warn_roots_deprecated
+      MCPClient::Deprecations.warn(:roots, @logger)
+    end
+
+    # Serving a sampling/createMessage request. SEP-2596 also deprecated the
+    # includeContext values "thisServer" and "allServers", which arrive on
+    # the very same request, so both notices belong here.
+    # @param params [Hash, nil] the sampling/createMessage params
+    # @return [void]
+    def warn_sampling_deprecated(params = nil)
+      MCPClient::Deprecations.warn(:sampling, @logger)
+      value = params.is_a?(Hash) ? params['includeContext'] : nil
+      return unless %w[thisServer allServers].include?(value)
+
+      MCPClient::Deprecations.warn(:include_context, @logger, detail: "includeContext #{value}")
+    end
+
+    # Receiving or setting a log level over MCP: the whole Logging page is
+    # Deprecated (SEP-2577).
+    # @return [void]
+    def warn_logging_deprecated
+      MCPClient::Deprecations.warn(:logging, @logger)
+    end
+
+    # The notice for an input request fulfilled through the multi round-trip
+    # pattern, whose handler is the same callback the legacy
+    # server-initiated request would have reached.
+    # @param method [String] the input request's JSON-RPC method
+    # @param params [Hash, nil] the input request's params
+    # @return [void]
+    def warn_input_request_deprecated(method, params)
+      case method
+      when 'roots/list' then warn_roots_deprecated
+      when 'sampling/createMessage' then warn_sampling_deprecated(params)
+      end
+    end
+  end
+end

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -1,16 +1,21 @@
 # frozen_string_literal: true
 
 module MCPClient
-  # Deprecation notices for the features MCP 2026-07-28 placed in the
-  # Deprecated state of its feature lifecycle policy (SEP-2596): they keep
-  # working for at least the twelve-month deprecation window, but new
-  # integrations should not adopt them. The client logs one notice per
-  # feature per process, on the first use, and names the suggested migration.
+  # Deprecation notices for the features listed as Deprecated by the MCP
+  # 2026-07-28 deprecated features registry (feature lifecycle policy,
+  # SEP-2596): they keep working during their deprecation window, but new
+  # integrations should not adopt them. The earliest removal of each feature
+  # is set by the registry (https://modelcontextprotocol.io/specification/2026-07-28/deprecated);
+  # the HTTP+SSE transport and the includeContext values were deprecated by
+  # earlier revisions and may go sooner than the features 2026-07-28 itself
+  # deprecates. The client logs one notice per feature per process, on the
+  # first use, and names the suggested migration.
   #
   # Notices can be silenced with `MCPClient::Deprecations.enabled = false`.
   module Deprecations
-    # Every feature the 2026-07-28 revision lists in its deprecated features
-    # registry, keyed by the identifier passed to {.warn}.
+    # Every feature the 2026-07-28 deprecated features registry lists, keyed
+    # by the identifier passed to {.warn}. `since` is the protocol revision
+    # in which the feature entered the Deprecated state.
     REGISTRY = {
       roots: {
         feature: 'Roots',
@@ -32,14 +37,14 @@ module MCPClient
       },
       http_sse_transport: {
         feature: 'The HTTP+SSE transport',
-        since: '2026-07-28',
-        reference: 'SEP-2596 (deprecated since protocol version 2025-03-26)',
+        since: '2025-03-26',
+        reference: 'reclassified by SEP-2596 in 2026-07-28; earliest removal three months after SEP-2596 is Final',
         migration: 'migrate the server to Streamable HTTP (MCPClient::ServerStreamableHTTP)'
       },
       include_context: {
         feature: 'The includeContext values "thisServer" and "allServers"',
-        since: '2026-07-28',
-        reference: 'SEP-2596 (soft-deprecated since protocol version 2025-11-25)',
+        since: '2025-11-25',
+        reference: 'reclassified by SEP-2596 in 2026-07-28',
         migration: 'servers should omit includeContext or send "none"; the values are removed no later than Sampling'
       },
       dynamic_client_registration: {
@@ -66,22 +71,27 @@ module MCPClient
         @enabled
       end
 
-      # Log the notice for a deprecated feature once per process.
+      # Log the notice for a deprecated feature once per process. The notice
+      # counts as emitted only once the logger accepted it: a logger that
+      # drops warnings (level above WARN) or raises leaves it for a later use.
       # @param feature [Symbol] a {REGISTRY} key
       # @param logger [Logger, nil] where the notice goes (a nil logger emits nothing)
       # @param detail [String, nil] peer-supplied context quoted in the notice
       #   (control characters are escaped and the text is bounded)
       # @return [Boolean] true when a notice was written, false when it was
-      #   already emitted or notices are disabled
+      #   already emitted, notices are disabled or the logger drops warnings
       # @raise [ArgumentError] for an unknown feature
       def warn(feature, logger, detail: nil) # rubocop:disable Naming/PredicateMethod
         entry = REGISTRY[feature] or raise ArgumentError, "unknown deprecated feature: #{feature.inspect}"
         return false unless enabled? && logger
+        return false if logger.respond_to?(:warn?) && !logger.warn?
 
-        emitted = @mutex.synchronize { @emitted.add?(feature) }
-        return false unless emitted
+        @mutex.synchronize do
+          return false if @emitted.include?(feature)
 
-        logger.warn(message(entry, detail))
+          logger.warn(message(entry, detail))
+          @emitted << feature
+        end
         true
       end
 
@@ -102,14 +112,15 @@ module MCPClient
 
       # @return [String] the notice text
       def message(entry, detail)
-        text = "#{entry[:feature]} is deprecated in MCP #{entry[:since]} (#{entry[:reference]}); " \
-               "it keeps working during the deprecation window. Migration: #{entry[:migration]}."
+        text = "#{entry[:feature]} is deprecated since MCP #{entry[:since]} (#{entry[:reference]}); " \
+               "it keeps working during its deprecation window. Migration: #{entry[:migration]}."
         detail ? "#{text} Received: #{sanitize(detail)}" : text
       end
 
-      # @return [String] the detail with control characters escaped and its length bounded
+      # @return [String] the detail with control characters (and the Unicode
+      #   line and paragraph separators) escaped and its length bounded
       def sanitize(detail)
-        escaped = detail.to_s.gsub(/[[:cntrl:]]/) { |c| format('\\x%02X', c.ord) }
+        escaped = detail.to_s.gsub(/[[:cntrl:]\u0085\u2028\u2029]/) { |c| format('\\u%04X', c.ord) }
         escaped.length <= MAX_DETAIL_LENGTH ? escaped : "#{escaped[0, MAX_DETAIL_LENGTH]}..."
       end
     end

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -79,10 +79,12 @@ module MCPClient
     # Longest peer-supplied detail quoted in a notice.
     MAX_DETAIL_LENGTH = 200
 
-    # Marks a thread that is between claiming a feature's notice and coming
-    # back out of the logger. A thread-level variable, not a fiber-local
-    # one: what it guards is a claim this thread holds, which every fiber of
-    # the thread holds with it.
+    # Marks a thread that is inside a notice: from the moment it first asks
+    # the logger anything until it comes back out of the write. It covers
+    # the level probe as well as the write, because both are host code and
+    # either can reach a deprecated feature and come straight back in. A
+    # thread-level variable, not a fiber-local one: what it guards is a
+    # claim this thread holds, which every fiber of the thread holds with it.
     EMITTING_KEY = :mcp_client_deprecation_emitting
 
     # A notice claimed by a caller that is inside the logger right now, as
@@ -108,12 +110,14 @@ module MCPClient
 
       # Log the notice for a deprecated feature once per process. The notice
       # counts as emitted only once the logger accepted it: a logger that
-      # drops warnings (level above WARN), writes nowhere (`Logger.new(nil)`),
-      # fails to report its level or raises leaves it for a later use, and so
-      # do a nested attempt from inside another notice's logger and a caller
-      # that finds the notice already in flight (see {.emit_once}).
-      # Never raises for a logger failure: the deprecated feature
-      # keeps working whatever the log does (feature lifecycle policy).
+      # drops warnings (level above WARN), writes nowhere (`Logger.new(nil)`,
+      # or a device that was closed), fails to report its level or raises
+      # leaves it for a later use, and so do a nested attempt from inside
+      # another notice's logger — its `level` accessor as much as its `warn`
+      # — and a caller that finds the notice already in flight (see
+      # {.emit_once}). Never raises for a logger failure: the deprecated
+      # feature keeps working whatever the log does (feature lifecycle
+      # policy).
       #
       # A notice costs its caller what one `logger.warn` costs it, and no
       # more. That is not a promise that it never waits: every other
@@ -135,9 +139,23 @@ module MCPClient
       def warn(feature, logger, detail: nil)
         entry = REGISTRY[feature] or raise ArgumentError, "unknown deprecated feature: #{feature.inspect}"
         return false unless enabled? && logger
-        return false unless accepts_warnings?(logger)
+        # Asking the logger anything is already calling out to the host, so
+        # the reentrancy guard goes up here rather than around the write
+        # alone: `level` is host code too, and a host whose accessor reaches
+        # a deprecated feature (a formatter, a log subscriber, an audit hook
+        # reading the client's configuration) comes straight back into this
+        # method. Guarding only `logger.warn` leaves that probe recursing
+        # until the stack ends, and SystemStackError is not a StandardError,
+        # so it escapes the rescues that exist to keep the deprecated
+        # operation working and takes the host's `roots=` down with it.
+        return false if emitting?
 
-        emit_once(feature, logger) { logger.warn(message(entry, detail)) }
+        mark_emitting(true)
+        begin
+          accepts_warnings?(logger) && emit_once(feature, logger) { logger.warn(message(entry, detail)) }
+        ensure
+          mark_emitting(false)
+        end
       end
 
       # @param feature [Symbol] a {REGISTRY} key
@@ -190,9 +208,9 @@ module MCPClient
       # Standing down loses nothing that was there to lose: whoever holds
       # the claim is writing that notice, and if their logger fails the
       # claim is released, so the next use of the feature attempts it again.
-      # A thread already inside a notice stands down too, which keeps a
-      # logger callback from re-entering the host's logger under this
-      # module's own name.
+      # A thread already inside a notice stands down too — {.warn} turns it
+      # away before it reaches here — which keeps a logger callback from
+      # re-entering the host's logger under this module's own name.
       #
       # The logger is asked one more time whether it keeps warnings, next to
       # the write rather than at the top of {.warn}: `Logger#warn` returns
@@ -201,17 +219,18 @@ module MCPClient
       # nobody can read. A level that changes DURING the write is beyond
       # reach — that race is the host's own, and the same one two of its
       # threads have with each other.
+      #
+      # The caller ({.warn}) has already marked this thread as emitting, so
+      # both that second probe and the write itself run guarded.
       # @param feature [Symbol] a {REGISTRY} key
       # @param logger [Logger, #warn] the logger the emission writes to
       # @yield the emission, called with no lock of this module held
       # @return [Boolean] whether this call emitted the notice
       def emit_once(feature, logger)
-        return false if emitting?
         return false unless claim(feature)
 
         written = false
         begin
-          mark_emitting(true)
           if accepts_warnings?(logger)
             yield
             written = true
@@ -219,7 +238,6 @@ module MCPClient
         rescue StandardError
           written = false
         ensure
-          mark_emitting(false)
           settle(feature, written)
         end
         written
@@ -303,12 +321,30 @@ module MCPClient
       # `Logger.new(File::NULL)` into that (it opens no file), earlier
       # versions give it a real device, and either reading is safe here —
       # the notice is written or it stays owed.
+      #
+      # A CLOSED device reads the same way, and needs asking for separately:
+      # `Logger::LogDevice#write` rescues the failure of a write to a closed
+      # IO and reports it through `Kernel#warn`, so `Logger#warn` returns
+      # exactly as it does after a successful write and the caller cannot
+      # tell from its answer that the line went nowhere. Only the absence of
+      # a device is visible without asking, so a closed one would otherwise
+      # spend the process's notice on a stream nobody can read.
       # @param logger [Logger, #warn] the candidate logger
       # @return [Boolean] whether the logger provably writes nowhere
       def no_output_device?(logger)
-        logger.is_a?(::Logger) &&
-          logger.instance_variable_defined?(:@logdev) &&
-          logger.instance_variable_get(:@logdev).nil?
+        return false unless logger.is_a?(::Logger) && logger.instance_variable_defined?(:@logdev)
+
+        logdev = logger.instance_variable_get(:@logdev)
+        return true if logdev.nil?
+
+        device = logdev.respond_to?(:dev) ? logdev.dev : nil
+        return true if device.nil?
+
+        # A device that cannot say whether it is closed is taken as open: a
+        # notice written to a working stream is the point, and treating an
+        # unknown device as dead would suppress every notice a host with a
+        # custom log device should see.
+        device.respond_to?(:closed?) && device.closed?
       end
 
       # @return [String] the notice text

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'logger'
+
 module MCPClient
   # Deprecation notices for the features listed as Deprecated by the MCP
   # 2026-07-28 deprecated features registry (feature lifecycle policy,

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -79,6 +79,12 @@ module MCPClient
     # Longest peer-supplied detail quoted in a notice.
     MAX_DETAIL_LENGTH = 200
 
+    # Marks a thread that is between claiming a feature's gate and coming
+    # back out of the logger. A thread-level variable, not a fiber-local
+    # one: what it guards is a Mutex this thread already holds, which every
+    # fiber of the thread holds with it.
+    EMITTING_KEY = :mcp_client_deprecation_emitting
+
     @enabled = true
     @notices = {}
     @gates = {}
@@ -96,8 +102,10 @@ module MCPClient
 
       # Log the notice for a deprecated feature once per process. The notice
       # counts as emitted only once the logger accepted it: a logger that
-      # drops warnings (level above WARN), fails to report its level or
-      # raises leaves it for a later use. Never raises for a logger failure:
+      # drops warnings (level above WARN), writes nowhere (`Logger.new(nil)`),
+      # fails to report its level or raises leaves it for a later use, and so
+      # does a nested attempt from inside another notice's logger (see
+      # {.emit_once}). Never raises for a logger failure:
       # the deprecated feature keeps working whatever the log does (feature
       # lifecycle policy).
       #
@@ -161,22 +169,52 @@ module MCPClient
       # a caller waits on the gate exactly as long as it would have waited
       # on a shared logger's own lock, and never comes away from that wait
       # with the notice neither emitted nor its own to write.
+      #
+      # A gate is held across host code, so it is never waited for BY host
+      # code running inside one. A logger callback — a formatter, a log
+      # subscriber — may itself reach a deprecated feature, and a thread
+      # already inside a notice that then queued for a gate would deadlock:
+      # against its own gate for the same feature, or (with a logger that
+      # serializes its writes, as ::Logger does) against another thread that
+      # holds the second feature's gate and is waiting for that logger. So a
+      # thread inside a notice never queues: its nested attempt stands down
+      # at once and leaves that notice owed to a later use, exactly as a
+      # dropped one is. The notice it stood down from is not lost — whoever
+      # holds that gate is writing it.
       # @param feature [Symbol] a {REGISTRY} key
       # @yield the emission, called with no lock of this module held
       # @return [Boolean] whether this call emitted the notice
       def emit_once(feature)
+        return false if emitting?
+
         gate = gate_for(feature)
         return false unless gate
 
-        gate.synchronize do
-          return false if emitted?(feature)
+        begin
+          mark_emitting(true)
+          gate.synchronize do
+            return false if emitted?(feature)
 
-          yield
-          mark_emitted(feature)
-          true
+            yield
+            mark_emitted(feature)
+            true
+          end
+        ensure
+          mark_emitting(false)
         end
       rescue StandardError
         false
+      end
+
+      # @return [Boolean] whether this thread is already inside a notice
+      def emitting?
+        Thread.current.thread_variable_get(EMITTING_KEY) ? true : false
+      end
+
+      # @param value [Boolean] whether this thread is inside a notice
+      # @return [void]
+      def mark_emitting(value)
+        Thread.current.thread_variable_set(EMITTING_KEY, value)
       end
 
       # @param feature [Symbol] a {REGISTRY} key
@@ -224,9 +262,28 @@ module MCPClient
       # @param logger [Logger, #warn] the candidate logger
       # @return [Boolean] false when the logger drops warnings or asking failed
       def accepts_warnings?(logger)
-        !(logger.is_a?(::Logger) && logger.level > ::Logger::WARN)
+        return false if logger.is_a?(::Logger) && logger.level > ::Logger::WARN
+
+        !no_output_device?(logger)
       rescue StandardError
         false
+      end
+
+      # `Logger.new(nil)` is the documented no-output logger: it keeps every
+      # level, so the level check passes, and `warn` returns successfully
+      # having written nothing. Counting that as the notice would spend it on
+      # a reader that does not exist and silence every later use — including
+      # one holding a logger that does write. A logger has no device only
+      # when it was built without one: `logger` 1.7 also folds
+      # `Logger.new(File::NULL)` into that (it opens no file), earlier
+      # versions give it a real device, and either reading is safe here —
+      # the notice is written or it stays owed.
+      # @param logger [Logger, #warn] the candidate logger
+      # @return [Boolean] whether the logger provably writes nowhere
+      def no_output_device?(logger)
+        logger.is_a?(::Logger) &&
+          logger.instance_variable_defined?(:@logdev) &&
+          logger.instance_variable_get(:@logdev).nil?
       end
 
       # @return [String] the notice text

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module MCPClient
+  # Deprecation notices for the features MCP 2026-07-28 placed in the
+  # Deprecated state of its feature lifecycle policy (SEP-2596): they keep
+  # working for at least the twelve-month deprecation window, but new
+  # integrations should not adopt them. The client logs one notice per
+  # feature per process, on the first use, and names the suggested migration.
+  #
+  # Notices can be silenced with `MCPClient::Deprecations.enabled = false`.
+  module Deprecations
+    # Every feature the 2026-07-28 revision lists in its deprecated features
+    # registry, keyed by the identifier passed to {.warn}.
+    REGISTRY = {
+      roots: {
+        feature: 'Roots',
+        since: '2026-07-28',
+        reference: 'SEP-2577',
+        migration: 'pass directories or files through tool parameters, resource URIs or server configuration'
+      },
+      sampling: {
+        feature: 'Sampling',
+        since: '2026-07-28',
+        reference: 'SEP-2577',
+        migration: 'integrate directly with the LLM provider API instead of serving sampling/createMessage'
+      },
+      logging: {
+        feature: 'Logging',
+        since: '2026-07-28',
+        reference: 'SEP-2577',
+        migration: 'have the server log to stderr (stdio) or use OpenTelemetry instead of notifications/message'
+      },
+      http_sse_transport: {
+        feature: 'The HTTP+SSE transport',
+        since: '2026-07-28',
+        reference: 'SEP-2596 (deprecated since protocol version 2025-03-26)',
+        migration: 'migrate the server to Streamable HTTP (MCPClient::ServerStreamableHTTP)'
+      },
+      include_context: {
+        feature: 'The includeContext values "thisServer" and "allServers"',
+        since: '2026-07-28',
+        reference: 'SEP-2596 (soft-deprecated since protocol version 2025-11-25)',
+        migration: 'servers should omit includeContext or send "none"; the values are removed no later than Sampling'
+      },
+      dynamic_client_registration: {
+        feature: 'OAuth 2.0 Dynamic Client Registration (RFC 7591)',
+        since: '2026-07-28',
+        reference: 'MCP PR #2858',
+        migration: 'prefer a Client ID Metadata Document (client_id_metadata_url) or pre-registered credentials'
+      }
+    }.freeze
+
+    # Longest peer-supplied detail quoted in a notice.
+    MAX_DETAIL_LENGTH = 200
+
+    @enabled = true
+    @emitted = Set.new
+    @mutex = Mutex.new
+
+    class << self
+      # @return [Boolean] whether notices are logged (default true)
+      attr_writer :enabled
+
+      # @return [Boolean] whether notices are logged
+      def enabled?
+        @enabled
+      end
+
+      # Log the notice for a deprecated feature once per process.
+      # @param feature [Symbol] a {REGISTRY} key
+      # @param logger [Logger, nil] where the notice goes (a nil logger emits nothing)
+      # @param detail [String, nil] peer-supplied context quoted in the notice
+      #   (control characters are escaped and the text is bounded)
+      # @return [Boolean] true when a notice was written, false when it was
+      #   already emitted or notices are disabled
+      # @raise [ArgumentError] for an unknown feature
+      def warn(feature, logger, detail: nil) # rubocop:disable Naming/PredicateMethod
+        entry = REGISTRY[feature] or raise ArgumentError, "unknown deprecated feature: #{feature.inspect}"
+        return false unless enabled? && logger
+
+        emitted = @mutex.synchronize { @emitted.add?(feature) }
+        return false unless emitted
+
+        logger.warn(message(entry, detail))
+        true
+      end
+
+      # @param feature [Symbol] a {REGISTRY} key
+      # @return [Boolean] whether the notice for the feature was already logged
+      def emitted?(feature)
+        @mutex.synchronize { @emitted.include?(feature) }
+      end
+
+      # Forget which notices were emitted (each feature warns again on its
+      # next use). Intended for tests.
+      # @return [void]
+      def reset!
+        @mutex.synchronize { @emitted.clear }
+      end
+
+      private
+
+      # @return [String] the notice text
+      def message(entry, detail)
+        text = "#{entry[:feature]} is deprecated in MCP #{entry[:since]} (#{entry[:reference]}); " \
+               "it keeps working during the deprecation window. Migration: #{entry[:migration]}."
+        detail ? "#{text} Received: #{sanitize(detail)}" : text
+      end
+
+      # @return [String] the detail with control characters escaped and its length bounded
+      def sanitize(detail)
+        escaped = detail.to_s.gsub(/[[:cntrl:]]/) { |c| format('\\x%02X', c.ord) }
+        escaped.length <= MAX_DETAIL_LENGTH ? escaped : "#{escaped[0, MAX_DETAIL_LENGTH]}..."
+      end
+    end
+  end
+end

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -73,26 +73,30 @@ module MCPClient
 
       # Log the notice for a deprecated feature once per process. The notice
       # counts as emitted only once the logger accepted it: a logger that
-      # drops warnings (level above WARN) or raises leaves it for a later use.
+      # drops warnings (level above WARN) or raises leaves it for a later
+      # use. Never raises for a logger failure: the deprecated feature keeps
+      # working whatever the log does (feature lifecycle policy). The slot is
+      # reserved under the lock and the logger is called outside it.
       # @param feature [Symbol] a {REGISTRY} key
       # @param logger [Logger, nil] where the notice goes (a nil logger emits nothing)
       # @param detail [String, nil] peer-supplied context quoted in the notice
       #   (control characters are escaped and the text is bounded)
       # @return [Boolean] true when a notice was written, false when it was
-      #   already emitted, notices are disabled or the logger drops warnings
+      #   already emitted, notices are disabled, the logger drops warnings or failed
       # @raise [ArgumentError] for an unknown feature
-      def warn(feature, logger, detail: nil) # rubocop:disable Naming/PredicateMethod
+      def warn(feature, logger, detail: nil)
         entry = REGISTRY[feature] or raise ArgumentError, "unknown deprecated feature: #{feature.inspect}"
         return false unless enabled? && logger
-        return false if logger.respond_to?(:warn?) && !logger.warn?
+        return false if logger.is_a?(::Logger) && logger.level > ::Logger::WARN
+        return false unless @mutex.synchronize { @emitted.add?(feature) }
 
-        @mutex.synchronize do
-          return false if @emitted.include?(feature)
-
+        begin
           logger.warn(message(entry, detail))
-          @emitted << feature
+          true
+        rescue StandardError
+          @mutex.synchronize { @emitted.delete(feature) }
+          false
         end
-        true
       end
 
       # @param feature [Symbol] a {REGISTRY} key

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -79,18 +79,10 @@ module MCPClient
     # Longest peer-supplied detail quoted in a notice.
     MAX_DETAIL_LENGTH = 200
 
-    # How long a caller waits for another caller's in-flight notice to
-    # resolve. A notice must never hold up the deprecated operation, so the
-    # wait is bounded: a logger that blocks forever costs the contender this
-    # much and no more, after which it gives up on the notice (the
-    # reservation still belongs to its owner, which will either emit it or
-    # release it for a later use).
-    PENDING_WAIT_SECONDS = 0.25
-
     @enabled = true
     @notices = {}
+    @gates = {}
     @mutex = Mutex.new
-    @resolved = ConditionVariable.new
     @owner_pid = Process.pid
 
     class << self
@@ -107,8 +99,17 @@ module MCPClient
       # drops warnings (level above WARN), fails to report its level or
       # raises leaves it for a later use. Never raises for a logger failure:
       # the deprecated feature keeps working whatever the log does (feature
-      # lifecycle policy). The slot is reserved under the lock and the logger
-      # is called outside it.
+      # lifecycle policy).
+      #
+      # A notice costs its caller what one `logger.warn` costs it, and no
+      # more. That is not a promise that it never waits: every other
+      # `logger.warn` in this library blocks its caller the same way, so a
+      # logger that blocks forever blocks the library everywhere, not only
+      # here, and this path claims no exemption the rest of the code cannot
+      # claim. Where it does hold back is the module itself: the logger is
+      # called outside @mutex and under a gate held only for the feature
+      # being logged, so a notice in flight never delays another feature's
+      # notice, {.emitted?} or {.reset!}.
       # @param feature [Symbol] a {REGISTRY} key
       # @param logger [Logger, nil] where the notice goes (a nil logger emits nothing)
       # @param detail [String, nil] peer-supplied context quoted in the notice
@@ -120,24 +121,16 @@ module MCPClient
         entry = REGISTRY[feature] or raise ArgumentError, "unknown deprecated feature: #{feature.inspect}"
         return false unless enabled? && logger
         return false unless accepts_warnings?(logger)
-        return false unless reserve(feature)
 
-        begin
-          logger.warn(message(entry, detail))
-          settle(feature, :emitted)
-          true
-        rescue StandardError
-          settle(feature, nil)
-          false
-        end
+        emit_once(feature) { logger.warn(message(entry, detail)) }
       end
 
       # @param feature [Symbol] a {REGISTRY} key
       # @return [Boolean] whether a notice for the feature actually went out.
-      #   A reservation still in flight is not one: a caller is inside
-      #   `logger.warn` and may yet fail, which puts the notice back.
+      #   A caller currently inside `logger.warn` has not emitted one: it may
+      #   yet fail, which leaves the notice owed.
       def emitted?(feature)
-        @mutex.synchronize { notice_states[feature] == :emitted }
+        @mutex.synchronize { notice_states.key?(feature) }
       end
 
       # Forget which notices were emitted (each feature warns again on its
@@ -147,81 +140,79 @@ module MCPClient
         @mutex.synchronize do
           @owner_pid = Process.pid
           @notices.clear
-          @resolved.broadcast
+          @gates.clear
         end
       end
 
       private
 
-      # Claim the right to log a feature's notice. A feature is absent (never
-      # attempted), `:pending` (a caller is inside `logger.warn` for it right
-      # now) or `:emitted` (a notice went out). Only the caller that moves it
-      # from absent to `:pending` may log.
+      # Run the emission at most once per feature per process, and count it
+      # only once it came back without raising.
       #
-      # Reserving is not emitting: marking the feature spent before the logger
-      # had said anything could lose the notice outright. Two first uses that
-      # race with different loggers would have the reserving one block in a
-      # broken logger while the contender — holding a logger that works — saw
-      # the slot taken and gave up, and the reservation's later failure then
-      # left the notice owed to a use that may never come. So a caller that
-      # meets a reservation waits for its outcome, and takes the notice over
-      # if that outcome is a failure. The wait is bounded by
-      # {PENDING_WAIT_SECONDS}: a notice never holds up the deprecated
-      # operation, so a reservation that hangs costs the contender the notice,
-      # not its progress.
+      # Emitting is what spends the notice, not attempting to: marking the
+      # feature spent before the logger had said anything could lose the
+      # notice outright, since two first uses racing with different loggers
+      # would have the first one fail inside a broken logger while the
+      # second — holding a logger that works — saw the slot taken and stood
+      # down. So the attempt is serialized on a gate held only for the
+      # feature being logged, and a caller that arrives while another is
+      # inside the logger either finds the notice emitted (and stands down)
+      # or takes it over (the earlier attempt failed). Nothing is timed:
+      # a caller waits on the gate exactly as long as it would have waited
+      # on a shared logger's own lock, and never comes away from that wait
+      # with the notice neither emitted nor its own to write.
       # @param feature [Symbol] a {REGISTRY} key
-      # @return [Boolean] whether this caller may log the notice
-      def reserve(feature)
-        deadline = nil
-        @mutex.synchronize do
-          loop do
-            case notice_states[feature]
-            when :emitted
-              return false
-            when :pending
-              deadline ||= monotonic_time + PENDING_WAIT_SECONDS
-              remaining = deadline - monotonic_time
-              return false if remaining <= 0
+      # @yield the emission, called with no lock of this module held
+      # @return [Boolean] whether this call emitted the notice
+      def emit_once(feature)
+        gate = gate_for(feature)
+        return false unless gate
 
-              @resolved.wait(@mutex, remaining)
-            else
-              notice_states[feature] = :pending
-              return true
-            end
-          end
+        gate.synchronize do
+          return false if emitted?(feature)
+
+          yield
+          mark_emitted(feature)
+          true
+        end
+      rescue StandardError
+        false
+      end
+
+      # @param feature [Symbol] a {REGISTRY} key
+      # @return [Mutex, nil] the feature's emission gate, or nil when its
+      #   notice has already gone out and no attempt is needed
+      def gate_for(feature)
+        @mutex.synchronize do
+          return nil if notice_states.key?(feature)
+
+          @gates[feature] ||= Mutex.new
         end
       end
 
-      # Record how a reservation ended and wake whoever is waiting on it.
+      # Record that the feature's notice went out and retire its gate.
       # @param feature [Symbol] a {REGISTRY} key
-      # @param state [Symbol, nil] `:emitted`, or nil to release the
-      #   reservation so a contender or a later use can retry it
       # @return [void]
-      def settle(feature, state)
+      def mark_emitted(feature)
         @mutex.synchronize do
-          states = notice_states
-          state ? states[feature] = state : states.delete(feature)
-          @resolved.broadcast
+          notice_states[feature] = true
+          @gates.delete(feature)
         end
       end
 
-      # @return [Float] a clock that cannot jump backwards
-      def monotonic_time
-        Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      end
-
-      # What each feature's notice has reached IN THIS PROCESS: `:pending`
-      # while a caller is inside `logger.warn` for it, `:emitted` once one
-      # went out, absent otherwise. A prefork server (Puma, Unicorn) that
-      # warns while preloading would hand every worker an already-spent map
-      # and silence the worker's own first use, so an inherited map is
-      # dropped the first time the owning PID no longer matches. Callers hold
-      # @mutex.
-      # @return [Hash{Symbol => Symbol}]
+      # Which features have had their notice logged IN THIS PROCESS. A
+      # prefork server (Puma, Unicorn) that warned while preloading would
+      # hand every worker an already-spent map and silence the worker's own
+      # first use, so an inherited map is dropped the first time the owning
+      # PID no longer matches — along with the gates, whose Mutexes may have
+      # been left locked by a thread that did not survive the fork. Callers
+      # hold @mutex.
+      # @return [Hash{Symbol => true}]
       def notice_states
         if @owner_pid != Process.pid
           @owner_pid = Process.pid
           @notices = {}
+          @gates = {}
         end
         @notices
       end

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -79,15 +79,21 @@ module MCPClient
     # Longest peer-supplied detail quoted in a notice.
     MAX_DETAIL_LENGTH = 200
 
-    # Marks a thread that is between claiming a feature's gate and coming
+    # Marks a thread that is between claiming a feature's notice and coming
     # back out of the logger. A thread-level variable, not a fiber-local
-    # one: what it guards is a Mutex this thread already holds, which every
-    # fiber of the thread holds with it.
+    # one: what it guards is a claim this thread holds, which every fiber of
+    # the thread holds with it.
     EMITTING_KEY = :mcp_client_deprecation_emitting
+
+    # A notice claimed by a caller that is inside the logger right now, as
+    # opposed to {EMITTED} for one the logger took.
+    WRITING = :writing
+
+    # A notice that went out.
+    EMITTED = :emitted
 
     @enabled = true
     @notices = {}
-    @gates = {}
     @mutex = Mutex.new
     @owner_pid = Process.pid
 
@@ -104,33 +110,34 @@ module MCPClient
       # counts as emitted only once the logger accepted it: a logger that
       # drops warnings (level above WARN), writes nowhere (`Logger.new(nil)`),
       # fails to report its level or raises leaves it for a later use, and so
-      # does a nested attempt from inside another notice's logger (see
-      # {.emit_once}). Never raises for a logger failure:
-      # the deprecated feature keeps working whatever the log does (feature
-      # lifecycle policy).
+      # do a nested attempt from inside another notice's logger and a caller
+      # that finds the notice already in flight (see {.emit_once}).
+      # Never raises for a logger failure: the deprecated feature
+      # keeps working whatever the log does (feature lifecycle policy).
       #
       # A notice costs its caller what one `logger.warn` costs it, and no
       # more. That is not a promise that it never waits: every other
       # `logger.warn` in this library blocks its caller the same way, so a
       # logger that blocks forever blocks the library everywhere, not only
       # here, and this path claims no exemption the rest of the code cannot
-      # claim. Where it does hold back is the module itself: the logger is
-      # called outside @mutex and under a gate held only for the feature
-      # being logged, so a notice in flight never delays another feature's
-      # notice, {.emitted?} or {.reset!}.
+      # claim. What it does promise is that the waiting is the logger's: no
+      # caller ever waits for a lock of THIS module, which is never held
+      # while calling out, so a notice in flight never delays another
+      # feature's notice, another caller, {.emitted?} or {.reset!}.
       # @param feature [Symbol] a {REGISTRY} key
       # @param logger [Logger, nil] where the notice goes (a nil logger emits nothing)
       # @param detail [String, nil] peer-supplied context quoted in the notice
       #   (control characters are escaped and the text is bounded)
       # @return [Boolean] true when a notice was written, false when it was
-      #   already emitted, notices are disabled, the logger drops warnings or failed
+      #   already emitted or in flight, notices are disabled, the logger drops
+      #   warnings or failed
       # @raise [ArgumentError] for an unknown feature
       def warn(feature, logger, detail: nil)
         entry = REGISTRY[feature] or raise ArgumentError, "unknown deprecated feature: #{feature.inspect}"
         return false unless enabled? && logger
         return false unless accepts_warnings?(logger)
 
-        emit_once(feature) { logger.warn(message(entry, detail)) }
+        emit_once(feature, logger) { logger.warn(message(entry, detail)) }
       end
 
       # @param feature [Symbol] a {REGISTRY} key
@@ -138,7 +145,7 @@ module MCPClient
       #   A caller currently inside `logger.warn` has not emitted one: it may
       #   yet fail, which leaves the notice owed.
       def emitted?(feature)
-        @mutex.synchronize { notice_states.key?(feature) }
+        @mutex.synchronize { notice_states[feature] == EMITTED }
       end
 
       # Forget which notices were emitted (each feature warns again on its
@@ -148,7 +155,6 @@ module MCPClient
         @mutex.synchronize do
           @owner_pid = Process.pid
           @notices.clear
-          @gates.clear
         end
       end
 
@@ -159,51 +165,91 @@ module MCPClient
       #
       # Emitting is what spends the notice, not attempting to: marking the
       # feature spent before the logger had said anything could lose the
-      # notice outright, since two first uses racing with different loggers
-      # would have the first one fail inside a broken logger while the
-      # second — holding a logger that works — saw the slot taken and stood
-      # down. So the attempt is serialized on a gate held only for the
-      # feature being logged, and a caller that arrives while another is
-      # inside the logger either finds the notice emitted (and stands down)
-      # or takes it over (the earlier attempt failed). Nothing is timed:
-      # a caller waits on the gate exactly as long as it would have waited
-      # on a shared logger's own lock, and never comes away from that wait
-      # with the notice neither emitted nor its own to write.
+      # notice outright, since a first use that fails inside a broken logger
+      # would leave every later use looking at a spent slot. So an attempt
+      # is a CLAIM (see {.claim}), released again when the logger did not
+      # take the notice, and the feature is marked emitted only afterwards.
       #
-      # A gate is held across host code, so it is never waited for BY host
-      # code running inside one. A logger callback — a formatter, a log
-      # subscriber — may itself reach a deprecated feature, and a thread
-      # already inside a notice that then queued for a gate would deadlock:
-      # against its own gate for the same feature, or (with a logger that
-      # serializes its writes, as ::Logger does) against another thread that
-      # holds the second feature's gate and is waiting for that logger. So a
-      # thread inside a notice never queues: its nested attempt stands down
-      # at once and leaves that notice owed to a later use, exactly as a
-      # dropped one is. The notice it stood down from is not lost — whoever
-      # holds that gate is writing it.
+      # Nothing is ever waited for. A caller that finds the notice in flight
+      # stands down at once and leaves it to a later use, exactly as a
+      # dropped one is left — it does not queue behind the emission, and it
+      # does not take it over. Queueing is what buys a lock-order inversion,
+      # and no rule about who may queue can avoid it, because the waiter
+      # cannot know what it is holding: `logger.warn` is host code that
+      # serializes its writes (as ::Logger does behind its device lock) and
+      # that may reach a deprecated feature from a formatter, a log
+      # subscriber or an audit hook. A thread writing an ORDINARY log line
+      # holds that device lock and is not inside a notice at all; let it
+      # queue for a notice held by a thread that is waiting for the same
+      # device lock and both stop, taking the sampling request, the log
+      # level or the SSE `connect` behind the notice with them. A claim is
+      # a mark under @mutex instead, taken and released without ever calling
+      # out of this module, so a lock of ours is never held across host code
+      # and never acquired behind one of theirs.
+      #
+      # Standing down loses nothing that was there to lose: whoever holds
+      # the claim is writing that notice, and if their logger fails the
+      # claim is released, so the next use of the feature attempts it again.
+      # A thread already inside a notice stands down too, which keeps a
+      # logger callback from re-entering the host's logger under this
+      # module's own name.
+      #
+      # The logger is asked one more time whether it keeps warnings, next to
+      # the write rather than at the top of {.warn}: `Logger#warn` returns
+      # true whether it wrote or filtered, so a level that went up in
+      # between would otherwise spend the process's one notice on a warning
+      # nobody can read. A level that changes DURING the write is beyond
+      # reach — that race is the host's own, and the same one two of its
+      # threads have with each other.
       # @param feature [Symbol] a {REGISTRY} key
+      # @param logger [Logger, #warn] the logger the emission writes to
       # @yield the emission, called with no lock of this module held
       # @return [Boolean] whether this call emitted the notice
-      def emit_once(feature)
+      def emit_once(feature, logger)
         return false if emitting?
+        return false unless claim(feature)
 
-        gate = gate_for(feature)
-        return false unless gate
-
+        written = false
         begin
           mark_emitting(true)
-          gate.synchronize do
-            return false if emitted?(feature)
-
+          if accepts_warnings?(logger)
             yield
-            mark_emitted(feature)
-            true
+            written = true
           end
+        rescue StandardError
+          written = false
         ensure
           mark_emitting(false)
+          settle(feature, written)
         end
-      rescue StandardError
-        false
+        written
+      end
+
+      # Reserve this process's notice for the caller. The claim is a mark in
+      # the same map that records emitted notices, so a feature is claimable
+      # only while it is neither emitted nor being written right now, and
+      # taking it costs @mutex for the length of a hash lookup.
+      # @param feature [Symbol] a {REGISTRY} key
+      # @return [Boolean] whether the caller may write the notice
+      def claim(feature)
+        @mutex.synchronize do
+          states = notice_states
+          return false if states.key?(feature)
+
+          states[feature] = WRITING
+          true
+        end
+      end
+
+      # Close a claim: spend the notice, or hand it back to a later use.
+      # @param feature [Symbol] a {REGISTRY} key
+      # @param written [Boolean] whether the logger took the notice
+      # @return [void]
+      def settle(feature, written)
+        @mutex.synchronize do
+          states = notice_states
+          written ? states[feature] = EMITTED : states.delete(feature)
+        end
       end
 
       # @return [Boolean] whether this thread is already inside a notice
@@ -217,40 +263,19 @@ module MCPClient
         Thread.current.thread_variable_set(EMITTING_KEY, value)
       end
 
-      # @param feature [Symbol] a {REGISTRY} key
-      # @return [Mutex, nil] the feature's emission gate, or nil when its
-      #   notice has already gone out and no attempt is needed
-      def gate_for(feature)
-        @mutex.synchronize do
-          return nil if notice_states.key?(feature)
-
-          @gates[feature] ||= Mutex.new
-        end
-      end
-
-      # Record that the feature's notice went out and retire its gate.
-      # @param feature [Symbol] a {REGISTRY} key
-      # @return [void]
-      def mark_emitted(feature)
-        @mutex.synchronize do
-          notice_states[feature] = true
-          @gates.delete(feature)
-        end
-      end
-
-      # Which features have had their notice logged IN THIS PROCESS. A
-      # prefork server (Puma, Unicorn) that warned while preloading would
-      # hand every worker an already-spent map and silence the worker's own
-      # first use, so an inherited map is dropped the first time the owning
-      # PID no longer matches — along with the gates, whose Mutexes may have
-      # been left locked by a thread that did not survive the fork. Callers
-      # hold @mutex.
-      # @return [Hash{Symbol => true}]
+      # What this process knows about each feature's notice: {WRITING} while
+      # a caller is inside the logger, {EMITTED} once one came back having
+      # written it, absent otherwise. A prefork server (Puma, Unicorn) that
+      # warned while preloading would hand every worker an already-spent map
+      # and silence the worker's own first use, so an inherited map is
+      # dropped the first time the owning PID no longer matches — including
+      # any claim held by a thread that did not survive the fork, which no
+      # one in the child will ever settle. Callers hold @mutex.
+      # @return [Hash{Symbol => Symbol}]
       def notice_states
         if @owner_pid != Process.pid
           @owner_pid = Process.pid
           @notices = {}
-          @gates = {}
         end
         @notices
       end

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -6,63 +6,72 @@ module MCPClient
   # Deprecation notices for the features listed as Deprecated by the MCP
   # 2026-07-28 deprecated features registry (feature lifecycle policy,
   # SEP-2596): they keep working during their deprecation window, but new
-  # integrations should not adopt them. The earliest removal of each feature
-  # is set by the registry (https://modelcontextprotocol.io/specification/2026-07-28/deprecated)
-  # and recorded in `earliest_removal`. Only the HTTP+SSE transport may go
-  # sooner than the features 2026-07-28 itself deprecates: the includeContext
-  # values were deprecated by an earlier revision, but SEP-2596's transition
-  # provision ties them to Sampling, so they share the same window as Roots,
-  # Sampling and Logging. The client logs one notice per feature per process,
-  # on the first use, and names the suggested migration.
+  # integrations should not adopt them. `earliest_removal` carries the
+  # registry's own "Earliest removal" wording
+  # (https://modelcontextprotocol.io/specification/2026-07-28/deprecated)
+  # rather than a paraphrase of the policy floor: what the features
+  # 2026-07-28 deprecates wait for is the first revision RELEASED on or after
+  # 2027-07-28, which may fall well after that date, so a host must not plan
+  # around 2027-07-28 as a removal date. The includeContext values follow
+  # Sampling, and only the HTTP+SSE transport has a clock of its own. The
+  # earliest removal marks when a feature becomes eligible for removal; the
+  # actual removal is a Core Maintainer decision. The client logs one notice
+  # per feature per process, on the first use, and names both the earliest
+  # removal and the suggested migration.
   #
   # Notices can be silenced with `MCPClient::Deprecations.enabled = false`.
   module Deprecations
+    # The "Earliest removal" the registry gives Roots, Sampling, Logging and
+    # Dynamic Client Registration. It names a revision, not a date: the
+    # release on or after 2027-07-28 may itself be later than 2027-07-28.
+    REVISION_AFTER_2027_07_28 = 'the first revision released on or after 2027-07-28'
+
     # Every feature the 2026-07-28 deprecated features registry lists, keyed
     # by the identifier passed to {.warn}. `since` is the protocol revision
     # in which the feature entered the Deprecated state; `earliest_removal`
-    # is the soonest the registry allows it to go, and features that share a
-    # window carry the identical string.
+    # is the registry's "Earliest removal" cell verbatim, so features that
+    # share a window carry the identical string.
     REGISTRY = {
       roots: {
         feature: 'Roots',
         since: '2026-07-28',
         reference: 'SEP-2577',
-        earliest_removal: 'no earlier than twelve months after 2026-07-28',
+        earliest_removal: REVISION_AFTER_2027_07_28,
         migration: 'pass directories or files through tool parameters, resource URIs or server configuration'
       },
       sampling: {
         feature: 'Sampling',
         since: '2026-07-28',
         reference: 'SEP-2577',
-        earliest_removal: 'no earlier than twelve months after 2026-07-28',
+        earliest_removal: REVISION_AFTER_2027_07_28,
         migration: 'integrate directly with the LLM provider API instead of serving sampling/createMessage'
       },
       logging: {
         feature: 'Logging',
         since: '2026-07-28',
         reference: 'SEP-2577',
-        earliest_removal: 'no earlier than twelve months after 2026-07-28',
+        earliest_removal: REVISION_AFTER_2027_07_28,
         migration: 'have the server log to stderr (stdio) or use OpenTelemetry instead of notifications/message'
       },
       http_sse_transport: {
         feature: 'The HTTP+SSE transport',
         since: '2025-03-26',
         reference: 'reclassified by SEP-2596 in 2026-07-28',
-        earliest_removal: 'no earlier than three months after SEP-2596 is Final',
+        earliest_removal: 'three months after SEP-2596 reaches Final',
         migration: 'migrate the server to Streamable HTTP (MCPClient::ServerStreamableHTTP)'
       },
       include_context: {
         feature: 'The includeContext values "thisServer" and "allServers"',
         since: '2025-11-25',
         reference: 'reclassified by SEP-2596 in 2026-07-28',
-        earliest_removal: 'no earlier than twelve months after 2026-07-28',
+        earliest_removal: 'follows Sampling (SEP-2577)',
         migration: 'servers should omit includeContext or send "none"; the values are removed no later than Sampling'
       },
       dynamic_client_registration: {
         feature: 'OAuth 2.0 Dynamic Client Registration (RFC 7591)',
         since: '2026-07-28',
         reference: 'MCP PR #2858',
-        earliest_removal: 'no earlier than twelve months after 2026-07-28',
+        earliest_removal: REVISION_AFTER_2027_07_28,
         migration: 'prefer a Client ID Metadata Document (client_id_metadata_url) or pre-registered credentials'
       }
     }.freeze
@@ -73,6 +82,7 @@ module MCPClient
     @enabled = true
     @emitted = Set.new
     @mutex = Mutex.new
+    @owner_pid = Process.pid
 
     class << self
       # @return [Boolean] whether notices are logged (default true)
@@ -101,13 +111,13 @@ module MCPClient
         entry = REGISTRY[feature] or raise ArgumentError, "unknown deprecated feature: #{feature.inspect}"
         return false unless enabled? && logger
         return false unless accepts_warnings?(logger)
-        return false unless @mutex.synchronize { @emitted.add?(feature) }
+        return false unless @mutex.synchronize { emitted_set.add?(feature) }
 
         begin
           logger.warn(message(entry, detail))
           true
         rescue StandardError
-          @mutex.synchronize { @emitted.delete(feature) }
+          @mutex.synchronize { emitted_set.delete(feature) }
           false
         end
       end
@@ -115,17 +125,34 @@ module MCPClient
       # @param feature [Symbol] a {REGISTRY} key
       # @return [Boolean] whether the notice for the feature was already logged
       def emitted?(feature)
-        @mutex.synchronize { @emitted.include?(feature) }
+        @mutex.synchronize { emitted_set.include?(feature) }
       end
 
       # Forget which notices were emitted (each feature warns again on its
       # next use). Intended for tests.
       # @return [void]
       def reset!
-        @mutex.synchronize { @emitted.clear }
+        @mutex.synchronize do
+          @owner_pid = Process.pid
+          @emitted.clear
+        end
       end
 
       private
+
+      # The set of features already warned about IN THIS PROCESS. A prefork
+      # server (Puma, Unicorn) that warns while preloading would otherwise
+      # hand every worker an already-spent set and silence the worker's own
+      # first use, so an inherited set is dropped the first time the owning
+      # PID no longer matches. Callers hold @mutex.
+      # @return [Set<Symbol>]
+      def emitted_set
+        if @owner_pid != Process.pid
+          @owner_pid = Process.pid
+          @emitted = Set.new
+        end
+        @emitted
+      end
 
       # Whether the logger would keep a warning. Asking is itself protected:
       # a Logger subclass whose `level` accessor raises must not abort the
@@ -142,7 +169,8 @@ module MCPClient
       # @return [String] the notice text
       def message(entry, detail)
         text = "#{entry[:feature]} is deprecated since MCP #{entry[:since]} (#{entry[:reference]}); " \
-               "it keeps working during its deprecation window. Migration: #{entry[:migration]}."
+               'it keeps working during its deprecation window. Earliest removal: ' \
+               "#{entry[:earliest_removal]}. Migration: #{entry[:migration]}."
         detail ? "#{text} Received: #{sanitize(detail)}" : text
       end
 

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -79,9 +79,18 @@ module MCPClient
     # Longest peer-supplied detail quoted in a notice.
     MAX_DETAIL_LENGTH = 200
 
+    # How long a caller waits for another caller's in-flight notice to
+    # resolve. A notice must never hold up the deprecated operation, so the
+    # wait is bounded: a logger that blocks forever costs the contender this
+    # much and no more, after which it gives up on the notice (the
+    # reservation still belongs to its owner, which will either emit it or
+    # release it for a later use).
+    PENDING_WAIT_SECONDS = 0.25
+
     @enabled = true
-    @emitted = Set.new
+    @notices = {}
     @mutex = Mutex.new
+    @resolved = ConditionVariable.new
     @owner_pid = Process.pid
 
     class << self
@@ -111,21 +120,24 @@ module MCPClient
         entry = REGISTRY[feature] or raise ArgumentError, "unknown deprecated feature: #{feature.inspect}"
         return false unless enabled? && logger
         return false unless accepts_warnings?(logger)
-        return false unless @mutex.synchronize { emitted_set.add?(feature) }
+        return false unless reserve(feature)
 
         begin
           logger.warn(message(entry, detail))
+          settle(feature, :emitted)
           true
         rescue StandardError
-          @mutex.synchronize { emitted_set.delete(feature) }
+          settle(feature, nil)
           false
         end
       end
 
       # @param feature [Symbol] a {REGISTRY} key
-      # @return [Boolean] whether the notice for the feature was already logged
+      # @return [Boolean] whether a notice for the feature actually went out.
+      #   A reservation still in flight is not one: a caller is inside
+      #   `logger.warn` and may yet fail, which puts the notice back.
       def emitted?(feature)
-        @mutex.synchronize { emitted_set.include?(feature) }
+        @mutex.synchronize { notice_states[feature] == :emitted }
       end
 
       # Forget which notices were emitted (each feature warns again on its
@@ -134,24 +146,84 @@ module MCPClient
       def reset!
         @mutex.synchronize do
           @owner_pid = Process.pid
-          @emitted.clear
+          @notices.clear
+          @resolved.broadcast
         end
       end
 
       private
 
-      # The set of features already warned about IN THIS PROCESS. A prefork
-      # server (Puma, Unicorn) that warns while preloading would otherwise
-      # hand every worker an already-spent set and silence the worker's own
-      # first use, so an inherited set is dropped the first time the owning
-      # PID no longer matches. Callers hold @mutex.
-      # @return [Set<Symbol>]
-      def emitted_set
+      # Claim the right to log a feature's notice. A feature is absent (never
+      # attempted), `:pending` (a caller is inside `logger.warn` for it right
+      # now) or `:emitted` (a notice went out). Only the caller that moves it
+      # from absent to `:pending` may log.
+      #
+      # Reserving is not emitting: marking the feature spent before the logger
+      # had said anything could lose the notice outright. Two first uses that
+      # race with different loggers would have the reserving one block in a
+      # broken logger while the contender — holding a logger that works — saw
+      # the slot taken and gave up, and the reservation's later failure then
+      # left the notice owed to a use that may never come. So a caller that
+      # meets a reservation waits for its outcome, and takes the notice over
+      # if that outcome is a failure. The wait is bounded by
+      # {PENDING_WAIT_SECONDS}: a notice never holds up the deprecated
+      # operation, so a reservation that hangs costs the contender the notice,
+      # not its progress.
+      # @param feature [Symbol] a {REGISTRY} key
+      # @return [Boolean] whether this caller may log the notice
+      def reserve(feature)
+        deadline = nil
+        @mutex.synchronize do
+          loop do
+            case notice_states[feature]
+            when :emitted
+              return false
+            when :pending
+              deadline ||= monotonic_time + PENDING_WAIT_SECONDS
+              remaining = deadline - monotonic_time
+              return false if remaining <= 0
+
+              @resolved.wait(@mutex, remaining)
+            else
+              notice_states[feature] = :pending
+              return true
+            end
+          end
+        end
+      end
+
+      # Record how a reservation ended and wake whoever is waiting on it.
+      # @param feature [Symbol] a {REGISTRY} key
+      # @param state [Symbol, nil] `:emitted`, or nil to release the
+      #   reservation so a contender or a later use can retry it
+      # @return [void]
+      def settle(feature, state)
+        @mutex.synchronize do
+          states = notice_states
+          state ? states[feature] = state : states.delete(feature)
+          @resolved.broadcast
+        end
+      end
+
+      # @return [Float] a clock that cannot jump backwards
+      def monotonic_time
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      # What each feature's notice has reached IN THIS PROCESS: `:pending`
+      # while a caller is inside `logger.warn` for it, `:emitted` once one
+      # went out, absent otherwise. A prefork server (Puma, Unicorn) that
+      # warns while preloading would hand every worker an already-spent map
+      # and silence the worker's own first use, so an inherited map is
+      # dropped the first time the owning PID no longer matches. Callers hold
+      # @mutex.
+      # @return [Hash{Symbol => Symbol}]
+      def notice_states
         if @owner_pid != Process.pid
           @owner_pid = Process.pid
-          @emitted = Set.new
+          @notices = {}
         end
-        @emitted
+        @notices
       end
 
       # Whether the logger would keep a warning. Asking is itself protected:

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -7,52 +7,62 @@ module MCPClient
   # 2026-07-28 deprecated features registry (feature lifecycle policy,
   # SEP-2596): they keep working during their deprecation window, but new
   # integrations should not adopt them. The earliest removal of each feature
-  # is set by the registry (https://modelcontextprotocol.io/specification/2026-07-28/deprecated);
-  # the HTTP+SSE transport and the includeContext values were deprecated by
-  # earlier revisions and may go sooner than the features 2026-07-28 itself
-  # deprecates. The client logs one notice per feature per process, on the
-  # first use, and names the suggested migration.
+  # is set by the registry (https://modelcontextprotocol.io/specification/2026-07-28/deprecated)
+  # and recorded in `earliest_removal`. Only the HTTP+SSE transport may go
+  # sooner than the features 2026-07-28 itself deprecates: the includeContext
+  # values were deprecated by an earlier revision, but SEP-2596's transition
+  # provision ties them to Sampling, so they share the same window as Roots,
+  # Sampling and Logging. The client logs one notice per feature per process,
+  # on the first use, and names the suggested migration.
   #
   # Notices can be silenced with `MCPClient::Deprecations.enabled = false`.
   module Deprecations
     # Every feature the 2026-07-28 deprecated features registry lists, keyed
     # by the identifier passed to {.warn}. `since` is the protocol revision
-    # in which the feature entered the Deprecated state.
+    # in which the feature entered the Deprecated state; `earliest_removal`
+    # is the soonest the registry allows it to go, and features that share a
+    # window carry the identical string.
     REGISTRY = {
       roots: {
         feature: 'Roots',
         since: '2026-07-28',
         reference: 'SEP-2577',
+        earliest_removal: 'no earlier than twelve months after 2026-07-28',
         migration: 'pass directories or files through tool parameters, resource URIs or server configuration'
       },
       sampling: {
         feature: 'Sampling',
         since: '2026-07-28',
         reference: 'SEP-2577',
+        earliest_removal: 'no earlier than twelve months after 2026-07-28',
         migration: 'integrate directly with the LLM provider API instead of serving sampling/createMessage'
       },
       logging: {
         feature: 'Logging',
         since: '2026-07-28',
         reference: 'SEP-2577',
+        earliest_removal: 'no earlier than twelve months after 2026-07-28',
         migration: 'have the server log to stderr (stdio) or use OpenTelemetry instead of notifications/message'
       },
       http_sse_transport: {
         feature: 'The HTTP+SSE transport',
         since: '2025-03-26',
-        reference: 'reclassified by SEP-2596 in 2026-07-28; earliest removal three months after SEP-2596 is Final',
+        reference: 'reclassified by SEP-2596 in 2026-07-28',
+        earliest_removal: 'no earlier than three months after SEP-2596 is Final',
         migration: 'migrate the server to Streamable HTTP (MCPClient::ServerStreamableHTTP)'
       },
       include_context: {
         feature: 'The includeContext values "thisServer" and "allServers"',
         since: '2025-11-25',
         reference: 'reclassified by SEP-2596 in 2026-07-28',
+        earliest_removal: 'no earlier than twelve months after 2026-07-28',
         migration: 'servers should omit includeContext or send "none"; the values are removed no later than Sampling'
       },
       dynamic_client_registration: {
         feature: 'OAuth 2.0 Dynamic Client Registration (RFC 7591)',
         since: '2026-07-28',
         reference: 'MCP PR #2858',
+        earliest_removal: 'no earlier than twelve months after 2026-07-28',
         migration: 'prefer a Client ID Metadata Document (client_id_metadata_url) or pre-registered credentials'
       }
     }.freeze
@@ -75,10 +85,11 @@ module MCPClient
 
       # Log the notice for a deprecated feature once per process. The notice
       # counts as emitted only once the logger accepted it: a logger that
-      # drops warnings (level above WARN) or raises leaves it for a later
-      # use. Never raises for a logger failure: the deprecated feature keeps
-      # working whatever the log does (feature lifecycle policy). The slot is
-      # reserved under the lock and the logger is called outside it.
+      # drops warnings (level above WARN), fails to report its level or
+      # raises leaves it for a later use. Never raises for a logger failure:
+      # the deprecated feature keeps working whatever the log does (feature
+      # lifecycle policy). The slot is reserved under the lock and the logger
+      # is called outside it.
       # @param feature [Symbol] a {REGISTRY} key
       # @param logger [Logger, nil] where the notice goes (a nil logger emits nothing)
       # @param detail [String, nil] peer-supplied context quoted in the notice
@@ -89,7 +100,7 @@ module MCPClient
       def warn(feature, logger, detail: nil)
         entry = REGISTRY[feature] or raise ArgumentError, "unknown deprecated feature: #{feature.inspect}"
         return false unless enabled? && logger
-        return false if logger.is_a?(::Logger) && logger.level > ::Logger::WARN
+        return false unless accepts_warnings?(logger)
         return false unless @mutex.synchronize { @emitted.add?(feature) }
 
         begin
@@ -115,6 +126,18 @@ module MCPClient
       end
 
       private
+
+      # Whether the logger would keep a warning. Asking is itself protected:
+      # a Logger subclass whose `level` accessor raises must not abort the
+      # deprecated operation, so the failure is treated as "would not keep
+      # it" and the notice slot stays free for a later, working logger.
+      # @param logger [Logger, #warn] the candidate logger
+      # @return [Boolean] false when the logger drops warnings or asking failed
+      def accepts_warnings?(logger)
+        !(logger.is_a?(::Logger) && logger.level > ::Logger::WARN)
+      rescue StandardError
+        false
+      end
 
       # @return [String] the notice text
       def message(entry, detail)

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -79,6 +79,11 @@ module MCPClient
     # Longest peer-supplied detail quoted in a notice.
     MAX_DETAIL_LENGTH = 200
 
+    # How many wrappers deep the logger the host passed is looked through
+    # (see {.underlying_logger}). One or two is what a host actually builds;
+    # the bound is only there so a delegator that holds itself cannot spin.
+    MAX_UNWRAP_DEPTH = 8
+
     # Marks a thread that is inside a notice: from the moment it first asks
     # the logger anything until it comes back out of the write. It covers
     # the level probe as well as the write, because both are host code and
@@ -110,7 +115,8 @@ module MCPClient
 
       # Log the notice for a deprecated feature once per process. The notice
       # counts as emitted only once the logger accepted it: a logger that
-      # drops warnings (level above WARN), writes nowhere (`Logger.new(nil)`,
+      # drops warnings (its own level above WARN, or that of a logger it
+      # wraps), writes nowhere (`Logger.new(nil)`, a wrapper around one,
       # or a device that was closed), fails to report its level or raises
       # leaves it for a later use, and so do a nested attempt from inside
       # another notice's logger — its `level` accessor as much as its `warn`
@@ -305,11 +311,37 @@ module MCPClient
       # @param logger [Logger, #warn] the candidate logger
       # @return [Boolean] false when the logger drops warnings or asking failed
       def accepts_warnings?(logger)
-        return false if logger.is_a?(::Logger) && logger.level > ::Logger::WARN
+        return false if drops_warnings?(logger)
 
         !no_output_device?(logger)
       rescue StandardError
         false
+      end
+
+      # Whether the logger says it would drop a WARN record.
+      #
+      # A host's logger is rarely a bare ::Logger: Rails hands out a tagged
+      # or a broadcast logger, and an application that routes its own
+      # deprecation output wraps one itself. Every such wrapper answers
+      # `warn` without writing when the logger underneath is above WARN, so
+      # reading `level` off a ::Logger and nothing else spends the process's
+      # one notice on a line nobody can read — and silences the host's own
+      # working logger for good, since the slot is then marked emitted.
+      # `warn?` is the same question in the form a wrapper forwards, and it
+      # is asked only of an object that offers it: a minimal host logger
+      # implementing `warn` and nothing else is still taken at its word.
+      #
+      # A wrapper that filters on something a level cannot express — a tag,
+      # a source allow-list — cannot be asked at all, and does spend the
+      # notice. That is the boundary of what this can promise; what it may
+      # not do is fail the deprecated operation trying to establish more
+      # (see {.accepts_warnings?}).
+      # @param logger [Logger, #warn] the candidate logger
+      # @return [Boolean] whether a warning written now would be dropped
+      def drops_warnings?(logger)
+        return !logger.warn? if logger.respond_to?(:warn?)
+
+        logger.is_a?(::Logger) && logger.level > ::Logger::WARN
       end
 
       # `Logger.new(nil)` is the documented no-output logger: it keeps every
@@ -332,6 +364,7 @@ module MCPClient
       # @param logger [Logger, #warn] the candidate logger
       # @return [Boolean] whether the logger provably writes nowhere
       def no_output_device?(logger)
+        logger = underlying_logger(logger)
         return false unless logger.is_a?(::Logger) && logger.instance_variable_defined?(:@logdev)
 
         logdev = logger.instance_variable_get(:@logdev)
@@ -345,6 +378,23 @@ module MCPClient
         # unknown device as dead would suppress every notice a host with a
         # custom log device should see.
         device.respond_to?(:closed?) && device.closed?
+      end
+
+      # The logger under whatever the host wrapped it in. A Delegator
+      # forwards `warn` and `warn?` to the logger it holds, but not the
+      # question above: `instance_variable_defined?` is Object's own method
+      # and answers for the WRAPPER, so a wrapped `Logger.new(nil)` would
+      # read as some unknown logger that writes somewhere and spend the
+      # notice on a device that does not exist.
+      # @param logger [Logger, #warn] the logger the host passed
+      # @return [Object] the logger that would take the write
+      def underlying_logger(logger)
+        MAX_UNWRAP_DEPTH.times do
+          break unless defined?(::Delegator) && logger.is_a?(::Delegator)
+
+          logger = logger.__getobj__
+        end
+        logger
       end
 
       # @return [String] the notice text

--- a/lib/mcp_client/deprecations.rb
+++ b/lib/mcp_client/deprecations.rb
@@ -376,7 +376,10 @@ module MCPClient
         # A device that cannot say whether it is closed is taken as open: a
         # notice written to a working stream is the point, and treating an
         # unknown device as dead would suppress every notice a host with a
-        # custom log device should see.
+        # custom log device should see. An OPEN device that fails to write is
+        # the one failure this cannot see: ::Logger's device rescues it and
+        # reports on $stderr only, returning as if it had written, so such a
+        # notice is spent (the documented boundary of the retry guarantee).
         device.respond_to?(:closed?) && device.closed?
       end
 

--- a/lib/mcp_client/input_round_trips.rb
+++ b/lib/mcp_client/input_round_trips.rb
@@ -76,6 +76,10 @@ module MCPClient
         )
       end
 
+      # The handler this reaches is the same callback a legacy
+      # server-initiated request would have used, so Roots and Sampling are
+      # just as deprecated here (SEP-2577).
+      warn_input_request_deprecated(request_method, request['params'])
       begin
         response = instance_variable_get(handler_ivar).call(key, request['params'] || {})
       rescue StandardError => e

--- a/lib/mcp_client/input_round_trips.rb
+++ b/lib/mcp_client/input_round_trips.rb
@@ -102,6 +102,7 @@ module MCPClient
         )
       end
 
+      warn_input_request_answer_deprecated(request_method, response)
       response
     end
 

--- a/lib/mcp_client/input_round_trips.rb
+++ b/lib/mcp_client/input_round_trips.rb
@@ -69,6 +69,14 @@ module MCPClient
         )
       end
 
+      # The handler this reaches is the same callback a legacy
+      # server-initiated request would have used, so Roots and Sampling are
+      # just as deprecated here (SEP-2577). The notice precedes the
+      # sampling.tools refusal below, as it precedes the handler's own
+      # -32602 on the server-initiated path: the deprecated values were on
+      # the wire and a host with a handler asked for them, whichever
+      # sub-capability the request then trips over.
+      warn_input_request_deprecated(request_method, request['params'])
       if undeclared_sampling_tool_use?(request_method, request['params'])
         raise MCPClient::Errors::InputRequiredError.new(
           "Server requested tool-enabled #{shown_method} (key #{shown_key}) but the sampling.tools " \
@@ -76,10 +84,6 @@ module MCPClient
         )
       end
 
-      # The handler this reaches is the same callback a legacy
-      # server-initiated request would have used, so Roots and Sampling are
-      # just as deprecated here (SEP-2577).
-      warn_input_request_deprecated(request_method, request['params'])
       begin
         response = instance_variable_get(handler_ivar).call(key, request['params'] || {})
       rescue StandardError => e

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -815,7 +815,14 @@ module MCPClient
     def refused_undeclared_sampling_tools?(request_id, params)
       return false unless undeclared_sampling_tool_use?('sampling/createMessage', params)
 
-      @logger.warn('Rejecting tool-enabled sampling request: sampling.tools capability not declared')
+      # The line is a courtesy to the host; the refusal is the answer the peer
+      # is owed. A logger that fails here must not turn Invalid params into
+      # the dispatcher's Internal error.
+      begin
+        @logger.warn('Rejecting tool-enabled sampling request: sampling.tools capability not declared')
+      rescue StandardError
+        nil
+      end
       send_error_response(request_id, -32_602,
                           'Invalid params: tools/toolChoice provided but the sampling.tools ' \
                           'capability was not declared')

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -803,6 +803,25 @@ module MCPClient
       instance_variable_defined?(:@sampling_tools_supported) && @sampling_tools_supported
     end
 
+    # SEP-1577 (schema.ts CreateMessageRequestParams.tools/.toolChoice): "The
+    # client MUST return an error if this field is provided but
+    # ClientCapabilities.sampling.tools is not declared." The 2025-11-25
+    # server-initiated path refuses here, before any handler sees the request,
+    # with the Invalid params code sampling.mdx § Error Handling uses; the
+    # multi round-trip path refuses the same way in InputRoundTrips.
+    # @param request_id [String, Integer] the JSON-RPC request ID
+    # @param params [Hash] the sampling/createMessage params
+    # @return [Boolean] true when the request was refused (and answered)
+    def refused_undeclared_sampling_tools?(request_id, params)
+      return false unless undeclared_sampling_tool_use?('sampling/createMessage', params)
+
+      @logger.warn('Rejecting tool-enabled sampling request: sampling.tools capability not declared')
+      send_error_response(request_id, -32_602,
+                          'Invalid params: tools/toolChoice provided but the sampling.tools ' \
+                          'capability was not declared')
+      true
+    end
+
     # Result types defined by the core protocol (basic/index.mdx "ResultType").
     # Extensions add more (e.g. "task"); the accepted set widens with the
     # declared extensions this client implements (#accepted_result_types).

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -6,6 +6,7 @@ require 'json'
 require 'zlib'
 require 'stringio'
 require_relative 'deep_copy'
+require_relative 'deprecation_notices'
 require_relative 'header_params'
 require_relative 'json_rpc_common/envelopes'
 require_relative 'json_rpc_common/error_bodies'
@@ -26,6 +27,7 @@ module MCPClient
     include InputWaits
     include RoundTripMarker
     include ResultCompleteness
+    include DeprecationNotices
     include SubscriptionSupport
     include InputRoundTrips
     include ResultCaching

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -780,6 +780,13 @@ module MCPClient
     # before connect so the initialize request advertises it; it only takes
     # effect when a sampling request callback is also registered, since
     # sampling.tools is a sub-capability of sampling.
+    #
+    # @deprecated Sampling is deprecated since MCP 2026-07-28 (SEP-2577);
+    #   earliest removal is the first revision released on or after
+    #   2027-07-28, and this sub-capability goes with the capability it
+    #   refines. Declaring it raises no notice of its own — serving a
+    #   sampling/createMessage request does. Integrate directly with the LLM
+    #   provider API instead.
     # @return [void]
     def declare_sampling_tools
       @sampling_tools_supported = true

--- a/lib/mcp_client/json_rpc_common.rb
+++ b/lib/mcp_client/json_rpc_common.rb
@@ -426,7 +426,12 @@ module MCPClient
     def with_request_meta(params, claim: :none)
       params = merge_meta_spellings(params)
       defaults = host_request_meta(claim)
-      return params if defaults.empty? && !modern? && !reserved_meta_supplied?(params)
+      if defaults.empty? && !modern? && !reserved_meta_supplied?(params)
+        # Legacy traffic is passed through untouched — a `_meta` the caller
+        # supplied goes out as it stands, unless it names a transport-owned key.
+        warn_request_log_level_deprecated(params.is_a?(Hash) ? (params['_meta'] || params[:_meta]) : nil)
+        return params
+      end
 
       params = params.is_a?(Hash) ? params.dup : {}
       supplied = params.delete('_meta')
@@ -453,6 +458,7 @@ module MCPClient
       # server/utilities/caching: a result is bound to the parameters of the
       # request that produced it).
       params['_meta'] = MCPClient::DeepCopy.copy(meta)
+      warn_request_log_level_deprecated(meta)
       params
     end
 

--- a/lib/mcp_client/root.rb
+++ b/lib/mcp_client/root.rb
@@ -5,6 +5,12 @@ require 'uri'
 module MCPClient
   # Represents an MCP Root - a URI that defines a boundary where servers can operate
   # Roots are declared by clients to inform servers about relevant resources and their locations
+  #
+  # @deprecated Roots is deprecated since MCP 2026-07-28 (SEP-2577); earliest
+  #   removal is the first revision released on or after 2027-07-28. The class
+  #   keeps working for as long as the feature does, and building one raises no
+  #   notice — using the list does. Pass directories or files through tool
+  #   parameters, resource URIs or server configuration instead.
   class Root
     attr_reader :uri, :name, :meta
 

--- a/lib/mcp_client/server_base.rb
+++ b/lib/mcp_client/server_base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'deprecations'
+
 module MCPClient
   # Base class for MCP servers - serves as the interface for different server implementations
   class ServerBase

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -22,9 +22,7 @@ module MCPClient
   #   `ping` gets the empty result it requires). For elicitation support, use
   #   one of these transports instead:
   #   - ServerStdio: Full bidirectional JSON-RPC over stdin/stdout
-  #   - ServerSSE: Server requests via SSE stream, client responses via HTTP POST
   #   - ServerStreamableHTTP: Server requests via SSE-formatted responses, client responses via HTTP POST
-  #   - ServerStdio: Full bidirectional JSON-RPC over stdin/stdout
   #   - ServerSSE: Server requests via SSE stream, client responses via HTTP POST — but the
   #     HTTP+SSE transport is deprecated (SEP-2596; earliest removal three months after
   #     SEP-2596 reaches Final), so prefer ServerStreamableHTTP for a new integration

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -24,6 +24,10 @@ module MCPClient
   #   - ServerStdio: Full bidirectional JSON-RPC over stdin/stdout
   #   - ServerSSE: Server requests via SSE stream, client responses via HTTP POST
   #   - ServerStreamableHTTP: Server requests via SSE-formatted responses, client responses via HTTP POST
+  #   - ServerStdio: Full bidirectional JSON-RPC over stdin/stdout
+  #   - ServerSSE: Server requests via SSE stream, client responses via HTTP POST — but the
+  #     HTTP+SSE transport is deprecated (SEP-2596; earliest removal three months after
+  #     SEP-2596 reaches Final), so prefer ServerStreamableHTTP for a new integration
   class ServerHTTP < ServerBase
     require_relative 'server_http/json_rpc_transport'
 

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -424,6 +424,7 @@ module MCPClient
     # @return [Hash] empty result on success
     # @raise [MCPClient::Errors::ServerError] if server returns an error
     def log_level=(level)
+      MCPClient::Deprecations.warn(:logging, @logger)
       ensure_connected
       # MCP 2026-07-28 removed logging/setLevel: the level travels per request
       # in _meta["io.modelcontextprotocol/logLevel"].

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -423,8 +423,10 @@ module MCPClient
     #   'critical', 'alert', 'emergency')
     # @return [Hash] empty result on success
     # @raise [MCPClient::Errors::ServerError] if server returns an error
-    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577); have
-    #   the server log to stderr (stdio) or use OpenTelemetry instead.
+    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577);
+    #   earliest removal is the first revision released on or after
+    #   2027-07-28. Have the server log to stderr (stdio) or use
+    #   OpenTelemetry instead.
     def log_level=(level)
       MCPClient::Deprecations.warn(:logging, @logger)
       ensure_connected

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -569,6 +569,13 @@ module MCPClient
     end
 
     # Register a handler for roots/list input requests (MCP 2026-07-28).
+    #
+    # @deprecated Roots is deprecated since MCP 2026-07-28 (SEP-2577); earliest
+    #   removal is the first revision released on or after 2027-07-28. Registering
+    #   a handler is not itself use of Roots — a handler that answers with no root
+    #   exposes nothing deprecated — but a handler that answers with a root adopts
+    #   the deprecated feature and raises the notice. Pass directories or files
+    #   through tool parameters, resource URIs or server configuration instead.
     # @param block [Proc] callback that receives (key, params) and returns a ListRootsResult
     # @return [void]
     def on_roots_list_request(&block)
@@ -576,6 +583,11 @@ module MCPClient
     end
 
     # Register a handler for sampling input requests (MCP 2026-07-28).
+    #
+    # @deprecated Sampling is deprecated since MCP 2026-07-28 (SEP-2577); earliest
+    #   removal is the first revision released on or after 2027-07-28. Integrate
+    #   directly with the LLM provider API instead of serving
+    #   sampling/createMessage.
     # @param block [Proc] callback that receives (key, params) and returns a CreateMessageResult
     # @return [void]
     def on_sampling_request(&block)

--- a/lib/mcp_client/server_http.rb
+++ b/lib/mcp_client/server_http.rb
@@ -423,6 +423,8 @@ module MCPClient
     #   'critical', 'alert', 'emergency')
     # @return [Hash] empty result on success
     # @raise [MCPClient::Errors::ServerError] if server returns an error
+    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577); have
+    #   the server log to stderr (stdio) or use OpenTelemetry instead.
     def log_level=(level)
       MCPClient::Deprecations.warn(:logging, @logger)
       ensure_connected

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -8,6 +8,7 @@ require 'logger'
 require 'faraday'
 require 'faraday/retry'
 require 'faraday/follow_redirects'
+require_relative 'deprecations'
 
 module MCPClient
   # Implementation of MCP server that communicates via Server-Sent Events (SSE)

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -87,6 +87,7 @@ module MCPClient
                    retries: 0, retry_backoff: 1, name: nil, logger: nil)
       super(name: name)
       initialize_logger(logger)
+      MCPClient::Deprecations.warn(:http_sse_transport, @logger)
       @max_retries = retries
       @retry_backoff = retry_backoff
       # Normalize base_url: preserve trailing slash if explicitly provided for SSE endpoints

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -16,8 +16,8 @@ module MCPClient
   #
   # @deprecated The HTTP+SSE transport has been deprecated since MCP
   #   2025-03-26 and is listed in the 2026-07-28 deprecated features
-  #   registry (SEP-2596; earliest removal three months after SEP-2596 is
-  #   Final). Use {MCPClient::ServerStreamableHTTP}.
+  #   registry (SEP-2596); earliest removal is three months after SEP-2596
+  #   reaches Final. Use {MCPClient::ServerStreamableHTTP}.
   #
   # @note Elicitation Support (MCP 2025-06-18)
   #   This transport FULLY supports server-initiated elicitation requests via bidirectional
@@ -437,8 +437,10 @@ module MCPClient
     #   'critical', 'alert', 'emergency')
     # @return [Hash] empty result on success
     # @raise [MCPClient::Errors::ServerError] if server returns an error
-    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577); have
-    #   the server log to stderr (stdio) or use OpenTelemetry instead.
+    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577);
+    #   earliest removal is the first revision released on or after
+    #   2027-07-28. Have the server log to stderr (stdio) or use
+    #   OpenTelemetry instead.
     def log_level=(level)
       MCPClient::Deprecations.warn(:logging, @logger)
       ensure_initialized
@@ -461,7 +463,15 @@ module MCPClient
     # @return [Boolean] true if connection was successful
     # @raise [MCPClient::Errors::ConnectionError] if connection fails
     def connect
-      return true if @mutex.synchronize { @connection_established }
+      # An already-established connection is another use of the transport,
+      # and another chance at the notice: the first connect may have found
+      # notices disabled, a logger above WARN or a logger that raised, all of
+      # which leave the slot unspent. A long-lived connection would otherwise
+      # never retry it.
+      if @mutex.synchronize { @connection_established }
+        MCPClient::Deprecations.warn(:http_sse_transport, @logger)
+        return true
+      end
 
       # Check for pre-existing auth error (needed for tests)
       pre_existing_auth_error = @mutex.synchronize { @auth_error }
@@ -723,6 +733,9 @@ module MCPClient
         return
       end
 
+      # Serving roots/list means this transport declared, and is using, the
+      # deprecated Roots capability (SEP-2577) — with or without a Client.
+      warn_roots_deprecated
       # Call the registered callback
       result = @roots_list_request_callback.call(request_id, params)
 
@@ -761,6 +774,9 @@ module MCPClient
         return
       end
 
+      # Sampling, and the includeContext values it may carry, are deprecated
+      # (SEP-2577, SEP-2596) — with or without a Client.
+      warn_sampling_deprecated(params)
       # Call the registered callback
       result = @sampling_request_callback.call(request_id, params)
 

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -783,13 +783,18 @@ module MCPClient
       # If no callback is registered, return error
       unless @sampling_request_callback
         @logger.warn('Received sampling request but no callback registered, returning error')
-        send_error_response(request_id, -1, 'Sampling not supported')
+        # sampling.mdx § Error Handling reserves -1 for "User rejected sampling
+        # request"; a capability this client never declared is an unsupported
+        # method (-32601, Method not found), as Client#handle_sampling_request answers.
+        send_error_response(request_id, -32_601, 'Sampling not supported')
         return
       end
 
       # Sampling, and the includeContext values it may carry, are deprecated
       # (SEP-2577, SEP-2596) — with or without a Client.
       warn_sampling_deprecated(params)
+      return if refused_undeclared_sampling_tools?(request_id, params)
+
       # Call the registered callback
       result = @sampling_request_callback.call(request_id, params)
 

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -14,6 +14,11 @@ module MCPClient
   # Implementation of MCP server that communicates via Server-Sent Events (SSE)
   # Useful for communicating with remote MCP servers over HTTP
   #
+  # @deprecated The HTTP+SSE transport has been deprecated since MCP
+  #   2025-03-26 and is listed in the 2026-07-28 deprecated features
+  #   registry (SEP-2596; earliest removal three months after SEP-2596 is
+  #   Final). Use {MCPClient::ServerStreamableHTTP}.
+  #
   # @note Elicitation Support (MCP 2025-06-18)
   #   This transport FULLY supports server-initiated elicitation requests via bidirectional
   #   JSON-RPC. The server sends elicitation/create requests via the SSE stream, and the
@@ -88,7 +93,6 @@ module MCPClient
                    retries: 0, retry_backoff: 1, name: nil, logger: nil)
       super(name: name)
       initialize_logger(logger)
-      MCPClient::Deprecations.warn(:http_sse_transport, @logger)
       @max_retries = retries
       @retry_backoff = retry_backoff
       # Normalize base_url: preserve trailing slash if explicitly provided for SSE endpoints
@@ -434,6 +438,7 @@ module MCPClient
     # @return [Hash] empty result on success
     # @raise [MCPClient::Errors::ServerError] if server returns an error
     def log_level=(level)
+      MCPClient::Deprecations.warn(:logging, @logger)
       ensure_initialized
       require_capability!('logging', method: 'logging/setLevel')
       rpc_request('logging/setLevel', { level: level })
@@ -469,6 +474,10 @@ module MCPClient
         effective_timeout = [@read_timeout || 30, 30].min
         wait_for_connection(timeout: effective_timeout)
         start_activity_monitor
+        # The notice is about using the transport: MCPClient.connect builds
+        # (and tries) an SSE server while probing a URL that may end up on
+        # another transport, so only an established connection counts.
+        MCPClient::Deprecations.warn(:http_sse_transport, @logger)
         true
       rescue MCPClient::Errors::ConnectionError => e
         cleanup

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -642,6 +642,13 @@ module MCPClient
     end
 
     # Register a callback for roots/list requests (MCP 2025-06-18)
+    #
+    # @deprecated Roots is deprecated since MCP 2026-07-28 (SEP-2577); earliest
+    #   removal is the first revision released on or after 2027-07-28. Registering
+    #   a handler is not itself use of Roots — a handler that answers with no root
+    #   exposes nothing deprecated — but a handler that answers with a root adopts
+    #   the deprecated feature and raises the notice. Pass directories or files
+    #   through tool parameters, resource URIs or server configuration instead.
     # @param block [Proc] callback that receives (request_id, params) and returns response hash
     # @return [void]
     def on_roots_list_request(&block)
@@ -649,6 +656,11 @@ module MCPClient
     end
 
     # Register a callback for sampling requests (MCP 2025-11-25)
+    #
+    # @deprecated Sampling is deprecated since MCP 2026-07-28 (SEP-2577); earliest
+    #   removal is the first revision released on or after 2027-07-28. Integrate
+    #   directly with the LLM provider API instead of serving
+    #   sampling/createMessage.
     # @param block [Proc] callback that receives (request_id, params) and returns response hash
     # @return [void]
     def on_sampling_request(&block)

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -437,6 +437,8 @@ module MCPClient
     #   'critical', 'alert', 'emergency')
     # @return [Hash] empty result on success
     # @raise [MCPClient::Errors::ServerError] if server returns an error
+    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577); have
+    #   the server log to stderr (stdio) or use OpenTelemetry instead.
     def log_level=(level)
       MCPClient::Deprecations.warn(:logging, @logger)
       ensure_initialized

--- a/lib/mcp_client/server_sse.rb
+++ b/lib/mcp_client/server_sse.rb
@@ -733,11 +733,12 @@ module MCPClient
         return
       end
 
-      # Serving roots/list means this transport declared, and is using, the
-      # deprecated Roots capability (SEP-2577) — with or without a Client.
-      warn_roots_deprecated
       # Call the registered callback
       result = @roots_list_request_callback.call(request_id, params)
+      # Serving a roots/list answer that carries a root means this host
+      # declared, and is using, the deprecated Roots capability (SEP-2577) —
+      # with or without a Client. An empty answer is not use of it.
+      warn_roots_deprecated(result)
 
       # Send the response back to the server (echoing related-task _meta)
       send_roots_list_response(request_id, merge_related_task_meta(result, params))

--- a/lib/mcp_client/server_sse/sse_parser.rb
+++ b/lib/mcp_client/server_sse/sse_parser.rb
@@ -90,6 +90,14 @@ module MCPClient
       def process_notification?(data)
         return false unless data['method'] && !data.key?('id')
 
+        # notifications/message is the Logging utility, Deprecated as a whole
+        # in 2026-07-28 (SEP-2577). The notice belongs to the transport, not
+        # to MCPClient::Client: a host that registered on_notification on a
+        # ServerSSE receives log messages without a Client ever existing. It
+        # is raised here rather than only in
+        # {MCPClient::SubscriptionSupport#route_notification} because this
+        # transport is the one that does not go through it — see below.
+        warn_logging_deprecated if data['method'] == 'notifications/message'
         # The legacy SSE transport carries no subscriptions/listen stream, so
         # there is no delivery to run ahead of — but the transport's own caches
         # and a host that registered its invalidation on the dedicated hook

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -750,6 +750,8 @@ module MCPClient
     #   'critical', 'alert', 'emergency')
     # @return [Hash] empty result on success
     # @raise [MCPClient::Errors::ServerError] if server returns an error
+    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577); have
+    #   the server log to stderr (stdio) or use OpenTelemetry instead.
     def log_level=(level)
       MCPClient::Deprecations.warn(:logging, @logger)
       ensure_initialized

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -751,6 +751,7 @@ module MCPClient
     # @return [Hash] empty result on success
     # @raise [MCPClient::Errors::ServerError] if server returns an error
     def log_level=(level)
+      MCPClient::Deprecations.warn(:logging, @logger)
       ensure_initialized
       # MCP 2026-07-28 removed logging/setLevel: the level is declared per
       # request in _meta["io.modelcontextprotocol/logLevel"], so store it

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -876,11 +876,12 @@ module MCPClient
         return
       end
 
-      # Serving roots/list means this transport declared, and is using, the
-      # deprecated Roots capability (SEP-2577) — with or without a Client.
-      warn_roots_deprecated
       # Call the registered callback
       result = @roots_list_request_callback.call(request_id, params)
+      # Serving a roots/list answer that carries a root means this host
+      # declared, and is using, the deprecated Roots capability (SEP-2577) —
+      # with or without a Client. An empty answer is not use of it.
+      warn_roots_deprecated(result)
 
       # Send the response back to the server (echoing related-task _meta)
       send_roots_list_response(request_id, merge_related_task_meta(result, params))

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -907,13 +907,18 @@ module MCPClient
       # If no callback is registered, return error
       unless @sampling_request_callback
         @logger.warn('Received sampling request but no callback registered, returning error')
-        send_error_response(request_id, -1, 'Sampling not supported')
+        # sampling.mdx § Error Handling reserves -1 for "User rejected sampling
+        # request"; a capability this client never declared is an unsupported
+        # method (-32601, Method not found), as Client#handle_sampling_request answers.
+        send_error_response(request_id, -32_601, 'Sampling not supported')
         return
       end
 
       # Sampling, and the includeContext values it may carry, are deprecated
       # (SEP-2577, SEP-2596) — with or without a Client.
       warn_sampling_deprecated(params)
+      return if refused_undeclared_sampling_tools?(request_id, params)
+
       # Call the registered callback
       result = @sampling_request_callback.call(request_id, params)
 

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -787,6 +787,13 @@ module MCPClient
     end
 
     # Register a callback for roots/list requests (MCP 2025-06-18)
+    #
+    # @deprecated Roots is deprecated since MCP 2026-07-28 (SEP-2577); earliest
+    #   removal is the first revision released on or after 2027-07-28. Registering
+    #   a handler is not itself use of Roots — a handler that answers with no root
+    #   exposes nothing deprecated — but a handler that answers with a root adopts
+    #   the deprecated feature and raises the notice. Pass directories or files
+    #   through tool parameters, resource URIs or server configuration instead.
     # @param block [Proc] callback that receives (request_id, params) and returns response hash
     # @return [void]
     def on_roots_list_request(&block)
@@ -794,6 +801,11 @@ module MCPClient
     end
 
     # Register a callback for sampling requests (MCP 2025-11-25)
+    #
+    # @deprecated Sampling is deprecated since MCP 2026-07-28 (SEP-2577); earliest
+    #   removal is the first revision released on or after 2027-07-28. Integrate
+    #   directly with the LLM provider API instead of serving
+    #   sampling/createMessage.
     # @param block [Proc] callback that receives (request_id, params) and returns response hash
     # @return [void]
     def on_sampling_request(&block)

--- a/lib/mcp_client/server_stdio.rb
+++ b/lib/mcp_client/server_stdio.rb
@@ -750,8 +750,10 @@ module MCPClient
     #   'critical', 'alert', 'emergency')
     # @return [Hash] empty result on success
     # @raise [MCPClient::Errors::ServerError] if server returns an error
-    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577); have
-    #   the server log to stderr (stdio) or use OpenTelemetry instead.
+    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577);
+    #   earliest removal is the first revision released on or after
+    #   2027-07-28. Have the server log to stderr (stdio) or use
+    #   OpenTelemetry instead.
     def log_level=(level)
       MCPClient::Deprecations.warn(:logging, @logger)
       ensure_initialized
@@ -874,6 +876,9 @@ module MCPClient
         return
       end
 
+      # Serving roots/list means this transport declared, and is using, the
+      # deprecated Roots capability (SEP-2577) — with or without a Client.
+      warn_roots_deprecated
       # Call the registered callback
       result = @roots_list_request_callback.call(request_id, params)
 
@@ -893,6 +898,9 @@ module MCPClient
         return
       end
 
+      # Sampling, and the includeContext values it may carry, are deprecated
+      # (SEP-2577, SEP-2596) — with or without a Client.
+      warn_sampling_deprecated(params)
       # Call the registered callback
       result = @sampling_request_callback.call(request_id, params)
 

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -1395,13 +1395,18 @@ module MCPClient
       # If no callback is registered, return error
       unless @sampling_request_callback
         @logger.warn('Received sampling request but no callback registered, returning error')
-        send_error_response(request_id, -1, 'Sampling not supported')
+        # sampling.mdx § Error Handling reserves -1 for "User rejected sampling
+        # request"; a capability this client never declared is an unsupported
+        # method (-32601, Method not found), as Client#handle_sampling_request answers.
+        send_error_response(request_id, -32_601, 'Sampling not supported')
         return
       end
 
       # Sampling, and the includeContext values it may carry, are deprecated
       # (SEP-2577, SEP-2596) — with or without a Client.
       warn_sampling_deprecated(params)
+      return if refused_undeclared_sampling_tools?(request_id, params)
+
       # Call the registered callback
       result = @sampling_request_callback.call(request_id, params)
 

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -315,6 +315,7 @@ module MCPClient
     # @return [Hash] empty result on success
     # @raise [MCPClient::Errors::ServerError] if server returns an error
     def log_level=(level)
+      MCPClient::Deprecations.warn(:logging, @logger)
       ensure_connected
       # MCP 2026-07-28 removed logging/setLevel: the level travels per request
       # in _meta["io.modelcontextprotocol/logLevel"].

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -314,8 +314,10 @@ module MCPClient
     #   'critical', 'alert', 'emergency')
     # @return [Hash] empty result on success
     # @raise [MCPClient::Errors::ServerError] if server returns an error
-    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577); have
-    #   the server log to stderr (stdio) or use OpenTelemetry instead.
+    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577);
+    #   earliest removal is the first revision released on or after
+    #   2027-07-28. Have the server log to stderr (stdio) or use
+    #   OpenTelemetry instead.
     def log_level=(level)
       MCPClient::Deprecations.warn(:logging, @logger)
       ensure_connected
@@ -1362,6 +1364,9 @@ module MCPClient
         return
       end
 
+      # Serving roots/list means this transport declared, and is using, the
+      # deprecated Roots capability (SEP-2577) — with or without a Client.
+      warn_roots_deprecated
       # Call the registered callback
       result = @roots_list_request_callback.call(request_id, params)
 
@@ -1381,6 +1386,9 @@ module MCPClient
         return
       end
 
+      # Sampling, and the includeContext values it may carry, are deprecated
+      # (SEP-2577, SEP-2596) — with or without a Client.
+      warn_sampling_deprecated(params)
       # Call the registered callback
       result = @sampling_request_callback.call(request_id, params)
 

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -1364,11 +1364,12 @@ module MCPClient
         return
       end
 
-      # Serving roots/list means this transport declared, and is using, the
-      # deprecated Roots capability (SEP-2577) — with or without a Client.
-      warn_roots_deprecated
       # Call the registered callback
       result = @roots_list_request_callback.call(request_id, params)
+      # Serving a roots/list answer that carries a root means this host
+      # declared, and is using, the deprecated Roots capability (SEP-2577) —
+      # with or without a Client. An empty answer is not use of it.
+      warn_roots_deprecated(result)
 
       # Send the response back to the server (echoing related-task _meta)
       send_roots_list_response(request_id, merge_related_task_meta(result, params))

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -711,6 +711,13 @@ module MCPClient
     end
 
     # Register a callback for roots/list requests (MCP 2025-06-18)
+    #
+    # @deprecated Roots is deprecated since MCP 2026-07-28 (SEP-2577); earliest
+    #   removal is the first revision released on or after 2027-07-28. Registering
+    #   a handler is not itself use of Roots — a handler that answers with no root
+    #   exposes nothing deprecated — but a handler that answers with a root adopts
+    #   the deprecated feature and raises the notice. Pass directories or files
+    #   through tool parameters, resource URIs or server configuration instead.
     # @param block [Proc] callback that receives (request_id, params) and returns response hash
     # @return [void]
     def on_roots_list_request(&block)
@@ -718,6 +725,11 @@ module MCPClient
     end
 
     # Register a callback for sampling requests (MCP 2025-11-25)
+    #
+    # @deprecated Sampling is deprecated since MCP 2026-07-28 (SEP-2577); earliest
+    #   removal is the first revision released on or after 2027-07-28. Integrate
+    #   directly with the LLM provider API instead of serving
+    #   sampling/createMessage.
     # @param block [Proc] callback that receives (request_id, params) and returns response hash
     # @return [void]
     def on_sampling_request(&block)

--- a/lib/mcp_client/server_streamable_http.rb
+++ b/lib/mcp_client/server_streamable_http.rb
@@ -314,6 +314,8 @@ module MCPClient
     #   'critical', 'alert', 'emergency')
     # @return [Hash] empty result on success
     # @raise [MCPClient::Errors::ServerError] if server returns an error
+    # @deprecated Logging is deprecated since MCP 2026-07-28 (SEP-2577); have
+    #   the server log to stderr (stdio) or use OpenTelemetry instead.
     def log_level=(level)
       MCPClient::Deprecations.warn(:logging, @logger)
       ensure_connected

--- a/lib/mcp_client/subscription_support.rb
+++ b/lib/mcp_client/subscription_support.rb
@@ -271,6 +271,11 @@ module MCPClient
     # @return [void]
     def route_notification(method, params)
       handle_subscription_control(method, params)
+      # notifications/message is the Logging utility, Deprecated as a whole in
+      # 2026-07-28 (SEP-2577). The notice belongs here rather than in
+      # MCPClient::Client: a host that registered on_notification on the
+      # transport itself receives log messages without a Client ever existing.
+      warn_logging_deprecated if method == 'notifications/message'
       invalidate_cache_for_notification(method, params)
       # The host's caches go with the transport's, on their own hook rather
       # than on the host callback below: that callback is deliberately last —

--- a/spec/lib/mcp_client/authorization_2026_spec.rb
+++ b/spec/lib/mcp_client/authorization_2026_spec.rb
@@ -276,6 +276,8 @@ RSpec.describe 'MCP 2026-07-28 authorization' do
     end
 
     it 'registers a localhost redirect as a native application and warns that DCR is deprecated' do
+      MCPClient::Deprecations.enabled = true
+      MCPClient::Deprecations.reset!
       output = StringIO.new
       provider = provider_for(logger: Logger.new(output))
       stub_discovery(provider, as_meta(registration_endpoint: registration_endpoint))
@@ -284,7 +286,10 @@ RSpec.describe 'MCP 2026-07-28 authorization' do
       provider.start_authorization_flow
 
       expect(registration_bodies.first['application_type']).to eq('native')
-      expect(output.string).to match(/Dynamic Client Registration is deprecated/)
+      expect(output.string).to match(/Dynamic Client Registration .*deprecated/)
+    ensure
+      MCPClient::Deprecations.reset!
+      MCPClient::Deprecations.enabled = false
     end
 
     it 'registers a custom-scheme redirect as native and a remote https redirect as web' do

--- a/spec/lib/mcp_client/authorization_2026_spec.rb
+++ b/spec/lib/mcp_client/authorization_2026_spec.rb
@@ -275,21 +275,87 @@ RSpec.describe 'MCP 2026-07-28 authorization' do
       end
     end
 
-    it 'registers a localhost redirect as a native application and warns that DCR is deprecated' do
+    # The rest of the suite runs with notices off (spec_helper), because they
+    # are once per process and would make examples order-dependent; an example
+    # that wants one turns them on for its own duration.
+    def with_notices
       MCPClient::Deprecations.enabled = true
       MCPClient::Deprecations.reset!
-      output = StringIO.new
-      provider = provider_for(logger: Logger.new(output))
-      stub_discovery(provider, as_meta(registration_endpoint: registration_endpoint))
-      registered
-
-      provider.start_authorization_flow
-
-      expect(registration_bodies.first['application_type']).to eq('native')
-      expect(output.string).to match(/Dynamic Client Registration .*deprecated/)
+      yield
     ensure
       MCPClient::Deprecations.reset!
       MCPClient::Deprecations.enabled = false
+    end
+
+    it 'registers a localhost redirect as a native application and warns that DCR is deprecated' do
+      with_notices do
+        output = StringIO.new
+        provider = provider_for(logger: Logger.new(output))
+        stub_discovery(provider, as_meta(registration_endpoint: registration_endpoint))
+        registered
+
+        provider.start_authorization_flow
+
+        expect(registration_bodies.first['application_type']).to eq('native')
+        expect(output.string).to match(/Dynamic Client Registration .*deprecated/)
+      end
+    end
+
+    # What is deprecated is registering, not authorizing: the notice hangs on
+    # register_client and not on the priority order that reaches it, so a
+    # client that never registers is never told it uses a deprecated feature.
+    it 'stays silent for pre-registered credentials, which never register' do
+      with_notices do
+        output = StringIO.new
+        storage.set_client_info(server_url, client_info)
+        provider = provider_for(logger: Logger.new(output))
+        stub_discovery(provider, as_meta(registration_endpoint: registration_endpoint))
+        registration = stub_request(:post, registration_endpoint)
+
+        provider.start_authorization_flow
+
+        expect(registration).not_to have_been_requested
+        expect(MCPClient::Deprecations.emitted?(:dynamic_client_registration)).to be(false)
+        expect(output.string).not_to match(/Dynamic Client Registration/)
+      end
+    end
+
+    it 'stays silent for a Client ID Metadata Document client, the migration it names' do
+      with_notices do
+        output = StringIO.new
+        cimd_url = 'https://app.example.com/oauth/client-metadata.json'
+        provider = provider_for(logger: Logger.new(output), client_id_metadata_url: cimd_url)
+        stub_discovery(provider, as_meta(client_id_metadata_document_supported: true,
+                                         registration_endpoint: registration_endpoint))
+        registration = stub_request(:post, registration_endpoint)
+
+        provider.start_authorization_flow
+
+        expect(storage.get_client_info(server_url).registration_type).to eq('cimd')
+        expect(registration).not_to have_been_requested
+        expect(MCPClient::Deprecations.emitted?(:dynamic_client_registration)).to be(false)
+      end
+    end
+
+    # The notice is written before the request goes out, so a registration
+    # that then fails must still fail with ITS error: a logger that raises
+    # inside the notice may not replace the authorization server's answer.
+    it 'reports the registration failure even when the notice cannot be written' do
+      with_notices do
+        # A logger that writes, so the notice reaches it, and then fails on
+        # the write itself.
+        raising = Class.new(Logger) do
+          def warn(*) = raise(IOError, 'log device gone')
+        end.new(StringIO.new)
+        provider = provider_for(logger: raising)
+        stub_discovery(provider, as_meta(registration_endpoint: registration_endpoint))
+        registered(json_answer(400, { error: 'invalid_client_metadata' }))
+
+        expect { provider.start_authorization_flow }
+          .to raise_error(MCPClient::Errors::ConnectionError, /registration/i)
+        expect(registration_bodies.size).to eq(1)
+        expect(MCPClient::Deprecations.emitted?(:dynamic_client_registration)).to be(false)
+      end
     end
 
     it 'registers a custom-scheme redirect as native and a remote https redirect as web' do

--- a/spec/lib/mcp_client/deprecations_2026_removed_fields_logger_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_removed_fields_logger_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Dropping a field the revision removed is a protocol decision; saying so in
+# the log is a courtesy. A logger that raises must cost the notice, never the
+# elicitation — the same isolation MCPClient::Deprecations.warn already has.
+RSpec.describe 'MCP 2026-07-28 URL-mode elicitation — a failing logger' do
+  let(:raising_logger) do
+    Class.new do
+      attr_accessor :progname, :formatter
+
+      def level = Logger::WARN
+      def warn(*) = raise(IOError, 'log device is gone')
+      def debug(*) = nil
+      def info(*) = nil
+      def error(*) = nil
+    end.new
+  end
+
+  let(:handler) { ->(message, metadata) { @seen = [message, metadata] and { 'action' => 'accept' } } }
+  let(:client) do
+    MCPClient::Client.new(mcp_server_configs: [], logger: raising_logger, elicitation_handler: handler)
+  end
+  let(:modern_server) do
+    instance_double(MCPClient::ServerStdio).tap do |srv|
+      allow(srv).to receive(:respond_to?).with(:modern?).and_return(true)
+      allow(srv).to receive(:modern?).and_return(true)
+    end
+  end
+  let(:params) do
+    { 'mode' => 'url', 'message' => 'Sign in', 'url' => 'https://auth.example/start',
+      'elicitationId' => 'corr-1' }
+  end
+
+  it 'still serves the elicitation when the notice cannot be written' do
+    expect { client.send(:handle_elicitation_request, 1, params, modern_server) }.not_to raise_error
+    expect(@seen.first).to eq('Sign in')
+    expect(@seen.last).to eq({ 'mode' => 'url', 'url' => 'https://auth.example/start' })
+  end
+
+  it 'drops the removed field whether or not the notice was written' do
+    metadata = client.send(:url_elicitation_metadata, params, modern_server)
+
+    expect(metadata).not_to have_key('elicitationId')
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_removed_fields_logger_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_removed_fields_logger_spec.rb
@@ -34,7 +34,14 @@ RSpec.describe 'MCP 2026-07-28 URL-mode elicitation — a failing logger' do
   end
 
   it 'still serves the elicitation when the notice cannot be written' do
-    expect { client.send(:handle_elicitation_request, 1, params, modern_server) }.not_to raise_error
+    result = nil
+
+    expect { result = client.send(:handle_elicitation_request, 1, params, modern_server) }.not_to raise_error
+
+    # The handler's own answer, not a cancellation manufactured after it ran:
+    # a failing notice may cost the notice and nothing else. Checking only
+    # that the handler was reached would miss exactly that.
+    expect(result).to eq({ 'action' => 'accept' })
     expect(@seen.first).to eq('Sign in')
     expect(@seen.last).to eq({ 'mode' => 'url', 'url' => 'https://auth.example/start' })
   end

--- a/spec/lib/mcp_client/deprecations_2026_removed_fields_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_removed_fields_spec.rb
@@ -265,6 +265,71 @@ RSpec.describe 'MCP 2026-07-28 removed fields' do
 
       expect(seen).to include('elicitationId' => 'elic-1')
     end
+
+    # One client, two servers of different eras. A single-server client cannot
+    # tell "the era of the server that asked" from "the era of some server
+    # this client has": both readings give the same answer. Only a client
+    # holding both can, and a host talking to a modern and a legacy server at
+    # once is the ordinary case this contract exists for.
+    context 'with a modern and a legacy server on the same client' do
+      # The registered callbacks, in the order their servers were configured.
+      def registered_callbacks_for(*servers)
+        captured = {}
+        servers.each do |server|
+          allow(server).to receive(:on_elicitation_request) { |&block| captured[server.name] = block }
+          allow(server).to receive(:on_notification)
+          allow(server).to receive(:respond_to?).with(:on_elicitation_request).and_return(true)
+          allow(server).to receive(:respond_to?).with(:on_roots_list_request).and_return(false)
+          allow(server).to receive(:respond_to?).with(:on_sampling_request).and_return(false)
+          allow(server).to receive(:respond_to?).with(:modern?).and_return(true)
+        end
+        allow(MCPClient::ServerFactory).to receive(:create).and_return(*servers)
+
+        MCPClient::Client.new(
+          mcp_server_configs: servers.map { { type: 'stdio', command: 'true' } },
+          elicitation_handler: @handler
+        )
+        captured
+      end
+
+      # Both servers ask, interleaved, through the one handler the host
+      # registered: each request is answered on its own server's contract.
+      it 'gives each server\'s request the contract of that server' do
+        seen = []
+        @handler = lambda do |_message, metadata|
+          seen << metadata
+          { 'action' => 'accept' }
+        end
+
+        callbacks = registered_callbacks_for(modern_server, legacy_server)
+        request = url_params.merge('elicitationId' => 'elic-1')
+        callbacks['modern'].call(1, request)
+        callbacks['legacy'].call(2, request)
+        callbacks['modern'].call(3, request)
+
+        expect(seen[0]).to eq({ 'mode' => 'url', 'url' => 'https://example.com/auth' })
+        expect(seen[1]).to include('elicitationId' => 'elic-1')
+        expect(seen[2]).to eq({ 'mode' => 'url', 'url' => 'https://example.com/auth' })
+      end
+
+      # The same client with the eras the other way round: an implementation
+      # that reads one fixed server's era passes the order above by accident.
+      it 'does so whichever era the client configured first' do
+        seen = []
+        @handler = lambda do |_message, metadata|
+          seen << metadata
+          { 'action' => 'accept' }
+        end
+
+        callbacks = registered_callbacks_for(legacy_server, modern_server)
+        request = url_params.merge('elicitationId' => 'elic-1')
+        callbacks['legacy'].call(1, request)
+        callbacks['modern'].call(2, request)
+
+        expect(seen[0]).to include('elicitationId' => 'elic-1')
+        expect(seen[1]).to eq({ 'mode' => 'url', 'url' => 'https://example.com/auth' })
+      end
+    end
   end
 
   # The other field 2026-07-28 removed that a server could still try to push

--- a/spec/lib/mcp_client/deprecations_2026_removed_fields_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_removed_fields_spec.rb
@@ -1,0 +1,325 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+# MCP 2026-07-28 changelog, minor change 11: the revision removes the
+# `notifications/elicitation/complete` notification AND the `elicitationId`
+# field of URL-mode elicitation requests, both introduced in 2025-11-25.
+# Under the Multi Round-Trip Requests pattern the client learns the outcome by
+# retrying the original request, so a server-initiated completion signal and
+# its correlation id no longer fit the protocol; a server that needs to
+# correlate an elicitation across retries encodes its own identifier in
+# `requestState`.
+#
+# So the host contract for a MODERN (2026-07-28) server must not carry a field
+# the revision removed, and a non-conforming server must not be able to smuggle
+# a correlation id into it. For a LEGACY (2025-11-25) server the field is part
+# of the revision and the contract is unchanged.
+#
+# Every example here stays off the wire: no server is ever connected.
+RSpec.describe 'MCP 2026-07-28 removed fields' do
+  # The metadata hash a URL-mode elicitation handler is given.
+  def url_metadata_seen_by(client, params, server)
+    seen = nil
+    handler = lambda do |_message, metadata|
+      seen = metadata
+      { 'action' => 'accept' }
+    end
+    client.instance_variable_set(:@elicitation_handler, handler)
+    client.send(:handle_elicitation_request, 1, params, server)
+    seen
+  end
+
+  let(:modern_server) { double('modern-server', name: 'modern', modern?: true) }
+  let(:legacy_server) { double('legacy-server', name: 'legacy', modern?: false) }
+  let(:accepting_handler) { ->(_message, _metadata) { { 'action' => 'accept' } } }
+  let(:client) { MCPClient::Client.new(elicitation_handler: accepting_handler) }
+  let(:url_params) do
+    {
+      'mode' => 'url',
+      'message' => 'Visit to authorize',
+      'url' => 'https://example.com/auth'
+    }
+  end
+
+  describe 'the elicitationId of a URL-mode elicitation request' do
+    context 'with a modern (2026-07-28) server' do
+      it 'does not surface elicitationId to the host, even when the server sends one' do
+        metadata = url_metadata_seen_by(client, url_params.merge('elicitationId' => 'elic-1'), modern_server)
+
+        expect(metadata).to eq({ 'mode' => 'url', 'url' => 'https://example.com/auth' })
+        expect(metadata).not_to have_key('elicitationId')
+      end
+
+      it 'does not surface elicitationId when the server sends none' do
+        metadata = url_metadata_seen_by(client, url_params, modern_server)
+
+        expect(metadata).to eq({ 'mode' => 'url', 'url' => 'https://example.com/auth' })
+      end
+
+      it 'keeps the same contract for a three-argument handler' do
+        seen_metadata = nil
+        seen_extra = nil
+        handler = lambda do |_message, metadata, extra|
+          seen_metadata = metadata
+          seen_extra = extra
+          { 'action' => 'accept' }
+        end
+        client.instance_variable_set(:@elicitation_handler, handler)
+
+        params = url_params.merge('elicitationId' => 'elic-1', 'metadata' => { 'origin' => 'x' })
+        client.send(:handle_elicitation_request, 1, params, modern_server)
+
+        expect(seen_metadata).to eq({ 'mode' => 'url', 'url' => 'https://example.com/auth' })
+        expect(seen_extra).to eq({ 'origin' => 'x' })
+      end
+
+      it 'logs that a server-sent elicitationId was ignored' do
+        logger = client.instance_variable_get(:@logger)
+        allow(logger).to receive(:warn)
+
+        url_metadata_seen_by(client, url_params.merge('elicitationId' => 'elic-1'), modern_server)
+
+        expect(logger).to have_received(:warn).with(/elicitationId/)
+      end
+
+      it 'does not log the server-chosen correlation id itself' do
+        logger = client.instance_variable_get(:@logger)
+        allow(logger).to receive(:warn)
+
+        url_metadata_seen_by(client, url_params.merge('elicitationId' => 'secret-elic-1'), modern_server)
+
+        expect(logger).not_to have_received(:warn).with(/secret-elic-1/)
+      end
+
+      it 'logs nothing about elicitationId when the server sends none' do
+        logger = client.instance_variable_get(:@logger)
+        allow(logger).to receive(:warn)
+
+        url_metadata_seen_by(client, url_params, modern_server)
+
+        expect(logger).not_to have_received(:warn).with(/elicitationId/)
+      end
+
+      it 'still answers the elicitation normally' do
+        result = client.send(:handle_elicitation_request, 1, url_params.merge('elicitationId' => 'e'), modern_server)
+
+        expect(result['action']).to eq('accept')
+        expect(result).not_to have_key('content')
+      end
+
+      it 'leaves form-mode requests untouched' do
+        seen = nil
+        handler = lambda do |_message, schema|
+          seen = schema
+          { 'name' => 'Alice' }
+        end
+        client.instance_variable_set(:@elicitation_handler, handler)
+        schema = { 'type' => 'object', 'properties' => { 'name' => { 'type' => 'string' } } }
+
+        result = client.send(:handle_elicitation_request, 1, { 'message' => 'Name?', 'requestedSchema' => schema },
+                             modern_server)
+
+        expect(seen).to eq(schema)
+        expect(result).to eq({ 'action' => 'accept', 'content' => { 'name' => 'Alice' } })
+      end
+    end
+
+    context 'with a legacy (2025-11-25) server' do
+      it 'surfaces elicitationId to the host unchanged' do
+        metadata = url_metadata_seen_by(client, url_params.merge('elicitationId' => 'elic-1'), legacy_server)
+
+        expect(metadata).to eq(
+          { 'mode' => 'url', 'url' => 'https://example.com/auth', 'elicitationId' => 'elic-1' }
+        )
+      end
+
+      it 'keeps the key present (nil) when the server sends none' do
+        metadata = url_metadata_seen_by(client, url_params, legacy_server)
+
+        expect(metadata).to eq({ 'mode' => 'url', 'url' => 'https://example.com/auth', 'elicitationId' => nil })
+      end
+
+      it 'keeps the same contract for a three-argument handler' do
+        seen_metadata = nil
+        handler = lambda do |_message, metadata, _extra|
+          seen_metadata = metadata
+          { 'action' => 'accept' }
+        end
+        client.instance_variable_set(:@elicitation_handler, handler)
+
+        client.send(:handle_elicitation_request, 1, url_params.merge('elicitationId' => 'elic-1'), legacy_server)
+
+        expect(seen_metadata).to eq(
+          { 'mode' => 'url', 'url' => 'https://example.com/auth', 'elicitationId' => 'elic-1' }
+        )
+      end
+
+      it 'logs nothing about elicitationId' do
+        logger = client.instance_variable_get(:@logger)
+        allow(logger).to receive(:warn)
+
+        url_metadata_seen_by(client, url_params.merge('elicitationId' => 'elic-1'), legacy_server)
+
+        expect(logger).not_to have_received(:warn).with(/elicitationId/)
+      end
+    end
+
+    context 'when the era is not known (no server given)' do
+      it 'keeps the 2025-11-25 contract' do
+        metadata = url_metadata_seen_by(client, url_params.merge('elicitationId' => 'elic-1'), nil)
+
+        expect(metadata).to eq(
+          { 'mode' => 'url', 'url' => 'https://example.com/auth', 'elicitationId' => 'elic-1' }
+        )
+      end
+
+      it 'is what a two-argument call still gets' do
+        seen = nil
+        handler = lambda do |_message, metadata|
+          seen = metadata
+          { 'action' => 'accept' }
+        end
+        client.instance_variable_set(:@elicitation_handler, handler)
+
+        client.send(:handle_elicitation_request, 1, url_params.merge('elicitationId' => 'elic-1'))
+
+        expect(seen).to have_key('elicitationId')
+      end
+    end
+  end
+
+  describe 'the registered elicitation callback' do
+    # The transports call the registered callback with (request_id, params)
+    # only, so the era has to reach the handler from the registration itself.
+    def registered_callback_for(server)
+      captured = nil
+      allow(server).to receive(:on_elicitation_request) { |&block| captured = block }
+      allow(server).to receive(:on_notification)
+      allow(server).to receive(:respond_to?).with(:on_elicitation_request).and_return(true)
+      allow(server).to receive(:respond_to?).with(:on_roots_list_request).and_return(false)
+      allow(server).to receive(:respond_to?).with(:on_sampling_request).and_return(false)
+      allow(server).to receive(:respond_to?).with(:modern?).and_return(true)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+
+      MCPClient::Client.new(
+        mcp_server_configs: [{ type: 'stdio', command: 'true' }],
+        elicitation_handler: @handler
+      )
+      captured
+    end
+
+    it 'carries the modern server through, so the host sees no elicitationId' do
+      seen = nil
+      @handler = lambda do |_message, metadata|
+        seen = metadata
+        { 'action' => 'accept' }
+      end
+
+      callback = registered_callback_for(modern_server)
+      callback.call(1, url_params.merge('elicitationId' => 'elic-1'))
+
+      expect(seen).not_to have_key('elicitationId')
+    end
+
+    # A modern server asks for an elicitation through the multi round-trip
+    # pattern, which reaches the very same registered callback.
+    it 'drops elicitationId on the multi round-trip path too' do
+      seen = nil
+      handler = lambda do |_message, metadata|
+        seen = metadata
+        { 'action' => 'accept' }
+      end
+      # Constructed, never connected: no process is spawned and no request
+      # goes out.
+      server = MCPClient::ServerStdio.new(command: 'true')
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      expect(server).to be_modern
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+      MCPClient::Client.new(
+        mcp_server_configs: [{ type: 'stdio', command: 'true' }],
+        elicitation_handler: handler
+      )
+
+      responses = server.send(
+        :fulfil_input_requests,
+        { 'k1' => { 'method' => 'elicitation/create',
+                    'params' => url_params.merge('elicitationId' => 'elic-1') } },
+        {}
+      )
+
+      expect(responses['k1']).to eq({ 'action' => 'accept' })
+      expect(seen).to eq({ 'mode' => 'url', 'url' => 'https://example.com/auth' })
+    end
+
+    it 'carries the legacy server through, so the host still sees elicitationId' do
+      seen = nil
+      @handler = lambda do |_message, metadata|
+        seen = metadata
+        { 'action' => 'accept' }
+      end
+
+      callback = registered_callback_for(legacy_server)
+      callback.call(1, url_params.merge('elicitationId' => 'elic-1'))
+
+      expect(seen).to include('elicitationId' => 'elic-1')
+    end
+  end
+
+  # The other field 2026-07-28 removed that a server could still try to push
+  # at the client. A modern server is never sent `initialize`, which is the
+  # only place a session id is captured, so the header is structurally
+  # unreachable — this pins that, since nothing else feeds a modern response
+  # that actually carries one.
+  describe 'the Mcp-Session-Id header of a modern server response' do
+    let(:url) { 'https://example.com/mcp' }
+
+    def modern_result(method)
+      case method
+      when 'server/discover'
+        { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+          'capabilities' => { 'tools' => {} }, 'ttlMs' => 0 }
+      when 'tools/list'
+        { 'resultType' => 'complete', 'tools' => [] }
+      else
+        raise "unexpected method #{method}"
+      end
+    end
+
+    # Every response carries a session id the revision no longer has.
+    def stub_session_pushing_modern_server
+      requests = []
+      stub_request(:post, url).to_return do |request|
+        body = JSON.parse(request.body)
+        requests << { headers: request.headers, body: body }
+        { status: 200,
+          body: JSON.generate('jsonrpc' => '2.0', 'id' => body['id'], 'result' => modern_result(body['method'])),
+          headers: { 'Content-Type' => 'application/json', 'Mcp-Session-Id' => 'sess-1' } }
+      end
+      requests
+    end
+
+    it 'is never captured, echoed on a later request or terminated' do
+      get_stub = stub_request(:get, url).to_return(status: 405, body: '')
+      delete_stub = stub_request(:delete, url).to_return(status: 200, body: '')
+      requests = stub_session_pushing_modern_server
+      server = MCPClient::ServerStreamableHTTP.new(
+        base_url: 'https://example.com', endpoint: '/mcp', retries: 0, read_timeout: 2
+      )
+
+      begin
+        server.connect
+        server.list_tools
+        server.cleanup
+      ensure
+        server.cleanup
+      end
+
+      expect(requests.map { |r| r[:body]['method'] }).to eq(%w[server/discover tools/list])
+      requests.each { |r| expect(r[:headers]).not_to have_key('Mcp-Session-Id') }
+      expect(get_stub).not_to have_been_requested
+      expect(delete_stub).not_to have_been_requested
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round10_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round10_spec.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Round 10 of the 2026-07-28 deprecation review.
+#
+# Round 9 gave a notice two states — `:pending` while a caller is inside
+# `logger.warn`, `:emitted` once one succeeded — so that a contender could
+# wait for a reservation's outcome and take the notice over when the
+# reservation failed. The wait was bounded by a timeout, on the strength of a
+# promise this path cannot keep: that a notice never holds up the deprecated
+# operation.
+#
+# It cannot keep it, and the bound did not buy it. The bound constrains the
+# CONTENDERS, never the reservation's owner: a first use whose logger blocks
+# forever — a synchronous remote logger, stalled I/O — never returns from
+# `warn` at all, so the client construction, SSE connection or incoming
+# request that triggered it never completes either. And what the contenders
+# bought with their wait was nothing: a reservation that hangs is never
+# released, so every later first use of that feature waited the timeout out
+# again and still came away without the notice. Sampling, Logging and the
+# HTTP+SSE transport all have trigger points that are hit repeatedly, so
+# "every later first use" is not a corner case.
+#
+# The two ways to keep the stronger promise are both worse than dropping it.
+# A detached emission thread stops blocking anything but loses the ordering
+# between the notice and the operation it describes, and needs a thread per
+# stalled notice. `Timeout.timeout` around a host's logger raises inside
+# arbitrary third-party code — during its own IO, ensure blocks or internal
+# locking — which is how you corrupt a logger, not how you protect a caller.
+#
+# So the promise is narrowed to the one the rest of the library already makes:
+# every other `logger.warn` in this codebase blocks its caller exactly the
+# same way, and a logger that blocks forever blocks the library everywhere,
+# not only here. A notice costs its caller what one `logger.warn` costs it,
+# no more. What survives is what was real: the notice fires once per process,
+# a logger that raises or drops warnings neither breaks the deprecated
+# operation nor spends the notice, and the bookkeeping is rebuilt after a
+# fork. The reservation states, the condition variable and the timeout — the
+# machinery that existed only to serve the stronger promise — go, and with
+# them the wait that yielded nothing.
+#
+# Also: the `ServerHTTP` elicitation note, the last place that still offered
+# the HTTP+SSE transport as an ordinary alternative.
+RSpec.describe 'MCP 2026-07-28 deprecations (round 10)' do
+  # A logger whose #warn blocks until the example releases it, and then either
+  # raises or records the message. Deliberately not a ::Logger, so the level
+  # probe treats it as one that keeps warnings. Mirrors the round 9 helper.
+  gated_logger_class = Class.new do
+    def initialize
+      @entered = Queue.new
+      @release = Queue.new
+      @messages = []
+    end
+
+    attr_reader :messages
+
+    # Block until #release, then behave as instructed.
+    def warn(message)
+      @entered << :entered
+      raise 'logger is down' if @release.pop == :raise
+
+      @messages << message
+      nil
+    end
+
+    # Wait until a caller is inside #warn.
+    def await_entry = @entered.pop
+
+    def release(outcome = :succeed) = @release << outcome
+  end
+
+  describe 'a third first use, while the first one is stuck in its logger' do
+    around do |example|
+      MCPClient::Deprecations.enabled = true
+      MCPClient::Deprecations.reset!
+      example.run
+    ensure
+      MCPClient::Deprecations.reset!
+      MCPClient::Deprecations.enabled = false
+    end
+
+    let(:output) { StringIO.new }
+    let(:working_logger) { Logger.new(output) }
+    let(:gated_logger) { gated_logger_class.new }
+
+    # Wait until every thread is parked (blocked or finished), so the example
+    # exercises the queued path rather than a lucky ordering. Milliseconds:
+    # nothing here waits a timeout out.
+    def settle(*threads)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+      until threads.all? { |thread| thread.status == 'sleep' || !thread.status }
+        raise 'threads never settled' if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+        sleep 0.001
+      end
+    end
+
+    # These two examples state an outcome the timed-out reservation could only
+    # reach when the release beat the timeout — which is why they release
+    # immediately: an example that let the timeout expire would have to spend
+    # it, and spending it is the cost being removed. With the timeout gone the
+    # outcome holds however long the stuck logger stays stuck.
+    it 'is still owed the notice when the stuck logger finally fails' do
+      # Logging's notice fires from every notifications/message and every
+      # log_level=, so a second and a third first use are routine.
+      owner = Thread.new { MCPClient::Deprecations.warn(:logging, gated_logger) }
+      gated_logger.await_entry
+
+      second = Thread.new { MCPClient::Deprecations.warn(:logging, working_logger) }
+      third = Thread.new { MCPClient::Deprecations.warn(:logging, working_logger) }
+      settle(second, third)
+      gated_logger.release(:raise)
+
+      expect(owner.value).to be(false)
+      # Neither later use came away empty-handed: one of them logged the
+      # notice the failed one owed, the other stood down because it was
+      # already out. Under the timed-out reservation both got nothing.
+      expect([second.value, third.value].count(true)).to eq(1)
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(true)
+      expect(output.string.scan('Logging is deprecated').size).to eq(1)
+    end
+
+    it 'stands down exactly once when the stuck logger finally succeeds' do
+      owner = Thread.new { MCPClient::Deprecations.warn(:logging, gated_logger) }
+      gated_logger.await_entry
+
+      second = Thread.new { MCPClient::Deprecations.warn(:logging, working_logger) }
+      third = Thread.new { MCPClient::Deprecations.warn(:logging, working_logger) }
+      settle(second, third)
+      gated_logger.release(:succeed)
+
+      expect(owner.value).to be(true)
+      expect([second.value, third.value]).to eq([false, false])
+      expect(gated_logger.messages.size).to eq(1)
+      expect(output.string).not_to match(/Logging is deprecated/)
+    end
+
+    it 'never reaches past the feature it is logging' do
+      owner = Thread.new { MCPClient::Deprecations.warn(:logging, gated_logger) }
+      gated_logger.await_entry
+
+      # A notice blocks its own caller like any logger.warn, but a notice in
+      # flight is not a lock over the module: another feature's first use
+      # goes out while this one is still stuck, and so does the bookkeeping.
+      expect(MCPClient::Deprecations.warn(:sampling, working_logger)).to be(true)
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
+
+      gated_logger.release(:succeed)
+      expect(owner.value).to be(true)
+    end
+  end
+
+  describe 'the promise the module makes about what a notice costs' do
+    let(:source) { File.read(File.expand_path('../../../lib/mcp_client/deprecations.rb', __dir__)) }
+    let(:readme) { File.read(File.expand_path('../../../README.md', __dir__)) }
+
+    it 'no longer claims a notice never holds up the deprecated operation' do
+      expect(source).not_to match(/holds? up the deprecated operation/)
+      expect(MCPClient::Deprecations.constants).not_to include(:PENDING_WAIT_SECONDS)
+    end
+
+    it 'does not buy the claim back with a timeout around host logger code' do
+      expect(source).not_to include('Timeout')
+      expect(source).not_to include('Thread.new')
+    end
+
+    it 'says what a notice does cost, in the terms the rest of the library sets' do
+      expect(source).to match(/costs its caller what (a|one) `?logger\.warn`? costs it/i)
+    end
+
+    it 'still promises what it can keep' do
+      expect(source).to match(/once per process/i)
+      expect(source).to match(/never breaks the deprecated (operation|feature)|keeps working whatever the log does/i)
+    end
+
+    it 'says it in the README too, where the notices are documented' do
+      paragraph = readme.split(/\n\n+/).find { |block| block.include?('Notices go to the logger') }
+
+      expect(paragraph).not_to be_nil
+      expect(paragraph).to include('`logger.warn`')
+      expect(paragraph).to match(/blocks/)
+    end
+  end
+
+  describe 'the ServerHTTP elicitation note, which offers other transports' do
+    let(:note) do
+      source = File.read(File.expand_path('../../../lib/mcp_client/server_http.rb', __dir__))
+      lines = source.lines
+      start = lines.index { |line| line.match?(/@note Elicitation Support/) }
+      raise 'elicitation note not found' unless start
+
+      stop = lines[start..].index { |line| !line.match?(/^\s*#/) }
+      lines[start, stop].join
+    end
+
+    # A bullet in the note, with the continuation lines that belong to it.
+    def entry_for(note, transport)
+      lines = note.lines
+      index = lines.index { |line| line.match?(/^\s*#\s*-\s*#{transport}\b/) }
+      return nil unless index
+
+      entry = +lines[index]
+      lines[(index + 1)..].each do |line|
+        break if line.match?(/^\s*#\s*-\s/)
+
+        entry << line
+      end
+      entry
+    end
+
+    it 'marks the HTTP+SSE alternative as deprecated, as everywhere else does' do
+      sse_entry = entry_for(note, 'ServerSSE')
+
+      expect(sse_entry).not_to be_nil
+      expect(sse_entry).to match(/deprecat/i)
+      expect(sse_entry).to include('SEP-2596')
+      expect(sse_entry).to include('ServerStreamableHTTP')
+    end
+
+    it 'offers Streamable HTTP before the transport on its way out' do
+      expect(note.index('ServerStreamableHTTP')).to be < note.index('ServerSSE')
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round10_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round10_spec.rb
@@ -113,11 +113,14 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 10)' do
       gated_logger.release(:raise)
 
       expect(owner.value).to be(false)
-      # Neither later use came away empty-handed: one of them logged the
-      # notice the failed one owed, the other stood down because it was
-      # already out. Under the timed-out reservation both got nothing.
-      expect([second.value, third.value].count(true)).to eq(1)
-      expect(MCPClient::Deprecations.emitted?(:logging)).to be(true)
+      # Neither later use queued behind the stuck emission — the
+      # verification pass took that wait out, since a thread cannot know
+      # whether it holds a lock the stuck one needs — and neither spent the
+      # notice. Under the timed-out reservation they waited and still got
+      # nothing; here the wait is what goes, not the notice.
+      expect([second.value, third.value]).to eq([false, false])
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
+      expect(MCPClient::Deprecations.warn(:logging, working_logger)).to be(true)
       expect(output.string.scan('Logging is deprecated').size).to eq(1)
     end
 

--- a/spec/lib/mcp_client/deprecations_2026_round11_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round11_spec.rb
@@ -257,6 +257,31 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 11)' do
       expect(output.string.scan('Logging is deprecated').size).to eq(1)
     end
 
+    # A host that writes the key as a Symbol — the natural Ruby spelling for
+    # a hash literal — has adopted the deprecated utility just as much as one
+    # that writes the String. On the modern path the question never arises:
+    # `with_request_meta` builds the outgoing `_meta` and stringifies both the
+    # defaults and the supplied hash on the way. The LEGACY passthrough is
+    # where it does arise, because there the host's `_meta` goes out exactly
+    # as it was written and is the very hash the notice reads.
+    it 'warns when a legacy transport forwards a symbol-keyed log level' do
+      legacy = transport_class.new(logger, '2025-06-18')
+
+      params = legacy.with_request_meta({ '_meta' => { 'io.modelcontextprotocol/logLevel': 'debug' } })
+
+      expect(params['_meta']).to eq({ 'io.modelcontextprotocol/logLevel': 'debug' })
+      expect(output.string).to include('Logging is deprecated')
+    end
+
+    it 'warns when a legacy _meta is itself keyed by symbol' do
+      legacy = transport_class.new(logger, '2025-06-18')
+
+      params = legacy.with_request_meta({ _meta: { 'io.modelcontextprotocol/logLevel': 'warning' } })
+
+      expect(params[:_meta]).to eq({ 'io.modelcontextprotocol/logLevel': 'warning' })
+      expect(output.string).to include('Logging is deprecated')
+    end
+
     it 'warns when a legacy transport forwards it untouched' do
       legacy = transport_class.new(logger, '2025-06-18')
 

--- a/spec/lib/mcp_client/deprecations_2026_round11_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round11_spec.rb
@@ -1,0 +1,329 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Round 11 of the 2026-07-28 deprecation review.
+#
+# Round 10 replaced the reservation machinery with a per-feature gate held
+# across `logger.warn`. Holding ANY lock across host code buys a lock-order
+# inversion, and this one is reachable with nothing exotic: a real ::Logger
+# serializes its writes behind its own device lock, so two threads that warn
+# for two different features through the SAME logger take the two locks in
+# opposite orders the moment either logger callback — a formatter, a log
+# subscriber — touches a deprecated feature itself. Both threads then wait
+# forever, and the sampling request, the log level or the SSE `connect` that
+# raised the notice never returns. The same-thread case (a callback warning
+# for the feature being logged) only escaped because CRuby raises ThreadError
+# on a recursive lock and `emit_once` swallowed it in the rescue that means
+# "the logger failed" — an accident, not a decision.
+#
+# The fix keeps round 10's gate and its contract — one notice per feature per
+# process, a plain contender waits for another thread's emission and takes it
+# over when that emission fails — and adds the one rule that makes holding it
+# safe: a thread that is already inside a notice never waits for a gate. Its
+# nested attempt stands down at once and leaves that notice owed to a later
+# use, which is what the module already does with every notice it could not
+# write.
+#
+# Also in this round: `Logger.new(nil)` is a supported no-output logger whose
+# level sits below WARN, so the level probe accepted it and a notice was
+# marked emitted that nobody could read; and a modern host can adopt the
+# deprecated Logging utility without ever calling `log_level=`, by putting
+# `io.modelcontextprotocol/logLevel` in `request_meta` or in a per-call
+# `_meta` — which `with_request_meta` deliberately forwards on the wire.
+RSpec.describe 'MCP 2026-07-28 deprecations (round 11)' do
+  around do |example|
+    MCPClient::Deprecations.enabled = true
+    MCPClient::Deprecations.reset!
+    example.run
+  ensure
+    MCPClient::Deprecations.reset!
+    MCPClient::Deprecations.enabled = false
+  end
+
+  describe 'a notice raised from inside the logger of another notice' do
+    # A logger that serializes its writes behind one lock, the way ::Logger's
+    # LogDevice does. The first writer parks inside that lock until the
+    # example releases it, and then runs the example's callback while it is
+    # still held — a formatter or a log subscriber that itself reaches a
+    # deprecated feature. Deliberately not a ::Logger, so the level probe
+    # treats it as one that keeps warnings.
+    let(:serializing_logger_class) do
+      Class.new do
+        attr_reader :messages, :nested
+
+        def initialize(&on_first_write)
+          @write_lock = Mutex.new
+          @entered = Queue.new
+          @go = Queue.new
+          @messages = []
+          @on_first_write = on_first_write
+          @first = true
+        end
+
+        def warn(message)
+          @write_lock.synchronize do
+            if @first
+              @first = false
+              @entered << :entered
+              @go.pop
+              @nested = @on_first_write&.call
+            end
+            @messages << message
+          end
+          nil
+        end
+
+        # Wait until the first caller is inside #warn, holding the write lock.
+        def await_entry = @entered.pop
+
+        def release = (@go << :go)
+      end
+    end
+
+    let(:threads) { [] }
+
+    after { threads.each { |thread| thread.kill if thread.alive? } }
+
+    def start(&block)
+      thread = Thread.new(&block)
+      threads << thread
+      thread
+    end
+
+    # Nothing here is allowed to wedge the suite: a regression must fail the
+    # example, not hang it. Seconds, not milliseconds, so a loaded CI box
+    # never reports a deadlock that is only slowness.
+    def finished?(thread)
+      !thread.join(10).nil?
+    end
+
+    # Wait until every thread is parked (blocked or finished), so the example
+    # exercises the queued path rather than a lucky ordering.
+    def settle(*waiting)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+      until waiting.all? { |thread| thread.status == 'sleep' || !thread.status }
+        raise 'threads never settled' if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+        sleep 0.001
+      end
+    end
+
+    it 'stands down when the logger warns again for the feature being logged' do
+      logger = serializing_logger_class.new { MCPClient::Deprecations.warn(:logging, logger) }
+      emitter = start { MCPClient::Deprecations.warn(:logging, logger) }
+      logger.await_entry
+      logger.release
+
+      expect(finished?(emitter)).to be(true), 'the emitting thread never came back out of its own notice'
+      expect(emitter.value).to be(true)
+      # The nested attempt neither duplicated the notice nor waited for it.
+      expect(logger.nested).to be(false)
+      expect(logger.messages.size).to eq(1)
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(true)
+    end
+
+    it 'never waits for a second feature while it is inside the first one' do
+      # The inversion: the emitting thread holds :logging and wants
+      # :sampling, while the thread that holds :sampling wants the logger's
+      # write lock this one is inside.
+      logger = serializing_logger_class.new { MCPClient::Deprecations.warn(:sampling, logger) }
+      emitter = start { MCPClient::Deprecations.warn(:logging, logger) }
+      logger.await_entry
+      contender = start { MCPClient::Deprecations.warn(:sampling, logger) }
+      settle(contender)
+      logger.release
+
+      expect(finished?(emitter)).to be(true), 'the notice deadlocked against the logger it was writing to'
+      expect(finished?(contender)).to be(true)
+      expect(emitter.value).to be(true)
+      # The notice the nested attempt stood down from was not lost: the
+      # thread that was already holding it wrote it.
+      expect(logger.nested).to be(false)
+      expect(contender.value).to be(true)
+      expect(logger.messages.size).to eq(2)
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(true)
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+    end
+
+    it 'leaves a nested notice owed when no one else is holding it' do
+      logger = serializing_logger_class.new { MCPClient::Deprecations.warn(:sampling, logger) }
+      emitter = start { MCPClient::Deprecations.warn(:logging, logger) }
+      logger.await_entry
+      logger.release
+
+      expect(finished?(emitter)).to be(true)
+      expect(logger.nested).to be(false)
+      # Owed, not spent: the next use of Sampling still gets its notice.
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(false)
+      output = StringIO.new
+      expect(MCPClient::Deprecations.warn(:sampling, Logger.new(output))).to be(true)
+      expect(output.string).to include('Sampling is deprecated')
+    end
+
+    it 'still makes a plain contender wait for the emission it is racing' do
+      # Round 10's contract, unchanged: a thread that is not itself inside a
+      # notice waits for the one in flight rather than writing a second copy.
+      logger = serializing_logger_class.new
+      emitter = start { MCPClient::Deprecations.warn(:logging, logger) }
+      logger.await_entry
+      output = StringIO.new
+      contender = start { MCPClient::Deprecations.warn(:logging, Logger.new(output)) }
+      settle(contender)
+
+      expect(contender).to be_alive
+      logger.release
+
+      expect(finished?(emitter)).to be(true)
+      expect(finished?(contender)).to be(true)
+      expect(emitter.value).to be(true)
+      expect(contender.value).to be(false)
+      expect(output.string).not_to include('Logging is deprecated')
+    end
+  end
+
+  describe 'a logger that writes nowhere' do
+    it 'does not spend the notice on Logger.new(nil)' do
+      # Logger.new(nil) is a supported no-output logger: its level defaults
+      # to DEBUG, so the level probe passes and #warn returns true having
+      # written nothing. Marking the notice emitted there would silence every
+      # later warning from a logger that does write.
+      silent = Logger.new(nil)
+
+      expect(MCPClient::Deprecations.warn(:logging, silent)).to be(false)
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
+
+      output = StringIO.new
+      expect(MCPClient::Deprecations.warn(:logging, Logger.new(output))).to be(true)
+      expect(output.string).to include('Logging is deprecated')
+    end
+
+    it 'does not break the deprecated operation the silent logger belongs to' do
+      server = MCPClient::ServerStdio.new(command: 'true', logger: Logger.new(nil))
+      allow(server).to receive(:ensure_initialized)
+      allow(server).to receive(:modern?).and_return(true)
+
+      expect { server.log_level = 'debug' }.not_to raise_error
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
+    end
+
+    it 'still spends the notice on a logger with a device' do
+      # Only a logger built without a device is knowably unreadable. (Which
+      # ones those are is a `logger` version question: 1.7 opens no file for
+      # `Logger.new(File::NULL)` either, older versions do — hence a device
+      # this example can actually read back.)
+      expect(MCPClient::Deprecations.warn(:sampling, Logger.new(StringIO.new))).to be(true)
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+    end
+  end
+
+  describe 'the log level a modern request carries in its metadata' do
+    let(:output) { StringIO.new }
+    let(:logger) { Logger.new(output) }
+
+    let(:transport_class) do
+      Class.new do
+        include MCPClient::JsonRpcCommon
+
+        attr_reader :logger
+
+        def initialize(logger, protocol_version)
+          @logger = logger
+          @protocol_version = protocol_version
+        end
+      end
+    end
+
+    let(:transport) { transport_class.new(logger, '2026-07-28') }
+
+    it 'warns when the host default metadata carries the log level' do
+      transport.request_meta = { 'io.modelcontextprotocol/logLevel' => 'debug' }
+
+      params = transport.with_request_meta({ 'name' => 'tool' })
+
+      expect(params['_meta']['io.modelcontextprotocol/logLevel']).to eq('debug')
+      expect(output.string).to include('Logging is deprecated')
+      expect(output.string).to include('SEP-2577')
+    end
+
+    it 'warns when a per-call _meta carries it, and only once' do
+      2.times do
+        transport.with_request_meta({ '_meta' => { 'io.modelcontextprotocol/logLevel' => 'warning' } })
+      end
+
+      expect(output.string.scan('Logging is deprecated').size).to eq(1)
+    end
+
+    it 'warns when a legacy transport forwards it untouched' do
+      legacy = transport_class.new(logger, '2025-06-18')
+
+      params = legacy.with_request_meta({ '_meta' => { 'io.modelcontextprotocol/logLevel' => 'debug' } })
+
+      expect(params['_meta']['io.modelcontextprotocol/logLevel']).to eq('debug')
+      expect(output.string).to include('Logging is deprecated')
+    end
+
+    it 'warns for a notification that carries it, on the same wire path' do
+      transport.request_meta = -> { { 'io.modelcontextprotocol/logLevel' => 'error' } }
+
+      transport.build_jsonrpc_notification('notifications/progress', {})
+
+      expect(output.string).to include('Logging is deprecated')
+    end
+
+    it 'stays silent for a modern request that carries no log level' do
+      transport.request_meta = { 'com.example/tenant' => 'acme' }
+
+      params = transport.build_jsonrpc_request('tools/list', {}, 1)
+
+      expect(params['params']['_meta']).to include('com.example/tenant' => 'acme')
+      expect(output.string).not_to match(/deprecated/)
+    end
+  end
+
+  describe 'the documentation for the transport on its way out' do
+    let(:readme) { File.read(File.expand_path('../../../README.md', __dir__)) }
+    let(:entry_point) { File.read(File.expand_path('../../../lib/mcp_client.rb', __dir__)) }
+
+    it 'does not offer SSE as an unmarked elicitation transport' do
+      bullet = readme.lines.find { |line| line.start_with?('- **Elicitation**') }
+
+      expect(bullet).not_to be_nil
+      expect(bullet).to match(/deprecated/i)
+      expect(bullet.index('Streamable HTTP')).to be < bullet.index('HTTP+SSE')
+    end
+
+    it 'names the earliest removal where connect documents transport: :sse' do
+      lines = entry_point.lines
+      index = lines.index { |line| line.match?(/^\s*#\s*-\s*transport \[Symbol\]/) }
+      expect(index).not_to be_nil
+
+      entry = +lines[index]
+      lines[(index + 1)..].each do |line|
+        break if line.match?(/^\s*#\s*-\s/) || !line.match?(/^\s*#/)
+
+        entry << line
+      end
+
+      expect(entry).to include('SEP-2596')
+      expect(entry).to match(/three months after SEP-2596 reaches Final/)
+      expect(entry).to include(':streamable_http')
+    end
+
+    it 'documents both new ways a notice can go unwritten' do
+      paragraph = readme.split(/\n\n+/).find { |block| block.include?('Notices go to the logger') }
+
+      expect(paragraph).not_to be_nil
+      expect(paragraph).to include('`logger.warn`')
+      expect(paragraph).to match(/blocks/)
+      expect(paragraph).to match(/Logger\.new\(nil\)|writes nowhere|no output/i)
+    end
+
+    it 'documents the metadata route into the deprecated Logging utility' do
+      logging_row = readme.lines.find { |line| line.start_with?('| Logging (') }
+
+      expect(logging_row).not_to be_nil
+      expect(logging_row).to include('io.modelcontextprotocol/logLevel')
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round11_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round11_spec.rb
@@ -17,13 +17,15 @@ require 'spec_helper'
 # on a recursive lock and `emit_once` swallowed it in the rescue that means
 # "the logger failed" — an accident, not a decision.
 #
-# The fix keeps round 10's gate and its contract — one notice per feature per
-# process, a plain contender waits for another thread's emission and takes it
-# over when that emission fails — and adds the one rule that makes holding it
-# safe: a thread that is already inside a notice never waits for a gate. Its
-# nested attempt stands down at once and leaves that notice owed to a later
-# use, which is what the module already does with every notice it could not
-# write.
+# The round 11 fix kept round 10's gate and added the one rule that seemed to
+# make holding it safe: a thread already inside a notice never waits for a
+# gate, its nested attempt standing down at once and leaving that notice owed
+# to a later use — which is what the module already does with every notice it
+# could not write. That rule was not enough, because the thread holding the
+# logger's device lock need not be inside a notice at all (see the
+# verification pass), so no caller waits for a notice any more. The examples
+# below hold either way; what changed is the plain contender, which now
+# stands down where round 10 had it wait.
 #
 # Also in this round: `Logger.new(nil)` is a supported no-output logger whose
 # level sits below WARN, so the level probe accepted it and a notice was
@@ -161,23 +163,24 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 11)' do
       expect(output.string).to include('Sampling is deprecated')
     end
 
-    it 'still makes a plain contender wait for the emission it is racing' do
-      # Round 10's contract, unchanged: a thread that is not itself inside a
-      # notice waits for the one in flight rather than writing a second copy.
+    it 'has a plain contender stand down instead of waiting for the emission' do
+      # Round 10 had this contender wait; the verification pass took the wait
+      # out, because a thread that queues for a notice cannot know whether it
+      # is holding a lock the emitting thread needs. What it still must not
+      # do is write a second copy.
       logger = serializing_logger_class.new
       emitter = start { MCPClient::Deprecations.warn(:logging, logger) }
       logger.await_entry
       output = StringIO.new
       contender = start { MCPClient::Deprecations.warn(:logging, Logger.new(output)) }
-      settle(contender)
 
-      expect(contender).to be_alive
+      expect(finished?(contender)).to be(true), 'the contender queued behind the emission in flight'
+      expect(contender.value).to be(false)
       logger.release
 
       expect(finished?(emitter)).to be(true)
-      expect(finished?(contender)).to be(true)
       expect(emitter.value).to be(true)
-      expect(contender.value).to be(false)
+      expect(logger.messages.size).to eq(1)
       expect(output.string).not_to include('Logging is deprecated')
     end
   end

--- a/spec/lib/mcp_client/deprecations_2026_round11_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round11_spec.rb
@@ -249,12 +249,20 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 11)' do
       expect(output.string).to include('SEP-2577')
     end
 
+    # The notice is spent once, but the level it names is carried by every
+    # request that asked for it: a per-call value overrides the host default
+    # rather than disappearing with the warning that announced it.
     it 'warns when a per-call _meta carries it, and only once' do
-      2.times do
+      transport.request_meta = { 'io.modelcontextprotocol/logLevel' => 'error' }
+      MCPClient::Deprecations.reset!
+      output.truncate(output.rewind)
+
+      carried = Array.new(2) do
         transport.with_request_meta({ '_meta' => { 'io.modelcontextprotocol/logLevel' => 'warning' } })
       end
 
       expect(output.string.scan('Logging is deprecated').size).to eq(1)
+      expect(carried.map { |params| params['_meta']['io.modelcontextprotocol/logLevel'] }).to eq(%w[warning warning])
     end
 
     # A host that writes the key as a Symbol — the natural Ruby spelling for
@@ -299,8 +307,10 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 11)' do
     it 'warns for a notification that carries it, on the same wire path' do
       transport.request_meta = -> { { 'io.modelcontextprotocol/logLevel' => 'error' } }
 
-      transport.build_jsonrpc_notification('notifications/progress', {})
+      notification = transport.build_jsonrpc_notification('notifications/progress', {})
 
+      # The notice is about a level the notification really carries.
+      expect(notification['params']['_meta']['io.modelcontextprotocol/logLevel']).to eq('error')
       expect(output.string).to include('Logging is deprecated')
     end
 

--- a/spec/lib/mcp_client/deprecations_2026_round11_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round11_spec.rb
@@ -273,12 +273,17 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 11)' do
       expect(output.string).to include('Logging is deprecated')
     end
 
+    # A `_meta` written under the Symbol key is folded into the one
+    # String-keyed member in every era (the stateless stdio branch: mixed
+    # spellings must not slip past the reserved-field protection), so the
+    # notice reads the merged member and the request carries exactly one.
     it 'warns when a legacy _meta is itself keyed by symbol' do
       legacy = transport_class.new(logger, '2025-06-18')
 
       params = legacy.with_request_meta({ _meta: { 'io.modelcontextprotocol/logLevel': 'warning' } })
 
-      expect(params[:_meta]).to eq({ 'io.modelcontextprotocol/logLevel': 'warning' })
+      expect(params['_meta']).to eq({ 'io.modelcontextprotocol/logLevel' => 'warning' })
+      expect(params).not_to have_key(:_meta)
       expect(output.string).to include('Logging is deprecated')
     end
 

--- a/spec/lib/mcp_client/deprecations_2026_round12_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round12_spec.rb
@@ -17,6 +17,23 @@ require 'webmock/rspec'
 #     negotiated after the callback is registered, so reading it at
 #     registration time reads "not modern" for every server there is.
 RSpec.describe 'MCP 2026-07-28 deprecations (round 12)' do
+  # The child's report, or a prompt failure: a bookkeeping regression that
+  # leaves the child blocked must fail this example, not wedge the suite on
+  # an unbounded pipe read.
+  def bounded_fork_report(reader, pid)
+    report = reader.wait_readable(10) ? reader.read : nil
+    reader.close
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 10
+    until Process.waitpid(pid, Process::WNOHANG)
+      raise 'forked worker did not exit' if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+      sleep 0.01
+    end
+    report or raise 'forked worker reported nothing within 10s'
+  ensure
+    Process.kill('KILL', pid) rescue nil # rubocop:disable Style/RescueModifier
+  end
+
   let(:output) { StringIO.new }
   let(:logger) { Logger.new(output) }
 
@@ -183,9 +200,7 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 12)' do
         exit!(0)
       end
       writer.close
-      report = reader.read
-      reader.close
-      Process.waitpid(pid)
+      report = bounded_fork_report(reader, pid)
       gated.release
       holder.join
 

--- a/spec/lib/mcp_client/deprecations_2026_round12_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round12_spec.rb
@@ -1,0 +1,377 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'delegate'
+require 'webmock/rspec'
+
+# Round 12 of the 2026-07-28 deprecation review, on three things the earlier
+# rounds asserted about but never pinned:
+#
+#   * a logger the HOST WRAPPED. The notice is owed until a reader could have
+#     seen it, and a wrapper that filters is exactly as unreadable as the
+#     ::Logger it wraps — but only the bare ::Logger was ever asked.
+#   * the HTTP+SSE transport's own notification path. The Logging notice was
+#     hung on the routing every other transport shares; the legacy transport
+#     carries no subscription stream and does not go through it.
+#   * WHEN the elicitation contract reads a server's era. The era is
+#     negotiated after the callback is registered, so reading it at
+#     registration time reads "not modern" for every server there is.
+RSpec.describe 'MCP 2026-07-28 deprecations (round 12)' do
+  let(:output) { StringIO.new }
+  let(:logger) { Logger.new(output) }
+
+  around do |example|
+    MCPClient::Deprecations.enabled = true
+    MCPClient::Deprecations.reset!
+    example.run
+  ensure
+    MCPClient::Deprecations.reset!
+    MCPClient::Deprecations.enabled = false
+  end
+
+  # A host's logger is rarely a bare ::Logger: Rails hands out a tagged
+  # logger, a broadcast logger or some other Delegator, and an application
+  # that routes deprecation output of its own wraps one itself. Every such
+  # wrapper answers `warn` without writing when the logger under it drops the
+  # record, exactly as ::Logger does above its level — so the notice must be
+  # left owed, not spent on a line nobody can read.
+  describe 'a logger the host wrapped' do
+    # The wrappers a host actually holds: a Delegator around a ::Logger, and
+    # a hand-written forwarder that is not a Delegator at all but answers the
+    # standard level predicate.
+    def delegating_wrapper(level)
+      SimpleDelegator.new(Logger.new(output, level: level))
+    end
+
+    def forwarding_wrapper(level)
+      Class.new do
+        def initialize(logger)
+          @logger = logger
+        end
+
+        def warn?
+          @logger.warn?
+        end
+
+        def warn(message)
+          @logger.warn(message)
+        end
+      end.new(Logger.new(output, level: level))
+    end
+
+    %i[delegating_wrapper forwarding_wrapper].each do |kind|
+      context "that is a #{kind.to_s.sub('_wrapper', '')} one" do
+        it 'does not spend the notice while it drops warnings' do
+          wrapper = send(kind, Logger::ERROR)
+
+          expect(MCPClient::Deprecations.warn(:roots, wrapper)).to be(false)
+          expect(output.string).to eq('')
+          expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+        end
+
+        it 'writes the notice once the wrapped logger keeps warnings again' do
+          wrapper = send(kind, Logger::ERROR)
+          expect(MCPClient::Deprecations.warn(:roots, wrapper)).to be(false)
+
+          working = send(kind, Logger::WARN)
+
+          expect(MCPClient::Deprecations.warn(:roots, working)).to be(true)
+          expect(output.string).to match(/Roots .*deprecated/)
+          expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+        end
+
+        it 'still writes the notice when it keeps warnings' do
+          expect(MCPClient::Deprecations.warn(:sampling, send(kind, Logger::DEBUG))).to be(true)
+          expect(output.string).to match(/Sampling .*deprecated/)
+        end
+      end
+    end
+
+    # The whole point of the claim: a first use behind a filtered wrapper must
+    # not silence the host's own working logger later on.
+    it 'leaves a client that used the feature behind it able to warn again' do
+      wrapper = delegating_wrapper(Logger::ERROR)
+      MCPClient::Client.new(mcp_server_configs: [], roots: [{ uri: 'file:///tmp' }], logger: wrapper)
+
+      expect(output.string).to eq('')
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+
+      MCPClient::Client.new(mcp_server_configs: [], roots: [{ uri: 'file:///tmp' }], logger: logger)
+
+      expect(output.string).to match(/Roots .*deprecated/)
+    end
+
+    # `Logger.new(nil)` writes nowhere whatever its level says, and wrapping
+    # it hides the missing device as surely as wrapping hides the level.
+    it 'does not spend the notice on a wrapped no-output logger' do
+      wrapper = SimpleDelegator.new(Logger.new(nil))
+
+      expect(MCPClient::Deprecations.warn(:logging, wrapper)).to be(false)
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
+      expect(MCPClient::Deprecations.warn(:logging, logger)).to be(true)
+    end
+
+    # The README lists the ways a notice can go unwritten, so a host can tell
+    # whether the one it never saw was dropped or never owed.
+    it 'is documented where the other unwritten notices are' do
+      readme = File.read(File.expand_path('../../../README.md', __dir__))
+      paragraph = readme.split(/\n\n+/).find { |block| block.include?('Notices go to the logger') }
+
+      expect(paragraph).not_to be_nil
+      expect(paragraph).to match(/wrapp?ed|wrapper/i)
+      expect(paragraph).to include('warn?')
+    end
+
+    # Asking is host code like any other: a wrapper whose predicate raises
+    # must not take the host's `roots=` down with it, and must not spend the
+    # notice on an answer nobody got.
+    it 'never fails the deprecated operation for a wrapper that cannot answer' do
+      hostile = Class.new(SimpleDelegator) do
+        def warn?
+          raise 'no'
+        end
+      end.new(Logger.new(output))
+
+      expect { MCPClient::Deprecations.warn(:roots, hostile) }.not_to raise_error
+      expect(MCPClient::Deprecations.warn(:roots, hostile)).to be(false)
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+    end
+  end
+
+  # Two bookkeeping edges the earlier rounds describe in prose and never
+  # drive: a claim held by a thread that does not survive a fork, and the
+  # reentrancy guard's reach across the fibers of one thread.
+  describe 'a notice claimed by a thread the caller then leaves behind' do
+    # A logger whose #warn parks until released, so a claim can be held open
+    # across the fork. Deliberately not a ::Logger, so the level probe takes
+    # it for one that keeps warnings.
+    let(:gated_logger_class) do
+      Class.new do
+        def initialize
+          @entered = Queue.new
+          @release = Queue.new
+        end
+
+        def warn(_message)
+          @entered << :entered
+          @release.pop
+          nil
+        end
+
+        def await_entry = @entered.pop
+        def release = @release << :go
+      end
+    end
+
+    # A prefork server claims the notice in a thread that the fork does not
+    # copy: nobody in the child will ever settle that claim, so a child that
+    # inherited it would owe the notice for the life of the worker.
+    it 'is not owed forever by a worker forked while it was in flight' do
+      skip 'fork unavailable on this platform' unless Process.respond_to?(:fork)
+
+      gated = gated_logger_class.new
+      holder = Thread.new { MCPClient::Deprecations.warn(:roots, gated) }
+      gated.await_entry
+
+      reader, writer = IO.pipe
+      pid = fork do
+        reader.close
+        child_output = StringIO.new
+        emitted = MCPClient::Deprecations.warn(:roots, Logger.new(child_output))
+        writer.write("#{emitted}\t#{child_output.string.include?('Roots')}")
+        writer.close
+        exit!(0)
+      end
+      writer.close
+      report = reader.read
+      reader.close
+      Process.waitpid(pid)
+      gated.release
+      holder.join
+
+      expect(report).to eq("true\ttrue")
+    end
+
+    it 'stands down for a fiber of the thread that is already inside it' do
+      nested = []
+      reentrant = Class.new do
+        attr_accessor :nested
+
+        def warn(_message)
+          # A formatter, a log subscriber or an audit hook that reaches a
+          # deprecated feature from inside a Fiber. The guard is a THREAD
+          # variable, not a fiber-local one, because what it guards is a
+          # claim this thread holds and every fiber of it holds with it.
+          Fiber.new { @nested << MCPClient::Deprecations.warn(:logging, self) }.resume
+          nil
+        end
+      end.new
+      reentrant.nested = nested
+
+      expect(MCPClient::Deprecations.warn(:roots, reentrant)).to be(true)
+      expect(nested).to eq([false])
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
+    end
+  end
+
+  # The Logging notice belongs to the transport, so a host that never builds
+  # an MCPClient::Client still sees it. The HTTP+SSE transport parses its own
+  # notifications rather than going through the shared routing, so it needs
+  # asking separately — and it is the one transport whose users are most
+  # likely to be on the old shape of everything.
+  describe 'a notifications/message that reaches an HTTP+SSE transport directly' do
+    let(:server) { MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: logger) }
+
+    def deliver(method, params)
+      server.send(:handle_message_event,
+                  { data: JSON.generate('jsonrpc' => '2.0', 'method' => method, 'params' => params) })
+    end
+
+    it 'warns that Logging is deprecated, and still delivers the notification' do
+      delivered = []
+      server.on_notification { |method, params| delivered << [method, params] }
+
+      deliver('notifications/message', { 'level' => 'info', 'data' => 'hello' })
+
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(true)
+      expect(output.string).to match(/Logging is deprecated/)
+      expect(delivered).to eq([['notifications/message', { 'level' => 'info', 'data' => 'hello' }]])
+    end
+
+    it 'stays silent for notifications that are not log messages' do
+      server.on_notification { |_method, _params| nil }
+
+      deliver('notifications/tools/list_changed', {})
+
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
+    end
+
+    it 'warns even for a host that registered no notification callback' do
+      deliver('notifications/message', { 'level' => 'error', 'data' => 'boom' })
+
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(true)
+    end
+  end
+
+  # The transports call the elicitation callback with (request_id, params)
+  # only, so the era of the asking server has to come from the registration.
+  # It cannot be READ there: a server is registered on before it has ever
+  # spoken, so its era at that moment is "none" — the 2025-11-25 contract —
+  # for a server that is about to negotiate 2026-07-28.
+  describe 'the era of a URL-mode elicitation routed by a real transport' do
+    let(:url_params) do
+      { 'mode' => 'url', 'message' => 'Visit to authorize', 'url' => 'https://example.com/auth',
+        'elicitationId' => 'elic-1' }
+    end
+
+    # A client on one real stdio transport, built while the server has
+    # negotiated nothing, as a client always is. No subprocess is spawned and
+    # nothing is written: only the server-request dispatch runs.
+    def elicited(server)
+      seen = []
+      allow(server).to receive(:send_elicitation_response)
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+      MCPClient::Client.new(
+        mcp_server_configs: [{ type: 'stdio', command: 'true' }],
+        elicitation_handler: lambda { |_message, metadata|
+          seen << metadata
+          { 'action' => 'accept' }
+        }
+      )
+      seen
+    end
+
+    def ask(server, id)
+      server.send(:handle_server_request, { 'id' => id, 'method' => 'elicitation/create', 'params' => url_params })
+    end
+
+    it 'is the era the server negotiated after the callback was registered' do
+      server = MCPClient::ServerStdio.new(command: 'true')
+      seen = elicited(server)
+      expect(server).not_to be_modern
+
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      ask(server, 1)
+
+      expect(seen.last).to eq({ 'mode' => 'url', 'url' => 'https://example.com/auth' })
+    end
+
+    it 'follows the same server back to a legacy era on a later session' do
+      server = MCPClient::ServerStdio.new(command: 'true')
+      seen = elicited(server)
+
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      ask(server, 1)
+      # The host reconnected and the peer answered on the older revision.
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      ask(server, 2)
+
+      expect(seen[0]).not_to have_key('elicitationId')
+      expect(seen[1]).to eq(
+        { 'mode' => 'url', 'url' => 'https://example.com/auth', 'elicitationId' => 'elic-1' }
+      )
+    end
+
+    # 2025-11-25 REQUIRES elicitationId on a URL-mode request, so a transport
+    # that dropped it on the way to the callback would break that revision.
+    it 'carries elicitationId through a legacy transport to the host' do
+      server = MCPClient::ServerStdio.new(command: 'true')
+      seen = elicited(server)
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+
+      ask(server, 1)
+
+      expect(seen.last).to eq(
+        { 'mode' => 'url', 'url' => 'https://example.com/auth', 'elicitationId' => 'elic-1' }
+      )
+    end
+
+    # A host writes its handler from whichever passage it happened to read.
+    # The README says the contract twice — once where elicitation is
+    # introduced and once in the 2026-07-28 section — and a reader of the
+    # older passage that still showed the 2025-11-25 hash as universal would
+    # go looking for `metadata['elicitationId']` on a modern server, find
+    # nothing, and correlate against a completion signal the revision removed
+    # as well.
+    describe 'as the README states it' do
+      let(:readme) { File.read(File.expand_path('../../../README.md', __dir__)) }
+      # Every passage that shows a host the hash it will be handed.
+      let(:passages) { readme.split(/\n\s*\n/).grep(/'mode' => 'url'/) }
+
+      it 'is stated wherever the README shows the hash' do
+        expect(passages.size).to be >= 2
+        passages.each do |passage|
+          expect(passage).to include('2026-07-28'), passage
+          expect(passage).to include('2025-11-25'), passage
+        end
+      end
+
+      it 'never offers elicitationId without the revision it belongs to' do
+        passages.each do |passage|
+          next unless passage.include?('elicitationId')
+
+          expect(passage).to match(/\*\*2025-11-25\*\*/), passage
+          expect(passage).to match(/removed/i), passage
+        end
+      end
+    end
+
+    it 'answers the server whichever era it is on' do
+      server = MCPClient::ServerStdio.new(command: 'true')
+      answers = []
+      allow(server).to receive(:send_elicitation_response) { |id, result| answers << [id, result] }
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+      MCPClient::Client.new(
+        mcp_server_configs: [{ type: 'stdio', command: 'true' }],
+        elicitation_handler: ->(_message, _metadata) { { 'action' => 'accept' } }
+      )
+
+      server.instance_variable_set(:@protocol_version, '2026-07-28')
+      ask(server, 1)
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      ask(server, 2)
+
+      expect(answers).to eq([[1, { 'action' => 'accept' }], [2, { 'action' => 'accept' }]])
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round13_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round13_spec.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Round 13 of the 2026-07-28 deprecation review: a notice must not cost the
+# peer its answer. Every earlier example on these paths pinned the notice and
+# stopped there, so a transport that logged the notice and dropped the
+# response passed them all. Here the stdio transport is held to the response
+# envelope it owes a legacy sampling request, the sampling handler to the
+# includeContext value it was reported for, a multi round-trip failure with
+# notices enabled to the failure it is with them disabled, and a modern URL
+# elicitation to a complete discovery -> input_required -> continuation
+# exchange rather than a direct call into fulfilment.
+RSpec.describe 'MCP 2026-07-28 deprecations (round 13)' do
+  let(:output) { StringIO.new }
+  let(:logger) { Logger.new(output) }
+
+  around do |example|
+    MCPClient::Deprecations.enabled = true
+    MCPClient::Deprecations.reset!
+    example.run
+  ensure
+    MCPClient::Deprecations.reset!
+    MCPClient::Deprecations.enabled = false
+  end
+
+  let(:answer) do
+    { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'Paris' }, 'model' => 'm' }
+  end
+
+  def sampling_params(include_context = 'thisServer')
+    params = { 'messages' => [{ 'role' => 'user', 'content' => { 'type' => 'text', 'text' => 'Capital?' } }],
+               'maxTokens' => 100 }
+    params['includeContext'] = include_context unless include_context == :absent
+    params
+  end
+
+  # A stdio server driven by scripted responses (no subprocess), as the MRTR
+  # spec drives one. Returns every request the transport sent.
+  def script_stdio(server, responses)
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift
+      raise 'no scripted response left' unless responder
+
+      response = responder.respond_to?(:call) ? responder.call(sent.last) : responder
+      response.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+    sent
+  end
+
+  def discover_result
+    { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+      'capabilities' => { 'tools' => {}, 'resources' => {}, 'prompts' => {} } }
+  end
+
+  def input_required(requests)
+    { 'resultType' => 'input_required', 'requestState' => 'opaque-state', 'inputRequests' => requests }
+  end
+
+  def done
+    { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'done' }] } }
+  end
+
+  describe 'a legacy sampling request served by a stdio transport driven directly' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'true', logger: logger) }
+    let(:sent) { [] }
+    let(:seen) { [] }
+
+    before { allow(server).to receive(:send_message) { |message| sent << message } }
+
+    def serve(id, params = sampling_params)
+      server.send(:handle_server_request,
+                  { 'id' => id, 'method' => 'sampling/createMessage', 'params' => params })
+    end
+
+    it 'answers the peer with the handler result under the request id, the params intact' do
+      server.on_sampling_request do |_id, params|
+        seen << params
+        answer
+      end
+
+      serve(2)
+
+      expect(sent).to eq([{ 'jsonrpc' => '2.0', 'id' => 2, 'result' => answer }])
+      expect(seen).to eq([sampling_params])
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+      expect(MCPClient::Deprecations.emitted?(:include_context)).to be(true)
+    end
+
+    it 'answers the next request once the notice is spent' do
+      server.on_sampling_request { |id, _params| answer.merge('model' => "m-#{id}") }
+
+      serve(2)
+      serve(3)
+
+      expect(sent.map { |message| [message['id'], message['result']['model']] }).to eq([[2, 'm-2'], [3, 'm-3']])
+      expect(output.string.scan(/Sampling .*deprecated/).size).to eq(1)
+    end
+
+    it 'answers with the error envelope the handler chose' do
+      server.on_sampling_request do |_id, _params|
+        { 'error' => { 'code' => -32_001, 'message' => 'Sampling rejected' } }
+      end
+
+      serve(4)
+
+      expect(sent).to eq([{ 'jsonrpc' => '2.0', 'id' => 4,
+                            'error' => { 'code' => -32_001, 'message' => 'Sampling rejected' } }])
+    end
+
+    it 'answers Internal error, keeping the exception text local, when the handler raises' do
+      server.on_sampling_request { |_id, _params| raise 'provider down at /secret/path' }
+
+      serve(5)
+
+      expect(sent).to eq([{ 'jsonrpc' => '2.0', 'id' => 5,
+                            'error' => { 'code' => -32_603, 'message' => 'Internal error' } }])
+      expect(output.string).to include('/secret/path')
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+    end
+  end
+
+  describe 'a sampling input request on the multi round-trip path with notices enabled' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'true', read_timeout: 1, logger: logger) }
+    let(:seen) { [] }
+
+    def sampling_request(include_context = 'thisServer')
+      { 'method' => 'sampling/createMessage', 'params' => sampling_params(include_context) }
+    end
+
+    def exchange(requests)
+      sent = script_stdio(server, [{ 'result' => discover_result }, { 'result' => input_required(requests) }, done])
+      [server.call_tool('answer', {}), sent.select { |request| request['method'] == 'tools/call' }]
+    end
+
+    %w[thisServer allServers none].each do |value|
+      it "hands includeContext #{value} to the sampling handler unchanged" do
+        server.on_sampling_request do |_key, params|
+          seen << params
+          answer
+        end
+
+        result, calls = exchange('c' => sampling_request(value))
+
+        expect(seen).to eq([sampling_params(value)])
+        expect(seen.first['includeContext']).to eq(value)
+        expect(result['content'].first['text']).to eq('done')
+        expect(calls.last['params']['inputResponses']).to eq({ 'c' => answer })
+      end
+    end
+
+    it 'hands a request without includeContext to the sampling handler without one' do
+      server.on_sampling_request do |_key, params|
+        seen << params
+        answer
+      end
+
+      exchange('c' => sampling_request(:absent))
+
+      expect(seen).to eq([sampling_params(:absent)])
+      expect(seen.first).not_to have_key('includeContext')
+    end
+
+    def failing_exchange(requests)
+      script_stdio(server, [{ 'result' => discover_result }, { 'result' => input_required(requests) }])
+    end
+
+    def tools_calls(sent)
+      sent.count { |request| request['method'] == 'tools/call' }
+    end
+
+    it 'fails the round trip without a continuation when the handler raises, the notice already out' do
+      server.on_sampling_request { |_key, _params| raise 'provider down' }
+      sent = failing_exchange('c' => sampling_request)
+
+      expect { server.call_tool('answer', {}) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /failed/)
+      expect(tools_calls(sent)).to eq(1)
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+      expect(MCPClient::Deprecations.emitted?(:include_context)).to be(true)
+    end
+
+    it 'fails the round trip when the handler answers with an error' do
+      server.on_sampling_request { |_key, _params| { 'error' => { 'code' => -1, 'message' => 'Sampling rejected' } } }
+      sent = failing_exchange('c' => sampling_request)
+
+      expect { server.call_tool('answer', {}) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /Sampling rejected/)
+      expect(tools_calls(sent)).to eq(1)
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+    end
+
+    it 'fails the round trip when the handler returns something other than a result object' do
+      server.on_sampling_request { |_key, _params| 'Paris' }
+      sent = failing_exchange('c' => sampling_request)
+
+      expect { server.call_tool('answer', {}) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /expected a result object/)
+      expect(tools_calls(sent)).to eq(1)
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+    end
+
+    # No handler means no use of Sampling: the refusal is the same as with
+    # notices disabled, and nothing is said about a feature never adopted.
+    it 'stays silent when no sampling handler is registered' do
+      sent = failing_exchange('c' => sampling_request)
+
+      expect { server.call_tool('answer', {}) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /no handler is registered/)
+      expect(tools_calls(sent)).to eq(1)
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(false)
+      expect(MCPClient::Deprecations.emitted?(:include_context)).to be(false)
+    end
+
+    # The deprecated values were on the wire, and a host with a sampling
+    # handler asked for them: the 2025-11-25 path warns before its handler
+    # rejects the undeclared tools, and the round trip is the same use.
+    it 'still warns for a tool-enabled request it refuses for the undeclared sampling.tools capability' do
+      server.on_sampling_request do |_key, params|
+        seen << params
+        answer
+      end
+      request = sampling_request.merge('params' => sampling_params.merge('tools' => []))
+      sent = failing_exchange('c' => request)
+
+      expect { server.call_tool('answer', {}) }
+        .to raise_error(MCPClient::Errors::InputRequiredError, /sampling\.tools/)
+      expect(tools_calls(sent)).to eq(1)
+      expect(seen).to be_empty
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+      expect(MCPClient::Deprecations.emitted?(:include_context)).to be(true)
+      expect(output.string).to include('Received: includeContext thisServer')
+    end
+  end
+
+  # The removed-fields and round 12 examples reach the elicitation callback
+  # by calling fulfilment directly or dispatching a server-initiated request
+  # by hand. This is the exchange itself, on both eras of the same transport.
+  describe 'a URL elicitation fulfilled through the exchange a real transport runs' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'true', read_timeout: 1, logger: logger) }
+    let(:seen) { [] }
+    let(:url_params) do
+      { 'mode' => 'url', 'message' => 'Visit to authorize', 'url' => 'https://example.com/auth',
+        'elicitationId' => 'elic-1' }
+    end
+
+    # A client on this one transport, registered before the server has
+    # negotiated anything, as a client always is.
+    before do
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+      MCPClient::Client.new(
+        mcp_server_configs: [{ type: 'stdio', command: 'true' }], logger: logger,
+        elicitation_handler: lambda { |_message, metadata|
+          seen << metadata
+          { 'action' => 'accept' }
+        }
+      )
+    end
+
+    it 'discovers, receives the input request and continues with the answer on 2026-07-28' do
+      sent = script_stdio(server, [
+                            { 'result' => discover_result },
+                            { 'result' => input_required('k1' => { 'method' => 'elicitation/create',
+                                                                   'params' => url_params }) },
+                            done
+                          ])
+
+      result = server.call_tool('authorize', { 'scope' => 'read' })
+
+      expect(result['content'].first['text']).to eq('done')
+      expect(sent.map { |request| request['method'] }).to eq(%w[server/discover tools/call tools/call])
+      calls = sent.select { |request| request['method'] == 'tools/call' }
+      expect(calls.first['params']).to include('name' => 'authorize', 'arguments' => { 'scope' => 'read' })
+      expect(calls.first['params']).not_to have_key('requestState')
+      expect(calls.last['params']).to include('name' => 'authorize', 'arguments' => { 'scope' => 'read' },
+                                              'requestState' => 'opaque-state',
+                                              'inputResponses' => { 'k1' => { 'action' => 'accept' } })
+      expect(seen).to eq([{ 'mode' => 'url', 'url' => 'https://example.com/auth' }])
+    end
+
+    it 'serves the server-initiated request with the response envelope on 2025-11-25' do
+      sent = []
+      allow(server).to receive(:send_message) { |message| sent << message }
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      expect(server).not_to be_modern
+
+      server.send(:handle_server_request, { 'id' => 7, 'method' => 'elicitation/create', 'params' => url_params })
+
+      expect(sent).to eq([{ 'jsonrpc' => '2.0', 'id' => 7, 'result' => { 'action' => 'accept' } }])
+      expect(seen).to eq([{ 'mode' => 'url', 'url' => 'https://example.com/auth', 'elicitationId' => 'elic-1' }])
+    end
+
+    # The other half of changelog minor change 11: 2026-07-28 removed
+    # `notifications/elicitation/complete` along with the id it correlated
+    # by. This library never treated it as completion — the outcome is
+    # learned by retrying — so on either era it is an unknown notification:
+    # nothing raises, the elicitation handler is not invoked, and the id it
+    # carries reaches no host callback as an elicitation.
+    %w[2025-11-25 2026-07-28].each do |era|
+      it "ignores notifications/elicitation/complete on #{era}" do
+        server.instance_variable_set(:@protocol_version, era)
+
+        expect do
+          server.route_notification('notifications/elicitation/complete', { 'elicitationId' => 'elic-1' })
+        end.not_to raise_error
+
+        expect(seen).to be_empty
+        expect(output.string).not_to match(/error/i)
+      end
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round14_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round14_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 14)' do
       { 'mode' => 'url', 'message' => 'Visit to authorize', 'url' => 'https://example.com/auth' }
     end
 
-    before do
+    let!(:client) do
       allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
       MCPClient::Client.new(
         mcp_server_configs: [{ type: 'stdio', command: 'true' }], logger: logger,
@@ -294,7 +294,9 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 14)' do
     end
 
     it 'does not finish the interaction: the outcome is still the continuation the server answers' do
-      server.on_notification { |method, params| notified << [method, params] }
+      # Observed through the Client's own listener list, so the Client's
+      # notification routing stays in the path and is what is being watched.
+      client.on_notification { |_server, method, params| notified << [method, params] }
       sent = script_stdio(server, [
                             { 'result' => discover_result },
                             { 'result' => input_required('k1' => { 'method' => 'elicitation/create',
@@ -312,6 +314,35 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 14)' do
       expect(seen.size).to eq(2)
       # The removed notification is still handed to a generic listener as the
       # raw method it was sent under; nothing in the client acted on it.
+      expect(notified).to eq([['notifications/elicitation/complete', { 'elicitationId' => 'elic-1' }]] * 2)
+      expect(output.string).not_to match(/error/i)
+    end
+
+    # The same notification arriving as a PEER MESSAGE on the stream — read
+    # by the transport's own line handling between the continuation and the
+    # retry, as a stale server would send it — is routed like any other
+    # notification and finishes nothing either.
+    it 'does not finish the interaction when the notification arrives on the stream' do
+      client.on_notification { |_server, method, params| notified << [method, params] }
+      complete = { 'jsonrpc' => '2.0', 'method' => 'notifications/elicitation/complete',
+                   'params' => { 'elicitationId' => 'elic-1' } }
+      sent = script_stdio(server, [
+                            { 'result' => discover_result },
+                            lambda { |_request|
+                              server.send(:handle_line, "#{JSON.generate(complete)}\n")
+                              { 'result' => input_required('k1' => { 'method' => 'elicitation/create',
+                                                                     'params' => url_params }) }
+                            },
+                            done
+                          ])
+
+      result = server.call_tool('authorize', {})
+
+      expect(result['content'].first['text']).to eq('done')
+      expect(sent.map { |request| request['method'] }).to eq(%w[server/discover tools/call tools/call])
+      expect(sent.last.dig('params', 'inputResponses')).to eq({ 'k1' => { 'action' => 'accept' } })
+      expect(seen.size).to eq(1)
+      # Delivered once from the stream, once more from inside the handler.
       expect(notified).to eq([['notifications/elicitation/complete', { 'elicitationId' => 'elic-1' }]] * 2)
       expect(output.string).not_to match(/error/i)
     end

--- a/spec/lib/mcp_client/deprecations_2026_round14_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round14_spec.rb
@@ -1,0 +1,319 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 deprecations, fourteenth review round: a deprecation notice
+# is a side effect of the deprecated operation, never a substitute for it —
+# the level still reaches every server on its own era's path, deprecated
+# capabilities stay advertised on every exchange of a notice-enabled client,
+# and the removed completion notification cannot finish an interaction that
+# is still waiting on the server's answer.
+RSpec.describe 'MCP 2026-07-28 deprecations (round 14)' do
+  let(:output) { StringIO.new }
+  let(:logger) { Logger.new(output) }
+
+  around do |example|
+    MCPClient::Deprecations.enabled = true
+    MCPClient::Deprecations.reset!
+    example.run
+  ensure
+    MCPClient::Deprecations.reset!
+    MCPClient::Deprecations.enabled = false
+  end
+
+  # A stdio transport driven by scripted responses (no subprocess). Returns
+  # every request the transport sent.
+  def script_stdio(server, responses)
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift
+      raise 'no scripted response left' unless responder
+
+      response = responder.respond_to?(:call) ? responder.call(sent.last) : responder
+      response.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+    sent
+  end
+
+  # A stdio transport that already negotiated the 2025-11-25 handshake and
+  # declared logging; only the requests after it are of interest.
+  def legacy_stdio(server, capabilities: { 'logging' => {} })
+    allow(server).to receive(:ensure_initialized)
+    server.instance_variable_set(:@initialized, true)
+    server.instance_variable_set(:@protocol_version, '2025-11-25')
+    server.instance_variable_set(:@capabilities, capabilities)
+    server
+  end
+
+  # The modern server declares logging: a client only uses what was
+  # negotiated, on either era.
+  def discover_result
+    { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+      'capabilities' => { 'tools' => {}, 'resources' => {}, 'prompts' => {}, 'logging' => {} } }
+  end
+
+  def done
+    { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'done' }] } }
+  end
+
+  def input_required(requests)
+    { 'resultType' => 'input_required', 'requestState' => 'opaque-state', 'inputRequests' => requests }
+  end
+
+  describe 'the level a notice-enabled client sets' do
+    let(:legacy) { legacy_stdio(MCPClient::ServerStdio.new(command: 'true', logger: logger)) }
+    let(:modern) { MCPClient::ServerStdio.new(command: 'true', read_timeout: 1, logger: logger) }
+    let(:client) do
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(legacy, modern)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'true' },
+                                                 { type: 'stdio', command: 'true' }], logger: logger)
+    end
+
+    it 'reaches the legacy server as logging/setLevel and the modern one on its next request' do
+      legacy_sent = script_stdio(legacy, [{ 'result' => {} }])
+      modern_sent = script_stdio(modern, [{ 'result' => discover_result }, done])
+
+      client.log_level = 'debug'
+      modern.call_tool('t', {})
+
+      expect(output.string).to include('Logging is deprecated')
+      set_level = legacy_sent.find { |request| request['method'] == 'logging/setLevel' }
+      expect(set_level).not_to be_nil
+      expect(set_level['params']).to eq({ 'level' => 'debug' })
+      call = modern_sent.find { |request| request['method'] == 'tools/call' }
+      expect(call.dig('params', '_meta', 'io.modelcontextprotocol/logLevel')).to eq('debug')
+    end
+
+    it 'still reaches every server once the notice is spent' do
+      legacy_sent = script_stdio(legacy, [{ 'result' => {} }, { 'result' => {} }])
+      modern_sent = script_stdio(modern, [{ 'result' => discover_result }, done, done])
+
+      client.log_level = 'debug'
+      modern.call_tool('t', {})
+      client.log_level = 'warning'
+      modern.call_tool('t', {})
+
+      expect(output.string.scan('Logging is deprecated').size).to eq(1)
+      levels = legacy_sent.select { |request| request['method'] == 'logging/setLevel' }
+                          .map { |request| request.dig('params', 'level') }
+      expect(levels).to eq(%w[debug warning])
+      calls = modern_sent.select { |request| request['method'] == 'tools/call' }
+                         .map { |request| request.dig('params', '_meta', 'io.modelcontextprotocol/logLevel') }
+      expect(calls).to eq(%w[debug warning])
+    end
+
+    it 'skips only the legacy server whose negotiated set lacks logging' do
+      legacy_sent = script_stdio(legacy_stdio(legacy, capabilities: { 'tools' => {} }), [])
+      modern_sent = script_stdio(modern, [{ 'result' => discover_result }, done])
+
+      client.log_level = 'debug'
+      modern.call_tool('t', {})
+
+      expect(legacy_sent).to be_empty
+      call = modern_sent.find { |request| request['method'] == 'tools/call' }
+      expect(call.dig('params', '_meta', 'io.modelcontextprotocol/logLevel')).to eq('debug')
+    end
+  end
+
+  describe 'the level set through a logger that writes nothing' do
+    it 'is carried by the next modern request all the same' do
+      server = MCPClient::ServerStdio.new(command: 'true', read_timeout: 1, logger: Logger.new(nil))
+      sent = script_stdio(server, [{ 'result' => discover_result }, done])
+
+      server.log_level = 'debug'
+      server.call_tool('t', {})
+
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
+      call = sent.find { |request| request['method'] == 'tools/call' }
+      expect(call.dig('params', '_meta', 'io.modelcontextprotocol/logLevel')).to eq('debug')
+    end
+
+    it 'is sent to a legacy server all the same' do
+      server = legacy_stdio(MCPClient::ServerStdio.new(command: 'true', logger: Logger.new(nil)))
+      sent = script_stdio(server, [{ 'result' => {} }])
+
+      server.log_level = 'debug'
+
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
+      expect(sent.map { |request| request['method'] }).to eq(['logging/setLevel'])
+    end
+  end
+
+  describe 'the capabilities a notice-enabled client keeps advertising' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'true', read_timeout: 1, logger: logger) }
+    let(:url_params) do
+      { 'mode' => 'url', 'message' => 'Visit to authorize', 'url' => 'https://example.com/auth' }
+    end
+    let(:declared) do
+      { 'elicitation' => { 'form' => {}, 'url' => {} }, 'roots' => {}, 'sampling' => {} }
+    end
+
+    before do
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+      MCPClient::Client.new(
+        mcp_server_configs: [{ type: 'stdio', command: 'true' }], logger: logger,
+        roots: [MCPClient::Root.new(uri: 'file:///work', name: 'work')],
+        elicitation_handler: ->(_message, _metadata) { { 'action' => 'accept' } },
+        sampling_handler: lambda { |_params|
+          { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'x' }, 'model' => 'm' }
+        }
+      )
+    end
+
+    it 'names them on the first modern request and on the continuation alike' do
+      sent = script_stdio(server, [
+                            { 'result' => discover_result },
+                            { 'result' => input_required('k1' => { 'method' => 'elicitation/create',
+                                                                   'params' => url_params }) },
+                            done
+                          ])
+
+      server.call_tool('authorize', {})
+
+      calls = sent.select { |request| request['method'] == 'tools/call' }
+      expect(calls.size).to eq(2)
+      calls.each do |request|
+        advertised = request.dig('params', '_meta', 'io.modelcontextprotocol/clientCapabilities')
+        expect(advertised).to include(declared)
+        # 2026-07-28 sampling: a server SHOULD NOT send thisServer/allServers
+        # unless sampling.context is declared — it never is.
+        expect(advertised['sampling']).not_to have_key('context')
+      end
+      expect(output.string).to match(/deprecated/)
+    end
+
+    it 'advertises roots on every modern request even before any root is configured' do
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+      MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'true' }], logger: logger)
+      sent = script_stdio(server, [{ 'result' => discover_result }, done])
+
+      server.call_tool('t', {})
+
+      call = sent.find { |request| request['method'] == 'tools/call' }
+      expect(call.dig('params', '_meta', 'io.modelcontextprotocol/clientCapabilities')).to include('roots' => {})
+    end
+
+    it 'names them on the 2025-11-25 handshake' do
+      sent = script_stdio(server, [
+                            { 'error' => { 'code' => -32_601, 'message' => 'Method not found' } },
+                            { 'result' => { 'protocolVersion' => '2025-11-25', 'capabilities' => { 'tools' => {} },
+                                            'serverInfo' => { 'name' => 's', 'version' => '1' } } },
+                            done
+                          ])
+
+      server.call_tool('t', {})
+
+      handshake = sent.find { |request| request['method'] == 'initialize' }
+      expect(handshake).not_to be_nil
+      # The handshake still promises notifications/roots/list_changed; a
+      # modern session, which has no such notification, omits the flag.
+      expect(handshake.dig('params', 'capabilities')).to include(declared.merge('roots' => { 'listChanged' => true }))
+    end
+  end
+
+  describe 'a 2025-11-25 tool-enabled sampling request the client must refuse' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'true', logger: logger) }
+    let(:sent) { [] }
+
+    before do
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+      MCPClient::Client.new(
+        mcp_server_configs: [{ type: 'stdio', command: 'true' }], logger: logger,
+        sampling_handler: lambda { |_params|
+          { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'x' }, 'model' => 'm' }
+        }
+      )
+      allow(server).to receive(:send_message) { |message| sent << message }
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+    end
+
+    it 'refuses it on the wire and still gives the includeContext notice, as the round-trip path does' do
+      server.send(:handle_server_request, {
+                    'id' => 9, 'method' => 'sampling/createMessage',
+                    'params' => { 'messages' => [], 'maxTokens' => 5, 'includeContext' => 'thisServer',
+                                  'tools' => [] }
+                  })
+
+      expect(sent.size).to eq(1)
+      expect(sent.first.dig('error', 'code')).to eq(-32_602)
+      expect(sent.first.dig('error', 'message')).to match(/sampling\.tools/)
+      expect(output.string).to match(/includeContext thisServer/)
+      expect(output.string).to match(/Sampling .*deprecated/)
+    end
+
+    # The same MUST holds for a host driving the transport directly: the
+    # refusal is the transport's, not the Client callback's.
+    it 'is refused by the transport itself when a host serves sampling without declaring tools' do
+      transport = MCPClient::ServerStdio.new(command: 'true', logger: logger)
+      served = []
+      transport.on_sampling_request do |_id, params|
+        served << params
+        { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'x' }, 'model' => 'm' }
+      end
+      allow(transport).to receive(:send_message) { |message| sent << message }
+      transport.instance_variable_set(:@protocol_version, '2025-11-25')
+
+      transport.send(:handle_server_request, {
+                       'id' => 10, 'method' => 'sampling/createMessage',
+                       'params' => { 'messages' => [], 'maxTokens' => 5, 'toolChoice' => { 'mode' => 'auto' } }
+                     })
+
+      expect(served).to be_empty
+      expect(sent.size).to eq(1)
+      expect(sent.first.dig('error', 'code')).to eq(-32_602)
+      expect(sent.first.dig('error', 'message')).to match(/sampling\.tools/)
+      expect(output.string).to match(/Sampling .*deprecated/)
+    end
+  end
+
+  describe 'a completion notification arriving during an unfinished modern interaction' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'true', read_timeout: 1, logger: logger) }
+    let(:seen) { [] }
+    let(:notified) { [] }
+    let(:url_params) do
+      { 'mode' => 'url', 'message' => 'Visit to authorize', 'url' => 'https://example.com/auth' }
+    end
+
+    before do
+      allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+      MCPClient::Client.new(
+        mcp_server_configs: [{ type: 'stdio', command: 'true' }], logger: logger,
+        elicitation_handler: lambda { |_message, metadata|
+          seen << metadata
+          # The removed notification lands while this elicitation is still
+          # being served, as a stale server might send it.
+          server.route_notification('notifications/elicitation/complete', { 'elicitationId' => 'elic-1' })
+          { 'action' => 'accept' }
+        }
+      )
+    end
+
+    it 'does not finish the interaction: the outcome is still the continuation the server answers' do
+      server.on_notification { |method, params| notified << [method, params] }
+      sent = script_stdio(server, [
+                            { 'result' => discover_result },
+                            { 'result' => input_required('k1' => { 'method' => 'elicitation/create',
+                                                                   'params' => url_params }) },
+                            { 'result' => input_required('k2' => { 'method' => 'elicitation/create',
+                                                                   'params' => url_params }) },
+                            done
+                          ])
+
+      result = server.call_tool('authorize', {})
+
+      expect(result['content'].first['text']).to eq('done')
+      expect(sent.map { |request| request['method'] }).to eq(%w[server/discover tools/call tools/call tools/call])
+      expect(sent.last.dig('params', 'inputResponses')).to eq({ 'k2' => { 'action' => 'accept' } })
+      expect(seen.size).to eq(2)
+      # The removed notification is still handed to a generic listener as the
+      # raw method it was sent under; nothing in the client acted on it.
+      expect(notified).to eq([['notifications/elicitation/complete', { 'elicitationId' => 'elic-1' }]] * 2)
+      expect(output.string).not_to match(/error/i)
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round15_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round15_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 deprecations, fifteenth review round: the diagnostics a
+# deprecated operation writes never change the answer the peer gets — a
+# logger that fails on the way to a sampling refusal still leaves -32602 on
+# the wire — and the transport-direct sampling paths are pinned end to end
+# (no handler → -32601, declared tools → served), while the one write failure
+# a standard Logger hides from its caller is named as the boundary of the
+# notice's retry guarantee.
+RSpec.describe 'MCP 2026-07-28 deprecations (round 15)' do
+  let(:output) { StringIO.new }
+  let(:logger) { Logger.new(output) }
+
+  around do |example|
+    MCPClient::Deprecations.enabled = true
+    MCPClient::Deprecations.reset!
+    example.run
+  ensure
+    MCPClient::Deprecations.reset!
+    MCPClient::Deprecations.enabled = false
+  end
+
+  # A host logger whose WARN level is broken (its device raises on that
+  # path) while every other level still writes.
+  def warn_raising_logger
+    Class.new(Logger) do
+      def warn(*)
+        raise IOError, 'warn device gone'
+      end
+    end.new(output)
+  end
+
+  let(:answer) { { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'x' }, 'model' => 'm' } }
+  let(:tool_request) do
+    { 'messages' => [], 'maxTokens' => 5, 'tools' => [{ 'name' => 'lookup', 'inputSchema' => {} }],
+      'toolChoice' => { 'mode' => 'auto' } }
+  end
+
+  describe 'a sampling request served by a stdio transport driven directly' do
+    let(:sent) { [] }
+
+    def stdio(log)
+      server = MCPClient::ServerStdio.new(command: 'true', logger: log)
+      allow(server).to receive(:send_message) { |message| sent << message }
+      server.instance_variable_set(:@protocol_version, '2025-11-25')
+      server
+    end
+
+    def serve(server, id, params)
+      server.send(:handle_server_request, { 'id' => id, 'method' => 'sampling/createMessage', 'params' => params })
+    end
+
+    # A capability this host never registered for is an unsupported method,
+    # not a rejected request: -32601, the envelope complete, and no notice
+    # for a feature the host does not use.
+    it 'answers a host with no sampling handler with -32601 and spends no notice' do
+      serve(stdio(logger), 2, { 'messages' => [], 'maxTokens' => 5, 'includeContext' => 'thisServer' })
+
+      expect(sent).to eq([{ 'jsonrpc' => '2.0', 'id' => 2,
+                            'error' => { 'code' => -32_601, 'message' => 'Sampling not supported' } }])
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(false)
+      expect(MCPClient::Deprecations.emitted?(:include_context)).to be(false)
+      expect(output.string).not_to match(/deprecated/)
+    end
+
+    # SEP-1577's refusal is the transport's answer to the peer; the line it
+    # logs about it is a courtesy to the host. A logger that fails on that
+    # line must not turn Invalid params into Internal error.
+    it 'still refuses undeclared tool use with -32602 when the logger fails on the warning' do
+      server = stdio(warn_raising_logger)
+      served = []
+      server.on_sampling_request do |_id, params|
+        served << params
+        answer
+      end
+
+      serve(server, 3, tool_request)
+
+      expect(served).to be_empty
+      expect(sent.size).to eq(1)
+      expect(sent.first['error']).to include('code' => -32_602)
+      expect(sent.first['error']['message']).to match(/sampling\.tools/)
+    end
+
+    it 'serves a tool-enabled request, parameters intact, once the host declared sampling.tools' do
+      server = stdio(logger)
+      server.declare_sampling_tools
+      served = []
+      server.on_sampling_request do |_id, params|
+        served << params
+        answer
+      end
+
+      serve(server, 4, tool_request)
+
+      expect(served).to eq([tool_request])
+      expect(sent).to eq([{ 'jsonrpc' => '2.0', 'id' => 4, 'result' => answer }])
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+    end
+  end
+
+  describe 'a sampling request routed by an HTTP transport whose logger fails on the warning' do
+    let(:posted) { [] }
+
+    {
+      'the HTTP+SSE transport' => lambda { |logger|
+        MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: logger)
+      },
+      'the Streamable HTTP transport' => lambda { |logger|
+        MCPClient::ServerStreamableHTTP.new(base_url: 'http://localhost:1/mcp', logger: logger)
+      }
+    }.each do |label, build|
+      it "still refuses undeclared tool use with -32602 on #{label}" do
+        server = build.call(warn_raising_logger)
+        allow(server).to receive(:ensure_initialized) if server.respond_to?(:ensure_initialized, true)
+        allow(server).to receive(:post_jsonrpc_response) { |response| posted << response }
+        served = []
+        server.on_sampling_request do |_id, params|
+          served << params
+          answer
+        end
+
+        server.send(:handle_server_request,
+                    { 'id' => 5, 'method' => 'sampling/createMessage', 'params' => tool_request })
+
+        expect(served).to be_empty
+        expect(posted.size).to eq(1)
+        expect(posted.first['error']).to include('code' => -32_602)
+        expect(posted.first['error']['message']).to match(/sampling\.tools/)
+      end
+    end
+  end
+
+  # ::Logger's device catches its own write failure and reports it on
+  # $stderr only ("log writing failed."), so `logger.warn` returns as if it
+  # had written. A device that is closed is recognised and the notice kept
+  # owed; a device that is open and fails to write is beyond reach — the
+  # boundary of the retry guarantee, pinned here so it is not mistaken for a
+  # promise.
+  describe 'a standard logger whose open device fails to write' do
+    let(:failing_device) do
+      Class.new(StringIO) do
+        def write(*)
+          raise IOError, 'disk gone'
+        end
+      end.new
+    end
+    let(:failing_logger) { Logger.new(failing_device) }
+
+    it 'spends the notice, reporting the failure only where ::Logger does' do
+      stderr = StringIO.new
+      original = $stderr
+      $stderr = stderr
+      begin
+        expect(MCPClient::Deprecations.warn(:roots, failing_logger)).to be(true)
+      ensure
+        $stderr = original
+      end
+
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+      expect(stderr.string).to include('log writing failed')
+      expect(MCPClient::Deprecations.warn(:roots, logger)).to be(false)
+      expect(output.string).to be_empty
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round16_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round16_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 deprecations, sixteenth review round: the notice is a side
+# effect, never the operation. Every transport that still offers Logging must
+# be shown doing the deprecated work on its own era's path — the HTTP
+# transports carry their own `log_level=`, and a notice-only one would have
+# passed the suite before this file — and the Roots answer a modern server
+# asks for through the multi round-trip pattern must reach the wire under the
+# key the server named, with its opaque state echoed back.
+RSpec.describe 'MCP 2026-07-28 deprecations (round 16)' do
+  let(:output) { StringIO.new }
+  let(:logger) { Logger.new(output) }
+
+  around do |example|
+    MCPClient::Deprecations.enabled = true
+    MCPClient::Deprecations.reset!
+    example.run
+  ensure
+    MCPClient::Deprecations.reset!
+    MCPClient::Deprecations.enabled = false
+  end
+
+  # Each HTTP transport implements `log_level=` itself. The notice is asserted
+  # elsewhere; what is asserted here is the operation the notice is about.
+  describe 'the log level an HTTP transport is given' do
+    # A transport whose connection is already established, so the setter runs
+    # against the era under test without any wire traffic of its own.
+    def http_transport(klass, version)
+      server = klass.new(base_url: 'http://localhost:1', logger: logger)
+      server.instance_variable_set(:@protocol_version, version)
+      allow(server).to receive(:ensure_connected)
+      allow(server).to receive(:ensure_initialized) if server.respond_to?(:ensure_initialized, true)
+      server
+    end
+
+    [MCPClient::ServerHTTP, MCPClient::ServerStreamableHTTP].each do |klass|
+      context "with #{klass}" do
+        it 'carries it on every later modern request instead of sending logging/setLevel' do
+          server = http_transport(klass, '2026-07-28')
+          expect(server).to be_modern
+          sent = []
+          allow(server).to receive(:rpc_request) { |method, params| sent << [method, params] }
+
+          server.log_level = 'debug'
+
+          expect(sent).to be_empty
+          expect(server.with_request_meta({ 'name' => 'tool' })['_meta']['io.modelcontextprotocol/logLevel'])
+            .to eq('debug')
+        end
+
+        it 'sends logging/setLevel on a legacy session' do
+          server = http_transport(klass, '2025-06-18')
+          expect(server).not_to be_modern
+          allow(server).to receive(:require_capability!)
+          sent = []
+          allow(server).to receive(:rpc_request) { |method, params| sent << [method, params] }
+
+          server.log_level = 'debug'
+
+          expect(sent.size).to eq(1)
+          method, params = sent.first
+          expect(method).to eq('logging/setLevel')
+          expect(params.transform_keys(&:to_s)).to eq({ 'level' => 'debug' })
+        end
+
+        it 'refuses a level the protocol does not define, before anything goes out' do
+          server = http_transport(klass, '2026-07-28')
+          sent = []
+          allow(server).to receive(:rpc_request) { |method, params| sent << [method, params] }
+
+          expect { server.log_level = 'chatty' }.to raise_error(ArgumentError, /chatty/)
+          expect(sent).to be_empty
+          expect(server.with_request_meta({ 'name' => 'tool' })['_meta'])
+            .not_to have_key('io.modelcontextprotocol/logLevel')
+        end
+      end
+    end
+
+    # The HTTP+SSE transport is itself pre-2026 and negotiates no modern
+    # revision, so Logging there is only ever the request path.
+    it 'sends logging/setLevel from the HTTP+SSE transport' do
+      server = MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: logger)
+      allow(server).to receive(:ensure_initialized)
+      allow(server).to receive(:require_capability!)
+      sent = []
+      allow(server).to receive(:rpc_request) { |method, params| sent << [method, params] }
+
+      server.log_level = 'debug'
+
+      expect(sent.size).to eq(1)
+      method, params = sent.first
+      expect(method).to eq('logging/setLevel')
+      expect(params.transform_keys(&:to_s)).to eq({ 'level' => 'debug' })
+    end
+  end
+
+  # A stdio transport driven by scripted responses (no subprocess), as the
+  # multi round-trip specs drive one. Returns every request it sent.
+  def script_stdio(server, responses)
+    sent = []
+    allow(server).to receive(:connect).and_return(true)
+    allow(server).to receive(:start_reader)
+    allow(server).to receive(:start_stderr_reader)
+    server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+    allow(server).to receive(:send_request) { |req| sent << req }
+    allow(server).to receive(:wait_response) do |id, **_opts|
+      responder = responses.shift
+      raise 'no scripted response left' unless responder
+
+      response = responder.respond_to?(:call) ? responder.call(sent.last) : responder
+      response.merge('jsonrpc' => '2.0', 'id' => id)
+    end
+    sent
+  end
+
+  def discover_result
+    { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+      'capabilities' => { 'tools' => {}, 'resources' => {}, 'prompts' => {} } }
+  end
+
+  # MCP 2026-07-28 asks for roots through the multi round-trip pattern rather
+  # than a server-initiated request. Answering the handler is not enough: the
+  # answer has to leave the client under the key the server named, beside the
+  # opaque state it must echo, or the server never receives the roots it asked
+  # for and the notice stands for nothing.
+  describe 'the Roots answer a modern server asks for mid-request' do
+    it 'continues the request with the roots under the key the server named' do
+      client = MCPClient::Client.new(mcp_server_configs: [MCPClient.stdio_config(command: 'true')],
+                                     logger: logger,
+                                     roots: [{ uri: 'file:///workspace', name: 'Workspace' }])
+      # The constructor's own notice is not what this example is about.
+      MCPClient::Deprecations.reset!
+      output.truncate(output.rewind)
+      server = client.servers.first
+      sent = script_stdio(server, [
+                            { 'result' => discover_result },
+                            { 'result' => { 'resultType' => 'input_required',
+                                            'requestState' => 'opaque-state',
+                                            'inputRequests' => {
+                                              'r1' => { 'method' => 'roots/list', 'params' => {} }
+                                            } } },
+                            { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'done' }] } }
+                          ])
+
+      result = server.call_tool('index', { 'scope' => 'all' })
+
+      expect(result['content'].first['text']).to eq('done')
+      expect(sent.map { |request| request['method'] }).to eq(%w[server/discover tools/call tools/call])
+      calls = sent.select { |request| request['method'] == 'tools/call' }
+      expect(calls.first['params']).not_to have_key('requestState')
+      expect(calls.last['params']).to include(
+        'name' => 'index',
+        'arguments' => { 'scope' => 'all' },
+        'requestState' => 'opaque-state',
+        'inputResponses' => { 'r1' => { 'roots' => [{ 'uri' => 'file:///workspace', 'name' => 'Workspace' }] } }
+      )
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+      expect(output.string).to match(/Roots .*deprecated/)
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round5_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Round 5 of the 2026-07-28 deprecation review: a logger that misbehaves must
+# never reach the deprecated operation (not even through its `level`
+# accessor), and the earliest removal of each feature lives in the registry
+# so the prose cannot drift away from it.
+RSpec.describe 'MCP 2026-07-28 deprecations (round 5)' do
+  let(:output) { StringIO.new }
+  let(:logger) { Logger.new(output) }
+
+  around do |example|
+    MCPClient::Deprecations.enabled = true
+    MCPClient::Deprecations.reset!
+    example.run
+  ensure
+    MCPClient::Deprecations.reset!
+    MCPClient::Deprecations.enabled = false
+  end
+
+  # A Logger subclass whose level accessor is broken: asking whether it drops
+  # warnings raises, exactly as a custom logger with a lazily configured level
+  # might.
+  let(:broken_level_logger) do
+    Class.new(Logger) do
+      def level = raise(IOError, 'level unavailable')
+    end.new(File::NULL)
+  end
+
+  describe 'a logger whose level accessor raises' do
+    it 'declines the notice without spending it and without raising' do
+      expect(MCPClient::Deprecations.warn(:roots, broken_level_logger)).to be(false)
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+
+      expect(MCPClient::Deprecations.warn(:roots, logger)).to be(true)
+      expect(output.string).to match(/Roots .*deprecated/)
+    end
+
+    it 'keeps serving the deprecated features it guards' do
+      broken = broken_level_logger
+      handler = lambda { |_messages, _prefs, _system, _max|
+        { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'ok' }, 'model' => 'm' }
+      }
+      c = MCPClient::Client.new(mcp_server_configs: [], logger: broken, sampling_handler: handler,
+                                roots: [{ uri: 'file:///tmp', name: 'tmp' }])
+      params = { 'messages' => [], 'maxTokens' => 5, 'includeContext' => 'thisServer' }
+
+      expect(c.send(:handle_sampling_request, 1, params)['content']['text']).to eq('ok')
+      expect { c.log_level = 'debug' }.not_to raise_error
+
+      server = MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: broken)
+      allow(server).to receive(:start_sse_thread)
+      allow(server).to receive(:wait_for_connection)
+      allow(server).to receive(:start_activity_monitor)
+      expect(server.connect).to be(true)
+    end
+  end
+
+  describe 'the earliest removal of each feature' do
+    let(:registry) { MCPClient::Deprecations::REGISTRY }
+
+    it 'is recorded for every feature' do
+      registry.each do |key, entry|
+        expect(entry[:earliest_removal]).to be_a(String), key.to_s
+        expect(entry[:earliest_removal]).not_to be_empty, key.to_s
+      end
+    end
+
+    it 'gives only the HTTP+SSE transport a shorter clock than the 2026-07-28 features' do
+      # SEP-2596 reclassified both the HTTP+SSE transport and the
+      # includeContext values, but only the transport may go early: its
+      # transition provision ties includeContext to Sampling.
+      long_window = registry[:sampling][:earliest_removal]
+      expect(long_window).to eq('no earlier than twelve months after 2026-07-28')
+      %i[roots logging dynamic_client_registration include_context].each do |key|
+        expect(registry[key][:earliest_removal]).to eq(long_window), key.to_s
+      end
+
+      expect(registry[:http_sse_transport][:earliest_removal])
+        .to eq('no earlier than three months after SEP-2596 is Final')
+    end
+
+    it 'is what the README documents, verbatim' do
+      readme = File.read(File.expand_path('../../../README.md', __dir__))
+      section = readme[/### Deprecated features.*?\n## /m] || readme
+      registry.each do |key, entry|
+        expect(section).to include(entry[:earliest_removal]), key.to_s
+      end
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round5_spec.rb
@@ -57,6 +57,76 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 5)' do
     end
   end
 
+  # `level` is host code, and the notice asks for it BEFORE it writes. A host
+  # whose accessor reaches back into a deprecated feature therefore re-enters
+  # the notice on a path the reentrancy guard has to cover too: a guard that
+  # only wraps `logger.warn` leaves the probe recursing until the stack ends,
+  # and a SystemStackError is not a StandardError, so it escapes the rescue
+  # that exists to keep the deprecated operation working.
+  describe 'a logger whose level accessor re-enters a deprecated feature' do
+    # A `level` accessor that uses Roots, as a formatter, a log subscriber or
+    # an audit hook reading the client's configuration would.
+    def reentrant_logger(io)
+      Class.new(Logger) do
+        attr_accessor :client
+
+        def level
+          @client&.roots = []
+          super
+        end
+      end.new(io)
+    end
+
+    it 'still sets the roots, and lets the nested notice stand down' do
+      broken = reentrant_logger(output)
+      client = MCPClient::Client.new(mcp_server_configs: [], logger: broken)
+      broken.client = client
+
+      expect { client.roots = [{ uri: 'file:///workspace', name: 'Workspace' }] }.not_to raise_error
+      expect(client.roots.map(&:uri)).to eq(['file:///workspace'])
+    end
+
+    it 'writes the notice exactly once, from the outermost use' do
+      broken = reentrant_logger(output)
+      client = MCPClient::Client.new(mcp_server_configs: [], logger: broken)
+      broken.client = client
+
+      client.roots = [{ uri: 'file:///workspace', name: 'Workspace' }]
+
+      expect(output.string.scan(/Roots .*deprecated/).size).to eq(1)
+    end
+  end
+
+  # A standard ::Logger whose device was closed swallows the write failure
+  # inside Logger::LogDevice (it rescues and reports through Kernel#warn), so
+  # `logger.warn` returns as if it had written. Counting that as the notice
+  # spends the process's one notice on a line nobody can read, and silences
+  # every later use — including one holding a logger that does write.
+  describe 'a standard logger whose device is closed' do
+    let(:closed_logger) do
+      Logger.new(StringIO.new).tap(&:close)
+    end
+
+    it 'declines the notice without spending it' do
+      expect(MCPClient::Deprecations.warn(:roots, closed_logger)).to be(false)
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+    end
+
+    it 'leaves the notice owed, so a working logger still writes it' do
+      MCPClient::Deprecations.warn(:roots, closed_logger)
+
+      expect(MCPClient::Deprecations.warn(:roots, logger)).to be(true)
+      expect(output.string).to match(/Roots .*deprecated/)
+    end
+
+    it 'keeps serving the deprecated feature' do
+      client = MCPClient::Client.new(mcp_server_configs: [], logger: closed_logger)
+
+      expect { client.roots = [{ uri: 'file:///workspace', name: 'Workspace' }] }.not_to raise_error
+      expect(client.roots.map(&:uri)).to eq(['file:///workspace'])
+    end
+  end
+
   describe 'the earliest removal of each feature' do
     let(:registry) { MCPClient::Deprecations::REGISTRY }
 

--- a/spec/lib/mcp_client/deprecations_2026_round5_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round5_spec.rb
@@ -67,25 +67,43 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 5)' do
       end
     end
 
-    it 'gives only the HTTP+SSE transport a shorter clock than the 2026-07-28 features' do
-      # SEP-2596 reclassified both the HTTP+SSE transport and the
-      # includeContext values, but only the transport may go early: its
-      # transition provision ties includeContext to Sampling.
+    it 'gives the features 2026-07-28 deprecates one shared clock' do
+      # The exact wording is pinned in the round 6 spec, against the
+      # registry's own "Earliest removal" column; here only the grouping.
       long_window = registry[:sampling][:earliest_removal]
-      expect(long_window).to eq('no earlier than twelve months after 2026-07-28')
-      %i[roots logging dynamic_client_registration include_context].each do |key|
+      %i[roots logging dynamic_client_registration].each do |key|
         expect(registry[key][:earliest_removal]).to eq(long_window), key.to_s
       end
 
-      expect(registry[:http_sse_transport][:earliest_removal])
-        .to eq('no earlier than three months after SEP-2596 is Final')
+      # SEP-2596 reclassified both the HTTP+SSE transport and the
+      # includeContext values, but only the transport has a clock of its own:
+      # the transition provision ties includeContext to Sampling.
+      expect(registry[:include_context][:earliest_removal]).to match(/follows Sampling/)
+      expect(registry[:http_sse_transport][:earliest_removal]).not_to eq(long_window)
+      expect(registry[:http_sse_transport][:earliest_removal]).to match(/SEP-2596/)
     end
 
-    it 'is what the README documents, verbatim' do
+    # The table row each feature owns, so a clock cannot satisfy the pin from
+    # some other feature's row.
+    let(:rows) do
+      {
+        roots: /^\| Roots \(.*$/,
+        sampling: /^\| Sampling \(.*$/,
+        logging: /^\| Logging \(.*$/,
+        http_sse_transport: /^\| HTTP\+SSE transport \(.*$/,
+        include_context: /^\| `includeContext`.*$/,
+        dynamic_client_registration: /^\| OAuth Dynamic Client Registration.*$/
+      }
+    end
+
+    it 'is what the README documents, verbatim, on that feature\'s own row' do
       readme = File.read(File.expand_path('../../../README.md', __dir__))
       section = readme[/### Deprecated features.*?\n## /m] || readme
+      expect(rows.keys).to match_array(registry.keys)
       registry.each do |key, entry|
-        expect(section).to include(entry[:earliest_removal]), key.to_s
+        row = section[rows.fetch(key)]
+        expect(row).not_to be_nil, "no README table row for #{key}"
+        expect(row).to include(entry[:earliest_removal]), "#{key}: #{row}"
       end
     end
   end

--- a/spec/lib/mcp_client/deprecations_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round6_spec.rb
@@ -85,7 +85,9 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 6)' do
     end
 
     it 'covers every API this gem marks deprecated' do
-      expect(tags.size).to be >= 7
+      # Round 8 added the sse_config builder and the Roots and Sampling
+      # callback registrations on all four transports.
+      expect(tags.size).to be >= 17
     end
 
     it 'cites the deprecation SEP and the earliest removal on each one' do

--- a/spec/lib/mcp_client/deprecations_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round6_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Round 6 of the 2026-07-28 deprecation review: the registry carries the
+# deprecated-features registry's own earliest-removal wording (a revision, not
+# a calendar date), every YARD mark and the runtime notice name that clock,
+# the notices fire from the transport entry points a host can reach without a
+# Client, and the once-per-process bookkeeping survives a fork.
+RSpec.describe 'MCP 2026-07-28 deprecations (round 6)' do
+  let(:output) { StringIO.new }
+  let(:logger) { Logger.new(output) }
+
+  around do |example|
+    MCPClient::Deprecations.enabled = true
+    MCPClient::Deprecations.reset!
+    example.run
+  ensure
+    MCPClient::Deprecations.reset!
+    MCPClient::Deprecations.enabled = false
+  end
+
+  let(:registry) { MCPClient::Deprecations::REGISTRY }
+  # https://modelcontextprotocol.io/specification/2026-07-28/deprecated,
+  # "Earliest removal" column, verbatim.
+  let(:revision_window) { 'the first revision released on or after 2027-07-28' }
+
+  describe 'the earliest removal the registry records' do
+    it 'is the registry\'s own wording, not a paraphrase of the policy floor' do
+      %i[roots sampling logging dynamic_client_registration].each do |key|
+        expect(registry[key][:earliest_removal]).to eq(revision_window), key.to_s
+      end
+      expect(registry[:include_context][:earliest_removal]).to eq('follows Sampling (SEP-2577)')
+      expect(registry[:http_sse_transport][:earliest_removal]).to eq('three months after SEP-2596 reaches Final')
+    end
+
+    it 'never states a bare removal date a host could plan around' do
+      registry.each do |key, entry|
+        expect(entry[:earliest_removal]).not_to match(/\A\s*(no earlier than\s+)?2\d{3}-\d\d-\d\d\s*\z/), key.to_s
+      end
+    end
+  end
+
+  describe 'the runtime notice' do
+    it 'names the earliest removal alongside the SEP and the migration' do
+      MCPClient::Deprecations.warn(:roots, logger)
+
+      expect(output.string).to include('SEP-2577')
+      expect(output.string).to include(revision_window)
+      expect(output.string).to include(registry[:roots][:migration])
+    end
+
+    it 'names the transport clock for the HTTP+SSE transport' do
+      MCPClient::Deprecations.warn(:http_sse_transport, logger)
+
+      expect(output.string).to include('three months after SEP-2596 reaches Final')
+    end
+  end
+
+  describe 'the YARD marks on the deprecated APIs' do
+    # Feature lifecycle policy, tier-1 SDK obligation: mark the API with the
+    # language's native mechanism, referencing the deprecation SEP *and* the
+    # earliest removal where the mechanism permits.
+    def deprecated_tags(source)
+      tags = []
+      current = nil
+      source.each_line do |line|
+        if (match = line.match(/^\s*#\s*@deprecated\b(.*)$/))
+          tags << (current = +match[1].strip)
+        elsif current.nil?
+          next
+        elsif line.match?(/^\s*#\s*@\w/) || !line.match?(/^\s*#/)
+          current = nil
+        elsif (match = line.match(/^\s*#\s?(.*)$/))
+          current << " #{match[1].strip}"
+        end
+      end
+      tags
+    end
+
+    let(:tags) do
+      Dir[File.expand_path('../../../lib/**/*.rb', __dir__)].flat_map do |path|
+        deprecated_tags(File.read(path)).map { |tag| [path, tag] }
+      end
+    end
+
+    it 'covers every API this gem marks deprecated' do
+      expect(tags.size).to be >= 7
+    end
+
+    it 'cites the deprecation SEP and the earliest removal on each one' do
+      windows = registry.each_value.map { |entry| entry[:earliest_removal] }.uniq
+      tags.each do |path, tag|
+        label = "#{File.basename(path)}: #{tag}"
+        expect(tag).to match(/SEP-\d+|PR #\d+/), label
+        expect(windows.any? { |window| tag.include?(window) }).to be(true), label
+      end
+    end
+  end
+
+  describe 'a transport driven directly, without a Client' do
+    let(:server) { MCPClient::ServerStdio.new(command: 'true', logger: logger) }
+
+    before { allow(server).to receive(:send_message) }
+
+    it 'warns when it serves a roots/list request' do
+      server.on_roots_list_request { |_id, _params| { 'roots' => [] } }
+      server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
+
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+      expect(output.string).to match(/Roots .*deprecated/)
+    end
+
+    it 'warns when it serves a sampling request, and for its includeContext' do
+      server.on_sampling_request do |_id, _params|
+        { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'ok' }, 'model' => 'm' }
+      end
+      server.send(:handle_server_request,
+                  { 'id' => 2, 'method' => 'sampling/createMessage',
+                    'params' => { 'messages' => [], 'maxTokens' => 5, 'includeContext' => 'thisServer' } })
+
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+      expect(MCPClient::Deprecations.emitted?(:include_context)).to be(true)
+      expect(output.string).to include('thisServer')
+    end
+
+    it 'stays silent about roots when it has no handler to serve them with' do
+      server.send(:handle_server_request, { 'id' => 3, 'method' => 'roots/list', 'params' => {} })
+
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+    end
+
+    it 'warns when a notifications/message reaches its own callback' do
+      delivered = []
+      server.on_notification { |method, params| delivered << [method, params] }
+      server.route_notification('notifications/message', { 'level' => 'info', 'data' => 'hello' })
+
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(true)
+      expect(output.string).to match(/Logging is deprecated/)
+      expect(delivered).to eq([['notifications/message', { 'level' => 'info', 'data' => 'hello' }]])
+    end
+
+    it 'stays silent for notifications that are not log messages' do
+      server.route_notification('notifications/tools/list_changed', {})
+
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
+    end
+  end
+
+  describe 'an SSE connection that was already established' do
+    let(:server) { MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: logger) }
+
+    it 'retries the notice the first connect could not emit' do
+      MCPClient::Deprecations.enabled = false
+      allow(server).to receive(:start_sse_thread)
+      allow(server).to receive(:wait_for_connection)
+      allow(server).to receive(:start_activity_monitor)
+      expect(server.connect).to be(true)
+      server.instance_variable_set(:@connection_established, true)
+      expect(MCPClient::Deprecations.emitted?(:http_sse_transport)).to be(false)
+
+      MCPClient::Deprecations.enabled = true
+      expect(server.connect).to be(true)
+
+      expect(MCPClient::Deprecations.emitted?(:http_sse_transport)).to be(true)
+      expect(output.string).to match(/HTTP\+SSE transport is deprecated/)
+    end
+  end
+
+  describe 'the once-per-process bookkeeping across a fork' do
+    it 'lets a forked worker emit the notice its parent already spent' do
+      skip 'fork unavailable on this platform' unless Process.respond_to?(:fork)
+
+      expect(MCPClient::Deprecations.warn(:roots, logger)).to be(true)
+
+      reader, writer = IO.pipe
+      pid = fork do
+        reader.close
+        child_output = StringIO.new
+        emitted = MCPClient::Deprecations.warn(:roots, Logger.new(child_output))
+        writer.write("#{emitted}\t#{child_output.string.include?('Roots')}")
+        writer.close
+        exit!(0)
+      end
+      writer.close
+      report = reader.read
+      reader.close
+      Process.wait(pid)
+
+      expect(report).to eq("true\ttrue")
+      # The parent's own bookkeeping is untouched by the child.
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+    end
+  end
+
+  describe 'the README' do
+    let(:readme) { File.read(File.expand_path('../../../README.md', __dir__)) }
+
+    it 'flags log_level= as deprecated in the subsection that shows it off' do
+      # The 2026-07-28 subsection that presents log_level= is where a reader
+      # copies it from, so the Logging deprecation has to be stated there and
+      # not only in the table further down the page.
+      section = readme[/### Discovery and per-request metadata\n.*?(?=\n### )/m]
+
+      expect(section).to include('log_level=')
+      expect(section).to include('SEP-2577')
+      expect(section).to match(/deprecat/i)
+      expect(section).to include('#deprecated-features')
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round6_spec.rb
@@ -103,8 +103,9 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 6)' do
 
     before { allow(server).to receive(:send_message) }
 
-    it 'warns when it serves a roots/list request' do
-      server.on_roots_list_request { |_id, _params| { 'roots' => [] } }
+    it 'warns when it serves a roots/list request that carries a root' do
+      # Round 7 narrowed the trigger: an empty answer is not use of Roots.
+      server.on_roots_list_request { |_id, _params| { 'roots' => [{ 'uri' => 'file:///workspace' }] } }
       server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
 
       expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)

--- a/spec/lib/mcp_client/deprecations_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round6_spec.rb
@@ -8,6 +8,23 @@ require 'spec_helper'
 # the notices fire from the transport entry points a host can reach without a
 # Client, and the once-per-process bookkeeping survives a fork.
 RSpec.describe 'MCP 2026-07-28 deprecations (round 6)' do
+  # The child's report, or a prompt failure: a bookkeeping regression that
+  # leaves the child blocked must fail this example, not wedge the suite on
+  # an unbounded pipe read.
+  def bounded_fork_report(reader, pid)
+    report = reader.wait_readable(10) ? reader.read : nil
+    reader.close
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 10
+    until Process.waitpid(pid, Process::WNOHANG)
+      raise 'forked worker did not exit' if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+      sleep 0.01
+    end
+    report or raise 'forked worker reported nothing within 10s'
+  ensure
+    Process.kill('KILL', pid) rescue nil # rubocop:disable Style/RescueModifier
+  end
+
   let(:output) { StringIO.new }
   let(:logger) { Logger.new(output) }
 
@@ -227,9 +244,7 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 6)' do
         exit!(0)
       end
       writer.close
-      report = reader.read
-      reader.close
-      Process.wait(pid)
+      report = bounded_fork_report(reader, pid)
 
       expect(report).to eq("true\ttrue")
       # The parent's own bookkeeping is untouched by the child.

--- a/spec/lib/mcp_client/deprecations_2026_round6_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round6_spec.rb
@@ -41,6 +41,47 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 6)' do
     end
   end
 
+  # The lifecycle policy's mark-and-warn obligation is to point the host at
+  # the replacement, so the migration text is a requirement and not a
+  # decoration. Written down here rather than read back off the production
+  # table: an example that compares REGISTRY[...][:migration] with the notice
+  # it produced agrees with an empty string just as happily.
+  describe 'the replacement the registry names for each feature' do
+    # What the published registry's "Migration" column tells a host to do,
+    # one distinguishing phrase per row.
+    let(:replacements) do
+      {
+        roots: ['tool parameters', 'resource URIs', 'server configuration'],
+        sampling: ['LLM provider'],
+        logging: %w[stderr OpenTelemetry],
+        http_sse_transport: ['Streamable HTTP'],
+        include_context: ['omit includeContext', '"none"'],
+        dynamic_client_registration: ['Client ID Metadata Document', 'pre-registered credentials']
+      }
+    end
+
+    it 'says what to use instead, in the registry and in the notice it writes' do
+      expect(replacements.keys).to match_array(registry.keys)
+      replacements.each do |key, phrases|
+        MCPClient::Deprecations.reset!
+        output.truncate(output.rewind)
+        expect(MCPClient::Deprecations.warn(key, logger)).to be(true)
+
+        phrases.each do |phrase|
+          expect(registry[key][:migration]).to include(phrase), key.to_s
+          expect(output.string).to include(phrase), key.to_s
+        end
+      end
+    end
+
+    it 'never leaves a feature without one' do
+      registry.each do |key, entry|
+        expect(entry[:migration]).to be_a(String)
+        expect(entry[:migration].split.size).to be >= 4, key.to_s
+      end
+    end
+  end
+
   describe 'the runtime notice' do
     it 'names the earliest removal alongside the SEP and the migration' do
       MCPClient::Deprecations.warn(:roots, logger)

--- a/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Round 7 of the 2026-07-28 deprecation review: the Roots notice fires for a
+# host that actually uses Roots — a configured list, a `roots=` call, or an
+# answer that carries a root — and not for the empty answer every Client
+# gives by default; and the keyword APIs that carry a deprecated feature
+# name the earliest removal, not just the SEP.
+RSpec.describe 'MCP 2026-07-28 deprecations (round 7)' do
+  let(:output) { StringIO.new }
+  let(:logger) { Logger.new(output) }
+
+  around do |example|
+    MCPClient::Deprecations.enabled = true
+    MCPClient::Deprecations.reset!
+    example.run
+  ensure
+    MCPClient::Deprecations.reset!
+    MCPClient::Deprecations.enabled = false
+  end
+
+  let(:registry) { MCPClient::Deprecations::REGISTRY }
+  let(:revision_window) { 'the first revision released on or after 2027-07-28' }
+
+  describe 'the Roots notice and the host that never opted in' do
+    # A Client registers its roots/list handler unconditionally (roots can be
+    # set at any time through `roots=`), so "a handler is registered" says
+    # nothing about whether the host adopted the deprecated feature. Only an
+    # answer that actually carries a root does.
+    def stdio_server(client)
+      client.servers.first
+    end
+
+    let(:client_config) { MCPClient.stdio_config(command: 'true') }
+
+    context 'with a Client that never configured a root' do
+      let(:client) { MCPClient::Client.new(mcp_server_configs: [client_config], logger: logger) }
+
+      it 'stays silent when it answers roots/list with the default empty list' do
+        server = stdio_server(client)
+        allow(server).to receive(:send_message)
+
+        server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
+
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+        expect(output.string).not_to match(/Roots/)
+      end
+
+      it 'still answers the request with an empty roots list' do
+        server = stdio_server(client)
+        sent = []
+        allow(server).to receive(:send_message) { |message| sent << message }
+
+        server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
+
+        expect(sent.last['result']).to eq({ 'roots' => [] })
+      end
+    end
+
+    context 'with a Client that configured a root' do
+      it 'warns when it answers roots/list with that root' do
+        client = MCPClient::Client.new(mcp_server_configs: [client_config], logger: logger,
+                                       roots: [{ uri: 'file:///workspace', name: 'Workspace' }])
+        # The constructor's own notice is not what this example is about.
+        MCPClient::Deprecations.reset!
+        output.truncate(output.rewind)
+
+        server = stdio_server(client)
+        allow(server).to receive(:send_message)
+        server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
+
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+        expect(output.string).to match(/Roots .*deprecated/)
+      end
+    end
+
+    context 'with a Client whose roots were set after construction' do
+      it 'warns on the roots= call itself' do
+        client = MCPClient::Client.new(mcp_server_configs: [client_config], logger: logger)
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+
+        client.roots = [{ uri: 'file:///workspace' }]
+
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+      end
+    end
+
+    context 'with a transport driven directly' do
+      let(:server) { MCPClient::ServerStdio.new(command: 'true', logger: logger) }
+
+      before { allow(server).to receive(:send_message) }
+
+      it 'stays silent for a handler that answers with no roots' do
+        server.on_roots_list_request { |_id, _params| { 'roots' => [] } }
+        server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
+
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+      end
+
+      it 'warns for a handler that answers with a root' do
+        server.on_roots_list_request { |_id, _params| { 'roots' => [{ 'uri' => 'file:///workspace' }] } }
+        server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
+
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+      end
+    end
+
+    context 'with the multi round-trip pattern' do
+      let(:server) { MCPClient::ServerStdio.new(command: 'true', logger: logger) }
+
+      def fulfil(server, response)
+        server.on_roots_list_request { |_id, _params| response }
+        server.send(:fulfil_input_request, 'roots',
+                    { 'method' => 'roots/list', 'params' => {} },
+                    { 'inputRequests' => {} })
+      end
+
+      it 'stays silent when the handler answers with no roots' do
+        expect(fulfil(server, { 'roots' => [] })).to eq({ 'roots' => [] })
+
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+      end
+
+      it 'warns when the handler answers with a root' do
+        answer = { 'roots' => [{ 'uri' => 'file:///workspace' }] }
+        expect(fulfil(server, answer)).to eq(answer)
+
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+      end
+    end
+  end
+
+  describe 'the README' do
+    let(:readme) { File.read(File.expand_path('../../../README.md', __dir__)) }
+
+    it 'documents the trigger the Roots notice actually has' do
+      row = readme[/^\| Roots \(.*$/]
+
+      expect(row).not_to be_nil
+      expect(row).to include('roots:')
+      expect(row).to include('Client#roots=')
+      expect(row).to match(%r{roots/list})
+    end
+
+    it 'says a client that never configured a root is not warned' do
+      section = readme[/### Deprecated features\n.*?(?=\n## )/m]
+
+      expect(section).to match(/empty (roots )?list/i)
+    end
+  end
+
+  describe 'the keyword APIs that carry a deprecated feature' do
+    # Feature lifecycle policy, tier-1 SDK obligation: an API that exposes a
+    # deprecated feature names the SEP *and* the earliest removal wherever it
+    # is documented. A keyword argument has no @deprecated tag of its own, so
+    # the round 6 tag sweep never reached these.
+    def doc_block(source, start_pattern)
+      lines = source.lines
+      index = lines.index { |line| line.match?(start_pattern) }
+      return nil unless index
+
+      block = +lines[index].sub(/^\s*#\s?/, '')
+      lines[(index + 1)..].each do |line|
+        break unless line.match?(/^\s*#/)
+        break if line.match?(/^\s*#\s*[@-]\s?\S/)
+
+        block << " #{line.sub(/^\s*#\s?/, '').strip}"
+      end
+      block
+    end
+
+    let(:client_source) { File.read(File.expand_path('../../../lib/mcp_client/client.rb', __dir__)) }
+    let(:module_source) { File.read(File.expand_path('../../../lib/mcp_client.rb', __dir__)) }
+
+    let(:documented_apis) do
+      [
+        ['Client.new roots:', doc_block(client_source, /^\s*#\s*@param roots\b/)],
+        ['Client.new sampling_handler:', doc_block(client_source, /^\s*#\s*@param sampling_handler\b/)],
+        ['MCPClient.connect sampling_handler', doc_block(module_source, /^\s*#\s*-\s*sampling_handler\b/)]
+      ]
+    end
+
+    it 'documents every one of them' do
+      documented_apis.each do |label, block|
+        expect(block).not_to(be_nil, label)
+      end
+    end
+
+    it 'marks each one deprecated, with its SEP and its earliest removal' do
+      windows = registry.each_value.map { |entry| entry[:earliest_removal] }.uniq
+
+      documented_apis.each do |label, block|
+        expect(block).to match(/deprecat/i), "#{label}: #{block}"
+        expect(block).to include('SEP-2577'), "#{label}: #{block}"
+        expect(windows.any? { |window| block.include?(window) }).to be(true), "#{label}: #{block}"
+      end
+    end
+
+    it 'names the same window the registry gives Roots and Sampling' do
+      documented_apis.each do |label, block|
+        expect(block).to include(revision_window), "#{label}: #{block}"
+      end
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
@@ -78,6 +78,10 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 7)' do
     context 'with a Client whose roots were set after construction' do
       it 'warns on the roots= call itself' do
         client = MCPClient::Client.new(mcp_server_configs: [client_config], logger: logger)
+        # `roots=` tells every connected server the list changed; the stub
+        # keeps this example off the wire, where `true` never answers and the
+        # notification would wait out the discovery timeout.
+        allow(stdio_server(client)).to receive(:rpc_notify)
         expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
 
         client.roots = [{ uri: 'file:///workspace' }]

--- a/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
@@ -108,6 +108,25 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 7)' do
 
         expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
       end
+
+      # The handler is host code and its answer is a plain Ruby Hash that
+      # nothing converted, so a host that writes `{ roots: [...] }` — the
+      # natural Ruby spelling — is using Roots exactly as much as one that
+      # writes the string key. Reading only the string key makes the notice
+      # depend on how the host happened to type the literal.
+      it 'warns for a handler that answers with a symbol-keyed root' do
+        server.on_roots_list_request { |_id, _params| { roots: [{ 'uri' => 'file:///workspace' }] } }
+        server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
+
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+      end
+
+      it 'stays silent for a symbol-keyed answer that carries no root' do
+        server.on_roots_list_request { |_id, _params| { roots: [] } }
+        server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
+
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+      end
     end
 
     context 'with the multi round-trip pattern' do

--- a/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
@@ -158,7 +158,9 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 7)' do
     # Feature lifecycle policy, tier-1 SDK obligation: an API that exposes a
     # deprecated feature names the SEP *and* the earliest removal wherever it
     # is documented. A keyword argument has no @deprecated tag of its own, so
-    # the round 6 tag sweep never reached these.
+    # the round 6 tag sweep never reached these. Round 8 extended the sweep to
+    # the transport callbacks a host registers when it drives a transport
+    # without a Client.
     def doc_block(source, start_pattern)
       lines = source.lines
       index = lines.index { |line| line.match?(start_pattern) }
@@ -177,12 +179,47 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 7)' do
     let(:client_source) { File.read(File.expand_path('../../../lib/mcp_client/client.rb', __dir__)) }
     let(:module_source) { File.read(File.expand_path('../../../lib/mcp_client.rb', __dir__)) }
 
+    # The @deprecated tag of the doc block above a definition.
+    def deprecated_tag_above(source, definition)
+      lines = source.lines
+      index = lines.index { |line| line.match?(definition) }
+      return nil unless index
+
+      start = index
+      start -= 1 while start.positive? && lines[start - 1].match?(/^\s*#/)
+      tag_at = (start...index).find { |i| lines[i].match?(/^\s*#\s*@deprecated\b/) }
+      return nil unless tag_at
+
+      text = +lines[tag_at].sub(/^\s*#\s?/, '').strip
+      lines[(tag_at + 1)...index].each do |line|
+        break if line.match?(/^\s*#\s*@\w/)
+
+        text << " #{line.sub(/^\s*#\s?/, '').strip}"
+      end
+      text
+    end
+
+    let(:transport_sources) do
+      %w[server_sse server_stdio server_http server_streamable_http].to_h do |name|
+        [name, File.read(File.expand_path("../../../lib/mcp_client/#{name}.rb", __dir__))]
+      end
+    end
+
+    let(:transport_callbacks) do
+      transport_sources.flat_map do |name, source|
+        [["#{name} on_roots_list_request",
+          deprecated_tag_above(source, /^\s*def on_roots_list_request\b/)],
+         ["#{name} on_sampling_request",
+          deprecated_tag_above(source, /^\s*def on_sampling_request\b/)]]
+      end
+    end
+
     let(:documented_apis) do
       [
         ['Client.new roots:', doc_block(client_source, /^\s*#\s*@param roots\b/)],
         ['Client.new sampling_handler:', doc_block(client_source, /^\s*#\s*@param sampling_handler\b/)],
         ['MCPClient.connect sampling_handler', doc_block(module_source, /^\s*#\s*-\s*sampling_handler\b/)]
-      ]
+      ] + transport_callbacks
     end
 
     it 'documents every one of them' do

--- a/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
@@ -152,8 +152,9 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 7)' do
 
     context 'with a transport driven directly' do
       let(:server) { MCPClient::ServerStdio.new(command: 'true', logger: logger) }
+      let(:sent) { [] }
 
-      before { allow(server).to receive(:send_message) }
+      before { allow(server).to receive(:send_message) { |message| sent << message } }
 
       it 'stays silent for a handler that answers with no roots' do
         server.on_roots_list_request { |_id, _params| { 'roots' => [] } }
@@ -167,6 +168,8 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 7)' do
         server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
 
         expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+        expect(sent).to eq([{ 'jsonrpc' => '2.0', 'id' => 1,
+                              'result' => { 'roots' => [{ 'uri' => 'file:///workspace' }] } }])
       end
 
       # The handler is host code and its answer is a plain Ruby Hash that
@@ -179,6 +182,11 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 7)' do
         server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
 
         expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+        # The answer reaches the peer as it was given: the wire form of a
+        # symbol-keyed root is the same JSON as the string-keyed one.
+        expect(sent.size).to eq(1)
+        expect(sent.first['id']).to eq(1)
+        expect(JSON.parse(JSON.generate(sent.first['result']))).to eq({ 'roots' => [{ 'uri' => 'file:///workspace' }] })
       end
 
       it 'stays silent for a symbol-keyed answer that carries no root' do

--- a/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
@@ -88,6 +88,66 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 7)' do
 
         expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
       end
+
+      # The notice may not stand between the host and the wire. The rest of
+      # the suite runs with notices OFF, so the examples that pin
+      # list_changed elsewhere cannot catch a `roots=` that warned and
+      # returned: only an example with notices ON can.
+      it 'still tells a legacy server the list changed, and still spares a modern one' do
+        client = MCPClient::Client.new(mcp_server_configs: [client_config, client_config], logger: logger)
+        legacy, modern = client.servers
+        legacy.instance_variable_set(:@protocol_version, '2025-11-25')
+        modern.instance_variable_set(:@protocol_version, '2026-07-28')
+        notified = []
+        { legacy: legacy, modern: modern }.each do |era, server|
+          allow(server).to receive(:rpc_notify) { |method, params| notified << [era, method, params] }
+        end
+
+        client.roots = [{ uri: 'file:///workspace' }]
+
+        expect(notified).to eq([[:legacy, 'notifications/roots/list_changed', {}]])
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+      end
+
+      # Emptying the list is not use of Roots, and the server that asks next
+      # is answered with the list the host actually left it.
+      it 'answers roots/list with the emptied list after the last root is cleared' do
+        client = MCPClient::Client.new(mcp_server_configs: [client_config], logger: logger,
+                                       roots: [{ uri: 'file:///workspace' }])
+        server = stdio_server(client)
+        allow(server).to receive(:rpc_notify)
+        sent = []
+        allow(server).to receive(:send_message) { |message| sent << message }
+
+        client.roots = []
+        server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
+
+        expect(sent.last['result']).to eq({ 'roots' => [] })
+      end
+    end
+
+    # 2026-07-28 asks for roots through the multi round-trip pattern instead
+    # of a server-initiated request, and that path reaches the same Client
+    # handler. A modern server is the only kind that can ask this way, so
+    # nothing else in this file covers it.
+    context 'with a Client answering the multi round-trip roots request' do
+      it 'still returns the configured roots, and warns for them' do
+        client = MCPClient::Client.new(mcp_server_configs: [client_config], logger: logger,
+                                       roots: [{ uri: 'file:///workspace', name: 'Workspace' }])
+        # The constructor's own notice is not what this example is about.
+        MCPClient::Deprecations.reset!
+        output.truncate(output.rewind)
+        server = stdio_server(client)
+        server.instance_variable_set(:@protocol_version, '2026-07-28')
+        expect(server).to be_modern
+
+        responses = server.send(:fulfil_input_requests,
+                                { 'r1' => { 'method' => 'roots/list', 'params' => {} } }, {})
+
+        expect(responses['r1']).to eq({ 'roots' => [{ 'uri' => 'file:///workspace', 'name' => 'Workspace' }] })
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+        expect(output.string).to match(/Roots .*deprecated/)
+      end
     end
 
     context 'with a transport driven directly' do

--- a/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round7_spec.rb
@@ -109,8 +109,11 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 7)' do
         expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
       end
 
-      # Emptying the list is not use of Roots, and the server that asks next
-      # is answered with the list the host actually left it.
+      # Reaching for `roots=` at all is use of Roots — the README says the
+      # notice fires when the host configures `roots:`, calls `Client#roots=`
+      # or serves an answer carrying a root — so clearing the list raises it
+      # like any other assignment, and the server that asks next is answered
+      # with the list the host actually left it.
       it 'answers roots/list with the emptied list after the last root is cleared' do
         client = MCPClient::Client.new(mcp_server_configs: [client_config], logger: logger,
                                        roots: [{ uri: 'file:///workspace' }])
@@ -118,11 +121,16 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 7)' do
         allow(server).to receive(:rpc_notify)
         sent = []
         allow(server).to receive(:send_message) { |message| sent << message }
+        # The constructor's own notice is not what the assignment must raise.
+        MCPClient::Deprecations.reset!
+        output.truncate(output.rewind)
 
         client.roots = []
         server.send(:handle_server_request, { 'id' => 1, 'method' => 'roots/list', 'params' => {} })
 
         expect(sent.last['result']).to eq({ 'roots' => [] })
+        expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+        expect(output.string).to match(/Roots .*deprecated/)
       end
     end
 

--- a/spec/lib/mcp_client/deprecations_2026_round8_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round8_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Round 8 of the 2026-07-28 deprecation review.
+#
+# HTTP+SSE is the one deprecated feature on a short clock — three months
+# after SEP-2596 reaches Final, and SEP-2596 is Final — and it is also the
+# place a new integration is most likely to start, so every spot that offers
+# it as an ordinary choice among the transports has to say so and point at
+# Streamable HTTP.
+#
+# And the transport-level callback registrations for Roots and Sampling carry
+# the native @deprecated mark: a host that drives a transport directly and
+# copies `server.on_sampling_request { ... }` out of the YARD would otherwise
+# meet SEP-2577 for the first time in a runtime notice. Round 7 deliberately
+# stopped treating a registered `roots/list` handler as use of Roots, so
+# without a mark at the registration site that handler has no mark at all.
+RSpec.describe 'MCP 2026-07-28 deprecations (round 8)' do
+  let(:registry) { MCPClient::Deprecations::REGISTRY }
+  let(:sse_window) { registry[:http_sse_transport][:earliest_removal] }
+  let(:revision_window) { MCPClient::Deprecations::REVISION_AFTER_2027_07_28 }
+  let(:readme) { File.read(File.expand_path('../../../README.md', __dir__)) }
+  let(:module_source) { File.read(File.expand_path('../../../lib/mcp_client.rb', __dir__)) }
+
+  # The comment block immediately above a definition, joined into one string.
+  def preceding_doc(source, definition)
+    lines = source.lines
+    index = lines.index { |line| line.match?(definition) }
+    return nil unless index
+
+    block = []
+    cursor = index - 1
+    while cursor >= 0 && lines[cursor].match?(/^\s*#/)
+      block.unshift(lines[cursor].sub(/^\s*#\s?/, '').strip)
+      cursor -= 1
+    end
+    block.join(' ')
+  end
+
+  # A bullet (or `@param`-style line) plus its continuation lines, stopping at
+  # the next bullet or tag. Mirrors the round 7 helper.
+  def doc_block(source, start_pattern)
+    lines = source.lines
+    index = lines.index { |line| line.match?(start_pattern) }
+    return nil unless index
+
+    block = +lines[index].sub(/^\s*#\s?/, '')
+    lines[(index + 1)..].each do |line|
+      break unless line.match?(/^\s*#/)
+      break if line.match?(/^\s*#\s*[@-]\s?\S/)
+
+      block << " #{line.sub(/^\s*#\s?/, '').strip}"
+    end
+    block
+  end
+
+  describe 'the README, wherever HTTP+SSE is offered as a choice' do
+    it 'marks the Overview transport bullet and names Streamable HTTP' do
+      bullet = readme[/^- \*\*SSE\*\*.*$/]
+
+      expect(bullet).not_to be_nil
+      expect(bullet).to match(/deprecat/i)
+      expect(bullet).to include('Streamable HTTP')
+    end
+
+    it 'marks the Quick Connect line that reaches for an /sse URL' do
+      line = readme[%r{^client = MCPClient\.connect\('http://localhost:8000/sse'\).*$}]
+
+      expect(line).not_to be_nil
+      expect(line).to match(/deprecat/i)
+    end
+
+    it 'marks the /sse row of the transport-detection table' do
+      row = readme[%r{^\| Ends with `/sse` \|.*$}]
+
+      expect(row).not_to be_nil
+      expect(row).to match(/deprecat/i)
+    end
+
+    it 'points every one of those marks at the deprecated-features section' do
+      overview = readme[/^- \*\*SSE\*\*.*$/]
+      table_row = readme[%r{^\| Ends with `/sse` \|.*$}]
+
+      [overview, table_row].each do |text|
+        expect(text).to include('#deprecated-features'), text
+      end
+    end
+
+    it 'keeps the deprecated-features table as the place the window is spelled out' do
+      row = readme[/^\| HTTP\+SSE transport .*$/]
+
+      expect(row).to include(sse_window)
+    end
+  end
+
+  describe 'MCPClient.connect, where the transport is chosen' do
+    it 'marks the /sse target bullet with the SEP and the earliest removal' do
+      block = doc_block(module_source, %r{^\s*#\s*-\s*URLs ending in /sse\b})
+
+      expect(block).not_to be_nil
+      expect(block).to match(/deprecat/i)
+      expect(block).to include('SEP-2596')
+      expect(block).to include(sse_window)
+      expect(block).to include('Streamable HTTP')
+    end
+
+    it 'marks the @example that connects to an SSE server' do
+      heading = module_source[/^\s*#\s*@example Connect to (an )?SSE server.*$/]
+
+      expect(heading).not_to be_nil
+      expect(heading).to match(/deprecat/i)
+    end
+  end
+
+  describe 'MCPClient.sse_config' do
+    it 'carries a native @deprecated tag' do
+      doc = preceding_doc(module_source, /^\s*def self\.sse_config\b/)
+
+      expect(doc).to include('@deprecated')
+    end
+
+    it 'cites SEP-2596, the earliest removal and the replacement builder' do
+      doc = preceding_doc(module_source, /^\s*def self\.sse_config\b/)
+
+      expect(doc).to include('SEP-2596')
+      expect(doc).to include(sse_window)
+      expect(doc).to include('streamable_http_config')
+    end
+  end
+
+  describe 'the transport callbacks for the deprecated SEP-2577 features' do
+    {
+      'ServerSSE' => 'server_sse.rb',
+      'ServerStdio' => 'server_stdio.rb',
+      'ServerHTTP' => 'server_http.rb',
+      'ServerStreamableHTTP' => 'server_streamable_http.rb'
+    }.each do |transport, file|
+      context "on #{transport}" do
+        let(:source) { File.read(File.expand_path("../../../lib/mcp_client/#{file}", __dir__)) }
+        let(:sampling_doc) { preceding_doc(source, /^\s*def on_sampling_request\b/) }
+        let(:roots_doc) { preceding_doc(source, /^\s*def on_roots_list_request\b/) }
+
+        it 'marks on_sampling_request at the registration site' do
+          expect(sampling_doc).to include('@deprecated')
+          expect(sampling_doc).to include('SEP-2577')
+          expect(sampling_doc).to include(revision_window)
+        end
+
+        it 'marks on_roots_list_request at the registration site' do
+          expect(roots_doc).to include('@deprecated')
+          expect(roots_doc).to include('SEP-2577')
+          expect(roots_doc).to include(revision_window)
+        end
+
+        it 'warns at the roots registration site that an answer carrying a root is the use' do
+          # Round 7 made registration alone silent at runtime, so the mark is
+          # the only thing that reaches a host reading the YARD.
+          expect(roots_doc).to match(/registering .*not/i)
+          expect(roots_doc).to match(/root/i)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round9_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round9_spec.rb
@@ -13,11 +13,14 @@ require 'spec_helper'
 # contender, holding a logger that works, sees the slot taken and returns
 # false; the reserving one then raises and releases the slot, and if there is
 # no later use nothing is ever logged. A reservation and an emitted notice
-# have to be distinguishable so a contender can wait for the outcome and take
-# the notice over when the reservation fails. (Round 10 kept that outcome and
-# dropped the machinery: the contender now waits on the feature's emission
-# gate, with no bounded wait to expire and nothing to hand back a notice that
-# was neither emitted nor owed.)
+# have to be distinguishable, so that a failed reservation leaves the notice
+# owed rather than spent. (Round 10 kept that outcome and dropped the
+# machinery, moving the attempt onto the feature's emission gate; the
+# verification pass then dropped the WAIT as well — a caller that meets a
+# notice in flight stands down instead of queueing behind it, because
+# queueing for a notice is what deadlocks against the logger writing it.
+# What survives every round is this: a notice that was not written is not
+# spent, so the feature's next use still gets it.)
 #
 # Then the places round 8's HTTP+SSE sweep did not reach. Round 8 marked the
 # Overview bullet, the Quick Connect line, the `/sse` detection row and
@@ -141,7 +144,7 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 9)' do
       expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
     end
 
-    it 'hands the notice to the contender when the reservation fails' do
+    it 'leaves the notice owed to a later use when the reservation fails' do
       reserver = Thread.new { MCPClient::Deprecations.warn(:roots, gated_logger) }
       gated_logger.await_entry
 
@@ -150,21 +153,28 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 9)' do
       sleep 0.05
       gated_logger.release(:raise)
 
-      expect(reserver.value).to be(false)
-      expect(contender.value).to be(true)
-      expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+      # The contender stands down instead of taking the reservation over: it
+      # cannot know that it is not itself holding a lock the reserving thread
+      # needs (see the verification pass). What it must not do is come away
+      # having spent a notice nobody wrote.
+      expect([reserver.value, contender.value]).to eq([false, false])
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+      expect(MCPClient::Deprecations.warn(:roots, working_logger)).to be(true)
       expect(output.string).to match(/Roots is deprecated/)
     end
 
     it 'never loses the only viable notice, whatever the interleaving' do
       # Same race without the sleep: whichever way the two land, a working
-      # logger was present for a first use, so a notice must have gone out.
+      # logger was present for a first use, so the notice is either out or
+      # still owed — never neither.
       reserver = Thread.new { MCPClient::Deprecations.warn(:roots, gated_logger) }
       gated_logger.await_entry
       contender = Thread.new { MCPClient::Deprecations.warn(:roots, working_logger) }
       gated_logger.release(:raise)
 
-      expect([reserver.value, contender.value]).to eq([false, true])
+      expect(reserver.value).to be(false)
+      written = contender.value || MCPClient::Deprecations.warn(:roots, working_logger)
+      expect(written).to be(true)
       expect(output.string).to match(/Roots is deprecated/)
     end
 

--- a/spec/lib/mcp_client/deprecations_2026_round9_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round9_spec.rb
@@ -1,0 +1,326 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Round 9 of the 2026-07-28 deprecation review.
+#
+# Three threads of it.
+#
+# The bookkeeping first. A notice is owed once per process, and the slot was
+# spent the moment a caller reserved it — before the logger had said anything.
+# Two first uses that race with different loggers could therefore lose the
+# notice outright: the reserving one blocks inside a broken logger while the
+# contender, holding a logger that works, sees the slot taken and returns
+# false; the reserving one then raises and releases the slot, and if there is
+# no later use nothing is ever logged. A reservation and an emitted notice
+# have to be distinguishable so a contender can wait for the outcome and take
+# the notice over when the reservation fails.
+#
+# Then the places round 8's HTTP+SSE sweep did not reach. Round 8 marked the
+# Overview bullet, the Quick Connect line, the `/sse` detection row and
+# `sse_config` itself; the Advanced Configuration example that calls
+# `sse_config`, the auto-detect fallback row, and `MCPClient.connect`'s
+# multiple-server example and "Other HTTP URLs" text still offered the
+# transport as an ordinary choice. This continues that sweep rather than
+# repeating it.
+#
+# And two documentation claims that do not hold: `protocol:` /
+# `discover_timeout:` are not carried to the HTTP+SSE transport by any route,
+# and the deprecated-features table — which claims to list what triggers each
+# first-use notice — omitted the transport-level Sampling trigger that round 8
+# tagged on `on_sampling_request`.
+RSpec.describe 'MCP 2026-07-28 deprecations (round 9)' do
+  let(:readme) { File.read(File.expand_path('../../../README.md', __dir__)) }
+  let(:module_source) { File.read(File.expand_path('../../../lib/mcp_client.rb', __dir__)) }
+
+  # A bullet (or `@param`-style line) plus its continuation lines, stopping at
+  # the next bullet or tag. Mirrors the round 7 and round 8 helper.
+  def doc_block(source, start_pattern)
+    lines = source.lines
+    index = lines.index { |line| line.match?(start_pattern) }
+    return nil unless index
+
+    block = +lines[index].sub(/^\s*#\s?/, '')
+    lines[(index + 1)..].each do |line|
+      break unless line.match?(/^\s*#/)
+      break if line.match?(/^\s*#\s*[@-]\s?\S/)
+
+      block << " #{line.sub(/^\s*#\s?/, '').strip}"
+    end
+    block
+  end
+
+  # Every YARD `@example` in a source file, as [heading, body] pairs. A body
+  # runs until the next tag or the end of the comment block.
+  def yard_examples(source)
+    examples = []
+    open = false
+    source.lines.each do |line|
+      if (heading = line[/^\s*#\s*@example\s*(.*)$/, 1])
+        examples << [heading.strip, +'']
+        open = true
+      elsif !open
+        next
+      elsif line.match?(/^\s*#\s*@\w/) || !line.match?(/^\s*#/)
+        open = false
+      else
+        examples.last[1] << line.sub(/^\s*#\s?/, '')
+      end
+    end
+    examples
+  end
+
+  # The comment lines directly above the first README line containing a marker.
+  def readme_comment_above(marker)
+    lines = readme.lines
+    index = lines.index { |line| line.include?(marker) }
+    return nil unless index
+
+    block = []
+    cursor = index - 1
+    while cursor >= 0 && lines[cursor].match?(/^\s*#/)
+      block.unshift(lines[cursor].sub(/^\s*#\s?/, '').strip)
+      cursor -= 1
+    end
+    block.join(' ')
+  end
+
+  # A logger whose #warn blocks until the example releases it, and then either
+  # raises or records the message. Deliberately not a ::Logger, so the level
+  # probe treats it as one that keeps warnings.
+  gated_logger_class = Class.new do
+    def initialize
+      @entered = Queue.new
+      @release = Queue.new
+      @messages = []
+    end
+
+    attr_reader :messages
+
+    # Block until #release, then behave as instructed.
+    def warn(message)
+      @entered << :entered
+      raise 'logger is down' if @release.pop == :raise
+
+      @messages << message
+      nil
+    end
+
+    # Wait until a caller is inside #warn.
+    def await_entry = @entered.pop
+
+    def release(outcome = :succeed) = @release << outcome
+  end
+
+  describe 'the once-per-process bookkeeping when two first uses race' do
+    around do |example|
+      MCPClient::Deprecations.enabled = true
+      MCPClient::Deprecations.reset!
+      example.run
+    ensure
+      MCPClient::Deprecations.reset!
+      MCPClient::Deprecations.enabled = false
+    end
+
+    let(:output) { StringIO.new }
+    let(:working_logger) { Logger.new(output) }
+    let(:gated_logger) { gated_logger_class.new }
+
+    it 'does not count a reservation as an emitted notice' do
+      reserver = Thread.new { MCPClient::Deprecations.warn(:roots, gated_logger) }
+      gated_logger.await_entry
+
+      # The slot is reserved, but nothing has been logged yet.
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+
+      gated_logger.release(:succeed)
+      expect(reserver.value).to be(true)
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+    end
+
+    it 'hands the notice to the contender when the reservation fails' do
+      reserver = Thread.new { MCPClient::Deprecations.warn(:roots, gated_logger) }
+      gated_logger.await_entry
+
+      contender = Thread.new { MCPClient::Deprecations.warn(:roots, working_logger) }
+      # Let the contender reach the in-flight reservation before it resolves.
+      sleep 0.05
+      gated_logger.release(:raise)
+
+      expect(reserver.value).to be(false)
+      expect(contender.value).to be(true)
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+      expect(output.string).to match(/Roots is deprecated/)
+    end
+
+    it 'never loses the only viable notice, whatever the interleaving' do
+      # Same race without the sleep: whichever way the two land, a working
+      # logger was present for a first use, so a notice must have gone out.
+      reserver = Thread.new { MCPClient::Deprecations.warn(:roots, gated_logger) }
+      gated_logger.await_entry
+      contender = Thread.new { MCPClient::Deprecations.warn(:roots, working_logger) }
+      gated_logger.release(:raise)
+
+      expect([reserver.value, contender.value]).to eq([false, true])
+      expect(output.string).to match(/Roots is deprecated/)
+    end
+
+    it 'lets the contender stand down when the reservation succeeds' do
+      reserver = Thread.new { MCPClient::Deprecations.warn(:roots, gated_logger) }
+      gated_logger.await_entry
+      contender = Thread.new { MCPClient::Deprecations.warn(:roots, working_logger) }
+      sleep 0.05
+      gated_logger.release(:succeed)
+
+      expect(reserver.value).to be(true)
+      expect(contender.value).to be(false)
+      # Exactly one notice: the contender waited for the outcome rather than
+      # logging a duplicate.
+      expect(gated_logger.messages.size).to eq(1)
+      expect(output.string).not_to match(/Roots is deprecated/)
+    end
+
+    it 'never holds up the deprecated operation behind a reservation that hangs' do
+      reserver = Thread.new { MCPClient::Deprecations.warn(:roots, gated_logger) }
+      gated_logger.await_entry
+
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      # The reservation never resolves; the contender must give up on it.
+      expect(MCPClient::Deprecations.warn(:roots, working_logger)).to be(false)
+      waited = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      expect(waited).to be <= (MCPClient::Deprecations::PENDING_WAIT_SECONDS * 4)
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+
+      gated_logger.release(:succeed)
+      reserver.join
+    end
+  end
+
+  describe 'a reservation that fails with no contender waiting' do
+    around do |example|
+      MCPClient::Deprecations.enabled = true
+      MCPClient::Deprecations.reset!
+      example.run
+    ensure
+      MCPClient::Deprecations.reset!
+      MCPClient::Deprecations.enabled = false
+    end
+
+    let(:output) { StringIO.new }
+
+    it 'is still owed to the next use' do
+      broken = Class.new do
+        def warn(_message) = raise('logger is down')
+      end.new
+
+      expect(MCPClient::Deprecations.warn(:logging, broken)).to be(false)
+      expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
+      expect(MCPClient::Deprecations.warn(:logging, Logger.new(output))).to be(true)
+      expect(output.string).to match(/Logging is deprecated/)
+    end
+  end
+
+  describe 'the README, in the HTTP+SSE spots round 8 did not reach' do
+    it 'marks the Advanced Configuration sse_config example' do
+      comment = readme_comment_above('MCPClient.sse_config(')
+
+      expect(comment).not_to be_nil
+      expect(comment).to match(/deprecat/i)
+      expect(comment).to include('Streamable HTTP')
+    end
+
+    it 'marks the auto-detect fallback row, which reaches for SSE too' do
+      row = readme[/^\| Other HTTP URLs \|.*$/]
+
+      expect(row).not_to be_nil
+      expect(row).to match(/deprecat/i)
+      expect(row).to include('#deprecated-features')
+    end
+
+    it 'leaves no unmarked SSE row in the transport-detection table' do
+      table = readme[/^\| URL Pattern \| Transport \|.*?\n\n/m]
+      sse_rows = table.lines.select { |line| line.start_with?('|') && line.match?(/SSE/) }
+
+      expect(sse_rows).not_to be_empty
+      sse_rows.each { |row| expect(row).to match(/deprecat/i), row }
+    end
+  end
+
+  describe 'MCPClient.connect, in the spots round 8 did not reach' do
+    it 'marks the "Other HTTP URLs" fallback, whose middle step is HTTP+SSE' do
+      block = doc_block(module_source, /^\s*#\s*-\s*Other HTTP URLs\b/)
+
+      expect(block).not_to be_nil
+      expect(block).to match(/deprecat/i)
+      expect(block).to include('SEP-2596')
+    end
+
+    it 'marks every @example that reaches for an /sse URL' do
+      sse_examples = yard_examples(module_source).select { |_heading, body| body.include?('/sse') }
+
+      # The dedicated SSE example still exists and is still marked; no other
+      # example may casually reach for the deprecated transport.
+      expect(sse_examples).not_to be_empty
+      sse_examples.each do |heading, body|
+        expect("#{heading} #{body}").to match(/deprecat/i), heading
+      end
+    end
+  end
+
+  describe 'the README claim that protocol: and discover_timeout: are available' do
+    # The one prose paragraph that offers the two options.
+    let(:paragraph) do
+      readme.split(/\n\n+/).find { |block| block.include?('discover_timeout:') && !block.start_with?('```') }
+    end
+
+    it 'is made in a paragraph the sweep can find' do
+      expect(paragraph).not_to be_nil
+      expect(paragraph).to include('discover_timeout:')
+    end
+
+    it 'only names builders that really take both options' do
+      named = %w[stdio_config http_config streamable_http_config sse_config]
+              .select { |builder| paragraph.include?("`#{builder}`") }
+
+      expect(named).not_to be_empty
+      named.each do |builder|
+        keywords = MCPClient.method(builder).parameters.map(&:last)
+        expect(keywords).to include(:protocol), builder
+        expect(keywords).to include(:discover_timeout), builder
+      end
+    end
+
+    it 'does not offer them on the HTTP+SSE transport, which rejects them' do
+      expect(MCPClient.method(:sse_config).parameters.map(&:last)).not_to include(:protocol, :discover_timeout)
+      expect(MCPClient::ServerSSE.instance_method(:initialize).parameters.map(&:last))
+        .not_to include(:protocol, :discover_timeout)
+      expect(paragraph).not_to include('sse_config')
+    end
+
+    it 'says so, because MCPClient.connect silently drops them for an /sse URL' do
+      dropped = MCPClient.send(:extract_sse_options, { protocol: :modern, discover_timeout: 5 })
+
+      expect(dropped).not_to include(:protocol)
+      expect(dropped).not_to include(:discover_timeout)
+      expect(paragraph).to match(/HTTP\+SSE/)
+      expect(paragraph).to match(/\bnot\b|never|no era|ignore/i)
+    end
+  end
+
+  describe 'the deprecated-features table, which lists what triggers each notice' do
+    it 'names the transport-level Sampling trigger round 8 tagged' do
+      row = readme[/^\| Sampling .*$/]
+
+      expect(row).not_to be_nil
+      expect(row).to include('on_sampling_request')
+    end
+
+    it 'still names the Client-level triggers alongside it' do
+      row = readme[/^\| Sampling .*$/]
+
+      expect(row).to include('sampling_handler:')
+      expect(row).to include('MCPClient.connect')
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_round9_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round9_spec.rb
@@ -14,7 +14,10 @@ require 'spec_helper'
 # false; the reserving one then raises and releases the slot, and if there is
 # no later use nothing is ever logged. A reservation and an emitted notice
 # have to be distinguishable so a contender can wait for the outcome and take
-# the notice over when the reservation fails.
+# the notice over when the reservation fails. (Round 10 kept that outcome and
+# dropped the machinery: the contender now waits on the feature's emission
+# gate, with no bounded wait to expire and nothing to hand back a notice that
+# was neither emitted nor owed.)
 #
 # Then the places round 8's HTTP+SSE sweep did not reach. Round 8 marked the
 # Overview bullet, the Quick Connect line, the `/sse` detection row and
@@ -180,20 +183,21 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 9)' do
       expect(output.string).not_to match(/Roots is deprecated/)
     end
 
-    it 'never holds up the deprecated operation behind a reservation that hangs' do
+    # Round 9 bounded the contender's wait, on the strength of a promise this
+    # path cannot keep (the bound never constrained the blocked caller
+    # itself). Round 10 narrowed the promise instead: a notice costs its
+    # caller what a `logger.warn` costs it, no more. What a notice still may
+    # not do is reach past the feature it is logging, which is what this
+    # example — and the round 10 file — pin in its place.
+    it 'never holds up anything but the feature it is logging' do
       reserver = Thread.new { MCPClient::Deprecations.warn(:roots, gated_logger) }
       gated_logger.await_entry
 
-      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      # The reservation never resolves; the contender must give up on it.
-      expect(MCPClient::Deprecations.warn(:roots, working_logger)).to be(false)
-      waited = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
-
-      expect(waited).to be <= (MCPClient::Deprecations::PENDING_WAIT_SECONDS * 4)
+      expect(MCPClient::Deprecations.warn(:logging, working_logger)).to be(true)
       expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
 
       gated_logger.release(:succeed)
-      reserver.join
+      expect(reserver.value).to be(true)
     end
   end
 

--- a/spec/lib/mcp_client/deprecations_2026_round9_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round9_spec.rb
@@ -187,12 +187,17 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 9)' do
     it 'lets the contender stand down when the reservation succeeds' do
       reserver = Thread.new { MCPClient::Deprecations.warn(:roots, gated_logger) }
       gated_logger.await_entry
-      contender = Thread.new { MCPClient::Deprecations.warn(:roots, working_logger) }
-      sleep 0.05
+      # The contender runs to completion on this thread while the reserver is
+      # parked inside its logger: the slot is reserved and cannot settle until
+      # this example releases it, so the interleaving under test is the one
+      # that happened, not the one a sleep hoped for. A contender does not
+      # queue for a notice in flight, so this returns at once.
+      contended = MCPClient::Deprecations.warn(:roots, working_logger)
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
       gated_logger.release(:succeed)
 
       expect(reserver.value).to be(true)
-      expect(contender.value).to be(false)
+      expect(contended).to be(false)
       # Exactly one notice: the contender waited for the outcome rather than
       # logging a duplicate.
       expect(gated_logger.messages.size).to eq(1)

--- a/spec/lib/mcp_client/deprecations_2026_round9_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_round9_spec.rb
@@ -149,8 +149,14 @@ RSpec.describe 'MCP 2026-07-28 deprecations (round 9)' do
       gated_logger.await_entry
 
       contender = Thread.new { MCPClient::Deprecations.warn(:roots, working_logger) }
-      # Let the contender reach the in-flight reservation before it resolves.
-      sleep 0.05
+      # The contender runs to COMPLETION while the reservation is still held:
+      # the reserver is parked inside its logger and cannot settle until this
+      # example releases it. So the interleaving under test is the one that
+      # happened, rather than the one a sleep hoped for — a contender that
+      # was not scheduled inside 50ms used to meet a released slot, claim it
+      # legitimately and fail this example for being right. Bounded, so a
+      # regression fails the example instead of wedging the suite.
+      expect(contender.join(10)).not_to be_nil
       gated_logger.release(:raise)
 
       # The contender stands down instead of taking the reservation over: it

--- a/spec/lib/mcp_client/deprecations_2026_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_spec.rb
@@ -238,8 +238,11 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
   end
 
   it 'works when loaded on its own' do
+    # $stdout, not File::NULL: a notice is spent only on a logger that has a
+    # device, and `logger` 1.7 gives `Logger.new(File::NULL)` none. The
+    # subprocess's own stdout is redirected below, so nothing is printed.
     script = "require 'mcp_client/deprecations'; " \
-             'exit(MCPClient::Deprecations.warn(:roots, Logger.new(File::NULL)) ? 0 : 1)'
+             'exit(MCPClient::Deprecations.warn(:roots, Logger.new($stdout)) ? 0 : 1)'
     expect(system(RbConfig.ruby, '-Ilib', '-e', script, out: File::NULL, err: File::NULL)).to be(true)
   end
 

--- a/spec/lib/mcp_client/deprecations_2026_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'webmock/rspec'
 
 # MCP 2026-07-28 placed Roots, Sampling, Logging, the HTTP+SSE transport, the
 # includeContext values thisServer / allServers and Dynamic Client
@@ -118,6 +119,38 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
     expect(MCPClient::Deprecations.warn(:roots, logger)).to be(true)
     expect(MCPClient::Deprecations.warn(:roots, logger)).to be(false)
     expect { MCPClient::Deprecations.warn(:bogus, logger) }.to raise_error(ArgumentError, /bogus/)
+  end
+
+  it 'is loaded by the standalone client entry point' do
+    script = "require 'mcp_client/client'; " \
+             'MCPClient::Client.new(mcp_server_configs: [], sampling_handler: ->(*) {}, roots: [], ' \
+             "logger: Logger.new(File::NULL)).log_level = 'debug'"
+    expect(system(RbConfig.ruby, '-Ilib', '-e', script, out: File::NULL, err: File::NULL)).to be(true)
+  end
+
+  it 'logs the Dynamic Client Registration notice once and silences it with the rest' do
+    meta = MCPClient::Auth::ServerMetadata.new(issuer: 'https://auth.example.com',
+                                               authorization_endpoint: 'https://auth.example.com/authorize',
+                                               token_endpoint: 'https://auth.example.com/token',
+                                               registration_endpoint: 'https://auth.example.com/register',
+                                               code_challenge_methods_supported: ['S256'])
+    stub_request(:post, 'https://auth.example.com/register')
+      .to_return(status: 201, headers: { 'Content-Type' => 'application/json' }, body: { client_id: 'dyn' }.to_json)
+    register = lambda do
+      provider = MCPClient::Auth::OAuthProvider.new(server_url: 'https://mcp.example.com/mcp',
+                                                    redirect_uri: 'http://localhost:8080/callback', logger: logger)
+      allow(provider).to receive(:discover_authorization_server).and_return(meta)
+      provider.start_authorization_flow
+    end
+
+    register.call
+    register.call
+    expect(output.string.scan(/Dynamic Client Registration .*deprecated/).size).to eq(1)
+
+    MCPClient::Deprecations.enabled = false
+    output.truncate(0)
+    register.call
+    expect(output.string).not_to match(/deprecated/)
   end
 
   it 'never lets peer-controlled detail forge log lines' do

--- a/spec/lib/mcp_client/deprecations_2026_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_spec.rb
@@ -108,14 +108,25 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
   end
 
   it 'warns when the log level is set on a server directly' do
-    server = MCPClient::ServerStdio.new(command: 'echo test', logger: logger)
-    allow(server).to receive(:rpc_request).and_return({})
-    allow(server).to receive(:ensure_initialized)
-    allow(server).to receive(:modern?).and_return(true)
+    servers = [
+      MCPClient::ServerStdio.new(command: 'echo test', logger: logger),
+      MCPClient::ServerHTTP.new(base_url: 'http://localhost:1', logger: logger),
+      MCPClient::ServerStreamableHTTP.new(base_url: 'http://localhost:1', logger: logger),
+      MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: logger)
+    ]
+    servers.each do |server|
+      MCPClient::Deprecations.reset!
+      output.truncate(0)
+      allow(server).to receive(:rpc_request).and_return({})
+      allow(server).to receive(:ensure_initialized) if server.respond_to?(:ensure_initialized, true)
+      allow(server).to receive(:ensure_connected) if server.respond_to?(:ensure_connected, true)
+      allow(server).to receive(:modern?).and_return(true)
+      allow(server).to receive(:require_capability!) if server.respond_to?(:require_capability!, true)
 
-    server.log_level = 'debug'
+      server.log_level = 'debug'
 
-    expect(output.string).to match(/Logging .*deprecated/)
+      expect(output.string).to match(/Logging .*deprecated/), server.class.name
+    end
   end
 
   it 'warns when a server sends a log message' do
@@ -155,18 +166,67 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
     expect(MCPClient::Deprecations.warn(:roots, logger)).to be(true)
   end
 
-  it 'does not mark a notice emitted when the logger raises' do
+  it 'swallows a logger failure and leaves the notice for a later use' do
     broken = Object.new
     def broken.warn(_message) = raise(IOError, 'closed stream')
 
-    expect { MCPClient::Deprecations.warn(:roots, broken) }.to raise_error(IOError)
+    expect(MCPClient::Deprecations.warn(:roots, broken)).to be(false)
     expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+    expect(MCPClient::Deprecations.warn(:roots, logger)).to be(true)
+  end
+
+  it 'keeps serving deprecated features when the logger fails' do
+    broken = Logger.new(StringIO.new)
+    def broken.warn(*) = raise(IOError, 'closed stream')
+    handler = lambda { |_messages, _prefs, _system, _max|
+      { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'ok' }, 'model' => 'm' }
+    }
+    c = MCPClient::Client.new(mcp_server_configs: [], logger: broken, sampling_handler: handler, roots: roots)
+    params = { 'messages' => [], 'maxTokens' => 5, 'includeContext' => 'thisServer' }
+    expect(c.send(:handle_sampling_request, 1, params)['content']['text']).to eq('ok')
+    expect { c.log_level = 'debug' }.not_to raise_error
+
+    server = MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: broken)
+    allow(server).to receive(:start_sse_thread)
+    allow(server).to receive(:wait_for_connection)
+    allow(server).to receive(:start_activity_monitor)
+    expect(server.connect).to be(true)
+  end
+
+  it 'does not call warn? on a strict Logger double' do
+    strict = instance_double(Logger, warn: nil)
+
+    expect(MCPClient::Deprecations.warn(:roots, strict)).to be(true)
+  end
+
+  it 'logs outside its lock so a logger may consult the registry' do
+    logger.formatter = proc { |severity, _time, _prog, msg| "#{severity} #{MCPClient::Deprecations.emitted?(:logging)} #{msg}\n" }
+
+    expect(MCPClient::Deprecations.warn(:roots, logger)).to be(true)
+    expect(output.string).to match(/Roots .*deprecated/)
+  end
+
+  it 'emits each notice exactly once under concurrent first uses' do
+    threads = Array.new(8) do
+      Thread.new do
+        MCPClient::Deprecations.warn(:roots, logger)
+        MCPClient::Deprecations.warn(:logging, logger)
+      end
+    end
+    threads.each(&:join)
+
+    expect(output.string.scan(/Roots .*deprecated/).size).to eq(1)
+    expect(output.string.scan(/Logging .*deprecated/).size).to eq(1)
   end
 
   it 'stays silent when notices are disabled' do
     MCPClient::Deprecations.enabled = false
-    client(roots: roots, sampling_handler: ->(_m, _p, _s, _t) { {} })
-    MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: logger)
+    client(roots: roots, sampling_handler: ->(_m, _p, _s, _t) { {} }).log_level = 'debug'
+    server = MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: logger)
+    allow(server).to receive(:start_sse_thread)
+    allow(server).to receive(:wait_for_connection)
+    allow(server).to receive(:start_activity_monitor)
+    server.connect
 
     expect(output.string).not_to match(/deprecated/)
   end

--- a/spec/lib/mcp_client/deprecations_2026_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_spec.rb
@@ -29,18 +29,51 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
     [{ uri: 'file:///tmp', name: 'tmp' }]
   end
 
+  # What the published registry says about each feature, written down here so
+  # a wrong revision or a wrong SEP in the production table has to disagree
+  # with an expected value rather than merely with itself. `since` is the
+  # revision in which the feature ENTERED the Deprecated state, which for the
+  # two features SEP-2596 reclassified is older than 2026-07-28.
+  # `earliest_removal` and `migration` are pinned against the registry's own
+  # wording in the round 5 and round 6 specs.
+  let(:expected_registry) do
+    {
+      roots: { feature: 'Roots', since: '2026-07-28', reference: 'SEP-2577' },
+      sampling: { feature: 'Sampling', since: '2026-07-28', reference: 'SEP-2577' },
+      logging: { feature: 'Logging', since: '2026-07-28', reference: 'SEP-2577' },
+      http_sse_transport: { feature: 'The HTTP+SSE transport', since: '2025-03-26',
+                            reference: 'reclassified by SEP-2596 in 2026-07-28' },
+      include_context: { feature: 'The includeContext values "thisServer" and "allServers"',
+                         since: '2025-11-25', reference: 'reclassified by SEP-2596 in 2026-07-28' },
+      dynamic_client_registration: { feature: 'OAuth 2.0 Dynamic Client Registration (RFC 7591)',
+                                     since: '2026-07-28', reference: 'MCP PR #2858' }
+    }
+  end
+
   it 'lists every feature the revision placed in the Deprecated state' do
-    expect(MCPClient::Deprecations::REGISTRY.keys)
-      .to contain_exactly(:roots, :sampling, :logging, :http_sse_transport, :include_context,
-                          :dynamic_client_registration)
+    expect(MCPClient::Deprecations::REGISTRY.keys).to match_array(expected_registry.keys)
     MCPClient::Deprecations::REGISTRY.each_value do |entry|
-      expect(entry.keys).to include(:feature, :since, :reference, :migration)
+      expect(entry.keys).to include(:feature, :since, :reference, :earliest_removal, :migration)
     end
-    # The registry records when each feature entered the Deprecated state,
-    # not the revision that reclassified it.
-    expect(MCPClient::Deprecations::REGISTRY[:http_sse_transport][:since]).to eq('2025-03-26')
-    expect(MCPClient::Deprecations::REGISTRY[:include_context][:since]).to eq('2025-11-25')
-    expect(MCPClient::Deprecations::REGISTRY[:roots][:since]).to eq('2026-07-28')
+  end
+
+  it 'records the name, the deprecating revision and the SEP of each one' do
+    expected_registry.each do |key, expected|
+      entry = MCPClient::Deprecations::REGISTRY.fetch(key)
+      expect(entry.slice(:feature, :since, :reference)).to eq(expected), key.to_s
+    end
+  end
+
+  it 'names the feature and its own revision in the notice it writes' do
+    expected_registry.each do |key, expected|
+      MCPClient::Deprecations.reset!
+      output.truncate(output.rewind)
+
+      expect(MCPClient::Deprecations.warn(key, logger)).to be(true)
+
+      sentence = "#{expected[:feature]} is deprecated since MCP #{expected[:since]} (#{expected[:reference]})"
+      expect(output.string).to include(sentence), key.to_s
+    end
   end
 
   it 'warns once when roots are configured' do
@@ -191,6 +224,45 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
     allow(server).to receive(:wait_for_connection)
     allow(server).to receive(:start_activity_monitor)
     expect(server.connect).to be(true)
+  end
+
+  # `log_level=` on a client with no servers reaches no transport at all, so
+  # it cannot show that Logging still WORKS behind a failing logger — only
+  # that the call returns. Drive a server of each era instead: the legacy one
+  # must still send logging/setLevel, and the modern one must still record the
+  # level every later request carries. Neither notice can be written, so both
+  # stay owed.
+  it 'still sets the log level on the wire when the logger fails' do
+    broken = Logger.new(StringIO.new)
+    def broken.warn(*) = raise(IOError, 'closed stream')
+
+    legacy = MCPClient::ServerStdio.new(command: 'true', logger: broken)
+    legacy.instance_variable_set(:@protocol_version, '2025-06-18')
+    allow(legacy).to receive(:ensure_initialized)
+    allow(legacy).to receive(:require_capability!)
+    calls = []
+    allow(legacy).to receive(:rpc_request) { |method, params| calls << [method, params] }
+
+    legacy.send(:log_level=, 'debug')
+
+    expect(calls).to eq([['logging/setLevel', { 'level' => 'debug' }]])
+    expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
+  end
+
+  it 'still carries the log level on a modern request when the logger fails' do
+    broken = Logger.new(StringIO.new)
+    def broken.warn(*) = raise(IOError, 'closed stream')
+
+    modern = MCPClient::ServerStdio.new(command: 'true', logger: broken)
+    modern.instance_variable_set(:@protocol_version, '2026-07-28')
+    allow(modern).to receive(:ensure_initialized)
+    expect(modern).to be_modern
+
+    modern.send(:log_level=, 'debug')
+    params = modern.with_request_meta({ 'name' => 'tool' })
+
+    expect(params['_meta']['io.modelcontextprotocol/logLevel']).to eq('debug')
+    expect(MCPClient::Deprecations.emitted?(:logging)).to be(false)
   end
 
   it 'does not call warn? on a strict Logger double' do

--- a/spec/lib/mcp_client/deprecations_2026_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_spec.rb
@@ -35,8 +35,12 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
                           :dynamic_client_registration)
     MCPClient::Deprecations::REGISTRY.each_value do |entry|
       expect(entry.keys).to include(:feature, :since, :reference, :migration)
-      expect(entry[:since]).to eq('2026-07-28')
     end
+    # The registry records when each feature entered the Deprecated state,
+    # not the revision that reclassified it.
+    expect(MCPClient::Deprecations::REGISTRY[:http_sse_transport][:since]).to eq('2025-03-26')
+    expect(MCPClient::Deprecations::REGISTRY[:include_context][:since]).to eq('2025-11-25')
+    expect(MCPClient::Deprecations::REGISTRY[:roots][:since]).to eq('2026-07-28')
   end
 
   it 'warns once when roots are configured' do
@@ -67,17 +71,20 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
     expect(output.string).to include('LLM provider')
   end
 
-  it 'warns when a sampling request asks for thisServer or allServers context but still serves it' do
-    handler = lambda { |_messages, _prefs, _system, _max|
-      { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'ok' }, 'model' => 'm' }
-    }
-    c = client(sampling_handler: handler)
-    params = { 'messages' => [], 'maxTokens' => 5, 'includeContext' => 'allServers' }
+  %w[thisServer allServers].each do |value|
+    it "warns when a sampling request asks for #{value} context but still serves it" do
+      handler = lambda { |_messages, _prefs, _system, _max|
+        { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'ok' }, 'model' => 'm' }
+      }
+      c = client(sampling_handler: handler)
+      params = { 'messages' => [], 'maxTokens' => 5, 'includeContext' => value }
 
-    result = c.send(:handle_sampling_request, 1, params)
+      result = c.send(:handle_sampling_request, 1, params)
 
-    expect(result['content']['text']).to eq('ok')
-    expect(output.string).to match(/includeContext.*allServers.*deprecated/i)
+      expect(result['content']['text']).to eq('ok')
+      expect(output.string).to include("Received: includeContext #{value}")
+      expect(MCPClient::Deprecations.emitted?(:include_context)).to be(true)
+    end
   end
 
   it 'does not mention includeContext for none or an absent field' do
@@ -100,11 +107,60 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
     expect(output.string).to include('stderr')
   end
 
-  it 'warns that the HTTP+SSE transport is deprecated' do
-    MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: logger)
+  it 'warns when the log level is set on a server directly' do
+    server = MCPClient::ServerStdio.new(command: 'echo test', logger: logger)
+    allow(server).to receive(:rpc_request).and_return({})
+    allow(server).to receive(:ensure_initialized)
+    allow(server).to receive(:modern?).and_return(true)
+
+    server.log_level = 'debug'
+
+    expect(output.string).to match(/Logging .*deprecated/)
+  end
+
+  it 'warns when a server sends a log message' do
+    server = MCPClient::ServerStdio.new(command: 'echo test', logger: logger)
+    allow(MCPClient::ServerFactory).to receive(:create).and_return(server)
+    c = MCPClient::Client.new(mcp_server_configs: [{ type: 'stdio', command: 'x' }], logger: logger)
+
+    c.send(:process_notification, server, 'notifications/message', { 'level' => 'info', 'data' => 'hello' })
+
+    expect(output.string).to match(/Logging .*deprecated/)
+  end
+
+  it 'warns that the HTTP+SSE transport is deprecated once it is connected, not when it is built' do
+    server = MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: logger)
+    expect(output.string).not_to match(/deprecated/)
+
+    # MCPClient.connect tries SSE while probing a URL that may end up on
+    # another transport: a failed attempt must not spend the notice.
+    expect { server.connect }.to raise_error(MCPClient::Errors::ConnectionError)
+    expect(MCPClient::Deprecations.emitted?(:http_sse_transport)).to be(false)
+
+    allow(server).to receive(:start_sse_thread)
+    allow(server).to receive(:wait_for_connection)
+    allow(server).to receive(:start_activity_monitor)
+    server.connect
 
     expect(output.string).to match(/HTTP\+SSE transport .*deprecated/)
     expect(output.string).to include('Streamable HTTP')
+    expect(output.string).to include('2025-03-26')
+  end
+
+  it 'does not spend the notice on a logger that drops warnings' do
+    quiet = Logger.new(output, level: Logger::ERROR)
+
+    expect(MCPClient::Deprecations.warn(:roots, quiet)).to be(false)
+    expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+    expect(MCPClient::Deprecations.warn(:roots, logger)).to be(true)
+  end
+
+  it 'does not mark a notice emitted when the logger raises' do
+    broken = Object.new
+    def broken.warn(_message) = raise(IOError, 'closed stream')
+
+    expect { MCPClient::Deprecations.warn(:roots, broken) }.to raise_error(IOError)
+    expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
   end
 
   it 'stays silent when notices are disabled' do
@@ -154,8 +210,16 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
   end
 
   it 'never lets peer-controlled detail forge log lines' do
-    MCPClient::Deprecations.warn(:include_context, logger, detail: "allServers\nWARN forged")
+    MCPClient::Deprecations.warn(:include_context, logger, detail: "allServers\nWARN forged\u2028more")
 
     expect(output.string).not_to include("\nWARN forged")
+    expect(output.string).not_to include("\u2028")
+  end
+
+  it 'bounds the quoted detail' do
+    MCPClient::Deprecations.warn(:include_context, logger, detail: 'x' * 5000)
+
+    expect(output.string.length).to be < 1000
+    expect(output.string).to include('...')
   end
 end

--- a/spec/lib/mcp_client/deprecations_2026_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_spec.rb
@@ -237,6 +237,12 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
     expect { MCPClient::Deprecations.warn(:bogus, logger) }.to raise_error(ArgumentError, /bogus/)
   end
 
+  it 'works when loaded on its own' do
+    script = "require 'mcp_client/deprecations'; " \
+             'exit(MCPClient::Deprecations.warn(:roots, Logger.new(File::NULL)) ? 0 : 1)'
+    expect(system(RbConfig.ruby, '-Ilib', '-e', script, out: File::NULL, err: File::NULL)).to be(true)
+  end
+
   it 'is loaded by the standalone client entry point' do
     script = "require 'mcp_client/client'; " \
              'MCPClient::Client.new(mcp_server_configs: [], sampling_handler: ->(*) {}, roots: [], ' \

--- a/spec/lib/mcp_client/deprecations_2026_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_spec.rb
@@ -272,17 +272,35 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
     register.call
     expect(output.string.scan(/Dynamic Client Registration .*deprecated/).size).to eq(1)
 
+    # Reset before disabling: a notice already spent stays silent whether or
+    # not the switch works, so silence after two registrations would say
+    # nothing about `enabled = false`.
+    MCPClient::Deprecations.reset!
     MCPClient::Deprecations.enabled = false
     output.truncate(0)
     register.call
+    expect(MCPClient::Deprecations.emitted?(:dynamic_client_registration)).to be(false)
     expect(output.string).not_to match(/deprecated/)
+
+    # And the notice really was owed again, so the silence above was the
+    # switch and nothing else.
+    MCPClient::Deprecations.enabled = true
+    register.call
+    expect(output.string).to match(/Dynamic Client Registration .*deprecated/)
   end
 
   it 'never lets peer-controlled detail forge log lines' do
-    MCPClient::Deprecations.warn(:include_context, logger, detail: "allServers\nWARN forged\u2028more")
+    # Assert the notice went out as well: an example that only checks for
+    # what is absent passes on a notice that was never written at all.
+    expect(MCPClient::Deprecations.warn(:include_context, logger,
+                                        detail: "allServers\nWARN forged\u2028more")).to be(true)
 
+    expect(output.string).to include('includeContext values')
+    expect(output.string).to include('Received: allServers\u000AWARN forged\u2028more')
     expect(output.string).not_to include("\nWARN forged")
     expect(output.string).not_to include("\u2028")
+    # One line: the escaping is what keeps the peer's text inside the notice.
+    expect(output.string.lines.size).to eq(1)
   end
 
   it 'bounds the quoted detail' do

--- a/spec/lib/mcp_client/deprecations_2026_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# MCP 2026-07-28 placed Roots, Sampling, Logging, the HTTP+SSE transport, the
+# includeContext values thisServer / allServers and Dynamic Client
+# Registration in the Deprecated state (SEP-2577, SEP-2596, PR #2858). They
+# keep working; the client says so once per process and points at the
+# suggested migration.
+RSpec.describe 'MCP 2026-07-28 deprecations' do
+  let(:output) { StringIO.new }
+  let(:logger) { Logger.new(output) }
+
+  around do |example|
+    MCPClient::Deprecations.enabled = true
+    MCPClient::Deprecations.reset!
+    example.run
+  ensure
+    MCPClient::Deprecations.reset!
+    MCPClient::Deprecations.enabled = false
+  end
+
+  def client(**opts)
+    MCPClient::Client.new(mcp_server_configs: [], logger: logger, **opts)
+  end
+
+  def roots
+    [{ uri: 'file:///tmp', name: 'tmp' }]
+  end
+
+  it 'lists every feature the revision placed in the Deprecated state' do
+    expect(MCPClient::Deprecations::REGISTRY.keys)
+      .to contain_exactly(:roots, :sampling, :logging, :http_sse_transport, :include_context,
+                          :dynamic_client_registration)
+    MCPClient::Deprecations::REGISTRY.each_value do |entry|
+      expect(entry.keys).to include(:feature, :since, :reference, :migration)
+      expect(entry[:since]).to eq('2026-07-28')
+    end
+  end
+
+  it 'warns once when roots are configured' do
+    client(roots: roots)
+    client(roots: roots)
+
+    expect(output.string.scan(/Roots .*deprecated/).size).to eq(1)
+    expect(output.string).to include('SEP-2577')
+  end
+
+  it 'stays silent for a client that uses none of the deprecated features' do
+    client
+
+    expect(output.string).not_to match(/deprecated/)
+  end
+
+  it 'warns when roots are assigned later' do
+    c = client
+    c.roots = roots
+
+    expect(output.string).to match(/Roots .*deprecated/)
+  end
+
+  it 'warns once when a sampling handler is configured' do
+    client(sampling_handler: ->(_m, _p, _s, _t) { {} })
+
+    expect(output.string).to match(/Sampling .*deprecated/)
+    expect(output.string).to include('LLM provider')
+  end
+
+  it 'warns when a sampling request asks for thisServer or allServers context but still serves it' do
+    handler = lambda { |_messages, _prefs, _system, _max|
+      { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'ok' }, 'model' => 'm' }
+    }
+    c = client(sampling_handler: handler)
+    params = { 'messages' => [], 'maxTokens' => 5, 'includeContext' => 'allServers' }
+
+    result = c.send(:handle_sampling_request, 1, params)
+
+    expect(result['content']['text']).to eq('ok')
+    expect(output.string).to match(/includeContext.*allServers.*deprecated/i)
+  end
+
+  it 'does not mention includeContext for none or an absent field' do
+    handler = lambda { |_messages, _prefs, _system, _max|
+      { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'ok' }, 'model' => 'm' }
+    }
+    c = client(sampling_handler: handler)
+    output.truncate(0)
+
+    c.send(:handle_sampling_request, 1, { 'messages' => [], 'maxTokens' => 5, 'includeContext' => 'none' })
+    c.send(:handle_sampling_request, 2, { 'messages' => [], 'maxTokens' => 5 })
+
+    expect(output.string).not_to match(/includeContext/)
+  end
+
+  it 'warns when the log level is set' do
+    client.log_level = 'debug'
+
+    expect(output.string).to match(/Logging .*deprecated/)
+    expect(output.string).to include('stderr')
+  end
+
+  it 'warns that the HTTP+SSE transport is deprecated' do
+    MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: logger)
+
+    expect(output.string).to match(/HTTP\+SSE transport .*deprecated/)
+    expect(output.string).to include('Streamable HTTP')
+  end
+
+  it 'stays silent when notices are disabled' do
+    MCPClient::Deprecations.enabled = false
+    client(roots: roots, sampling_handler: ->(_m, _p, _s, _t) { {} })
+    MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: logger)
+
+    expect(output.string).not_to match(/deprecated/)
+  end
+
+  it 'reports whether a notice was emitted and rejects unknown features' do
+    expect(MCPClient::Deprecations.warn(:roots, logger)).to be(true)
+    expect(MCPClient::Deprecations.warn(:roots, logger)).to be(false)
+    expect { MCPClient::Deprecations.warn(:bogus, logger) }.to raise_error(ArgumentError, /bogus/)
+  end
+
+  it 'never lets peer-controlled detail forge log lines' do
+    MCPClient::Deprecations.warn(:include_context, logger, detail: "allServers\nWARN forged")
+
+    expect(output.string).not_to include("\nWARN forged")
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_spec.rb
@@ -106,7 +106,13 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
 
   %w[thisServer allServers].each do |value|
     it "warns when a sampling request asks for #{value} context but still serves it" do
-      handler = lambda { |_messages, _prefs, _system, _max|
+      # A five-argument handler, so "still serves it" is the request the
+      # handler was given and not merely a result that came back: the
+      # deprecation is a warning, and SEP-2596 leaves the wire alone, so the
+      # value the server asked for must still reach the host untouched.
+      seen = nil
+      handler = lambda { |_messages, _prefs, _system, _max, request|
+        seen = request
         { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'ok' }, 'model' => 'm' }
       }
       c = client(sampling_handler: handler)
@@ -114,6 +120,7 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
 
       result = c.send(:handle_sampling_request, 1, params)
 
+      expect(seen).to include('includeContext' => value)
       expect(result['content']['text']).to eq('ok')
       expect(output.string).to include("Received: includeContext #{value}")
       expect(MCPClient::Deprecations.emitted?(:include_context)).to be(true)

--- a/spec/lib/mcp_client/deprecations_2026_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_spec.rb
@@ -390,4 +390,39 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
     expect(output.string.length).to be < 1000
     expect(output.string).to include('...')
   end
+
+  # The bound is an implementation contract, not a wire rule, so pin the
+  # limit the code documents: a detail exactly that long is quoted whole and
+  # one character longer is cut at the limit. The notice's own wording
+  # contains an ellipsis, so read the quoted detail rather than the line.
+  def quoted_detail = output.string[/Received: (.*)\n/, 1]
+
+  it 'quotes a detail up to the limit whole and cuts anything past it' do
+    # The number is spelled out, not read from the constant: an example that
+    # reads MAX_DETAIL_LENGTH agrees with whatever the constant says and
+    # pins nothing.
+    limit = 200
+    expect(MCPClient::Deprecations::MAX_DETAIL_LENGTH).to eq(limit)
+
+    MCPClient::Deprecations.warn(:include_context, logger, detail: 'x' * limit)
+    at_limit = quoted_detail
+    MCPClient::Deprecations.reset!
+    output.truncate(output.rewind)
+    MCPClient::Deprecations.warn(:include_context, logger, detail: 'x' * (limit + 1))
+
+    expect(at_limit).to eq('x' * limit)
+    expect(quoted_detail).to eq("#{'x' * limit}...")
+  end
+
+  # The limit counts the ESCAPED text — the form the notice actually carries
+  # — so a control character near the limit is what pushes the quote over it,
+  # and the cut lands inside the escape sequence rather than past it.
+  it 'measures the bound in escaped characters' do
+    limit = 200
+
+    MCPClient::Deprecations.warn(:include_context, logger, detail: "#{'x' * (limit - 1)}\n")
+
+    expect(quoted_detail).to eq("#{'x' * (limit - 1)}\\...")
+    expect(output.string.lines.size).to eq(1)
+  end
 end

--- a/spec/lib/mcp_client/deprecations_2026_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_spec.rb
@@ -276,6 +276,8 @@ RSpec.describe 'MCP 2026-07-28 deprecations' do
     strict = instance_double(Logger, warn: nil)
 
     expect(MCPClient::Deprecations.warn(:roots, strict)).to be(true)
+    # Returning true is a claim that the notice was written: pin the write.
+    expect(strict).to have_received(:warn).with(a_string_matching(/Roots .*deprecated/)).once
   end
 
   it 'logs outside its lock so a logger may consult the registry' do

--- a/spec/lib/mcp_client/deprecations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_verify_spec.rb
@@ -1,0 +1,475 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Verification pass over the 2026-07-28 deprecation notices.
+#
+# Round 11 stopped a thread that is already INSIDE a notice from queueing for
+# an emission gate. That is not the only way into the inversion, because the
+# thread holding the logger's device lock need not be inside a notice at all:
+# an ordinary `logger.info` holds it for as long as the write takes, and the
+# device — a formatter, a log subscriber, an audit hook the host installed —
+# may itself reach a deprecated feature. That thread then queues for a gate
+# held by a second thread which is waiting for the very device lock the first
+# one holds, and neither moves again. Round 11's `emitting?` guard cannot see
+# it: the first thread is doing ordinary logging, not writing a notice.
+#
+# There is no version of "wait for the gate" that survives this, because the
+# waiter cannot know whether it holds a lock the emitter needs. So no lock of
+# this module is held across host logging code and none is ever waited for:
+# the once-per-process accounting is an atomic claim, taken and released
+# under a mutex this module never holds while calling out. A caller that
+# finds a notice in flight stands down rather than queueing behind it, and
+# the notice stays owed to a later use exactly as a dropped one does.
+#
+# That also closes a second hole. A contender that waited took the notice
+# over on a level check it made BEFORE the wait: if its logger stopped
+# keeping warnings in the meantime, the warning was filtered and the
+# process's one notice was marked emitted having been written nowhere — and
+# lowering the level again did not bring it back. Nothing takes a notice
+# over any more, and the level check now sits next to the write instead of at
+# the top of `warn`.
+#
+# The rest of this pass is coverage. The Roots and Sampling notice hooks on
+# both SSE transports and the Sampling hook on the multi round-trip path
+# could each be deleted with the whole focused suite still green, and the
+# marking checks counted `@deprecated` tags (which cannot show that an API
+# has one) and accepted any registry window (which cannot show that an API
+# names its own). These examples also run with notices ENABLED through paths
+# the rest of the suite only exercises with them off (spec_helper disables
+# them for the suite), so a notice that broke the request it describes would
+# fail here.
+RSpec.describe 'MCP 2026-07-28 deprecations (verification)' do
+  let(:output) { StringIO.new }
+  let(:logger) { Logger.new(output) }
+
+  around do |example|
+    MCPClient::Deprecations.enabled = true
+    MCPClient::Deprecations.reset!
+    example.run
+  ensure
+    MCPClient::Deprecations.reset!
+    MCPClient::Deprecations.enabled = false
+  end
+
+  let(:threads) { [] }
+
+  after { threads.each { |thread| thread.kill if thread.alive? } }
+
+  def start(&block)
+    thread = Thread.new(&block)
+    threads << thread
+    thread
+  end
+
+  # Nothing here may wedge the suite: a regression has to fail the example,
+  # not hang it. Seconds, not milliseconds, so a loaded CI box never reports
+  # a deadlock that is only slowness.
+  def finished?(thread)
+    !thread.join(10).nil?
+  end
+
+  # Wait until every thread is parked (blocked or finished), so an example
+  # exercises the contended path rather than a lucky ordering.
+  def settle(*waiting)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+    until waiting.all? { |thread| thread.status == 'sleep' || !thread.status }
+      raise 'threads never settled' if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+      sleep 0.001
+    end
+  end
+
+  # A logger whose #warn blocks until the example releases it and then either
+  # raises or records the message. Deliberately not a ::Logger, so the level
+  # probe treats it as one that keeps warnings. Mirrors rounds 9 to 11.
+  let(:gated_logger_class) do
+    Class.new do
+      attr_reader :messages
+
+      def initialize
+        @entered = Queue.new
+        @release = Queue.new
+        @messages = []
+      end
+
+      def warn(message)
+        @entered << :entered
+        raise 'logger is down' if @release.pop == :raise
+
+        @messages << message
+        nil
+      end
+
+      # Wait until a caller is inside #warn.
+      def await_entry = @entered.pop
+
+      def release(outcome = :succeed) = @release << outcome
+    end
+  end
+
+  describe 'a notice raised from inside an ordinary log line' do
+    # A device for a real ::Logger, which serializes every write behind its
+    # device lock. The first write parks inside that lock until the example
+    # releases it, and then runs the host's callback while it is still held.
+    # Nothing here is inside a notice: the thread is writing an info line.
+    let(:callback_device_class) do
+      Class.new do
+        attr_reader :messages, :nested
+
+        def initialize(&on_first_write)
+          @messages = []
+          @entered = Queue.new
+          @go = Queue.new
+          @on_first_write = on_first_write
+          @first = true
+        end
+
+        def write(message)
+          @messages << message
+          return unless @first
+
+          @first = false
+          @entered << :entered
+          @go.pop
+          @nested = @on_first_write&.call
+        end
+
+        def close = nil
+
+        # Wait until the first writer is inside #write, holding the lock.
+        def await_entry = @entered.pop
+
+        def release = (@go << :go)
+      end
+    end
+
+    let(:device) { callback_device_class.new { MCPClient::Deprecations.warn(:roots, host_logger) } }
+    let(:host_logger) { Logger.new(device) }
+
+    it 'does not deadlock against the logger another notice is writing to' do
+      ordinary = start { host_logger.info('an ordinary line') }
+      device.await_entry
+      # This thread now owns the Roots attempt and is queued for the device
+      # lock the ordinary line is holding. The ordinary line's callback is
+      # about to ask for Roots in turn: the inversion, with neither thread
+      # inside a notice when it took the lock it holds.
+      notice = start { MCPClient::Deprecations.warn(:roots, host_logger) }
+      settle(notice)
+      device.release
+
+      expect(finished?(ordinary)).to be(true), 'an ordinary log line deadlocked against a deprecation notice'
+      expect(finished?(notice)).to be(true), 'the notice never came back out of the logger'
+      expect(notice.value).to be(true)
+      # The callback's attempt stood down instead of queueing: the notice it
+      # wanted is the one the other thread is writing.
+      expect(device.nested).to be(false)
+      expect(device.messages.grep(/Roots .*deprecated/).size).to eq(1)
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+    end
+
+    it 'still writes the notice when no other thread is holding it' do
+      # The standing down above is the contended case, not a blanket refusal
+      # to warn from inside a write: with nothing in flight the callback's
+      # first use is served where it happens, through the same logger.
+      ordinary = start { host_logger.info('an ordinary line') }
+      device.await_entry
+      device.release
+
+      expect(finished?(ordinary)).to be(true)
+      expect(device.nested).to be(true)
+      expect(device.messages.grep(/Roots .*deprecated/).size).to eq(1)
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+    end
+  end
+
+  describe 'a notice that was never written' do
+    it 'is not spent by a contender whose logger stopped keeping warnings' do
+      gated = gated_logger_class.new
+      quiet = Logger.new(output)
+      emitter = start { MCPClient::Deprecations.warn(:roots, gated) }
+      gated.await_entry
+      contender = start { MCPClient::Deprecations.warn(:roots, quiet) }
+      settle(contender)
+      # The level a contender checked before it met the notice in flight is
+      # not the level its logger has when it would write.
+      quiet.level = Logger::ERROR
+      gated.release(:raise)
+
+      expect(finished?(emitter)).to be(true)
+      expect(finished?(contender)).to be(true)
+      expect([emitter.value, contender.value]).to eq([false, false])
+      expect(output.string).not_to match(/Roots .*deprecated/)
+      # Nothing was written, so nothing was spent.
+      expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+      quiet.level = Logger::DEBUG
+      expect(MCPClient::Deprecations.warn(:roots, quiet)).to be(true)
+      expect(output.string).to match(/Roots .*deprecated/)
+    end
+
+    it 'is not spent by a level that went up after the probe' do
+      # A logger whose level is raised between the module's probe and the
+      # write, as another thread raising it would do. ::Logger#warn returns
+      # true either way, so "the logger took it" cannot be read off the
+      # return value: the check has to sit next to the write.
+      raised_after_probe = Class.new(Logger) do
+        def level
+          current = super
+          self.level = Logger::ERROR
+          current
+        end
+      end.new(output)
+
+      expect(MCPClient::Deprecations.warn(:sampling, raised_after_probe)).to be(false)
+      expect(output.string).not_to match(/Sampling .*deprecated/)
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(false)
+      expect(MCPClient::Deprecations.warn(:sampling, Logger.new(output))).to be(true)
+      expect(output.string).to match(/Sampling .*deprecated/)
+    end
+  end
+
+  describe 'a server-initiated request routed by an HTTP transport' do
+    let(:posted) { [] }
+    let(:sampling_answer) do
+      { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'ok' }, 'model' => 'm' }
+    end
+
+    # Route one request through the transport's own dispatch, capturing the
+    # response it posts back to the server.
+    def route(server, message)
+      allow(server).to receive(:ensure_initialized) if server.respond_to?(:ensure_initialized, true)
+      allow(server).to receive(:post_jsonrpc_response) { |response| posted << response }
+      server.send(:handle_server_request, message)
+    end
+
+    {
+      'the HTTP+SSE transport' => lambda { |logger|
+        MCPClient::ServerSSE.new(base_url: 'http://localhost:1/sse', logger: logger)
+      },
+      'the Streamable HTTP transport' => lambda { |logger|
+        MCPClient::ServerStreamableHTTP.new(base_url: 'http://localhost:1/mcp', logger: logger)
+      }
+    }.each do |label, build|
+      context "on #{label}" do
+        let(:server) { build.call(logger) }
+
+        it 'warns for a roots/list answer that carries a root, and still answers it' do
+          server.on_roots_list_request { |_id, _params| { 'roots' => [{ 'uri' => 'file:///workspace' }] } }
+
+          route(server, { 'id' => 7, 'method' => 'roots/list', 'params' => {} })
+
+          expect(MCPClient::Deprecations.emitted?(:roots)).to be(true)
+          expect(output.string).to match(/Roots .*deprecated/)
+          expect(posted.last).to include('jsonrpc' => '2.0', 'id' => 7)
+          expect(posted.last['result']).to eq({ 'roots' => [{ 'uri' => 'file:///workspace' }] })
+        end
+
+        it 'stays silent for an answer that carries no root, and still answers it' do
+          server.on_roots_list_request { |_id, _params| { 'roots' => [] } }
+
+          route(server, { 'id' => 8, 'method' => 'roots/list', 'params' => {} })
+
+          expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+          expect(posted.last['result']).to eq({ 'roots' => [] })
+        end
+
+        it 'warns for a sampling request and its includeContext, and still answers it' do
+          server.on_sampling_request { |_id, _params| sampling_answer }
+          params = { 'messages' => [], 'maxTokens' => 5, 'includeContext' => 'allServers' }
+
+          route(server, { 'id' => 9, 'method' => 'sampling/createMessage', 'params' => params })
+
+          expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+          expect(output.string).to match(/Sampling .*deprecated/)
+          expect(output.string).to include('Received: includeContext allServers')
+          expect(posted.last).to include('jsonrpc' => '2.0', 'id' => 9)
+          expect(posted.last['result']).to eq(sampling_answer)
+        end
+      end
+    end
+  end
+
+  describe 'the Sampling notice on the multi round-trip path' do
+    # A stdio server driven by scripted responses (no subprocess), as the
+    # MRTR spec drives one.
+    def script_stdio(server, responses)
+      sent = []
+      allow(server).to receive(:connect).and_return(true)
+      allow(server).to receive(:start_reader)
+      allow(server).to receive(:start_stderr_reader)
+      server.instance_variable_set(:@stdin, double('stdin', puts: nil, flush: nil, closed?: true, close: nil))
+      allow(server).to receive(:send_request) { |req| sent << req }
+      allow(server).to receive(:wait_response) do |id, **_opts|
+        responder = responses.shift
+        raise 'no scripted response left' unless responder
+
+        response = responder.respond_to?(:call) ? responder.call(sent.last) : responder
+        response.merge('jsonrpc' => '2.0', 'id' => id)
+      end
+      sent
+    end
+
+    def discover_result
+      { 'resultType' => 'complete', 'supportedVersions' => ['2026-07-28'],
+        'capabilities' => { 'tools' => {}, 'resources' => {}, 'prompts' => {} } }
+    end
+
+    def sampling_input_required(value)
+      params = { 'messages' => [{ 'role' => 'user', 'content' => { 'type' => 'text', 'text' => 'Capital?' } }],
+                 'maxTokens' => 100 }
+      params['includeContext'] = value if value
+      { 'resultType' => 'input_required', 'requestState' => 'opaque-state',
+        'inputRequests' => { 'c' => { 'method' => 'sampling/createMessage', 'params' => params } } }
+    end
+
+    let(:answer) do
+      { 'role' => 'assistant', 'content' => { 'type' => 'text', 'text' => 'Paris' }, 'model' => 'm' }
+    end
+    let(:server) { MCPClient::ServerStdio.new(command: 'true', read_timeout: 1, logger: logger) }
+
+    # Drive one tools/call that the server answers with an input_required
+    # sampling request, and return what the retry carried.
+    def exchange(include_context)
+      server.on_sampling_request { |_key, _params| answer }
+      sent = script_stdio(server, [{ 'result' => discover_result },
+                                   { 'result' => sampling_input_required(include_context) },
+                                   { 'result' => { 'content' => [{ 'type' => 'text', 'text' => 'done' }] } }])
+      [server.call_tool('answer', {}), sent.select { |request| request['method'] == 'tools/call' }]
+    end
+
+    it 'warns for Sampling, and still completes the round trip' do
+      result, calls = exchange(nil)
+
+      expect(result['content'].first['text']).to eq('done')
+      expect(calls.size).to eq(2)
+      expect(calls.last['params']['inputResponses']).to eq({ 'c' => answer })
+      expect(calls.last['params']['requestState']).to eq('opaque-state')
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+      expect(output.string).to match(/Sampling .*deprecated/)
+      expect(output.string).to include('LLM provider')
+    end
+
+    %w[thisServer allServers].each do |value|
+      it "warns for includeContext #{value} it carries, and still completes the round trip" do
+        result, calls = exchange(value)
+
+        expect(result['content'].first['text']).to eq('done')
+        expect(calls.last['params']['inputResponses']).to eq({ 'c' => answer })
+        expect(MCPClient::Deprecations.emitted?(:include_context)).to be(true)
+        expect(output.string).to include("Received: includeContext #{value}")
+      end
+    end
+
+    it 'stays silent about includeContext for the value that is not deprecated' do
+      result, = exchange('none')
+
+      expect(result['content'].first['text']).to eq('done')
+      expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+      expect(MCPClient::Deprecations.emitted?(:include_context)).to be(false)
+      expect(output.string).not_to include('includeContext')
+    end
+  end
+
+  describe 'the APIs this gem marks deprecated' do
+    let(:registry) { MCPClient::Deprecations::REGISTRY }
+
+    # Every API this gem offers that exposes a feature the 2026-07-28
+    # registry deprecates, and the feature it exposes. Counting `@deprecated`
+    # tags cannot show that a given API carries one, and a tag that names ANY
+    # registry window cannot show that it names its own: both need the
+    # inventory written down. Each entry is [label, file under lib/, the
+    # definition the tag sits above, the registry feature].
+    def inventory
+      transports = { 'server_sse.rb' => 'ServerSSE', 'server_stdio.rb' => 'ServerStdio',
+                     'server_http.rb' => 'ServerHTTP', 'server_streamable_http.rb' => 'ServerStreamableHTTP' }
+      transports.flat_map do |file, klass|
+        [["#{klass}#log_level=", "mcp_client/#{file}", /^\s*def log_level=/, :logging],
+         ["#{klass}#on_roots_list_request", "mcp_client/#{file}", /^\s*def on_roots_list_request\b/, :roots],
+         ["#{klass}#on_sampling_request", "mcp_client/#{file}", /^\s*def on_sampling_request\b/, :sampling]]
+      end + [
+        ['MCPClient.sse_config', 'mcp_client.rb', /^\s*def self\.sse_config\b/, :http_sse_transport],
+        ['MCPClient::ServerSSE', 'mcp_client/server_sse.rb', /^\s*class ServerSSE\b/, :http_sse_transport],
+        ['MCPClient::Client#roots', 'mcp_client/client.rb', /^\s*attr_reader :servers\b/, :roots],
+        ['MCPClient::Client#roots=', 'mcp_client/client.rb', /^\s*def roots=/, :roots],
+        ['MCPClient::Client#log_level=', 'mcp_client/client.rb', /^\s*def log_level=/, :logging],
+        ['MCPClient::Root', 'mcp_client/root.rb', /^\s*class Root\b/, :roots],
+        ['MCPClient::JsonRpcCommon#declare_sampling_tools', 'mcp_client/json_rpc_common.rb',
+         /^\s*def declare_sampling_tools\b/, :sampling],
+        ['MCPClient::Auth::OAuthProvider#register_client', 'mcp_client/auth/oauth_provider.rb',
+         /^\s*def register_client\b/, :dynamic_client_registration]
+      ]
+    end
+
+    def source_for(file)
+      File.read(File.expand_path("../../../lib/#{file}", __dir__))
+    end
+
+    # The `@deprecated` tag of the doc block above a definition: its line
+    # number and its text, or nil when the definition carries no tag.
+    def deprecated_tag(source, definition)
+      lines = source.lines
+      index = lines.index { |line| line.match?(definition) }
+      return nil unless index
+
+      start = index
+      start -= 1 while start.positive? && lines[start - 1].match?(/^\s*#/)
+      tag_at = (start...index).find { |i| lines[i].match?(/^\s*#\s*@deprecated\b/) }
+      return nil unless tag_at
+
+      text = +lines[tag_at].sub(/^\s*#\s?/, '').strip
+      lines[(tag_at + 1)...index].each do |line|
+        break if line.match?(/^\s*#\s*@\w/)
+
+        text << " #{line.sub(/^\s*#\s?/, '').strip}"
+      end
+      [tag_at + 1, text]
+    end
+
+    def tags
+      inventory.map do |label, file, definition, feature|
+        [label, feature, deprecated_tag(source_for(file), definition)]
+      end
+    end
+
+    it 'marks each one of them at its own definition' do
+      tags.each do |label, _feature, tag|
+        expect(tag).not_to(be_nil, "#{label} exposes a deprecated feature with no @deprecated tag")
+      end
+    end
+
+    it 'cites the SEP that deprecated the feature the API exposes' do
+      tags.each do |label, feature, tag|
+        sep = registry[feature][:reference][/SEP-\d+|PR #\d+/]
+        expect(tag&.last).to include(sep), "#{label} (#{feature}) should cite #{sep}"
+      end
+    end
+
+    it "names that feature's own earliest removal, not merely some registry window" do
+      windows = registry.each_value.map { |entry| entry[:earliest_removal] }.uniq
+      tags.each do |label, feature, tag|
+        window = registry[feature][:earliest_removal]
+        expect(tag&.last).to include(window), "#{label} (#{feature}) should name: #{window}"
+        (windows - [window]).each do |other|
+          expect(tag&.last).not_to include(other), "#{label} (#{feature}) names another feature's window: #{other}"
+        end
+      end
+    end
+
+    it 'accounts for every @deprecated tag the library carries' do
+      claimed = inventory.filter_map do |_label, file, definition, _feature|
+        found = deprecated_tag(source_for(file), definition)
+        [file, found.first] if found
+      end
+      marked = Dir[File.expand_path('../../../lib/**/*.rb', __dir__)].flat_map do |path|
+        file = path.sub(%r{\A.*/lib/}, '')
+        File.readlines(path).each_with_index.filter_map do |line, index|
+          [file, index + 1] if line.match?(/^\s*#\s*@deprecated\b/)
+        end
+      end
+
+      # A mark the inventory does not know about is an API nothing checks the
+      # SEP or the window of.
+      expect((marked - claimed).sort).to eq([])
+    end
+  end
+end

--- a/spec/lib/mcp_client/deprecations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_verify_spec.rb
@@ -389,7 +389,7 @@ RSpec.describe 'MCP 2026-07-28 deprecations (verification)' do
       end + [
         ['MCPClient.sse_config', 'mcp_client.rb', /^\s*def self\.sse_config\b/, :http_sse_transport],
         ['MCPClient::ServerSSE', 'mcp_client/server_sse.rb', /^\s*class ServerSSE\b/, :http_sse_transport],
-        ['MCPClient::Client#roots', 'mcp_client/client.rb', /^\s*attr_reader :servers\b/, :roots],
+        ['MCPClient::Client#roots', 'mcp_client/client.rb', /^\s*attr_reader :roots\b/, :roots],
         ['MCPClient::Client#roots=', 'mcp_client/client.rb', /^\s*def roots=/, :roots],
         ['MCPClient::Client#log_level=', 'mcp_client/client.rb', /^\s*def log_level=/, :logging],
         ['MCPClient::Root', 'mcp_client/root.rb', /^\s*class Root\b/, :roots],
@@ -470,6 +470,72 @@ RSpec.describe 'MCP 2026-07-28 deprecations (verification)' do
       # A mark the inventory does not know about is an API nothing checks the
       # SEP or the window of.
       expect((marked - claimed).sort).to eq([])
+    end
+
+    # The examples above read the SOURCE, which is where a tag is written but
+    # not where a host reads it. What a host reads is the generated API
+    # documentation, and a comment that sits in the right place in the file
+    # can still fail to reach it: `@!attribute` directives are one such case
+    # — YARD drops the docstring of the LAST directive in a block preceding a
+    # combined `attr_reader`, so `Client#roots` documented that way came out
+    # with no tags at all while every source-text check above passed. So ask
+    # YARD for the objects it publishes and read the tags off those.
+    describe 'as YARD publishes them' do
+      # Parsing the library is the expensive part; one registry serves every
+      # example here. YARD's registry is process-global, so it is restored
+      # afterwards for anything else that may rely on it.
+      before(:context) do
+        require 'yard'
+        @saved_registry = YARD::Registry.all.dup
+        YARD::Registry.clear
+        YARD.parse([File.expand_path('../../../lib/**/*.rb', __dir__)], [], YARD::Logger::ERROR)
+      end
+
+      after(:context) do
+        YARD::Registry.clear
+        @saved_registry.each { |object| YARD::Registry.register(object) }
+      end
+
+      # The path YARD knows the API by. The transports are listed unqualified.
+      def yard_path(label)
+        label.start_with?('MCPClient') ? label : "MCPClient::#{label}"
+      end
+
+      def documented
+        inventory.map do |label, _file, _definition, feature|
+          path = yard_path(label)
+          [path, feature, YARD::Registry.at(path)]
+        end
+      end
+
+      it 'publishes an object for every API in the inventory' do
+        documented.each do |path, _feature, object|
+          expect(object).not_to(be_nil, "YARD publishes no object at #{path}")
+        end
+      end
+
+      it 'carries a deprecated tag on each of them' do
+        documented.each do |path, _feature, object|
+          tags = object ? object.tags(:deprecated) : []
+          expect(tags.size).to(eq(1), "#{path} is published with #{tags.size} deprecated tags, expected 1")
+        end
+      end
+
+      it "cites the SEP and that feature's own earliest removal" do
+        windows = registry.each_value.map { |entry| entry[:earliest_removal] }.uniq
+        documented.each do |path, feature, object|
+          # YARD hard-wraps a tag's text, so the line breaks it chose are not
+          # part of what the tag says.
+          tag = object&.tags(:deprecated)&.first
+          text = tag ? tag.text.to_s.gsub(/\s+/, ' ') : ''
+          entry = registry[feature]
+          expect(text).to include(entry[:reference][/SEP-\d+|PR #\d+/]), path
+          expect(text).to include(entry[:earliest_removal]), path
+          (windows - [entry[:earliest_removal]]).each do |other|
+            expect(text).not_to include(other), "#{path} names another feature's window: #{other}"
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/mcp_client/deprecations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_verify_spec.rb
@@ -335,7 +335,48 @@ RSpec.describe 'MCP 2026-07-28 deprecations (verification)' do
 
           expect(MCPClient::Deprecations.emitted?(:sampling)).to be(false)
           expect(MCPClient::Deprecations.emitted?(:include_context)).to be(false)
-          expect(posted.last['error']).to include('message' => 'Sampling not supported')
+          # sampling.mdx § Error Handling reserves -1 for "User rejected
+          # sampling request"; a capability the client never declared is an
+          # unsupported method, -32601, as Client#handle_sampling_request answers.
+          expect(posted.last['error']).to include('code' => -32_601, 'message' => 'Sampling not supported')
+        end
+
+        # SEP-1577: "The client MUST return an error if this field is provided
+        # but ClientCapabilities.sampling.tools is not declared" — on the 2025
+        # server-initiated path as on the round-trip one, and with the notices
+        # a served-or-refused sampling request owes going out first.
+        it 'refuses a tool-enabled request the host never declared sampling.tools for, notices first' do
+          served = []
+          server.on_sampling_request do |_id, params|
+            served << params
+            sampling_answer
+          end
+
+          route(server, { 'id' => 12, 'method' => 'sampling/createMessage',
+                          'params' => { 'messages' => [], 'maxTokens' => 5, 'includeContext' => 'thisServer',
+                                        'tools' => [{ 'name' => 'lookup', 'inputSchema' => {} }] } })
+
+          expect(served).to be_empty
+          expect(posted.last['error']).to include('code' => -32_602)
+          expect(posted.last['error']['message']).to match(/sampling\.tools/)
+          expect(posted.last).not_to have_key('result')
+          expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+          expect(output.string).to include('Received: includeContext thisServer')
+        end
+
+        it 'serves the same request once the host declared sampling.tools' do
+          served = []
+          server.on_sampling_request do |_id, params|
+            served << params
+            sampling_answer
+          end
+          server.declare_sampling_tools
+
+          route(server, { 'id' => 13, 'method' => 'sampling/createMessage',
+                          'params' => { 'messages' => [], 'maxTokens' => 5, 'toolChoice' => { 'mode' => 'auto' } } })
+
+          expect(served.last).to include('toolChoice' => { 'mode' => 'auto' })
+          expect(posted.last['result']).to eq(sampling_answer)
         end
 
         # Roots counts as used only once an answer carries a root, and an

--- a/spec/lib/mcp_client/deprecations_2026_verify_spec.rb
+++ b/spec/lib/mcp_client/deprecations_2026_verify_spec.rb
@@ -274,16 +274,79 @@ RSpec.describe 'MCP 2026-07-28 deprecations (verification)' do
         end
 
         it 'warns for a sampling request and its includeContext, and still answers it' do
-          server.on_sampling_request { |_id, _params| sampling_answer }
+          # The notice runs before the handler and is handed the very params
+          # the handler is about to get, so "still serves it" has to be read
+          # off THOSE params: SEP-2596 deprecates the two values, it does not
+          # change what the transport passes on.
+          served = nil
+          server.on_sampling_request do |_id, request_params|
+            served = request_params
+            sampling_answer
+          end
           params = { 'messages' => [], 'maxTokens' => 5, 'includeContext' => 'allServers' }
 
           route(server, { 'id' => 9, 'method' => 'sampling/createMessage', 'params' => params })
 
+          expect(served).to include('includeContext' => 'allServers')
           expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
           expect(output.string).to match(/Sampling .*deprecated/)
           expect(output.string).to include('Received: includeContext allServers')
           expect(posted.last).to include('jsonrpc' => '2.0', 'id' => 9)
           expect(posted.last['result']).to eq(sampling_answer)
+        end
+
+        # The notice is once per process; the feature is not. A second
+        # request after the notice is spent is served exactly as the first.
+        it 'keeps serving sampling after the notice has been spent' do
+          server.on_sampling_request { |_id, _params| sampling_answer }
+
+          2.times do |i|
+            route(server, { 'id' => 20 + i, 'method' => 'sampling/createMessage',
+                            'params' => { 'messages' => [], 'maxTokens' => 5 } })
+          end
+
+          expect(posted.map { |response| response['id'] }).to eq([20, 21])
+          expect(posted.map { |response| response['result'] }).to eq([sampling_answer, sampling_answer])
+          expect(output.string.scan(/Sampling .*deprecated/).size).to eq(1)
+        end
+
+        # Serving the request is the use, so a handler that then fails does
+        # not get the notice back — and the peer gets the transport's own
+        # constant error, not something the notice changed.
+        it 'answers the error of a sampling handler that raises, notice spent' do
+          server.on_sampling_request { |_id, _params| raise 'handler exploded' }
+
+          route(server, { 'id' => 10, 'method' => 'sampling/createMessage',
+                          'params' => { 'messages' => [], 'maxTokens' => 5 } })
+
+          expect(MCPClient::Deprecations.emitted?(:sampling)).to be(true)
+          expect(posted.last['error']).to eq({ 'code' => -32_603, 'message' => 'Internal error' })
+          expect(posted.last).not_to have_key('result')
+          # The handler's text is host-internal: logged here, never posted.
+          expect(output.string).to include('handler exploded')
+          expect(JSON.generate(posted.last)).not_to include('handler exploded')
+        end
+
+        # A capability this host never registered for is not a deprecated
+        # feature it uses: the rejection goes out and the notice stays owed.
+        it 'stays silent when it has no sampling handler to serve with' do
+          route(server, { 'id' => 11, 'method' => 'sampling/createMessage',
+                          'params' => { 'messages' => [], 'maxTokens' => 5, 'includeContext' => 'thisServer' } })
+
+          expect(MCPClient::Deprecations.emitted?(:sampling)).to be(false)
+          expect(MCPClient::Deprecations.emitted?(:include_context)).to be(false)
+          expect(posted.last['error']).to include('message' => 'Sampling not supported')
+        end
+
+        # Roots counts as used only once an answer carries a root, and an
+        # answer that never came carries none.
+        it 'stays silent when the roots handler raises' do
+          server.on_roots_list_request { |_id, _params| raise 'no roots today' }
+
+          route(server, { 'id' => 12, 'method' => 'roots/list', 'params' => {} })
+
+          expect(MCPClient::Deprecations.emitted?(:roots)).to be(false)
+          expect(posted.last['error']).to eq({ 'code' => -32_603, 'message' => 'Internal error' })
         end
       end
     end

--- a/spec/lib/mcp_client/tasks_extension_2026_round43_spec.rb
+++ b/spec/lib/mcp_client/tasks_extension_2026_round43_spec.rb
@@ -336,19 +336,29 @@ RSpec.describe 'MCP 2026-07-28 tasks extension — round 43' do
       expect(update['params']['inputResponses']).to eq({ 'consent' => { 'action' => 'accept' } })
     end
 
-    it 'still hands a 2025-11-25 elicitationId to the host when the request carries one' do
+    # The session here is 2026-07-28 (it answers server/discover), and the
+    # deprecations branch removed elicitationId from the modern URL-mode host
+    # contract: a modern server that sends the field anyway cannot smuggle a
+    # correlation id to the host through it, and the client names the field in
+    # one warning without quoting its value. The 2025-11-25 contract, key
+    # present and all, is pinned on that branch.
+    it 'keeps a modern server from smuggling an elicitationId to the host' do
       seen = []
+      logger = instance_double(Logger, warn: nil, info: nil, debug: nil, error: nil, :level= => nil)
       client = client_for(stdio, elicitation_handler: lambda { |_message, details|
         seen << details
         { action: 'accept' }
       })
+      client.instance_variable_set(:@logger, logger)
       request = url_request.merge('params' => url_request['params'].merge('elicitationId' => 'e-1'))
       asks = detailed_task(status: 'input_required', 'inputRequests' => { 'consent' => request })
       scripted(stdio, 'tasks/get' => [asks, done], 'tasks/update' => [{}])
 
       client.wait_for_task('task-1', timeout: 5)
 
-      expect(seen.first).to include('elicitationId' => 'e-1')
+      expect(seen.first).not_to have_key('elicitationId')
+      expect(seen.first).to eq({ 'mode' => 'url', 'url' => 'https://consent.example.com/session/1' })
+      expect(logger).to have_received(:warn).with(/elicitationId/).at_least(:once)
     end
 
     def sampling_request(tools: true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,10 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  # Deprecation notices are once-per-process and would make examples
+  # order-dependent; only the deprecations spec turns them on.
+  config.before(:suite) { MCPClient::Deprecations.enabled = false }
+
   # Reset WebMock before each test to ensure test isolation
   config.before(:each) do
     WebMock.reset!


### PR DESCRIPTION
Eleventh (final) PR of the MCP 2026-07-28 series, stacked on #233.

## What

MCP 2026-07-28 adopts a feature lifecycle policy and places six features in the Deprecated state (changelog "Deprecated" 1–4: SEP-2577, SEP-2596, PR #2858). They remain fully functional during the deprecation window; new integrations should not adopt them.

- **`MCPClient::Deprecations`** — `REGISTRY` names every deprecated feature with its reference and suggested migration; `Deprecations.warn(feature, logger, detail:)` logs one notice per feature per process on first use (peer-supplied detail is sanitized and bounded); `Deprecations.enabled = false` silences the notices; `reset!` / `emitted?` for tests.
- **Wired in**: Roots (`roots:` at construction and `Client#roots=`), Sampling (`sampling_handler:`), Logging (`Client#log_level=`), the HTTP+SSE transport (`ServerSSE.new`), and a sampling request carrying `includeContext: "thisServer" | "allServers"` (still served, per SEP-2596). Dynamic Client Registration already warned in #232 and is listed in the registry.
- **README** — the "MCP Protocol Support" section now describes the dual-era 2026-07-28 client, a new "MCP 2026-07-28 Features" section documents discovery and per-request metadata, multi round-trip requests, `x-mcp-header`, `subscriptions/listen`, cacheable results, the tasks extension and the authorization changes, and a "Deprecated features" table gives each migration. Roots / Sampling / Logging subsections carry a deprecation note.
- **CHANGELOG** gains the Deprecations section.

Behaviour is otherwise unchanged; the notices are disabled for the test suite except in the deprecations spec.

## Tests

`spec/lib/mcp_client/deprecations_2026_spec.rb` (12 examples): registry completeness, one notice per feature per process, silence without the feature, each wiring point, includeContext detail (served, none/absent silent), the disabled switch, unknown feature rejection, log-line forging. Full suite: 2263 examples, 0 failures; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoErzDypnq7hhuFBtueML7