### PR TITLE
deps: bump jwt 3.1.2 → 3.2.0 in the lockfile (CVE-2026-45363)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     hashdiff (1.2.1)
     io-console (0.8.2)
     json (2.21.2)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)


### PR DESCRIPTION
Closes #236.

## What the report gets right

The committed `Gemfile.lock` pins `jwt (3.1.2)`, and 3.2.0 exists (as does the 2.10.3 backport), consistent with the fix landing where the reporter says.

## What it gets wrong

**`jwt` is not a dependency of this gem.** The gemspec declares `base64`, `faraday`, `faraday-follow_redirects`, `faraday-retry` — nothing else. Nobody installing `ruby-mcp-client` receives `jwt`.

It reaches the lockfile transitively through the **development** group:

```
gemini-ai → googleauth → jwt (>= 1.4, < 4.0)
           → signet    → jwt (>= 1.5, < 4.0)
```

Nothing in `lib`, `spec` or `examples` requires `jwt` or verifies a token — the CVE is about verification accepting an empty secret, and this codebase never verifies one. **The released gem was never exposed.**

The suggested diff also does not apply: there is no `gem 'jwt', '3.1.2'` line in the `Gemfile` to change; the constraint comes from `googleauth`.

## Why bump anyway

One line, it keeps scanners quiet, and the development bundle is what runs the Gemini example against real credentials.

`bundle update jwt` moves `jwt` alone — the entire diff is:

```diff
-    jwt (3.1.2)
+    jwt (3.2.0)
```

## Verification

4397 examples, 0 failures on Ruby 3.3.8 **and** 4.0.6; rubocop clean across 232 files; `bundle check` satisfied on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoErzDypnq7hhuFBtueML7