### PR TITLE
examples: a 2026-07-28 server, and three clients that use it

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -54,6 +54,22 @@ Each of these spawns its own Python server over stdio — no external server or 
 | `test_structured_outputs.rb` | Structured tool outputs and output schemas |
 | `test_tool_annotations.rb` | Tool annotation hints |
 
+### MCP 2026-07-28 (stateless protocol)
+
+All three run against `mcp_2026_07_28_server.py` on port `8933`, the only
+example server that speaks the 2026-07-28 revision: no `initialize`
+handshake, no session id, no GET event stream.
+
+| Example | What it shows |
+|---------|---------------|
+| `mcp_2026_07_28_features.rb` | Era detection, cacheable results (`ttlMs` / `cacheScope`), structured output, `x-mcp-header` parameters, the three typed errors |
+| `subscriptions_listen_example.rb` | `subscriptions/listen` streams — what the server acknowledged, what it refused, notifications, graceful close |
+| `multi_round_trip_example.rb` | `resultType: "input_required"` answered by the elicitation handler, and `InputRequiredError` without one |
+
+Point them elsewhere with `MCP_SERVER_URL`. Note that `examples/secrets.env`
+may set that variable for the remote examples, so the harness pins it per
+example.
+
 ### Echo Servers (FastMCP / Flask)
 
 The harness starts the paired Python server, then runs the Ruby client against it.
