### PR TITLE
test: lock the record two client threads write in the tasks spec

### DIFF
--- a/spec/lib/mcp_client/tasks_extension_2026_regressions_spec.rb
+++ b/spec/lib/mcp_client/tasks_extension_2026_regressions_spec.rb
@@ -5054,10 +5054,17 @@ RSpec.describe 'MCP 2026-07-28 tasks extension — round 42' do
       })
       negotiated
       creating
+      # Two client threads write this record while the example reads it, so
+      # the appends and the reads take a lock. Without one an append can be
+      # lost against a concurrent read, and the example fails counting a
+      # request that really did go out.
+      sent_lock = Mutex.new
       sent = []
+      record = ->(entry) { sent_lock.synchronize { sent << entry } }
+      snapshot = -> { sent_lock.synchronize { sent.dup } }
       updated = false
       allow(stdio).to receive(:rpc_request) do |method, params, **_kw|
-        sent << [method, params]
+        record.call([method, params])
         case method
         when 'tasks/get'
           if updated
@@ -5078,13 +5085,13 @@ RSpec.describe 'MCP 2026-07-28 tasks extension — round 42' do
       # The first wait is inside the handler with k1 reserved; the second
       # polls the same input_required task and finds nothing left to answer.
       second = Thread.new { client.wait_for_task(task) }
-      wait_for { sent.count { |method, _| method == 'tasks/get' } >= 2 }
+      wait_for { snapshot.call.count { |method, _| method == 'tasks/get' } >= 2 }
       release << true
 
       expect(first.value).to be_completed
       expect(second.value).to be_completed
       expect(handled).to eq(1)
-      updates = sent.select { |pair| pair.first == 'tasks/update' }
+      updates = snapshot.call.select { |pair| pair.first == 'tasks/update' }
       expect(updates.size).to eq(1)
       expect(updates.dig(0, 1, :inputResponses) || updates.dig(0, 1, 'inputResponses')).to have_key('k1')
     end


### PR DESCRIPTION
CI failed this example once on Ruby 4.0.6, on a PR that changes no code (#241, version + CHANGELOG + lockfile):

```
1) MCP 2026-07-28 tasks extension — round 42 two waits on one task through the
   public API drive one round between them: the host is asked once and one update goes out
   Failure/Error: expect(updates.size).to eq(1)
```

The assertion just above it — the host is asked exactly once — held, so exactly one round trip happened. What differed was the *record* of it.

## Cause

The example records every request in a plain `Array` that **both client threads append to** while the example itself reads it with `count` and `select`:

```ruby
sent = []
allow(stdio).to receive(:rpc_request) { |method, params, **_kw| sent << [method, params] }
...
wait_for { sent.count { |method, _| method == 'tasks/get' } >= 2 }
```

An append lost against a concurrent read produces exactly the observed failure: a request that really did go out, missing from the record. Appends and reads now take a lock.

## What I can and cannot claim

This removes a genuine data race in the harness. I could **not** reproduce the original failure locally — 45 runs, isolated, as a whole file, and under CPU load with 8 busy cores, all green both before and after the change. So this is the most plausible cause, not a proven one. If the failure recurs after this, the record was not the problem and the next place to look is the reservation handoff itself.

The only other example in the file that appends from a thread reads its array after `Thread#join`, which is already ordered; it is left alone.

## Verification

rubocop clean; the example passes 20/20 under load on Ruby 4.0.6, as it did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoErzDypnq7hhuFBtueML7