### PR TITLE
release: 3.0.0 — MCP 2026-07-28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,106 @@
 # Changelog
 
-## Unreleased — MCP 2026-07-28
+## 3.0.0 — MCP 2026-07-28 (2026-09-08)
 
-Groundwork for the 2026-07-28 protocol revision (stateless, per-request
-metadata). Each feature lands in its own PR; this section accumulates them.
+Full support for the MCP 2026-07-28 protocol revision. The revision makes the
+protocol stateless: there is no `initialize` handshake, no session and no
+server-to-client request channel. A client identifies a server with a
+`server/discover` probe and carries its own identity in each request's
+`_meta`; anything the server needs back it asks for through the result.
+
+**Most existing code keeps working unchanged.** The client detects which
+revision a server speaks and adapts, and talking to a 2025-11-25 or earlier
+server is the same conversation it was in 2.1.0. The major version marks the
+size of the new surface and the behaviour changes listed below — read them
+before upgrading, particularly the OAuth ones, which can require a
+configuration change or a re-authorization.
+
+### What is new, in one line each
+
+| Feature | Entry point |
+|---------|-------------|
+| Stateless protocol, era detection | `server.modern?`, `protocol_era`, `protocol: :auto/:modern/:legacy` |
+| Per-request metadata | `MCPClient::Client.new(request_meta:)` |
+| Streamable HTTP modern mode | no session id, no GET stream, broken-stream re-issue |
+| Custom headers from tool parameters | `x-mcp-header` → `Mcp-Param-*`, `MCPClient::HeaderParams` |
+| Multi round-trip requests | `resultType: "input_required"`, `InputRequiredError` |
+| Subscriptions | `client.listen(notifications:)` |
+| Cacheable results | `ttlMs` / `cacheScope`, `server.cache_info` |
+| Tasks extension | `extensions: ['io.modelcontextprotocol/tasks']`, `call_tool_as_task` |
+| Authorization | RFC 9207 `iss` validation, issuer-bound tokens and clients |
+| JSON Schema | 2020-12 dialects, local `$ref`, composition bounds |
+| Deprecations | `MCPClient::Deprecations` registry and notices |
+
+### Behaviour changes to be aware of when upgrading
+
+- **Ruby 3.3 or newer is required.** The floor moved from 3.2 to 3.3 after
+  2.1.0 shipped, so this is the release that carries it for anyone upgrading
+  from 2.1.0.
+- **Every HTTP and stdio connection now begins with a `server/discover`
+  probe.** A legacy server answers it with an error and the client falls back
+  to `initialize`, which costs one extra round trip on first connect. Skip the
+  probe with `protocol: :legacy`, or bound it with `discover_timeout:`.
+- **Tool definitions with an invalid `x-mcp-header` annotation are excluded
+  from `list_tools` with a warning** rather than being offered and failing at
+  call time.
+- **`structuredContent` is validated against the tool's `outputSchema`** when
+  the tool declares one, and an unsupported JSON Schema dialect is reported as
+  an error rather than silently skipped.
+- **Results with `cacheScope: "private"` are bound to the credentials their
+  request went out with** and are never served to another authorization
+  context.
+- **A redirect URI that is neither loopback HTTP nor HTTPS is now refused.**
+  `OAuthProvider#redirect_uri=` raises `ArgumentError` for anything else (a
+  private-use scheme URI is fine): the revision requires every redirect URI to
+  be localhost or HTTPS. A host that configured a plain-HTTP callback on a
+  non-loopback address has to change it.
+- **Stored OAuth credentials and tokens are bound to the authorization server
+  that issued them.** Records persisted by an earlier version carry no issuer:
+  a token is bound to the server it is first read under, and a dynamic client
+  registration whose authorization server cannot be established is retired and
+  re-registered. Some users will have to authorize again once. Credentials a
+  host pre-registered are kept, but they are only used for the authorization
+  server they name — pass `issuer:` with them.
+- **Roots, Sampling, Logging, the HTTP+SSE transport and OAuth Dynamic Client
+  Registration now log a deprecation notice** once per feature per process on
+  first use. They keep working; silence the notices with
+  `MCPClient::Deprecations.enabled = false`.
+
+### Examples
+
+`examples/mcp_2026_07_28_server.py` is a Flask server that speaks the new
+revision, with three clients against it: `mcp_2026_07_28_features.rb`,
+`subscriptions_listen_example.rb` and `multi_round_trip_example.rb`. All
+examples are run by `examples/run_all_examples.sh`.
+
+### Fixed during release review
+
+- **Two overlapping `-32020` retries could each be sent under the other's tool
+  definition.** A `tools/call` rejected with `-32020` refreshes `tools/list`
+  and retries under the definition that refresh brought; the pin carrying it
+  across the retry is per-thread, but it was filled from the transport's
+  *shared* tool cache. Two calls to one tool rejected at the same time both
+  went out under whichever refresh landed last. The refresh now hands its own
+  list to the check that pins. It also costs one `tools/list` less, because
+  that check no longer looks the tool up a second time.
+- **The lock serializing a resource's authorization state could be replaced
+  while it was held.** The registry was an `ObjectSpace::WeakMap`, which holds
+  its *values* weakly as well as its keys; the value is the table of
+  per-resource monitors and nothing else referenced it, so a garbage collection
+  between two acquisitions dropped it and the next caller built a fresh
+  monitor. Two providers sharing one storage could then be inside the critical
+  section at the same time — the section that keeps a token from being written
+  over state that changed after it was validated. It is an
+  `ObjectSpace::WeakKeyMap` now: weak keys, strong values.
+
+### Test suite
+
+The specs written during development — one file per adversarial review round —
+were consolidated into one canonical and one `*_regressions_spec.rb` file per
+feature. Only specs whose every covered line and branch is covered elsewhere
+were removed, measured with line-and-branch coverage against identical
+library code: 296 files and 5550 examples became 103 files and 4397 examples,
+with the coverage set unchanged at 15434 line-and-branch items.
 
 ### Deprecations (feature lifecycle policy)
 