@@ -93,6 +109,7 @@ Server-initiated user interactions over stdio, SSE, and Streamable HTTP. The `te
 | File | Role |
 |------|------|
 | `echo_server.py` | FastMCP SSE echo server |
+| `mcp_2026_07_28_server.py` | MCP 2026-07-28 server (Flask, `:8933`): `server/discover`, cache hints, `x-mcp-header`, `input_required`, tasks, listen streams |
 | `echo_server_streamable.py` | Flask Streamable HTTP echo server |
 | `echo_server_with_annotations.py` | Echo server advertising tool annotations |
 | `mcp_2025_11_25_server.py` | Backs `test_mcp_2025_11_25.rb` |

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,7 +62,7 @@ handshake, no session id, no GET event stream.
 
 | Example | What it shows |
 |---------|---------------|
-| `mcp_2026_07_28_features.rb` | Era detection, cacheable results (`ttlMs` / `cacheScope`), structured output, `x-mcp-header` parameters, the three typed errors |
+| `mcp_2026_07_28_features.rb` | Era detection, cacheable results (`ttlMs` / `cacheScope`), structured output, `x-mcp-header` parameters, the three typed errors, and the tasks extension |
 | `subscriptions_listen_example.rb` | `subscriptions/listen` streams — what the server acknowledged, what it refused, notifications, graceful close |
 | `multi_round_trip_example.rb` | `resultType: "input_required"` answered by the elicitation handler, and `InputRequiredError` without one |
 

--- a/examples/mcp_2026_07_28_features.rb
+++ b/examples/mcp_2026_07_28_features.rb
@@ -120,6 +120,34 @@ begin
     check("#{trigger} raises #{klass.name.split('::').last}", false, "got #{e.class}: #{e.message[0, 60]}")
   end
 
+  # --- 6. Tasks extension -------------------------------------------------
+  # Tasks are an extension in this revision: the server offers it in
+  # discovery, the client declares it, and only then may a tools/call be
+  # answered with a task handle instead of a result. A client that declares
+  # nothing gets an ordinary result from the same tool.
+  section('6. Tasks extension')
+  tasked = MCPClient::Client.new(
+    mcp_server_configs: [MCPClient.streamable_http_config(base_url: server_url)],
+    extensions: ['io.modelcontextprotocol/tasks'],
+    logger: logger
+  )
+  begin
+    handle = tasked.call_tool_as_task('slow_build', { 'target' => 'app' })
+    failures << 'task handle' unless check('tools/call answered with a task', !handle.task_id.nil?,
+                                           "#{handle.task_id} (#{handle.status})")
+    finished = tasked.wait_for_task(handle, timeout: 30)
+    built = (finished.result['content'] || [])&.first&.fetch('text', nil)
+    failures << 'task result' unless check('polled to completion', finished.completed?, built)
+  ensure
+    tasked.cleanup
+  end
+
+  # The same tool, called by this client, which declared no extension.
+  plain = client.call_tool('slow_build', { 'target' => 'app' })
+  plain_text = (plain['content'] || plain[:content])&.first&.fetch('text', nil)
+  failures << 'task optional' unless check('undeclared client gets an ordinary result',
+                                           plain_text.to_s.include?('built'), plain_text)
+
   puts
   if failures.empty?
     puts '✅ MCP 2026-07-28 features demo completed successfully'

--- a/examples/mcp_2026_07_28_features.rb
+++ b/examples/mcp_2026_07_28_features.rb
@@ -1,0 +1,136 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Example: the MCP 2026-07-28 protocol end to end.
+#
+# The 2026-07-28 revision is stateless. There is no `initialize` handshake and
+# no session: the client identifies the server with a `server/discover` probe,
+# then carries its own identity in each request's `_meta`. This example walks
+# the parts of that revision a host actually touches:
+#
+#   1. era detection            — modern?, protocol_version, protocol_era
+#   2. cacheable results        — ttlMs / cacheScope and cache_info
+#   3. structured output        — structuredContent validated against outputSchema
+#   4. x-mcp-header parameters  — a tool argument travelling as a request header
+#   5. typed errors             — the three JSON-RPC codes the revision adds
+#
+# Subscriptions and multi round-trip requests have examples of their own:
+# subscriptions_listen_example.rb and multi_round_trip_example.rb.
+#
+# Start the server first:
+#
+#   python3 examples/mcp_2026_07_28_server.py &   # port 8933
+#   ruby examples/mcp_2026_07_28_features.rb
+#
+# Point it elsewhere with MCP_SERVER_URL.
+
+require 'bundler/setup'
+require_relative '../lib/mcp_client'
+require 'logger'
+
+logger = Logger.new($stdout)
+logger.level = Logger::WARN
+
+server_url = ENV.fetch('MCP_SERVER_URL', 'http://localhost:8933/mcp')
+
+client = MCPClient.create_client(
+  mcp_server_configs: [MCPClient.streamable_http_config(base_url: server_url)],
+  logger: logger
+)
+
+failures = []
+
+def section(title)
+  puts "\n#{title}"
+  puts '─' * title.length
+end
+
+def check(label, condition, detail = nil)
+  suffix = detail ? " — #{detail}" : ''
+  puts "  #{condition ? '✅' : '❌'} #{label}#{suffix}"
+  condition
+end
+
+begin
+  # --- 1. Era detection ----------------------------------------------------
+  # The client probes with server/discover before anything else. A modern
+  # answer means no handshake and no session id on any later request.
+  section('1. Protocol era')
+  server = client.servers.first
+  client.list_tools # forces the probe
+
+  failures << 'era' unless check('modern?', server.modern?, server.modern?.inspect)
+  failures << 'version' unless check('protocol_version', server.protocol_version == '2026-07-28',
+                                     server.protocol_version)
+  failures << 'era name' unless check('protocol_era', server.protocol_era == :modern, server.protocol_era.inspect)
+
+  # --- 2. Cacheable results ------------------------------------------------
+  # Lists carry ttlMs and cacheScope. While a list is fresh the client serves
+  # it from memory instead of asking again.
+  section('2. Cacheable results')
+  info = server.cache_info(:tools)
+  failures << 'ttl' unless check('tools list has a ttl', info && info[:ttl_ms].to_i.positive?,
+                                 info && "ttlMs=#{info[:ttl_ms]}")
+  failures << 'scope' unless check('cacheScope recorded', info && info[:cache_scope] == 'public',
+                                   info && info[:cache_scope])
+  failures << 'fresh' unless check('entry is fresh', info && info[:fresh], info && info[:fresh].inspect)
+
+  read = client.read_resource('file:///reports/summary.txt')
+  read_info = server.cache_info(:read, 'file:///reports/summary.txt')
+  failures << 'read cached' unless check('resources/read cached per URI', !read_info.nil?,
+                                         read_info && "ttlMs=#{read_info[:ttl_ms]}")
+  first = read.is_a?(Array) ? read.first : (read['contents'] || read[:contents])&.first
+  puts "     read: #{first.respond_to?(:text) ? first.text : first.inspect}"
+
+  # --- 3. Structured output ------------------------------------------------
+  # 2026-07-28 widened structuredContent to any JSON value. When the tool
+  # declares an outputSchema the client validates the result against it.
+  section('3. Structured output')
+  echoed = client.call_tool('echo', { 'message' => 'hello 2026' })
+  structured = echoed['structuredContent'] || echoed[:structuredContent]
+  failures << 'structured' unless check('structuredContent returned', !structured.nil?, structured.inspect)
+  failures << 'structured value' unless check('matches the outputSchema',
+                                              structured && structured['echoed'] == 'hello 2026' &&
+                                              structured['length'] == 10)
+
+  # --- 4. x-mcp-header parameters -----------------------------------------
+  # `tenant` is annotated x-mcp-header in the tool definition, so the client
+  # sends it as the Mcp-Param-tenant header rather than in the JSON body. The
+  # server here refuses the call when the header is missing.
+  section('4. Parameters carried as headers')
+  report = client.call_tool('tenant_report', { 'tenant' => 'acme', 'section' => 'usage' })
+  text = (report['content'] || report[:content])&.first&.fetch('text', nil)
+  failures << 'header param' unless check('tool answered from the header', text.to_s.include?('acme'), text)
+
+  # --- 5. Typed errors -----------------------------------------------------
+  # The revision adds three JSON-RPC codes, each with its own error class.
+  section('5. Typed errors')
+  {
+    'header_mismatch' => MCPClient::Errors::HeaderMismatchError,
+    'missing_capability' => MCPClient::Errors::MissingRequiredClientCapabilityError,
+    'unsupported_version' => MCPClient::Errors::UnsupportedProtocolVersionError
+  }.each do |trigger, klass|
+    client.call_tool('echo', { 'message' => 'x', 'fail_with' => trigger })
+    failures << trigger
+    check("#{trigger} raises #{klass.name.split('::').last}", false, 'no error raised')
+  rescue klass => e
+    check("#{trigger} raises #{klass.name.split('::').last}", true, e.message[0, 60])
+  rescue StandardError => e
+    failures << trigger
+    check("#{trigger} raises #{klass.name.split('::').last}", false, "got #{e.class}: #{e.message[0, 60]}")
+  end
+
+  puts
+  if failures.empty?
+    puts '✅ MCP 2026-07-28 features demo completed successfully'
+  else
+    puts "❌ failed checks: #{failures.uniq.join(', ')}"
+    exit 1
+  end
+rescue StandardError => e
+  puts "\n❌ #{e.class}: #{e.message}"
+  puts e.backtrace.first(5)
+  exit 1
+ensure
+  client.cleanup
+end

--- a/examples/mcp_2026_07_28_server.py
+++ b/examples/mcp_2026_07_28_server.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""
+MCP 2026-07-28 reference server (Streamable HTTP, modern era).
+
+The other example servers in this directory speak the handshake-based
+protocol: a client sends `initialize`, gets a session id back and carries it
+on every later request. The 2026-07-28 revision removes all of that. There is
+no handshake, no session and no server-to-client request channel; a client
+announces itself on each request in `_meta`, and anything the server needs
+back it asks for through the *result* rather than by calling the client.
+
+This server exists so the Ruby examples have something that actually answers
+that way. It implements, one endpoint each:
+
+  server/discover        the probe that identifies the era, with capabilities
+                         and a cache hint
+  tools/list             tools carrying JSON Schema 2020-12, an outputSchema
+                         and an x-mcp-header annotation, with a cache hint
+  tools/call             echo, structured output, header-derived parameters,
+                         a multi round-trip (input_required) tool and a
+                         task-augmented one
+  resources/list         a resource list with a cache hint
+  resources/read         a read result with a per-URI ttlMs
+  prompts/list           a prompt list with a cache hint
+  subscriptions/listen   a long-lived SSE notification stream
+  tasks/get              polling for the task-augmented tool
+
+Every request is checked for `io.modelcontextprotocol/protocolVersion` in
+`_meta`, and the typed 2026-07-28 errors are reachable on demand — see the
+`fail_with` tool argument.
+
+Run it:
+
+    pip install flask
+    python3 examples/mcp_2026_07_28_server.py      # http://localhost:8933/mcp
+
+Then point any of the 2026 examples at it:
+
+    ruby examples/mcp_2026_07_28_features.rb
+    ruby examples/subscriptions_listen_example.rb
+    ruby examples/multi_round_trip_example.rb
+
+This is a teaching server, not a production one: state lives in memory, and
+the "authorization" it does is a string comparison. It binds to localhost.
+"""
+
+import json
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+
+from flask import Flask, Response, request
+
+app = Flask(__name__)
+
+PROTOCOL_VERSION = "2026-07-28"
+
+# _meta keys the revision reserves. A modern client sends the first three on
+# every request; the server echoes its own identity back in serverInfo.
+META_VERSION = "io.modelcontextprotocol/protocolVersion"
+META_CLIENT_INFO = "io.modelcontextprotocol/clientInfo"
+META_CLIENT_CAPS = "io.modelcontextprotocol/clientCapabilities"
+META_SERVER_INFO = "io.modelcontextprotocol/serverInfo"
+META_SUBSCRIPTION_ID = "io.modelcontextprotocol/subscriptionId"
+
+# JSON-RPC codes the 2026-07-28 revision adds.
+HEADER_MISMATCH = -32020
+MISSING_CAPABILITY = -32021
+UNSUPPORTED_VERSION = -32022
+
+SERVER_INFO = {"name": "mcp-2026-07-28-example", "version": "1.0.0"}
+
+# ---------------------------------------------------------------------------
+# In-memory state
+# ---------------------------------------------------------------------------
+
+tasks = {}
+tasks_lock = threading.Lock()
+
+# requestState -> what the client has already answered, for the multi
+# round-trip tool. The state is opaque to the client and echoed verbatim.
+pending_rounds = {}
+rounds_lock = threading.Lock()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
+
+TOOLS = [
+    {
+        "name": "echo",
+        "description": "Echo a message back as text and as structured content.",
+        "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "message": {"type": "string", "description": "What to echo"},
+                "fail_with": {
+                    "type": "string",
+                    "description": "Return a typed 2026-07-28 error instead: "
+                    "header_mismatch, missing_capability or unsupported_version",
+                },
+            },
+            "required": ["message"],
+        },
+        "outputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "echoed": {"type": "string"},
+                "length": {"type": "integer"},
+            },
+            "required": ["echoed", "length"],
+        },
+    },
+    {
+        # `x-mcp-header` moves a parameter out of the JSON body and into an
+        # `Mcp-Param-{name}` request header. The client mirrors it there; this
+        # server reads it from the header and rejects a call that arrives
+        # without it, which is what drives the -32020 refresh-and-retry path.
+        "name": "tenant_report",
+        "description": "Report for one tenant; the tenant travels as a request header.",
+        "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "tenant": {
+                    "type": "string",
+                    "description": "Tenant id, sent as the Mcp-Param-Tenant header",
+                    # The annotation names the header, so this argument
+                    # travels as `Mcp-Param-Tenant` instead of in the body.
+                    "x-mcp-header": "Tenant",
+                },
+                "section": {"type": "string"},
+            },
+            "required": ["tenant"],
+        },
+    },
+    {
+        "name": "create_ticket",
+        "description": "Open a ticket; asks for the missing details mid-request.",
+        "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {"summary": {"type": "string"}},
+            "required": ["summary"],
+        },
+    },
+    {
+        "name": "slow_build",
+        "description": "A long-running build, answered as a task.",
+        "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {"target": {"type": "string"}},
+        },
+        "execution": {"taskSupport": "optional"},
+    },
+]
+
+RESOURCES = [
+    {
+        "uri": "file:///reports/summary.txt",
+        "name": "summary.txt",
+        "mimeType": "text/plain",
+        "description": "A short report that changes every few seconds.",
+    }
+]
+
+PROMPTS = [
+    {
+        "name": "summarize",
+        "description": "Summarize a report",
+        "arguments": [{"name": "style", "description": "terse or verbose", "required": False}],
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC plumbing
+# ---------------------------------------------------------------------------
+
+
+def error(request_id, code, message, data=None):
+    body = {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
+    if data is not None:
+        body["error"]["data"] = data
+    return body
+
+
+def result(request_id, payload):
+    """Every result carries resultType; 2026-07-28 makes it the discriminator."""
+    payload.setdefault("resultType", "complete")
+    payload.setdefault("_meta", {})[META_SERVER_INFO] = SERVER_INFO
+    return {"jsonrpc": "2.0", "id": request_id, "result": payload}
+
+
+def request_meta(params):
+    return (params or {}).get("_meta") or {}
+
+
+def check_protocol_version(params):
+    """Return an error tuple when the request does not declare a version we speak."""
+    declared = request_meta(params).get(META_VERSION)
+    if declared is None:
+        # A request with no version is a legacy client; this server has no
+        # legacy mode, so say so in the terms the revision defines.
+        return (UNSUPPORTED_VERSION, f"this server speaks {PROTOCOL_VERSION} only")
+    if declared != PROTOCOL_VERSION:
+        return (UNSUPPORTED_VERSION, f"unsupported protocol version: {declared}")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Method handlers
+# ---------------------------------------------------------------------------
+
+
+def handle_discover(request_id, params):
+    """The probe that tells a client which era it is talking to.
+
+    A modern answer names the revision and the capabilities; ttlMs and
+    cacheScope let the client hold on to it instead of re-probing.
+    """
+    return result(
+        request_id,
+        {
+            "supportedVersions": [PROTOCOL_VERSION],
+            "capabilities": {
+                "tools": {"listChanged": True},
+                "resources": {"subscribe": True, "listChanged": True},
+                "prompts": {"listChanged": True},
+            },
+            "serverInfo": SERVER_INFO,
+            "ttlMs": 60_000,
+            "cacheScope": "public",
+        },
+    )
+
+
+def handle_tools_list(request_id, params):
+    return result(request_id, {"tools": TOOLS, "ttlMs": 30_000, "cacheScope": "public"})
+
+
+def handle_resources_list(request_id, params):
+    return result(request_id, {"resources": RESOURCES, "ttlMs": 30_000, "cacheScope": "public"})
+
+
+def handle_prompts_list(request_id, params):
+    return result(request_id, {"prompts": PROMPTS, "ttlMs": 30_000, "cacheScope": "public"})
+
+
+def handle_resources_read(request_id, params):
+    uri = (params or {}).get("uri")
+    if uri != RESOURCES[0]["uri"]:
+        return error(request_id, -32602, f"unknown resource: {uri}")
+    return result(
+        request_id,
+        {
+            "contents": [
+                {
+                    "uri": uri,
+                    "mimeType": "text/plain",
+                    "text": f"report generated at {now_iso()}",
+                }
+            ],
+            # Per-URI freshness: the client serves this read from its cache
+            # until the ttl elapses, then fetches again.
+            "ttlMs": 5_000,
+            "cacheScope": "public",
+        },
+    )
+
+
+def handle_prompts_get(request_id, params):
+    style = ((params or {}).get("arguments") or {}).get("style", "terse")
+    return result(
+        request_id,
+        {
+            "description": f"A {style} summary prompt",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": {"type": "text", "text": f"Summarize the report, {style}ly."},
+                }
+            ],
+        },
+    )
+
+
+def echo_tool(request_id, arguments):
+    fail_with = arguments.get("fail_with")
+    if fail_with == "header_mismatch":
+        return error(request_id, HEADER_MISMATCH, "header does not match the tool definition")
+    if fail_with == "missing_capability":
+        # -32021 carries the capabilities the server needed. The shape is
+        # mandated: without it the client cannot tell a real modern rejection
+        # from an intermediary emitting a bare -32021, and treats it as an
+        # ordinary tool failure.
+        return error(
+            request_id,
+            MISSING_CAPABILITY,
+            "this tool needs a capability you did not declare",
+            {"requiredCapabilities": {"elicitation": {"form": {}}}},
+        )
+    if fail_with == "unsupported_version":
+        # -32022 names what the server does speak, and what it was asked for,
+        # so the client can retry on a mutually supported version.
+        return error(
+            request_id,
+            UNSUPPORTED_VERSION,
+            "unsupported protocol version",
+            {"supported": [PROTOCOL_VERSION], "requested": "2099-01-01"},
+        )
+
+    message = arguments.get("message", "")
+    return result(
+        request_id,
+        {
+            "content": [{"type": "text", "text": message}],
+            # 2026-07-28 widened structuredContent to any JSON value; this
+            # one matches the tool's outputSchema, so the client validates it.
+            "structuredContent": {"echoed": message, "length": len(message)},
+            "isError": False,
+        },
+    )
+
+
+def tenant_report_tool(request_id, arguments):
+    """The tenant arrives as a header, not in the arguments."""
+    header_tenant = request.headers.get("Mcp-Param-Tenant")
+    if not header_tenant:
+        # What a server says when the header it needs did not arrive. The
+        # client refreshes tools/list once and retries.
+        return error(request_id, HEADER_MISMATCH, "Mcp-Param-Tenant header is required for this tool")
+
+    section = arguments.get("section", "overview")
+    return result(
+        request_id,
+        {
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"{section} report for tenant {header_tenant}",
+                }
+            ],
+            "isError": False,
+            # Bound to the credentials this request went out with: the client
+            # keeps it out of any other authorization context's cache.
+            "cacheScope": "private",
+            "ttlMs": 10_000,
+        },
+    )
+
+
+def create_ticket_tool(request_id, arguments, params):
+    """Multi round-trip: the server asks, the client answers, the client retries.
+
+    First call comes back as input_required with the questions and an opaque
+    requestState. The client fulfils each question with the handlers it
+    already has and re-sends the same request with inputResponses plus that
+    state echoed back; this handler then sees the answers and completes.
+    """
+    responses = (params or {}).get("inputResponses")
+    state = (params or {}).get("requestState")
+
+    if responses and state:
+        with rounds_lock:
+            summary = pending_rounds.pop(state, {}).get("summary", arguments.get("summary", ""))
+        reporter = (responses.get("reporter") or {}).get("content", {})
+        name = reporter.get("name", "unknown") if isinstance(reporter, dict) else "unknown"
+        ticket_id = f"TICKET-{uuid.uuid4().hex[:6].upper()}"
+        return result(
+            request_id,
+            {
+                "content": [
+                    {"type": "text", "text": f"{ticket_id} opened for {name}: {summary}"}
+                ],
+                "isError": False,
+            },
+        )
+
+    state = uuid.uuid4().hex
+    with rounds_lock:
+        pending_rounds[state] = {"summary": arguments.get("summary", "")}
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "resultType": "input_required",
+            "requestState": state,
+            "inputRequests": {
+                "reporter": {
+                    "method": "elicitation/create",
+                    "params": {
+                        "mode": "form",
+                        "message": "Who is reporting this ticket?",
+                        "requestedSchema": {
+                            "type": "object",
+                            "properties": {"name": {"type": "string"}},
+                            "required": ["name"],
+                        },
+                    },
+                }
+            },
+        },
+    }
+
+
+def run_task(task_id):
+    time.sleep(1.5)
+    with tasks_lock:
+        task = tasks.get(task_id)
+        if not task or task["status"] == "cancelled":
+            return
+        task["status"] = "completed"
+        task["lastUpdatedAt"] = now_iso()
+        task["result"] = {
+            "content": [{"type": "text", "text": f"built {task['target']}"}],
+            "isError": False,
+        }
+
+
+def slow_build_tool(request_id, arguments):
+    task_id = f"task-{uuid.uuid4().hex[:8]}"
+    created = now_iso()
+    with tasks_lock:
+        tasks[task_id] = {
+            "taskId": task_id,
+            "status": "working",
+            "createdAt": created,
+            "lastUpdatedAt": created,
+            "target": arguments.get("target", "default"),
+            "result": None,
+        }
+    threading.Thread(target=run_task, args=(task_id,), daemon=True).start()
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "resultType": "task",
+            "taskId": task_id,
+            "status": "working",
+            "createdAt": created,
+            "lastUpdatedAt": created,
+            "ttlMs": 60_000,
+            "pollIntervalMs": 200,
+        },
+    }
+
+
+def handle_tasks_get(request_id, params):
+    task_id = (params or {}).get("taskId")
+    with tasks_lock:
+        task = tasks.get(task_id)
+        if not task:
+            return error(request_id, -32602, f"unknown task: {task_id}")
+        payload = {
+            "taskId": task["taskId"],
+            "status": task["status"],
+            "createdAt": task["createdAt"],
+            "lastUpdatedAt": task["lastUpdatedAt"],
+            "ttlMs": 60_000,
+            "pollIntervalMs": 200,
+        }
+        if task["status"] == "completed" and task["result"]:
+            payload.update(task["result"])
+    return result(request_id, payload)
+
+
+def handle_tools_call(request_id, params):
+    name = (params or {}).get("name")
+    arguments = (params or {}).get("arguments") or {}
+
+    if name == "echo":
+        return echo_tool(request_id, arguments)
+    if name == "tenant_report":
+        return tenant_report_tool(request_id, arguments)
+    if name == "create_ticket":
+        return create_ticket_tool(request_id, arguments, params)
+    if name == "slow_build":
+        return slow_build_tool(request_id, arguments)
+    return error(request_id, -32602, f"unknown tool: {name}")
+
+
+# ---------------------------------------------------------------------------
+# subscriptions/listen — one long-lived SSE stream per request
+# ---------------------------------------------------------------------------
+
+
+def sse(payload):
+    return f"event: message\ndata: {json.dumps(payload)}\n\n"
+
+
+def listen_stream(request_id, params):
+    """Acknowledge what we will watch, send notifications, then end the request.
+
+    The subscription's identity is the listen request's id, carried on every
+    notification in `_meta`. Ending it is a normal response to that request;
+    the client also ends it by closing the stream.
+    """
+    wanted = (params or {}).get("notifications") or {}
+    acknowledged = {}
+    unsupported = {}
+    for key, value in wanted.items():
+        if key in ("toolsListChanged", "resourcesListChanged", "promptsListChanged"):
+            acknowledged[key] = value
+        else:
+            unsupported[key] = value
+
+    yield sse(
+        {
+            "jsonrpc": "2.0",
+            "method": "notifications/subscriptions/acknowledged",
+            "params": {
+                "_meta": {META_SUBSCRIPTION_ID: request_id},
+                "notifications": acknowledged,
+                "unsupported": unsupported,
+            },
+        }
+    )
+
+    for index in range(3):
+        time.sleep(0.6)
+        if "toolsListChanged" in acknowledged:
+            yield sse(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "notifications/tools/list_changed",
+                    "params": {"_meta": {META_SUBSCRIPTION_ID: request_id}, "round": index + 1},
+                }
+            )
+
+    yield sse(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"resultType": "complete", "_meta": {META_SUBSCRIPTION_ID: request_id}},
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTTP
+# ---------------------------------------------------------------------------
+
+HANDLERS = {
+    "server/discover": handle_discover,
+    "tools/list": handle_tools_list,
+    "tools/call": handle_tools_call,
+    "resources/list": handle_resources_list,
+    "resources/read": handle_resources_read,
+    "prompts/list": handle_prompts_list,
+    "prompts/get": handle_prompts_get,
+    "tasks/get": handle_tasks_get,
+}
+
+
+@app.route("/mcp", methods=["POST"])
+def handle_post():
+    body = request.get_json(silent=True) or {}
+    request_id = body.get("id")
+    method = body.get("method")
+    params = body.get("params") or {}
+
+    # Notifications carry no id and get no body back.
+    if request_id is None:
+        return Response("", status=202)
+
+    version_problem = check_protocol_version(params)
+    if version_problem:
+        code, message = version_problem
+        return json_response(error(request_id, code, message))
+
+    if method == "subscriptions/listen":
+        return Response(
+            listen_stream(request_id, params),
+            mimetype="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    handler = HANDLERS.get(method)
+    if not handler:
+        return json_response(error(request_id, -32601, f"method not found: {method}"))
+    return json_response(handler(request_id, params))
+
+
+def json_response(payload):
+    return Response(json.dumps(payload), mimetype="application/json")
+
+
+@app.route("/mcp", methods=["GET"])
+def handle_get():
+    """A modern server has no server-to-client channel, so there is no GET stream.
+
+    405 is the honest answer, and it is what the client expects: it opens no
+    GET at all once it has identified the server as modern.
+    """
+    return Response("the 2026-07-28 revision has no GET event stream", status=405)
+
+
+if __name__ == "__main__":
+    print(f"MCP {PROTOCOL_VERSION} example server on http://localhost:8933/mcp")
+    app.run(host="127.0.0.1", port=8933, threaded=True)

--- a/examples/mcp_2026_07_28_server.py
+++ b/examples/mcp_2026_07_28_server.py
@@ -63,6 +63,11 @@ META_CLIENT_INFO = "io.modelcontextprotocol/clientInfo"
 META_CLIENT_CAPS = "io.modelcontextprotocol/clientCapabilities"
 META_SERVER_INFO = "io.modelcontextprotocol/serverInfo"
 META_SUBSCRIPTION_ID = "io.modelcontextprotocol/subscriptionId"
+META_CLIENT_CAPS_EXTENSIONS = "extensions"
+
+# Tasks are negotiated per request: the server offers the extension in
+# discovery, and each request that wants task behaviour declares it back.
+TASKS_EXTENSION = "io.modelcontextprotocol/tasks"
 
 # JSON-RPC codes the 2026-07-28 revision adds.
 HEADER_MISMATCH = -32020
@@ -236,6 +241,11 @@ def handle_discover(request_id, params):
                 "tools": {"listChanged": True},
                 "resources": {"subscribe": True, "listChanged": True},
                 "prompts": {"listChanged": True},
+                # Tasks are an extension in this revision, and a client only
+                # accepts a task result from a server that negotiated it here.
+                # Without this the slow_build tool below is unreachable
+                # through the documented `extensions:` API.
+                "extensions": {TASKS_EXTENSION: {}},
             },
             "serverInfo": SERVER_INFO,
             "ttlMs": 60_000,
@@ -427,7 +437,28 @@ def run_task(task_id):
         }
 
 
-def slow_build_tool(request_id, arguments):
+def client_declared_tasks(params):
+    """Whether THIS request's client capabilities declare the tasks extension."""
+    caps = request_meta(params).get(META_CLIENT_CAPS) or {}
+    extensions = caps.get(META_CLIENT_CAPS_EXTENSIONS) or {}
+    return TASKS_EXTENSION in extensions
+
+
+def slow_build_tool(request_id, arguments, params):
+    # taskSupport is "optional", so this tool owes an ordinary result to a
+    # client that did not ask for task behaviour. Answering such a client with
+    # resultType "task" would leave work running that it may not accept and
+    # cannot collect: it rejects the unrecognized result type outright.
+    if not client_declared_tasks(params):
+        time.sleep(0.2)
+        return result(
+            request_id,
+            {
+                "content": [{"type": "text", "text": f"built {arguments.get('target', 'default')}"}],
+                "isError": False,
+            },
+        )
+
     task_id = f"task-{uuid.uuid4().hex[:8]}"
     created = now_iso()
     with tasks_lock:
@@ -456,6 +487,10 @@ def slow_build_tool(request_id, arguments):
 
 
 def handle_tasks_get(request_id, params):
+    if not client_declared_tasks(params):
+        return error(request_id, MISSING_CAPABILITY, "tasks/get needs the tasks extension",
+                     {"requiredCapabilities": {"extensions": {TASKS_EXTENSION: {}}}})
+
     task_id = (params or {}).get("taskId")
     with tasks_lock:
         task = tasks.get(task_id)
@@ -470,7 +505,9 @@ def handle_tasks_get(request_id, params):
             "pollIntervalMs": 200,
         }
         if task["status"] == "completed" and task["result"]:
-            payload.update(task["result"])
+            # A completed DetailedTask carries the tool's result as a nested
+            # `result` object, not merged into the task itself.
+            payload["result"] = task["result"]
     return result(request_id, payload)
 
 
@@ -485,7 +522,7 @@ def handle_tools_call(request_id, params):
     if name == "create_ticket":
         return create_ticket_tool(request_id, arguments, params)
     if name == "slow_build":
-        return slow_build_tool(request_id, arguments)
+        return slow_build_tool(request_id, arguments, params)
     return error(request_id, -32602, f"unknown tool: {name}")
 
 

--- a/examples/multi_round_trip_example.rb
+++ b/examples/multi_round_trip_example.rb
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Example: multi round-trip requests (MCP 2026-07-28).
+#
+# A modern server has no channel for calling the client back, so when it needs
+# something mid-request it says so in the *result*: `resultType:
+# "input_required"`, a set of `inputRequests`, and an opaque `requestState`.
+#
+# The client answers each request with the handlers it already has — the
+# elicitation handler here — and re-sends the original request with
+# `inputResponses` and that state echoed back verbatim. From the host's side
+# it is still one `call_tool`: the round trips happen underneath.
+#
+# What this shows:
+#
+#   - an elicitation handler answering a question the server asked mid-call
+#   - the tool returning its real result on the second round trip
+#   - the guard rails: a request the client cannot honour raises
+#     InputRequiredError with the requests and state attached
+#
+# Start the server first:
+#
+#   python3 examples/mcp_2026_07_28_server.py &   # port 8933
+#   ruby examples/multi_round_trip_example.rb
+
+require 'bundler/setup'
+require_relative '../lib/mcp_client'
+require 'logger'
+
+logger = Logger.new($stdout)
+logger.level = Logger::WARN
+
+server_url = ENV.fetch('MCP_SERVER_URL', 'http://localhost:8933/mcp')
+
+asked = []
+
+# A two-argument handler is called with the server's message and the schema
+# it wants filled in (a one-argument handler gets only the message). Return a
+# hash to answer, or nil/false to decline.
+elicitation_handler = lambda do |message, schema|
+  asked << message
+  puts "  server asks: #{message}"
+  puts "  requested schema: #{(schema['properties'] || {}).keys.inspect}"
+  puts '  answering with { "name" => "Ada Lovelace" }'
+  { 'name' => 'Ada Lovelace' }
+end
+
+# Handlers are constructor arguments, so this one goes through Client.new
+# rather than the create_client shorthand.
+client = MCPClient::Client.new(
+  mcp_server_configs: [MCPClient.streamable_http_config(base_url: server_url)],
+  elicitation_handler: elicitation_handler,
+  logger: logger
+)
+
+begin
+  puts 'Calling create_ticket — the server will need more before it can answer.'
+  result = client.call_tool('create_ticket', { 'summary' => 'Printer is on fire' })
+
+  text = (result['content'] || result[:content])&.first&.fetch('text', nil)
+  puts "  result: #{text}"
+
+  ok = asked.size == 1 && text.to_s.include?('Ada Lovelace') && text.to_s.include?('Printer is on fire')
+
+  puts "\nWithout a handler the same call cannot be completed:"
+  bare = MCPClient::Client.new(
+    mcp_server_configs: [MCPClient.streamable_http_config(base_url: server_url)],
+    logger: logger
+  )
+  begin
+    bare.call_tool('create_ticket', { 'summary' => 'Second ticket' })
+    puts '  ❌ expected InputRequiredError'
+    ok = false
+  rescue MCPClient::Errors::InputRequiredError => e
+    puts "  ✅ InputRequiredError: #{e.message[0, 70]}"
+    puts "     input_requests: #{e.input_requests.keys.inspect}, request_state present: #{!e.request_state.nil?}"
+  ensure
+    bare.cleanup
+  end
+
+  puts
+  if ok
+    puts '✅ multi round-trip demo completed successfully'
+  else
+    puts '❌ multi round-trip demo did not complete as expected'
+    exit 1
+  end
+rescue StandardError => e
+  puts "\n❌ #{e.class}: #{e.message}"
+  puts e.backtrace.first(5)
+  exit 1
+ensure
+  client.cleanup
+end

