### PR TITLE
test: scope the "no GET stream" assertions to the server under test

### DIFF
--- a/spec/lib/mcp_client/subscriptions_listen_2026_round11_spec.rb
+++ b/spec/lib/mcp_client/subscriptions_listen_2026_round11_spec.rb
@@ -804,7 +804,11 @@ RSpec.describe 'MCP 2026-07-28 subscriptions/listen — round 11' do
       deliveries = [received.pop(timeout: 3), received.pop(timeout: 3)]
       expect(deliveries).to contain_exactly([:tools, 'notifications/tools/list_changed'],
                                             [:prompts, 'notifications/prompts/list_changed'])
-      expect(a_request(:get, url)).not_to have_been_made
+      # This server's own traffic, not the process-global registry: another
+      # example's leaked events thread must not decide this one.
+      expect(server.instance_variable_get(:@events_thread)).to be_nil
+      expect(a_request(:get, url).with(headers: { 'Mcp-Protocol-Version' => '2026-07-28' }))
+        .not_to have_been_made
     end
   end
 

--- a/spec/lib/mcp_client/subscriptions_listen_2026_spec.rb
+++ b/spec/lib/mcp_client/subscriptions_listen_2026_spec.rb
@@ -486,7 +486,13 @@ RSpec.describe 'MCP 2026-07-28 subscriptions/listen' do
       expect(listens.size).to eq(2)
       expect(listens[1][:body]['id']).not_to eq(listens[0][:body]['id'])
       expect(listens[1][:headers].keys.map(&:downcase)).not_to include('last-event-id')
-      expect(a_request(:get, url)).not_to have_been_made
+      # This server's own traffic. WebMock's registry is process-global, so a
+      # legacy session's events thread leaking out of another example would
+      # otherwise fail this: what the example claims is that THIS transport
+      # never opens a GET, and its events thread is where a GET would come from.
+      expect(server.instance_variable_get(:@events_thread)).to be_nil
+      expect(a_request(:get, url).with(headers: { 'Mcp-Protocol-Version' => '2026-07-28' }))
+        .not_to have_been_made
       expect(subscription).to be_closed_gracefully
     end
 


### PR DESCRIPTION
`main` went red on `Test (Ruby 4.0.6, default)` after #230 merged, with one failure:

```
1) MCP 2026-07-28 subscriptions/listen on Streamable HTTP re-issues a fresh POST
   after a drop, whatever id and retry fields the old stream carried
   Failure/Error: expect(a_request(:get, url)).not_to have_been_made
```

Nothing is wrong with the production code. Two examples asserted "no GET stream" against WebMock's **process-global** request registry, so a legacy session's events thread leaking out of a different example — it re-opens the stream when the server answers a GET with 405 — could fail them depending on scheduling. That is why it passed on 3.3 and on the PR branch, and failed here.

Each example's actual claim is about the transport it created, so it is now asserted on that transport:

- `@events_thread` is `nil` — the only place a GET originates for this server;
- the GET check is scoped to `Mcp-Protocol-Version: 2026-07-28`, which a modern session sends and a leaking legacy session does not.

Same shape as the fix already applied in #228.

**Verification:** forcing `start_events_connection` in each example makes both fail; removing it makes them pass. Full suite green on Ruby 3.3.8 and 4.0.6 (3591 examples each), rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoErzDypnq7hhuFBtueML7