@@ -1047,8 +1144,11 @@ metadata). Each feature lands in its own PR; this section accumulates them.
   dropped through the optional `delete_token` storage method, see
   OAUTH.md), pre-registered credentials for another issuer raise a
   `ConnectionError` instead of being reused, credentials persisted before
-  these fields existed are bound on first use (as `dynamic` when they carry
-  `client_id_issued_at`, else `pre_registered`), and Client ID Metadata
+  these fields existed are bound on first use (as `dynamic` unless the record
+  says otherwise: `client_id_issued_at` is optional in RFC 7591, so its
+  absence proves nothing, and this library only ever stored registrations it
+  made itself — a host's pre-registered credentials are recorded as such
+  explicitly with `registration_type: 'pre_registered'`), and Client ID Metadata
   Document client ids stay portable. Authorization server metadata whose
   `issuer` is not the identifier it was fetched for is rejected (RFC 8414
   Section 3.3, byte for byte). Error responses are `state`-bound and their

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    ruby-mcp-client (2.1.0)
+    ruby-mcp-client (3.0.0)
       base64 (~> 0.2)
       faraday (~> 2.0)
       faraday-follow_redirects (~> 0.3)

--- a/lib/mcp_client/version.rb
+++ b/lib/mcp_client/version.rb
@@ -2,7 +2,7 @@
 
 module MCPClient
   # Current version of the MCP client gem
-  VERSION = '2.1.0'
+  VERSION = '3.0.0'
 
   # Latest MCP protocol revision this client implements (basic/versioning).
   # Modern revisions (2026-07-28 and later) carry the protocol version,


### PR DESCRIPTION
Last of four PRs. Stacked on #240; retargeted to `main` once the rest have merged. **Merge this one last.**

No client code changes here — only `lib/mcp_client/version.rb` and `CHANGELOG.md`. The code this release covers is in #238, #239 and #240.

## Contents

- Version 2.1.0 → **3.0.0**
- The accumulated `Unreleased` notes become the 3.0.0 entry: what the revision is, a table giving each feature's entry point, and an upgrade section.

## Upgrade notes, for reference

- **Ruby 3.3+ required.** The floor moved from 3.2 to 3.3 on 2026-08-21, *after* 2.1.0 shipped on 2026-08-04, so this is the release that carries it for anyone upgrading from 2.1.0.
- Every HTTP and stdio connection now begins with a `server/discover` probe (one extra round trip against a legacy server; skip with `protocol: :legacy`).
- Tool definitions with an invalid `x-mcp-header` annotation are excluded from `list_tools` with a warning rather than failing at call time.
- `structuredContent` is validated against a declared `outputSchema`, and an unsupported JSON Schema dialect is an error rather than silently skipped.
- Results with `cacheScope: "private"` are bound to the credentials their request went out with.
- Roots, Sampling, Logging, HTTP+SSE and OAuth Dynamic Client Registration log one deprecation notice per feature per process. Silence with `MCPClient::Deprecations.enabled = false`.

Existing code keeps working: the client detects a server's revision and adapts, and 2025-11-25 and earlier servers behave as they did in 2.1.0. The major bump marks the size of the new surface and the changes above.

## Verification

`gem build` produces `ruby-mcp-client-3.0.0.gem`. Suite and examples are verified in the preceding PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoErzDypnq7hhuFBtueML7