--- a/examples/run_all_examples.sh
+++ b/examples/run_all_examples.sh
@@ -293,6 +293,35 @@ fi
 stop_server
 
 # =========================================================================
+# Group C2 — MCP 2026-07-28 server (mcp_2026_07_28_server.py, :8933)
+#
+# The stateless revision: no initialize handshake, no session, no GET stream.
+# These three examples are the only ones that exercise it.
+# =========================================================================
+section "Group C2 · mcp_2026_07_28_server.py (Streamable HTTP, :8933)"
+start_server "mcp_2026_07_28_server.py" 8933 "$LOG_DIR/_server_2026.log" \
+  "$PYTHON" examples/mcp_2026_07_28_server.py
+if wait_ready 40; then
+  # MCP_SERVER_URL is pinned per example: secrets.env may set it for the
+  # remote-service examples in Group G, and these three must reach the local
+  # 2026 server rather than whatever that points at.
+  run_example "mcp_2026_07_28_features.rb" "features demo completed successfully" - -- \
+    env MCP_SERVER_URL=http://localhost:8933/mcp \
+    bundle exec ruby examples/mcp_2026_07_28_features.rb
+  run_example "subscriptions_listen_example.rb" "demo completed successfully" - -- \
+    env MCP_SERVER_URL=http://localhost:8933/mcp \
+    bundle exec ruby examples/subscriptions_listen_example.rb
+  run_example "multi_round_trip_example.rb" "demo completed successfully" - -- \
+    env MCP_SERVER_URL=http://localhost:8933/mcp \
+    bundle exec ruby examples/multi_round_trip_example.rb
+else
+  skip_example "mcp_2026_07_28_features.rb"      "mcp_2026_07_28_server.py (:8933) not ready"
+  skip_example "subscriptions_listen_example.rb" "mcp_2026_07_28_server.py (:8933) not ready"
+  skip_example "multi_round_trip_example.rb"     "mcp_2026_07_28_server.py (:8933) not ready"
+fi
+stop_server
+
+# =========================================================================
 # Group D — elicitation Flask server (elicitation_streamable_server.py, :8000)
 # =========================================================================
 section "Group D · elicitation_streamable_server.py (:8000)"

--- a/examples/subscriptions_listen_example.rb
+++ b/examples/subscriptions_listen_example.rb
@@ -77,20 +77,26 @@ begin
     puts "  ← #{method} #{round}"
   end
 
-  puts "\nClosing the subscription…"
-  subscription.close
-
-  # The server ends a subscription by answering the listen request; the client
-  # reports that as a graceful close rather than a dropped stream.
+  # This server ends the subscription itself once it has sent its three
+  # notifications: the response to the listen request IS the graceful end. A
+  # host that wants to stop earlier calls subscription.close instead, which
+  # ends the stream from this side.
+  puts "\nWaiting for the server to end the subscription…"
   deadline = Time.now + 5
   sleep 0.05 while !subscription.closed? && Time.now < deadline
+  subscription.close unless subscription.closed?
+
   puts "  state: #{subscription.state}"
+  puts "  ended by the server, gracefully: #{subscription.closed_gracefully?}"
 
   puts
-  if notifications.size >= 3 && subscription.closed?
+  # closed? alone would be true even if this side had given up on it, so the
+  # graceful flag is what says the server answered the listen request.
+  if notifications.size >= 3 && subscription.closed_gracefully?
     puts '✅ subscriptions/listen demo completed successfully'
   else
-    puts "❌ expected 3 notifications and a closed subscription, got #{notifications.size} and #{subscription.state}"
+    puts "❌ expected 3 notifications and a graceful close, got #{notifications.size} " \
+         "and #{subscription.state} (graceful: #{subscription.closed_gracefully?})"
     exit 1
   end
 rescue StandardError => e

--- a/examples/subscriptions_listen_example.rb
+++ b/examples/subscriptions_listen_example.rb
@@ -1,0 +1,102 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Example: subscriptions/listen (MCP 2026-07-28).
+#
+# The 2026-07-28 revision removed both `resources/subscribe` and the GET event
+# stream. A host that wants notifications opens one instead: a long-lived
+# `subscriptions/listen` request that stays open and delivers notifications on
+# its own response stream until either side ends it.
+#
+# What this shows:
+#
+#   - opening a stream for the notification types you want
+#   - what the server agreed to watch (acknowledged) and what it refused
+#     (unsupported) — asking for something a server does not offer is not an
+#     error, it just does not arrive
+#   - notifications arriving on the subscription's own thread
+#   - closing the stream, and the graceful end the server sends
+#
+# Start the server first:
+#
+#   python3 examples/mcp_2026_07_28_server.py &   # port 8933
+#   ruby examples/subscriptions_listen_example.rb
+
+require 'bundler/setup'
+require_relative '../lib/mcp_client'
+require 'logger'
+
+logger = Logger.new($stdout)
+logger.level = Logger::WARN
+
+server_url = ENV.fetch('MCP_SERVER_URL', 'http://localhost:8933/mcp')
+
+client = MCPClient.create_client(
+  mcp_server_configs: [MCPClient.streamable_http_config(base_url: server_url)],
+  logger: logger
+)
+
+received = Queue.new
+
+begin
+  puts 'Opening a subscriptions/listen stream…'
+
+  # `resource_subscriptions` is deliberately included: this server does not
+  # offer it, so it comes back under `unsupported` rather than failing the
+  # call. A host uses that to decide what it can rely on.
+  subscription = client.listen(
+    notifications: {
+      tools_list_changed: true,
+      resource_subscriptions: ['file:///reports/summary.txt']
+    }
+  ) do |method, params|
+    received << [method, params]
+  end
+
+  # `listen` returns as soon as the request is on the wire; the
+  # acknowledgment arrives on the stream a moment later.
+  deadline = Time.now + 5
+  sleep 0.02 while subscription.acknowledged.nil? && Time.now < deadline
+
+  puts "  acknowledged: #{subscription.acknowledged.inspect}"
+  puts "  unsupported:  #{subscription.unsupported.inspect}"
+
+  puts "\nWaiting for notifications (the server sends three)…"
+  deadline = Time.now + 10
+  notifications = []
+  while notifications.size < 3 && Time.now < deadline
+    begin
+      method, params = received.pop(timeout: deadline - Time.now)
+    rescue StandardError
+      break
+    end
+    break unless method
+
+    notifications << method
+    round = params['round'] ? "(round #{params['round']})" : ''
+    puts "  ← #{method} #{round}"
+  end
+
+  puts "\nClosing the subscription…"
+  subscription.close
+
+  # The server ends a subscription by answering the listen request; the client
+  # reports that as a graceful close rather than a dropped stream.
+  deadline = Time.now + 5
+  sleep 0.05 while !subscription.closed? && Time.now < deadline
+  puts "  state: #{subscription.state}"
+
+  puts
+  if notifications.size >= 3 && subscription.closed?
+    puts '✅ subscriptions/listen demo completed successfully'
+  else
+    puts "❌ expected 3 notifications and a closed subscription, got #{notifications.size} and #{subscription.state}"
+    exit 1
+  end
+rescue StandardError => e
+  puts "\n❌ #{e.class}: #{e.message}"
+  puts e.backtrace.first(5)
+  exit 1
+ensure
+  client.cleanup
+end


### PR DESCRIPTION
Second of four PRs splitting up the 3.0.0 release work. Stacked on #238; retargeted to `main` once that merges.

Every example server in this repo speaks the handshake protocol — `initialize`, a session id, a GET event stream. Nothing exercised the revision this client was just rewritten for.

## New server

`examples/mcp_2026_07_28_server.py` (Flask, port 8933) answers the stateless way: `server/discover`, per-request `_meta` version checking, `ttlMs`/`cacheScope` hints, an `x-mcp-header` annotated tool, an `input_required` tool, a task-augmented tool with `tasks/get`, and `subscriptions/listen` on its own SSE stream. It returns 405 to a GET, which is what a modern server owes a client that should never open one.

## Three clients

| Example | What it shows |
|---|---|
| `mcp_2026_07_28_features.rb` | era detection, cacheable results, structured output validated against an `outputSchema`, a parameter carried as a request header, the three typed errors |
| `subscriptions_listen_example.rb` | what the server agreed to watch and what it refused, notifications, graceful close |
| `multi_round_trip_example.rb` | the server asking for input mid-call and the elicitation handler answering it; `InputRequiredError` without a handler |

## Two things writing them surfaced

- **`MCP_SERVER_URL` is pinned per example in the harness.** `secrets.env` may set it for the remote-service examples, and these three must reach localhost. Without the pin they silently ran against the remote host and failed.
- **The client is strict in two ways a server author will meet.** An `x-mcp-header` annotation must be the header *name*, not `true`; and `-32021`/`-32022` are only treated as typed protocol errors when they carry the `data` their schema mandates. My first draft of the server got both wrong and the client caught both — the strictness is right, and it is now demonstrated.

## Verification

17/17 examples pass (`RUN_AI=0`; 5 paid-LLM and 1 interactive-OAuth skipped by the harness). rubocop clean, `bash -n` and `ast.parse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoErzDypnq7hhuFBtueML7